### PR TITLE
Add setting 'QueueScope' for server load balance environment. fix #326

### DIFF
--- a/src/Exceptionless.Core/Settings.cs
+++ b/src/Exceptionless.Core/Settings.cs
@@ -34,6 +34,10 @@ namespace Exceptionless.Core {
 
         public string AppScopePrefix => HasAppScope ? AppScope + "-" : String.Empty;
 
+        public string QueueScope { get; set; }
+
+        public string QueueScopePrefix => !String.IsNullOrEmpty(QueueScope) ? QueueScope + "-" : AppScopePrefix;
+
         public bool RunJobsInProcess { get; private set; }
 
         public int JobsIterationLimit { get; set; }
@@ -175,6 +179,7 @@ namespace Exceptionless.Core {
             ExceptionlessServerUrl = GetString(nameof(ExceptionlessServerUrl));
             WebsiteMode = GetEnum<WebsiteMode>(nameof(WebsiteMode), WebsiteMode.Dev);
             AppScope = GetString(nameof(AppScope), String.Empty);
+            QueueScope = GetString(nameof(QueueScope), String.Empty);
 
             RunJobsInProcess = GetBool(nameof(RunJobsInProcess), true);
             JobsIterationLimit = GetInt(nameof(JobsIterationLimit), -1);

--- a/src/Exceptionless.Insulation/Bootstrapper.cs
+++ b/src/Exceptionless.Insulation/Bootstrapper.cs
@@ -136,7 +136,7 @@ namespace Exceptionless.Insulation {
         }
 
         private static string GetQueueName<T>() {
-            return String.Concat(Settings.Current.AppScopePrefix, typeof(T).Name);
+            return String.Concat(Settings.Current.QueueScopePrefix, typeof(T).Name);
         }
 
         private static RedisCacheClient CreateRedisCacheClient(Container container, ILoggerFactory loggerFactory) {


### PR DESCRIPTION
Add `QueueScope` in settings used to generate queue name in redis or windows azure. For exceptionless servers in the load balance environment, avoid the absolutely separated data storage in elasticsearch when using `AppScope`, and avoid errors of chaos event reference among servers by using the default generated queue name without server specified prefix.