### PR TITLE
Added user information and tags to notice email

### DIFF
--- a/Source/Core/Mail/Templates/Notice/PlainText.cshtml
+++ b/Source/Core/Mail/Templates/Notice/PlainText.cshtml
@@ -1,5 +1,8 @@
 ﻿@using System
+@using System.Linq
+@using Exceptionless
 @using Exceptionless.Core.Extensions
+@using Exceptionless.Core.Models.Data
 @inherits RazorSharpEmail.EmailTemplate<Exceptionless.Core.Mail.Models.EventNotificationModel>
 @if (Model.IsNew) {
 <text>
@@ -34,6 +37,49 @@ Source:
 Source:
 @Model.Url
 </text>
+}
+@if (Model.Event.Tags != null && Model.Event.Tags.Any()) {
+<text>
+
+Tags:
+@String.Join(", ", Model.Event.Tags)
+</text>
+}
+@{
+	UserDescription userDescription = Model.Event.GetUserDescription();
+	UserInfo userInfo = Model.Event.GetUserIdentity();
+}
+@if (userInfo != null) {
+	if (!String.IsNullOrEmpty(userInfo.Name)) {
+<text>
+
+User's Name:
+@userInfo.Name
+</text>
+	}
+	if (!String.IsNullOrEmpty(userInfo.Identity)) {
+<text>
+
+User's Identity:
+@userInfo.Identity
+</text>
+	}
+}
+@if (userDescription != null) {
+	if (!String.IsNullOrEmpty(userDescription.EmailAddress)) {
+<text>
+
+User's Email:
+@userDescription.EmailAddress
+</text>
+	}
+	if (!String.IsNullOrEmpty(userDescription.Description)) {
+<text>
+
+User's Description:
+@userDescription.Description
+</text>
+	}
 }
 
 View the event:

--- a/Source/Tests/Mail/MailerTests.cs
+++ b/Source/Tests/Mail/MailerTests.cs
@@ -8,6 +8,7 @@ using Exceptionless.Core.Mail.Models;
 using Exceptionless.Core.Queues.Models;
 using Exceptionless.DateTimeExtensions;
 using Exceptionless.Core.Models;
+using Exceptionless.Core.Models.Data;
 using Exceptionless.Core.Plugins.Formatting;
 using Exceptionless.Tests.Utility;
 using Foundatio.Logging;
@@ -40,6 +41,42 @@ namespace Exceptionless.Api.Tests.Mail {
                     StackId = "1",
                     Message = "Happy days are here again...",
                     Type = Event.KnownTypes.Log
+                },
+                IsNew = true,
+                IsCritical = true,
+                IsRegression = false,
+                TotalOccurrences = 1,
+                ProjectName = "Testing"
+            });
+
+            await RunMailJobAsync();
+        }
+
+        [Fact(Skip = "Used for testing html formatting.")]
+        //[Fact]
+        public async Task SendLogNotificationWithExtrasAsync() {
+            await _mailer.SendEventNoticeAsync(Settings.Current.TestEmailAddress, new EventNotification {
+                Event = new PersistentEvent {
+                    Id = "1",
+                    OrganizationId = "1",
+                    ProjectId = "1",
+                    StackId = "1",
+                    Message = "Happy days are here again...",
+                    Type = Event.KnownTypes.Log,
+                    Tags = new TagSet { "important", "web" },
+                    Data = new DataDictionary {
+                        {
+                            Event.KnownDataKeys.UserInfo, new UserInfo {
+                                Name = "First Last",
+                                Identity = "firstylaster"
+                            }
+                        }, {
+                            Event.KnownDataKeys.UserDescription, new UserDescription {
+                                Description = "A person",
+                                EmailAddress = "useremail@domain.com"
+                            }
+                        }
+                    }
                 },
                 IsNew = true,
                 IsCritical = true,


### PR DESCRIPTION
For #177 

This pull request is incomplete. I wanted to get feedback on the new plain text email before I copied the changes to the HTML email.

Here is the plain text output with user info:

> A new  critical  event has occurred in the "Testing" project.
> 
> Tags:
> important, web
> 
> 
> User's Name:
> First Last
> 
> 
> User's Identity:
> firstylaster
> 
> 
> User's Email:
> useremail@domain.com
> 
> 
> User's Description:
> A person
> 
> 
> View the event:
> http://localhost:50000/event/1