### PR TITLE
Suppress auto-reply

### DIFF
--- a/src/Exceptionless.Core/Mail/SmtpMailSender.cs
+++ b/src/Exceptionless.Core/Mail/SmtpMailSender.cs
@@ -17,6 +17,8 @@ namespace Exceptionless.Core.Mail {
             var message = model.ToMailMessage();
             message.Headers.Add("X-Mailer-Machine", Environment.MachineName);
             message.Headers.Add("X-Mailer-Date", SystemClock.UtcNow.ToString());
+            message.Headers.Add("X-Auto-Response-Suppress", "All");
+            message.Headers.Add("Auto-Submitted", "auto-generated");
 
             var client = new SmtpClient();
             if (!String.IsNullOrEmpty(Settings.Current.SmtpHost)) {


### PR DESCRIPTION
Any receiver having auto-reply enabled will result in an auto-reply mail being sent back to the sender address for any notifications sent out from Exceptionless. I.e. for no-reply addresses will end up bouncing with several retries and mails received as a consequence.

By including certain headers to the mails sent will make the receiver (server) skip sending auto-reply for these types of mails.

Details of the related headers:
- http://www.redmine.org/issues/19558
- https://www.jitbit.com/maxblog/18-detecting-outlook-autoreplyout-of-office-emails-and-x-auto-response-suppress-header/