### PR TITLE
Fixed authorization on SetUserDescriptionAsync

### DIFF
--- a/Source/Api/Controllers/EventController.cs
+++ b/Source/Api/Controllers/EventController.cs
@@ -384,8 +384,8 @@ namespace Exceptionless.Api.Controllers {
         [HttpPost]
         [Route("by-ref/{referenceId:identifier}/user-description")]
         [Route("~/" + API_PREFIX + "/projects/{projectId:objectid}/events/by-ref/{referenceId:identifier}/user-description")]
-        //[OverrideAuthorization]
-        //[Authorize(Roles = AuthorizationRoles.Client)]
+        [OverrideAuthorization]
+        [Authorize(Roles = AuthorizationRoles.Client)]
         [ConfigurationResponseFilter]
         [ResponseType(typeof(List<PersistentEvent>))]
         public async Task<IHttpActionResult> SetUserDescriptionAsync(string referenceId, UserDescription description, string projectId = null) {


### PR DESCRIPTION
Attributes `OverrideAuthorization` and `Authorize` were commented out, making the client unable to use this API (due Authorization failed.)