### PR TITLE
Reduce console logging costs

### DIFF
--- a/src/Exceptionless.Web/appsettings.Production.yml
+++ b/src/Exceptionless.Web/appsettings.Production.yml
@@ -19,3 +19,11 @@ EnableAccountCreation: true
 # Exceptionless Client Settings
 ExceptionlessServerUrl: https://collector.exceptionless.io
 InternalProjectId: 50ca6b2423d6c8493020b823
+
+Serilog:
+  MinimumLevel:
+    Default: Warning
+  WriteTo:
+  - Name: Console
+    Args: 
+      theme: "Serilog.Sinks.SystemConsole.Themes.ConsoleTheme::None, Serilog.Sinks.Console"

--- a/src/Exceptionless.Web/appsettings.Staging.yml
+++ b/src/Exceptionless.Web/appsettings.Staging.yml
@@ -15,3 +15,11 @@ BaseURL: https://dev.exceptionless.io
 # Exceptionless Client Settings
 ExceptionlessServerUrl: https://dev-api.exceptionless.io
 InternalProjectId: 50ca6b2423d6c8493020b823
+
+Serilog:
+  MinimumLevel:
+    Default: Warning
+  WriteTo:
+  - Name: Console
+    Args: 
+      theme: "Serilog.Sinks.SystemConsole.Themes.ConsoleTheme::None, Serilog.Sinks.Console"

--- a/src/Exceptionless.Web/appsettings.yml
+++ b/src/Exceptionless.Web/appsettings.yml
@@ -17,6 +17,8 @@ Serilog:
       #Exceptionless.Core.Repositories: Verbose
   WriteTo:
   - Name: Console
+    Args: 
+      theme: "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Literate, Serilog.Sinks.Console"
   Enrich:
   - FromLogContext
   - WithMachineName


### PR DESCRIPTION
On Windows 97% of `EventController.PostAsync` is console logging

![image](https://user-images.githubusercontent.com/1142958/106376199-cf54a600-638a-11eb-8f95-374107f5ecb4.png)

Switching it to ansi mode (for Development) and no colors for Staging/Production reduces that to 75% https://github.com/serilog/serilog-sinks-console/issues/58

![image](https://user-images.githubusercontent.com/1142958/106376212-f90dcd00-638a-11eb-94fc-095b63c439db.png)

Changing it to be >= `Warning` for Staging/Production removes the cost entirely (assuming no errors 😉)

![image](https://user-images.githubusercontent.com/1142958/106376228-278ba800-638b-11eb-9171-7c58ba8f3625.png)

