### PR TITLE
Trying to fix server side of: https://github.com/exceptionless/Except…

### DIFF
--- a/Source/Api/Controllers/ProjectController.cs
+++ b/Source/Api/Controllers/ProjectController.cs
@@ -381,9 +381,10 @@ namespace Exceptionless.Api.Controllers {
         /// <response code="201">The project name is available.</response>
         /// <response code="204">The project name is not available.</response>
         [HttpGet]
-        [Route("check-name/{name:minlength(1)}/{organizationId}")]
-        public async Task<IHttpActionResult> IsNameAvailableAsync(string name, string organizationId) {
-            if (await IsProjectNameAvailableInternalAsync(organizationId, name))
+        [Route("check-name/{*name:minlength(1)}")]
+        [Route("~/" + API_PREFIX + "/organizations/{organization:objectid}/projects/check-name/{*name:minlength(1)}")]        
+        public async Task<IHttpActionResult> IsNameAvailableAsync(string name, string organization = null) {
+            if (await IsProjectNameAvailableInternalAsync(organization, name))
                 return StatusCode(HttpStatusCode.NoContent);
 
             return StatusCode(HttpStatusCode.Created);

--- a/Source/Api/Controllers/ProjectController.cs
+++ b/Source/Api/Controllers/ProjectController.cs
@@ -377,12 +377,13 @@ namespace Exceptionless.Api.Controllers {
         /// Check for unique name
         /// </summary>
         /// <param name="name">The project name to check.</param>
+        /// <param name="organizationId">The organizationId of the project.</param>
         /// <response code="201">The project name is available.</response>
         /// <response code="204">The project name is not available.</response>
         [HttpGet]
-        [Route("check-name/{*name:minlength(1)}")]
-        public async Task<IHttpActionResult> IsNameAvailableAsync(string name) {
-            if (await IsProjectNameAvailableInternalAsync(null, name))
+        [Route("check-name/{name:minlength(1)}/{organizationId}")]
+        public async Task<IHttpActionResult> IsNameAvailableAsync(string name, string organizationId) {
+            if (await IsProjectNameAvailableInternalAsync(organizationId, name))
                 return StatusCode(HttpStatusCode.NoContent);
 
             return StatusCode(HttpStatusCode.Created);

--- a/Source/Api/Controllers/ProjectController.cs
+++ b/Source/Api/Controllers/ProjectController.cs
@@ -377,7 +377,7 @@ namespace Exceptionless.Api.Controllers {
         /// Check for unique name
         /// </summary>
         /// <param name="name">The project name to check.</param>
-        /// <param name="organizationId">The organizationId of the project.</param>
+        /// <param name="organization">The organizationId of the project.</param>
         /// <response code="201">The project name is available.</response>
         /// <response code="204">The project name is not available.</response>
         [HttpGet]


### PR DESCRIPTION
It seems that the API to create the project already gets the OrganizationId but the check-name api is calling IsProjectNameAvailableInternalAsync method with this value as null.

I'm not sure how to change UI side to call chec-name API with OrganizationId param. Could someone help with this part?