### PR TITLE
Fixes #1289 Promoting a tab named the same as default tabs causes it to be unselectable via UI

### DIFF
--- a/src/Exceptionless.Web/ClientApp/app/event/event-controller.js
+++ b/src/Exceptionless.Web/ClientApp/app/event/event-controller.js
@@ -29,13 +29,18 @@
                 var vm = this;
 
                 function activateSessionEventsTab() {
-                    activateTab(translateService.T("Session Events"));
+                    const tabName = translateService.T("Session Events");
+                    activateTab(
+                        vm.tabs.findIndex(function (tab) {
+                            return tab.title === tabName;
+                        })
+                    );
                 }
 
-                function activateTab(tabName) {
+                function activateTab(tabIndex) {
                     for (var index = 0; index < vm.tabs.length; index++) {
                         var tab = vm.tabs[index];
-                        if (tab.title !== tabName) {
+                        if (tab.index !== tabIndex) {
                             tab.active = false;
                             continue;
                         }
@@ -223,7 +228,11 @@
 
                     vm.tabs = tabs;
                     $timeout(function () {
-                        activateTab(tabNameToActivate);
+                        activateTab(
+                            vm.tabs.findLastIndex(function (tab) {
+                                return tab.title === tabNameToActivate;
+                            })
+                        );
                     }, 1);
                 }
 

--- a/src/Exceptionless.Web/ClientApp/app/event/event.tpl.html
+++ b/src/Exceptionless.Web/ClientApp/app/event/event.tpl.html
@@ -42,7 +42,7 @@
                     <uib-tab
                         ng-repeat="tab in vm.tabs"
                         heading="{{::tab.title | translate}}"
-                        ng-click="vm.activateTab(tab.title)"
+                        ng-click="vm.activateTab(tab.index)"
                     >
                         <div
                             ng-include="'app/event/tabs/' + tab.template_key + '.tpl.html'"
@@ -58,7 +58,7 @@
                         ng-repeat="tab in vm.tabs"
                         heading="{{::tab.title}}"
                         is-open="tab.active"
-                        ng-click="vm.activateTab(tab.title)"
+                        ng-click="vm.activateTab(tab.index)"
                     >
                         <div
                             ng-include="'app/event/tabs/' + tab.template_key + '.tpl.html'"


### PR DESCRIPTION
![image](https://github.com/exceptionless/Exceptionless/assets/1020579/ba9b60cc-1337-4b0a-bba0-efab6480757f)
