### PR TITLE
Added ability to send slack webhook messages if the url ends with /slack

### DIFF
--- a/src/Exceptionless.Core/Bootstrapper.cs
+++ b/src/Exceptionless.Core/Bootstrapper.cs
@@ -261,7 +261,7 @@ public class Bootstrapper {
 
     public static DynamicTypeContractResolver GetJsonContractResolver() {
         var resolver = new DynamicTypeContractResolver(new LowerCaseUnderscorePropertyNamesContractResolver());
-        resolver.UseDefaultResolverFor(typeof(DataDictionary), typeof(SettingsDictionary), typeof(VersionOne.VersionOneWebHookStack), typeof(VersionOne.VersionOneWebHookEvent));
+        resolver.UseDefaultResolverFor(typeof(DataDictionary), typeof(SettingsDictionary), typeof(VersionOnePlugin.VersionOneWebHookStack), typeof(VersionOnePlugin.VersionOneWebHookEvent));
         return resolver;
     }
 

--- a/src/Exceptionless.Core/Pipeline/070_QueueNotificationAction.cs
+++ b/src/Exceptionless.Core/Pipeline/070_QueueNotificationAction.cs
@@ -45,7 +45,7 @@ public class QueueNotificationAction : EventPipelineActionBase {
             if (!ShouldCallWebHook(hook, ctx))
                 continue;
 
-            var context = new WebHookDataContext(hook.Version, ctx.Event, ctx.Organization, ctx.Project, ctx.Stack, ctx.IsNew, ctx.IsRegression);
+            var context = new WebHookDataContext(hook, ctx.Event, ctx.Organization, ctx.Project, ctx.Stack, ctx.IsNew, ctx.IsRegression);
             var notification = new WebHookNotification {
                 OrganizationId = ctx.Event.OrganizationId,
                 ProjectId = ctx.Event.ProjectId,

--- a/src/Exceptionless.Core/Plugins/PluginManagerBase.cs
+++ b/src/Exceptionless.Core/Plugins/PluginManagerBase.cs
@@ -42,8 +42,7 @@ public abstract class PluginManagerBase<TPlugin> where TPlugin : class, IPlugin 
 
             try {
                 AddPlugin(type);
-            }
-            catch (Exception ex) {
+            } catch (Exception ex) {
                 _logger.LogError(ex, "Unable to instantiate plugin of type {TypeFullName}: {Message}", type.FullName, ex.Message);
                 throw;
             }

--- a/src/Exceptionless.Core/Plugins/WebHook/Default/000_LoadDefaultsPlugin.cs
+++ b/src/Exceptionless.Core/Plugins/WebHook/Default/000_LoadDefaultsPlugin.cs
@@ -6,12 +6,12 @@ using Foundatio.Repositories;
 namespace Exceptionless.Core.Plugins.WebHook;
 
 [Priority(0)]
-public sealed class LoadDefaults : WebHookDataPluginBase {
+public sealed class LoadDefaultsPlugin : WebHookDataPluginBase {
     private readonly IOrganizationRepository _organizationRepository;
     private readonly IProjectRepository _projectRepository;
     private readonly IStackRepository _stackRepository;
 
-    public LoadDefaults(IOrganizationRepository organizationRepository, IProjectRepository projectRepository, IStackRepository stackRepository, AppOptions options) : base(options) {
+    public LoadDefaultsPlugin(IOrganizationRepository organizationRepository, IProjectRepository projectRepository, IStackRepository stackRepository, AppOptions options) : base(options) {
         _organizationRepository = organizationRepository;
         _projectRepository = projectRepository;
         _stackRepository = stackRepository;
@@ -27,7 +27,7 @@ public sealed class LoadDefaults : WebHookDataPluginBase {
         if (ctx.Project == null)
             throw new ArgumentException("Project not found.");
 
-        if (ctx.Organization == null)
+        if (ctx.Organization == null) 
             ctx.Organization = await _organizationRepository.GetByIdAsync(ctx.Event.OrganizationId, o => o.Cache()).AnyContext();
 
         if (ctx.Organization == null)

--- a/src/Exceptionless.Core/Plugins/WebHook/Default/005_SlackPlugin.cs
+++ b/src/Exceptionless.Core/Plugins/WebHook/Default/005_SlackPlugin.cs
@@ -16,10 +16,13 @@ public sealed class SlackPlugin : WebHookDataPluginBase {
             return Task.FromResult<object>(null);
 
         var error = ctx.Event.GetError();
-        if (error is null)
+        if (error is null) {
+            ctx.IsCancelled = true;
             return Task.FromResult<object>(null);
+        }
 
         var message = _pluginManager.GetSlackEventNotificationMessage(ctx.Event, ctx.Project, ctx.Event.IsCritical(), ctx.IsNew, ctx.IsRegression);
+        ctx.IsCancelled = message is null;
         return Task.FromResult<object>(message);
     }
 

--- a/src/Exceptionless.Core/Plugins/WebHook/Default/005_SlackPlugin.cs
+++ b/src/Exceptionless.Core/Plugins/WebHook/Default/005_SlackPlugin.cs
@@ -1,0 +1,32 @@
+﻿using Exceptionless.Core.Pipeline;
+using Exceptionless.Core.Plugins.Formatting;
+
+namespace Exceptionless.Core.Plugins.WebHook;
+
+[Priority(5)]
+public sealed class SlackPlugin : WebHookDataPluginBase {
+    private readonly FormattingPluginManager _pluginManager;
+
+    public SlackPlugin(FormattingPluginManager pluginManager, AppOptions options) : base(options) {
+        _pluginManager = pluginManager;
+    }
+
+    public override Task<object> CreateFromEventAsync(WebHookDataContext ctx) {
+        if (String.IsNullOrEmpty(ctx.WebHook.Url) || !ctx.WebHook.Url.EndsWith("/slack"))
+            return Task.FromResult<object>(null);
+
+        var error = ctx.Event.GetError();
+        if (error is null)
+            return Task.FromResult<object>(null);
+
+        var message = _pluginManager.GetSlackEventNotificationMessage(ctx.Event, ctx.Project, ctx.Event.IsCritical(), ctx.IsNew, ctx.IsRegression);
+        return Task.FromResult<object>(message);
+    }
+
+    public override Task<object> CreateFromStackAsync(WebHookDataContext ctx) {
+        if (!String.IsNullOrEmpty(ctx.WebHook.Url) && ctx.WebHook.Url.EndsWith("/slack"))
+            ctx.IsCancelled = true;
+
+        return Task.FromResult<object>(null);
+    }
+}

--- a/src/Exceptionless.Core/Plugins/WebHook/Default/010_VersionOnePlugin.cs
+++ b/src/Exceptionless.Core/Plugins/WebHook/Default/010_VersionOnePlugin.cs
@@ -5,11 +5,11 @@ using Exceptionless.Core.Pipeline;
 namespace Exceptionless.Core.Plugins.WebHook;
 
 [Priority(10)]
-public sealed class VersionOne : WebHookDataPluginBase {
-    public VersionOne(AppOptions options) : base(options) { }
+public sealed class VersionOnePlugin : WebHookDataPluginBase {
+    public VersionOnePlugin(AppOptions options) : base(options) { }
 
     public override Task<object> CreateFromEventAsync(WebHookDataContext ctx) {
-        if (!String.Equals(ctx.Version, Models.WebHook.KnownVersions.Version1))
+        if (!String.Equals(ctx.WebHook.Version, Models.WebHook.KnownVersions.Version1))
             return Task.FromResult<object>(null);
 
         var error = ctx.Event.GetError();
@@ -49,7 +49,7 @@ public sealed class VersionOne : WebHookDataPluginBase {
     }
 
     public override Task<object> CreateFromStackAsync(WebHookDataContext ctx) {
-        if (!String.Equals(ctx.Version, Models.WebHook.KnownVersions.Version1))
+        if (!String.Equals(ctx.WebHook.Version, Models.WebHook.KnownVersions.Version1))
             return Task.FromResult<object>(null);
 
         return Task.FromResult<object>(new VersionOneWebHookStack(_options.BaseURL) {

--- a/src/Exceptionless.Core/Plugins/WebHook/Default/020_VersionTwoPlugin.cs
+++ b/src/Exceptionless.Core/Plugins/WebHook/Default/020_VersionTwoPlugin.cs
@@ -5,11 +5,11 @@ using Microsoft.Extensions.Logging;
 namespace Exceptionless.Core.Plugins.WebHook;
 
 [Priority(20)]
-public sealed class VersionTwo : WebHookDataPluginBase {
-    public VersionTwo(AppOptions options, ILoggerFactory loggerFactory = null) : base(options, loggerFactory) { }
+public sealed class VersionTwoPlugin : WebHookDataPluginBase {
+    public VersionTwoPlugin(AppOptions options, ILoggerFactory loggerFactory = null) : base(options, loggerFactory) { }
 
     public override Task<object> CreateFromEventAsync(WebHookDataContext ctx) {
-        if (!String.Equals(ctx.Version, Models.WebHook.KnownVersions.Version2))
+        if (!String.Equals(ctx.WebHook.Version, Models.WebHook.KnownVersions.Version2))
             return Task.FromResult<object>(null);
 
         return Task.FromResult<object>(new WebHookEvent(_options.BaseURL) {
@@ -37,7 +37,7 @@ public sealed class VersionTwo : WebHookDataPluginBase {
     }
 
     public override Task<object> CreateFromStackAsync(WebHookDataContext ctx) {
-        if (!String.Equals(ctx.Version, Models.WebHook.KnownVersions.Version2))
+        if (!String.Equals(ctx.WebHook.Version, Models.WebHook.KnownVersions.Version2))
             return Task.FromResult<object>(null);
 
         return Task.FromResult<object>(new WebHookStack(_options.BaseURL) {

--- a/src/Exceptionless.Core/Plugins/WebHook/WebHookDataContext.cs
+++ b/src/Exceptionless.Core/Plugins/WebHook/WebHookDataContext.cs
@@ -4,8 +4,8 @@ using Exceptionless.Core.Models;
 namespace Exceptionless.Core.Plugins.WebHook;
 
 public class WebHookDataContext : ExtensibleObject {
-    public WebHookDataContext(string version, PersistentEvent ev, Organization organization = null, Project project = null, Stack stack = null, bool isNew = false, bool isRegression = false) {
-        Version = version ?? throw new ArgumentException("Version cannot be null.", nameof(version));
+    public WebHookDataContext(Models.WebHook webHook, PersistentEvent ev, Organization organization = null, Project project = null, Stack stack = null, bool isNew = false, bool isRegression = false) {
+        WebHook = webHook ?? throw new ArgumentException("WebHook cannot be null.", nameof(webHook));
         Organization = organization;
         Project = project;
         Stack = stack;
@@ -14,8 +14,8 @@ public class WebHookDataContext : ExtensibleObject {
         IsRegression = isRegression;
     }
 
-    public WebHookDataContext(string version, Stack stack, Organization organization = null, Project project = null, bool isNew = false, bool isRegression = false) {
-        Version = version ?? throw new ArgumentException("Version cannot be null.", nameof(version));
+    public WebHookDataContext(Models.WebHook webHook, Stack stack, Organization organization = null, Project project = null, bool isNew = false, bool isRegression = false) {
+        WebHook = webHook ?? throw new ArgumentException("WebHook cannot be null.", nameof(webHook));
         Organization = organization;
         Project = project;
         Stack = stack ?? throw new ArgumentException("Stack cannot be null.", nameof(stack));
@@ -23,12 +23,14 @@ public class WebHookDataContext : ExtensibleObject {
         IsRegression = isRegression;
     }
 
+    public Models.WebHook WebHook { get; set; }
     public PersistentEvent Event { get; set; }
     public Stack Stack { get; set; }
     public Organization Organization { get; set; }
     public Project Project { get; set; }
 
-    public string Version { get; set; }
     public bool IsNew { get; set; }
     public bool IsRegression { get; set; }
+
+    public bool IsCancelled { get; set; }
 }

--- a/src/Exceptionless.Core/Plugins/WebHook/WebHookDataPluginManager.cs
+++ b/src/Exceptionless.Core/Plugins/WebHook/WebHookDataPluginManager.cs
@@ -16,6 +16,9 @@ public class WebHookDataPluginManager : PluginManagerBase<IWebHookDataPlugin> {
             try {
                 object data = null;
                 await AppDiagnostics.TimeAsync(async () => data = await plugin.CreateFromEventAsync(context).AnyContext(), metricName).AnyContext();
+                if (context.IsCancelled)
+                    break;
+
                 if (data == null)
                     continue;
 
@@ -39,6 +42,9 @@ public class WebHookDataPluginManager : PluginManagerBase<IWebHookDataPlugin> {
             try {
                 object data = null;
                 await AppDiagnostics.TimeAsync(async () => data = await plugin.CreateFromStackAsync(context).AnyContext(), metricName).AnyContext();
+                if (context.IsCancelled)
+                    break;
+
                 if (data == null)
                     continue;
 

--- a/src/Exceptionless.Web/Controllers/StackController.cs
+++ b/src/Exceptionless.Web/Controllers/StackController.cs
@@ -371,15 +371,34 @@ public class StackController : RepositoryApiController<IStackRepository, Stack, 
         if (!promotedProjectHooks.Any())
             return NotImplemented("No promoted web hooks are configured for this project. Please add a promoted web hook to use this feature.");
 
+        using var _ = _logger.BeginScope(new ExceptionlessState()
+            .Organization(stack.OrganizationId)
+            .Project(stack.ProjectId)
+            .Tag("Promote")
+            .Identity(CurrentUser.EmailAddress)
+            .Property("User", CurrentUser)
+            .SetHttpContext(HttpContext));
+        
         foreach (var hook in promotedProjectHooks) {
-            var context = new WebHookDataContext(hook.Version, stack, isNew: stack.TotalOccurrences == 1, isRegression: stack.Status == StackStatus.Regressed);
+            if (!hook.IsEnabled) {
+                _logger.LogWarning("Unable to promote to disabled WebHook Id={WebHookId}, Url={WebHookUrl}", hook.Id, hook.Url);
+                continue;
+            }
+
+            var context = new WebHookDataContext(hook, stack, isNew: stack.TotalOccurrences == 1, isRegression: stack.Status == StackStatus.Regressed);
+            var data = await _webHookDataPluginManager.CreateFromStackAsync(context);
+            if (data is null) {
+                _logger.LogWarning("Unable to promote to WebHook with null payload Id={WebHookId}, Url={WebHookUrl}", hook.Id, hook.Url);
+                continue;
+            }
+
             await _webHookNotificationQueue.EnqueueAsync(new WebHookNotification {
                 OrganizationId = stack.OrganizationId,
                 ProjectId = stack.ProjectId,
                 WebHookId = hook.Id,
                 Url = hook.Url,
                 Type = WebHookType.General,
-                Data = await _webHookDataPluginManager.CreateFromStackAsync(context)
+                Data = data
             });
         }
 

--- a/tests/Exceptionless.Tests/Plugins/WebHookDataTests.cs
+++ b/tests/Exceptionless.Tests/Plugins/WebHookDataTests.cs
@@ -3,6 +3,8 @@ using Exceptionless.Tests.Utility;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Plugins.Formatting;
 using Exceptionless.Core.Plugins.WebHook;
+using Exceptionless.Core.Repositories;
+using Foundatio.Utility;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
@@ -65,13 +67,23 @@ public sealed class WebHookDataTests : TestWithServices {
         var settings = GetService<JsonSerializerSettings>();
         settings.Formatting = Formatting.Indented;
 
+        var hook = new WebHook {
+            Id = TestConstants.WebHookId,
+            OrganizationId = TestConstants.OrganizationId, 
+            ProjectId = TestConstants.ProjectId,
+            Url = "http://localhost:40000/test",
+            EventTypes = new[] { WebHookRepository.EventTypes.StackPromoted }, 
+            Version = version,
+            CreatedUtc = SystemClock.UtcNow
+        };
+
         var ev = JsonConvert.DeserializeObject<PersistentEvent>(json, settings);
         ev.OrganizationId = TestConstants.OrganizationId;
         ev.ProjectId = TestConstants.ProjectId;
         ev.StackId = TestConstants.StackId;
         ev.Id = TestConstants.EventId;
 
-        var context = new WebHookDataContext(version, ev, OrganizationData.GenerateSampleOrganization(GetService<BillingManager>(), GetService<BillingPlans>()), ProjectData.GenerateSampleProject()) {
+        var context = new WebHookDataContext(hook, ev, OrganizationData.GenerateSampleOrganization(GetService<BillingManager>(), GetService<BillingPlans>()), ProjectData.GenerateSampleProject()) {
             Stack = StackData.GenerateStack(id: TestConstants.StackId, organizationId: TestConstants.OrganizationId, projectId: TestConstants.ProjectId, title: _formatter.GetStackTitle(ev), signatureHash: "722e7afd4dca4a3c91f4d94fec89dfdc")
         };
         context.Stack.Tags = new TagSet { "Test" };

--- a/tests/Exceptionless.Tests/Utility/TestConstants.cs
+++ b/tests/Exceptionless.Tests/Utility/TestConstants.cs
@@ -44,6 +44,8 @@ public static class TestConstants {
     public const string SuspendedApiKey = "5ccd0826e447ad1e78877ab4";
     public const string InvalidApiKey = "1dddddd6e447ad1e78877ab1";
 
+    public const string WebHookId = "1ecd0826e447a44e78877cb2";
+
     public static readonly List<string> ExceptionTypes = new List<string> {
             "System.NullReferenceException",
             "System.ApplicationException",


### PR DESCRIPTION
- This allows you to send messages to discord using the slack url suffix,
- This doesn't work when promoting stacks.

I also had to base this off the usage branch due to metrics and some other minor changes