### PR TITLE
Add configuration settings parameter for the work timeout of background queues.

### DIFF
--- a/src/Exceptionless.Core/Bootstrapper.cs
+++ b/src/Exceptionless.Core/Bootstrapper.cs
@@ -161,7 +161,7 @@ namespace Exceptionless.Core {
         private static IQueue<T> CreateQueue<T>(Container container, TimeSpan? workItemTimeout = null, ILoggerFactory loggerFactory = null) where T : class {
             return new InMemoryQueue<T>(new InMemoryQueueOptions<T> {
                 Behaviors = container.GetAllInstances<IQueueBehavior<T>>(),
-                WorkItemTimeout = workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5.0)),
+                WorkItemTimeout = workItemTimeout.GetValueOrDefault(Settings.Current.QueueWorkTimeout),
                 Serializer = container.GetInstance<ISerializer>(),
                 LoggerFactory = loggerFactory
             });

--- a/src/Exceptionless.Core/Extensions/NameValueCollectionExtensions.cs
+++ b/src/Exceptionless.Core/Extensions/NameValueCollectionExtensions.cs
@@ -56,6 +56,21 @@ namespace Exceptionless.Core.Extensions {
             return GetBool(collection, name) ?? defaultValue;
         }
 
+        public static TimeSpan? GetTimeSpan(this NameValueCollection collection, string name) {
+            string value = collection[name];
+            if (value == null)
+                return null;
+
+            if (TimeSpan.TryParse(value, out var timespan))
+                return timespan;
+
+            return null;
+        }
+
+        public static TimeSpan GetTimeSpan(this NameValueCollection collection, string name, TimeSpan defaultValue) {
+            return GetTimeSpan(collection, name) ?? defaultValue;
+        }
+
         public static T GetEnum<T>(this NameValueCollection collection, string name, T? defaultValue = null) where T: struct {
             string value = GetValue(collection, name);
             if (value == null) {

--- a/src/Exceptionless.Core/Settings.cs
+++ b/src/Exceptionless.Core/Settings.cs
@@ -152,6 +152,8 @@ namespace Exceptionless.Core {
 
         public string SmtpPassword { get; private set; }
 
+        public TimeSpan QueueWorkTimeout { get; private set; }
+
         public override void Initialize() {
             EnvironmentVariablePrefix = "Exceptionless_";
 
@@ -236,6 +238,8 @@ namespace Exceptionless.Core {
             EnableActiveDirectoryAuth = GetBool(nameof(EnableActiveDirectoryAuth), !String.IsNullOrEmpty(LdapConnectionString));
 
             EnableSignalR = GetBool(nameof(EnableSignalR), true);
+
+            QueueWorkTimeout = GetTimeSpan(nameof(QueueWorkTimeout), TimeSpan.FromMinutes(5.0));
 
             Version = FileVersionInfo.GetVersionInfo(typeof(Settings).Assembly.Location).ProductVersion;
         }

--- a/src/Exceptionless.Core/Utility/SettingsBase.cs
+++ b/src/Exceptionless.Core/Utility/SettingsBase.cs
@@ -64,6 +64,14 @@ namespace Exceptionless.Core {
             return GetEnvironmentVariable(name) ?? GetConfigVariable(name) ?? ConfigurationManager.AppSettings[name] ?? defaultValue;
         }
 
+        protected static TimeSpan GetTimeSpan(string name, TimeSpan defaultValue) {
+            string value = GetEnvironmentVariable(name) ?? GetConfigVariable(name);
+            if (String.IsNullOrEmpty(value))
+                return ConfigurationManager.AppSettings.GetTimeSpan(name, defaultValue);
+
+            return TimeSpan.TryParse(value, out var timespan) ? timespan : defaultValue;
+        }
+
         protected static List<string> GetStringList(string name, string defaultValues = null, char[] separators = null) {
             string value = GetEnvironmentVariable(name) ?? GetConfigVariable(name);
             if (String.IsNullOrEmpty(value))

--- a/src/Exceptionless.Insulation/Bootstrapper.cs
+++ b/src/Exceptionless.Insulation/Bootstrapper.cs
@@ -116,7 +116,7 @@ namespace Exceptionless.Insulation {
                 Name = GetQueueName<T>().ToLowerInvariant(),
                 Retries = retries,
                 Behaviors = container.GetAllInstances<IQueueBehavior<T>>(),
-                WorkItemTimeout = workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5.0)),
+                WorkItemTimeout = workItemTimeout.GetValueOrDefault(Settings.Current.QueueWorkTimeout),
                 Serializer = container.GetInstance<ISerializer>(),
                 LoggerFactory = loggerFactory
             });
@@ -128,7 +128,7 @@ namespace Exceptionless.Insulation {
                 Name = GetQueueName<T>(),
                 Retries = retries,
                 Behaviors = container.GetAllInstances<IQueueBehavior<T>>(),
-                WorkItemTimeout = workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5.0)),
+                WorkItemTimeout = workItemTimeout.GetValueOrDefault(Settings.Current.QueueWorkTimeout),
                 RunMaintenanceTasks = runMaintenanceTasks,
                 Serializer = container.GetInstance<ISerializer>(),
                 LoggerFactory = loggerFactory


### PR DESCRIPTION
When the performance of elasticsearch is not fast as expected or there are too much log events, the hard code work timeout(5 minutes) will be not enough to post events to elasticsearch. So expose the QueueWorkTimeout configuration parameter to make chance to manually define the customized value in the deployment stage.