### PR TITLE
Fixes #1316 Preserve extended data titles

### DIFF
--- a/src/Exceptionless.Web/ClientApp/app/event/event.tpl.html
+++ b/src/Exceptionless.Web/ClientApp/app/event/event.tpl.html
@@ -15,13 +15,13 @@
       </div>
       <div class="panel-body">
         <uib-tabset class="tab-container hidden-xs" active="vm.activeTabIndex">
-          <uib-tab ng-repeat="tab in vm.tabs" heading="{{::tab.title | toSpacedWords | translate}}" ng-click="vm.activateTab(tab.title)">
+          <uib-tab ng-repeat="tab in vm.tabs" heading="{{::tab.title | translate}}" ng-click="vm.activateTab(tab.title)">
             <div ng-include="'app/event/tabs/' + tab.template_key + '.tpl.html'" ng-if="!vm.isAccordionVisible"></div>
           </uib-tab>
         </uib-tabset>
 
         <uib-accordion class="visible-xs">
-          <div uib-accordion-group class="panel-default" ng-repeat="tab in vm.tabs" heading="{{::tab.title | toSpacedWords}}" is-open="tab.active" ng-click="vm.activateTab(tab.title)">
+          <div uib-accordion-group class="panel-default" ng-repeat="tab in vm.tabs" heading="{{::tab.title}}" is-open="tab.active" ng-click="vm.activateTab(tab.title)">
             <div ng-include="'app/event/tabs/' + tab.template_key + '.tpl.html'" ng-if="vm.isAccordionVisible"></div>
           </div>
         </uib-accordion>

--- a/src/Exceptionless.Web/ClientApp/app/event/extended-data-item-directive.js
+++ b/src/Exceptionless.Web/ClientApp/app/event/extended-data-item-directive.js
@@ -26,21 +26,14 @@
         }
 
         function getData(data, exclusions) {
-          function toSpacedWords(value) {
-            value = value.replace(/_/g, ' ').replace(/\s+/g, ' ').trim();
-            value = value.replace(/([a-z0-9])([A-Z0-9])/g, '$1 $2');
-            return value.length > 1 ? value.charAt(0).toUpperCase() + value.slice(1) : value;
-          }
-
           exclusions = exclusions && exclusions.length ? exclusions : [];
-
           if (typeof data !== 'object' || !(data instanceof Object)) {
             return data;
           }
 
           return Object.keys(data)
             .filter(function(value) { return value && value.length && exclusions.indexOf(value) < 0; })
-            .map(function(value) { return { key: value, name: toSpacedWords(value) }; })
+            .map(function(value) { return { key: value, name: value }; })
             .sort(function(a, b) { return a.name - b.name; })
             .reduce(function(a, b) {
               a[b.name] = data[b.key];

--- a/src/Exceptionless.Web/ClientApp/app/event/extended-data-item-directive.tpl.html
+++ b/src/Exceptionless.Web/ClientApp/app/event/extended-data-item-directive.tpl.html
@@ -14,7 +14,7 @@
       </ul>
     </div>
   </div>
-  <h3>{{::vm.title | toSpacedWords}}</h3>
+  <h3>{{::vm.title}}</h3>
   <div ng-if="!vm.showRaw">
     <object-dump content="vm.filteredData"></object-dump>
   </div>

--- a/src/Exceptionless.Web/ClientApp/app/event/tabs/promoted.tpl.html
+++ b/src/Exceptionless.Web/ClientApp/app/event/tabs/promoted.tpl.html
@@ -1,4 +1,4 @@
-<h3 class="visible-print">{{::tab.title | toSpacedWords}}</h3>
+<h3 class="visible-print">{{::tab.title}}</h3>
 <table class="table table-striped table-bordered table-fixed table-key-value b-t">
   <tr>
     <th>{{::'Occurred On' | translate}}</th>


### PR DESCRIPTION
Fixes https://github.com/exceptionless/Exceptionless/issues/1316

This change also effects anything that doesn't have a defined title:

![image](https://github.com/exceptionless/Exceptionless/assets/1020579/a3e2bebf-1b57-402f-a699-101e7f7b34eb)


# Previous
![image](https://github.com/exceptionless/Exceptionless/assets/1020579/e230a706-5699-49b5-94fe-0eb777d211b7)

# New Behavior
![image](https://github.com/exceptionless/Exceptionless/assets/1020579/f701334e-1c3e-4a8f-8d29-3d05b7208361)


