### PR TITLE
Added empty LdapConnectionString to web.config

### DIFF
--- a/Source/Api/Web.config
+++ b/Source/Api/Web.config
@@ -3,6 +3,7 @@
   <connectionStrings>
     <add name="RedisConnectionString" connectionString="" />
     <add name="ElasticSearchConnectionString" connectionString="http://localhost:9200" />
+    <add name="LdapConnectionString" connectionString="" />
   </connectionStrings>
   <appSettings>
     <!-- Base url for the ui used to build links in emails and other places. -->


### PR DESCRIPTION
This should reduce the incidence of issue #239 and make it more consistent with how other connection string are handled in the application. 