### PR TITLE
Removed runAllManagedModulesForAllRequests setting for performance reasons

### DIFF
--- a/Source/Api/Web.config
+++ b/Source/Api/Web.config
@@ -1,9 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <configSections>
-    <section name="exceptionless" type="Exceptionless.ExceptionlessSection, Exceptionless.Extras" />
-  </configSections>
-  <exceptionless apiKey="Bx7JgglstPG544R34Tw9T7RlCed3OIwtYXVeyhT2" serverUrl="http://localhost:50000" enabled="true" />
   <connectionStrings>
     <add name="RedisConnectionString" connectionString="" />
     <add name="ElasticSearchConnectionString" connectionString="http://localhost:9200" />
@@ -34,8 +30,11 @@
     <!-- Internal project id keeps us from recursively logging to ourself -->
     <add key="InternalProjectId" value="54b56e480ef9605a88a13153" />
     
+    <!-- Exceptionless Api Key that allows us to log any application exceptions -->
+    <add key="Exceptionless:ApiKey" value="Bx7JgglstPG544R34Tw9T7RlCed3OIwtYXVeyhT2" />
+    <add key="Exceptionless:ServerUrl" value="http://localhost:50000" />
+    
     <add key="aspnet:UseTaskFriendlySynchronizationContext" value="true" />
-    <add key="vs:EnableBrowserLink" value="false" />
   </appSettings>
   <system.net>
     <mailSettings>

--- a/Source/Api/Web.config
+++ b/Source/Api/Web.config
@@ -56,7 +56,7 @@
     <httpRuntime targetFramework="4.5.1" maxUrlLength="1024" />
   </system.web>
   <system.webServer>
-    <modules runAllManagedModulesForAllRequests="true">
+    <modules>
       <remove name="RewriteModule" />
       <remove name="RoleManager" />
       <remove name="WebDAVModule" />

--- a/Source/Insulation/Exceptionless.Insulation.csproj
+++ b/Source/Insulation/Exceptionless.Insulation.csproj
@@ -30,24 +30,24 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Exceptionless, Version=3.0.1341.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Exceptionless.3.0.1341\lib\net45\Exceptionless.dll</HintPath>
+    <Reference Include="Exceptionless, Version=3.1.1382.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Exceptionless.3.1.1382\lib\net45\Exceptionless.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Exceptionless.Extras, Version=3.0.1341.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Exceptionless.3.0.1341\lib\net45\Exceptionless.Extras.dll</HintPath>
+    <Reference Include="Exceptionless.Extras, Version=3.1.1382.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Exceptionless.WebApi.3.1.1382\lib\net45\Exceptionless.Extras.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Exceptionless.NLog, Version=3.0.1341.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Exceptionless.NLog.3.0.1341\lib\net45\Exceptionless.NLog.dll</HintPath>
+    <Reference Include="Exceptionless.NLog, Version=3.1.1382.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Exceptionless.NLog.3.1.1382\lib\net45\Exceptionless.NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Exceptionless.Portable, Version=3.0.1341.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Exceptionless.Portable.3.0.1341\lib\portable-net40+sl50+win+wpa81+wp80\Exceptionless.Portable.dll</HintPath>
+    <Reference Include="Exceptionless.Portable, Version=3.1.1382.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Exceptionless.Portable.3.1.1382\lib\net45\Exceptionless.Portable.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Exceptionless.WebApi, Version=3.0.1341.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Exceptionless.WebApi.3.0.1341\lib\net45\Exceptionless.WebApi.dll</HintPath>
+    <Reference Include="Exceptionless.WebApi, Version=3.1.1382.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Exceptionless.WebApi.3.1.1382\lib\net45\Exceptionless.WebApi.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Foundatio, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Source/Insulation/packages.config
+++ b/Source/Insulation/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Exceptionless" version="3.0.1341" targetFramework="net451" />
-  <package id="Exceptionless.NLog" version="3.0.1341" targetFramework="net451" />
-  <package id="Exceptionless.Portable" version="3.0.1341" targetFramework="net451" />
-  <package id="Exceptionless.WebApi" version="3.0.1341" targetFramework="net451" />
+  <package id="Exceptionless" version="3.1.1382" targetFramework="net451" />
+  <package id="Exceptionless.NLog" version="3.1.1382" targetFramework="net451" />
+  <package id="Exceptionless.Portable" version="3.1.1382" targetFramework="net451" />
+  <package id="Exceptionless.WebApi" version="3.1.1382" targetFramework="net451" />
   <package id="Foundatio" version="1.0.272" targetFramework="net451" />
   <package id="Foundatio.AzureStorage" version="1.0.272" targetFramework="net451" />
   <package id="Foundatio.Redis" version="1.0.272" targetFramework="net451" />


### PR DESCRIPTION
http://www.hanselman.com/blog/BackToBasicsDynamicImageGenerationASPNETControllersRoutingIHttpHandlersAndRunAllManagedModulesForAllRequests.aspx

@ejsmith  I tried looking back in history and figuring out why this was added but
couldn't find anything other than it was added as a generic commit in 2012.  I did a really quick test and nothing seems broken.