### PR TITLE
Fix bug the previous page url and next page url will be generated incorrectly

### DIFF
--- a/src/Exceptionless.Api/Utility/Results/OkWithHeadersContentResult.cs
+++ b/src/Exceptionless.Api/Utility/Results/OkWithHeadersContentResult.cs
@@ -71,9 +71,7 @@ namespace Exceptionless.Api.Utility.Results {
             var nextParameters = new NameValueCollection(previousParameters);
             nextParameters["page"] = (page + 1).ToString();
 
-            string baseUrl = url.ToString();
-            if (!String.IsNullOrEmpty(url.Query))
-                baseUrl = baseUrl.Replace(url.Query, "");
+            string baseUrl = url.GetBaseUrl();
 
             string previousLink = $"<{baseUrl}?{previousParameters.ToQueryString()}>; rel=\"previous\"";
             string nextLink = $"<{baseUrl}?{nextParameters.ToQueryString()}>; rel=\"next\"";
@@ -125,9 +123,7 @@ namespace Exceptionless.Api.Utility.Results {
                 includePrevious = false;
             }
 
-            string baseUrl = url.ToString();
-            if (!String.IsNullOrEmpty(url.Query))
-                baseUrl = baseUrl.Replace(url.Query, "");
+            string baseUrl = url.GetBaseUrl();
 
             string previousLink = $"<{baseUrl}?{previousParameters.ToQueryString()}>; rel=\"previous\"";
             string nextLink = $"<{baseUrl}?{nextParameters.ToQueryString()}>; rel=\"next\"";

--- a/src/Exceptionless.Core/Extensions/UriExtensions.cs
+++ b/src/Exceptionless.Core/Extensions/UriExtensions.cs
@@ -10,7 +10,7 @@ namespace Exceptionless.Core.Extensions {
         }
 
         public static string ToQueryString(this IEnumerable<KeyValuePair<string, string>> collection) {
-            return collection.ToConcatenatedString(pair => pair.Key == null ? pair.Value : $"{pair.Key}={System.Web.HttpUtility.UrlEncode(pair.Value)}", "&");
+            return collection.ToConcatenatedString(pair => pair.Key == null ? pair.Value : $"{pair.Key}={Uri.EscapeDataString(pair.Value)}", "&");
         }
 
         /// <summary>

--- a/src/Exceptionless.Core/Extensions/UriExtensions.cs
+++ b/src/Exceptionless.Core/Extensions/UriExtensions.cs
@@ -10,7 +10,7 @@ namespace Exceptionless.Core.Extensions {
         }
 
         public static string ToQueryString(this IEnumerable<KeyValuePair<string, string>> collection) {
-            return collection.ToConcatenatedString(pair => pair.Key == null ? pair.Value : $"{pair.Key}={pair.Value}", "&");
+            return collection.ToConcatenatedString(pair => pair.Key == null ? pair.Value : $"{pair.Key}={System.Web.HttpUtility.UrlEncode(pair.Value)}", "&");
         }
 
         /// <summary>

--- a/src/Exceptionless.Core/Extensions/UriExtensions.cs
+++ b/src/Exceptionless.Core/Extensions/UriExtensions.cs
@@ -19,5 +19,9 @@ namespace Exceptionless.Core.Extensions {
         private static IEnumerable<KeyValuePair<string, string>> AsKeyValuePairs(this NameValueCollection collection) {
             return collection.AllKeys.Select(key => new KeyValuePair<string, string>(key, collection.Get(key)));
         }
+
+        public static string GetBaseUrl(this Uri uri) {
+            return uri.Scheme + "://" + uri.Authority + uri.AbsolutePath;
+        }		
     }
 }


### PR DESCRIPTION
Preparement: We have posted many logs with the same Chinese tag "测试"
Scenario: In the search box enter keyword "测试", there will be many pages records. But when clicking the next page button, the page will be just refreshed and stay at the first page instead of navigating to next page records correctly.
Root cause: The previous page url and next page url will be generated incorrectly when search with Chinese characters.
While debugging source code, the baseUrl will be like
```
https://mywebsite/api/v2/stacks/frequent?filter=fixed:false+hidden:false+(测试)&limit=10&mode=summary&offset=480m
```
and the value of url.Query will be like
```
?filter=fixed:false+hidden:false+(%E6%B5%8B%E8%AF%95)&limit=10&mode=summary&offset=480m
```
So when replace the query to empty string, nothing will happen.
I have intended to created new extension method to generate base urls to replace the original approach.