### PR TITLE
Add proper swagger support for a versioned api

### DIFF
--- a/src/Exceptionless.Api/Extensions/SwaggerExtensions.cs
+++ b/src/Exceptionless.Api/Extensions/SwaggerExtensions.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Exceptionless.Api.Extensions {
+    public static class SwaggerExtensions {
+        /// <summary>
+        /// Matches /api/{version}/ url's (where {version} = v1 or v2) to their matching swagger specification, 
+        /// and also resolves {version} parameters to absolute paths's for all versioned swagger specs
+        /// </summary>
+        public static void AddAutoVersioningSupport(this SwaggerGenOptions c) {
+            c.DocInclusionPredicate((version, apiDescription) => {
+                var regex = @"api\/(v\d)\/";
+                var urlMatches = Regex.Match(apiDescription.RelativePath, regex);
+                if (urlMatches.Groups.Count == 2) {
+                    // will be 'v1', 'v2', or '{version}'
+                    var urlVersion = urlMatches.Groups[1].Value.ToLower();
+                    if (urlVersion == version)
+                        return true;
+                }
+                return apiDescription.RelativePath.Contains("{version}");
+            });
+            c.OperationFilter<RemoveVersionParameters>();
+            c.DocumentFilter<SetVersionInPaths>();
+        }
+
+        private class RemoveVersionParameters : IOperationFilter {
+            public void Apply(Operation operation, OperationFilterContext context) {
+                var versionParameter = operation.Parameters?.SingleOrDefault(p => p.Name == "version");
+                if (versionParameter != null)
+                    operation.Parameters.Remove(versionParameter);
+            }
+        }
+
+        private class SetVersionInPaths : IDocumentFilter {
+            public void Apply(SwaggerDocument doc, DocumentFilterContext context) {
+                foreach (var item in doc.Paths.Where(kvp => kvp.Key.Contains("{version}")).ToArray()) {
+                    doc.Paths.Remove(item.Key);
+
+                    var key = item.Key.Replace("v{version}", doc.Info.Version);
+                    var toAdd = item.Value;
+
+                    if (!doc.Paths.ContainsKey(key)) {
+                        doc.Paths[key] = toAdd;
+                        continue;
+                    }
+
+                    Operation UpsertOperation(string v, Operation existingOp, Operation newOp) {
+                        if (existingOp != null && newOp != null)
+                            throw new InvalidOperationException($"Two operations with the same path ({key}) and verb ({v}) is not supported.");
+                        return existingOp ?? newOp;
+                    }
+
+                    var toUpdate = doc.Paths[key];
+                    toUpdate.Delete = UpsertOperation("Delete", toUpdate.Delete, toAdd.Delete);
+                    toUpdate.Put = UpsertOperation("Put", toUpdate.Put, toAdd.Put);
+                    toUpdate.Get = UpsertOperation("Get", toUpdate.Get, toAdd.Get);
+                    toUpdate.Head = UpsertOperation("Head", toUpdate.Head, toAdd.Head);
+                    toUpdate.Options = UpsertOperation("Options", toUpdate.Options, toAdd.Options);
+                    toUpdate.Patch = UpsertOperation("Patch", toUpdate.Patch, toAdd.Patch);
+                    toUpdate.Post = UpsertOperation("Post", toUpdate.Post, toAdd.Post);
+                }
+            }
+        }
+    }
+}

--- a/src/Exceptionless.Api/Startup.cs
+++ b/src/Exceptionless.Api/Startup.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Security.Claims;
 using System.Threading;
+using Exceptionless.Api.Extensions;
 using Exceptionless.Api.Hubs;
 using Exceptionless.Api.Security;
 using Exceptionless.Api.Utility;
@@ -50,7 +51,8 @@ namespace Exceptionless.Api {
             });
             app.UseSwaggerUI(s => {
                 s.RoutePrefix = "docs";
-                s.SwaggerEndpoint("/docs/v2/swagger.json", "Exceptionless API");
+                s.SwaggerEndpoint("/docs/v2/swagger.json", "Exceptionless API V2");
+                s.SwaggerEndpoint("/docs/v1/swagger.json", "Exceptionless API V1");
                 s.InjectStylesheet("docs.css");
                 s.InjectOnCompleteJavaScript("docs.js");
             });
@@ -121,9 +123,14 @@ namespace Exceptionless.Api {
             });
             services.AddSwaggerGen(c => {
                 c.SwaggerDoc("v2", new Info {
-                    Title = "Exceptionless API",
+                    Title = "Exceptionless API V2",
                     Version = "v2"
                 });
+                c.SwaggerDoc("v1", new Info {
+                    Title = "Exceptionless API V1",
+                    Version = "v1"
+                });
+
                 c.AddSecurityDefinition("access_token", new ApiKeyScheme {
                     Name = "access_token",
                     In = "header",
@@ -135,6 +142,7 @@ namespace Exceptionless.Api {
                 if (File.Exists($@"{AppDomain.CurrentDomain.BaseDirectory}\Exceptionless.Api.xml"))
                     c.IncludeXmlComments($@"{AppDomain.CurrentDomain.BaseDirectory}\Exceptionless.Api.xml");
                 c.IgnoreObsoleteActions();
+                c.AddAutoVersioningSupport();
             });
 
             Bootstrapper.RegisterServices(services, _loggerFactory);


### PR DESCRIPTION
Cleans up the swagger doc around versioned api's. No longer have optional {version} params in swagger spec. No longer have v1 and v2 api's in the same swagger spec. (there are now two exported swagger specs)