### PR TITLE
Default BaseURL is misleading

### DIFF
--- a/src/Exceptionless.Api/Web.config
+++ b/src/Exceptionless.Api/Web.config
@@ -7,7 +7,7 @@
   </connectionStrings>
   <appSettings>
     <!-- Base url for the ui used to build links in emails and other places. -->
-    <add key="BaseURL" value="http://localhost:9001/#" />
+    <add key="BaseURL" value="http://localhost:9001/#!" />
     <!-- Controls whether SSL is required. Only enable this if you have SSL configured. -->
     <add key="EnableSSL" value="false" />
     <!--


### PR DESCRIPTION
If URL re-writing is not enabled, the base url in the app config must end with "/#!" or links in emails will not work. (verification email link ends up redirecting to the dashboard, and doesn't actually verify the email)