### PR TITLE
Fix issue #4

### DIFF
--- a/Source/Clients/Shared/Logging/FileExceptionlessLog.cs
+++ b/Source/Clients/Shared/Logging/FileExceptionlessLog.cs
@@ -37,8 +37,17 @@ namespace Exceptionless.Logging {
         }
 
         protected virtual long GetFileSize() {
-            var info = new FileInfo(FilePath);
-            return info.Length;
+            try
+            {
+              if (File.Exists(FilePath))
+                  return new FileInfo(FilePath).Length;
+            }
+            catch (IOException ex)
+            {
+                System.Diagnostics.Trace.WriteLine("Exceptionless: Error getting size of file: {0}", ex.Message);
+            }
+            
+            return -1;
         }
 
         public string FilePath { get; private set; }

--- a/Source/Clients/Shared/Utility/IsolatedStorageDirectory.cs
+++ b/Source/Clients/Shared/Utility/IsolatedStorageDirectory.cs
@@ -56,8 +56,15 @@ namespace Exceptionless.Utility {
         public long GetFileSize(string filename) {
             string path = Path.Combine(SubDirectory, filename);
             string fullPath = IsolatedStorage.GetFullPath(path);
-            if (File.Exists(fullPath))
-                return new FileInfo(fullPath).Length;
+            try
+            {
+                if (File.Exists(fullPath))
+                    return new FileInfo(fullPath).Length;
+            }
+            catch (IOException ex)
+            {
+                System.Diagnostics.Trace.WriteLine("Exceptionless: Error getting size of file: {0}", ex.Message);
+            }
 
             return -1;
         }

--- a/Source/Clients/Tests/Log/FileExceptionlessLogTests.cs
+++ b/Source/Clients/Tests/Log/FileExceptionlessLogTests.cs
@@ -89,6 +89,12 @@ namespace Exceptionless.Client.Tests.Log {
         }
 
         [Fact]
+        public void CheckSizeDoesNotFailIfLogIsMissing() {
+            FileExceptionlessLog log = GetLog(LOG_FILE + ".doesnotexist");
+            Assert.DoesNotThrow(log.CheckFileSize);
+        }
+
+        [Fact]
         public void LogIsThreadSafe() {
             FileExceptionlessLog log = GetLog(LOG_FILE);
 


### PR DESCRIPTION
Checking for file existence and catching potential IO exceptions when
getting the length of a file.
Check that the file exists before getting it's length. Used GetFileSize
from IsolatedStorageDirectory as an example and also made that bullet
proof. Unit test to ensure that the method does not throw and exception,
it will just be ignored because the file will be less than "5MB".
