### PR TITLE
Added new heartbeat api endpoint

### DIFF
--- a/Source/Api/Controllers/EventController.cs
+++ b/Source/Api/Controllers/EventController.cs
@@ -449,7 +449,7 @@ namespace Exceptionless.Api.Controllers {
         /// <param name="version">The api version that should be used.</param>
         /// <param name="id">The session id or user id.</param>
         /// <param name="close">If true, the session will be closed.</param>
-        /// <response code="202">Accepted</response>
+        /// <response code="200">OK</response>
         /// <response code="400">No project id specified and no default project was found.</response>
         /// <response code="404">No project was found.</response>
         [HttpGet]
@@ -500,7 +500,7 @@ namespace Exceptionless.Api.Controllers {
         /// <param name="type">The event type</param>
         /// <param name="userAgent">The user agent that submitted the event.</param>
         /// <param name="parameters">Parameters that control what properties are set on the event</param>
-        /// <response code="202">Accepted</response>
+        /// <response code="200">OK</response>
         /// <response code="400">No project id specified and no default project was found.</response>
         /// <response code="404">No project was found.</response>
         [HttpGet]

--- a/Source/Api/Controllers/EventController.cs
+++ b/Source/Api/Controllers/EventController.cs
@@ -456,7 +456,7 @@ namespace Exceptionless.Api.Controllers {
         [Route("~/api/v{version:int=2}/projects/{projectId:objectid}/events/session/{sessionIdOrUserId:minlength(1)}/heartbeat")]
         [OverrideAuthorization]
         [Authorize(Roles = AuthorizationRoles.Client)]
-        public async Task<IHttpActionResult> GetSubmitHeartbeat(string projectId = null, int version = 2, string sessionIdOrUserId = null) {
+        public async Task<IHttpActionResult> RecordHeartbeatAsync(string projectId = null, int version = 2, string sessionIdOrUserId = null) {
             if (String.IsNullOrWhiteSpace(sessionIdOrUserId))
                 return Ok();
 
@@ -509,7 +509,7 @@ namespace Exceptionless.Api.Controllers {
         [OverrideAuthorization]
         [ConfigurationResponseFilter]
         [Authorize(Roles = AuthorizationRoles.Client)]
-        public async Task<IHttpActionResult> GetSubmitEvent(string projectId = null, int version = 2, string type = null, [UserAgent] string userAgent = null, [QueryStringParameters] IDictionary<string, string[]> parameters = null) {
+        public async Task<IHttpActionResult> GetSubmitEventAsync(string projectId = null, int version = 2, string type = null, [UserAgent] string userAgent = null, [QueryStringParameters] IDictionary<string, string[]> parameters = null) {
             if (parameters == null || parameters.Count == 0)
                 return Ok();
 

--- a/Source/Api/Controllers/EventController.cs
+++ b/Source/Api/Controllers/EventController.cs
@@ -471,8 +471,7 @@ namespace Exceptionless.Api.Controllers {
             if (project == null)
                 return NotFound();
             
-            string decodedId = Uri.UnescapeDataString(sessionIdOrUserId).Trim();
-            await _sessionCacheClient.SetAsync($"project:{project.Id}:{decodedId.ToSHA1()}:heartbeat", DateTime.UtcNow, TimeSpan.FromHours(2));
+            await _sessionCacheClient.SetAsync($"project:{project.Id}:{sessionIdOrUserId.ToSHA1()}:heartbeat", DateTime.UtcNow, TimeSpan.FromHours(2));
             
             return Ok();
         }

--- a/Source/Api/Controllers/ProjectController.cs
+++ b/Source/Api/Controllers/ProjectController.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using System.Web.Http;
 using System.Web.Http.Description;

--- a/Source/Core/Extensions/PersistentEventExtensions.cs
+++ b/Source/Core/Extensions/PersistentEventExtensions.cs
@@ -203,22 +203,7 @@ namespace Exceptionless {
             
             return startEvent;
         }
-
-        public static PersistentEvent ToSessionEndEvent(this PersistentEvent source, string sessionId) {
-            var endEvent = new PersistentEvent {
-                Date = source.Date,
-                OrganizationId = source.OrganizationId,
-                ProjectId = source.ProjectId,
-                Type = Event.KnownTypes.SessionEnd
-            };
-            
-            endEvent.SetSessionId(sessionId);
-            endEvent.SetUserIdentity(source.GetUserIdentity());
-            endEvent.AddRequestInfo(source.GetRequestInfo());
-
-            return endEvent;
-        }
-
+       
         public static IEnumerable<string> GetIpAddresses(this PersistentEvent ev) {
             if (ev == null)
                 yield break;

--- a/Source/Tests/Jobs/CloseInactiveSessionsJobTests.cs
+++ b/Source/Tests/Jobs/CloseInactiveSessionsJobTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Exceptionless.Api.Controllers;
 using Exceptionless.Api.Tests.Utility;
 using Exceptionless.Core.Billing;
 using Exceptionless.Core.Extensions;
@@ -33,12 +34,15 @@ namespace Exceptionless.Api.Tests.Jobs {
         public CloseInactiveSessionsJobTests(ITestOutputHelper output) : base(output) {}
 
         [Theory]
-        [InlineData(1, true)]
-        [InlineData(60, false)]
-        public async Task CloseInactiveSessions(int defaultInactivePeriodInMinutes, bool willCloseSession) {
+        [InlineData(1, true, null)]
+        [InlineData(1, true, 70)]
+        [InlineData(1, false, 50)]
+        [InlineData(60, false, null)]
+        public async Task CloseInactiveSessions(int defaultInactivePeriodInMinutes, bool willCloseSession, int? sessionHeartbeatUpdatedAgoInSeconds) {
             await ResetAsync();
 
-            var ev = GenerateEvent(DateTimeOffset.Now.SubtractMinutes(5), "blake@exceptionless.io");
+            const string userId = "blake@exceptionless.io";
+            var ev = GenerateEvent(DateTimeOffset.Now.SubtractMinutes(5), userId);
 
             var context = await _pipeline.RunAsync(ev);
             Assert.False(context.HasError, context.ErrorMessage);
@@ -53,6 +57,12 @@ namespace Exceptionless.Api.Tests.Jobs {
             Assert.Equal(0, sessionStart.Value);
             Assert.False(sessionStart.HasSessionEndTime());
 
+            var utcNow = DateTime.UtcNow;
+            if (sessionHeartbeatUpdatedAgoInSeconds.HasValue) {
+                var client = new ScopedCacheClient(_cacheClient, "session");
+                await client.SetAsync($"project:{sessionStart.ProjectId}:{userId.ToSHA1()}:heartbeat", utcNow.SubtractSeconds(sessionHeartbeatUpdatedAgoInSeconds.Value));
+            }
+
             _job.DefaultInactivePeriod = TimeSpan.FromMinutes(defaultInactivePeriodInMinutes);
             Assert.Equal(JobResult.Success, await _job.RunAsync());
             await _client.RefreshAsync();
@@ -60,11 +70,12 @@ namespace Exceptionless.Api.Tests.Jobs {
             Assert.Equal(2, events.Total);
 
             sessionStart = events.Documents.First(e => e.IsSessionStart());
+            decimal sessionStartDuration = (decimal)(sessionHeartbeatUpdatedAgoInSeconds.HasValue ? (utcNow.SubtractSeconds(sessionHeartbeatUpdatedAgoInSeconds.Value) - sessionStart.Date.UtcDateTime).TotalSeconds : 0);
             if (willCloseSession) {
-                Assert.Equal(0, sessionStart.Value);
+                Assert.Equal(sessionStartDuration, sessionStart.Value);
                 Assert.True(sessionStart.HasSessionEndTime());
             } else {
-                Assert.Equal(0, sessionStart.Value);
+                Assert.Equal(sessionStartDuration, sessionStart.Value);
                 Assert.False(sessionStart.HasSessionEndTime());
             }
         }


### PR DESCRIPTION
This adds new api fire and forget end point for sending heartbeats.

@ejsmith do you think we should decrease the job time and inactive session period from 10 minutes to something smaller so things run more often?