### PR TITLE
Discard fixed stack events that don't regress

### DIFF
--- a/tests/Exceptionless.Tests/Pipeline/EventPipelineTests.cs
+++ b/tests/Exceptionless.Tests/Pipeline/EventPipelineTests.cs
@@ -12,6 +12,7 @@ using Exceptionless.Core.Plugins.EventProcessor;
 using Exceptionless.Core.Queues.Models;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Repositories.Configuration;
+using Exceptionless.Core.Utility;
 using Exceptionless.DateTimeExtensions;
 using Exceptionless.Tests.Utility;
 using Foundatio.Repositories;
@@ -929,7 +930,7 @@ public sealed class EventPipelineTests : IntegrationTestsBase
         var organization = OrganizationData.GenerateSampleOrganization(_billingManager, _plans);
         var project = ProjectData.GenerateSampleProject();
 
-        var ev = EventData.GenerateEvent(organizationId: TestConstants.OrganizationId, projectId: TestConstants.ProjectId, type: Event.KnownTypes.Log, source: "test", occurrenceDate: SystemClock.OffsetNow);
+        var ev = EventData.GenerateEvent(organizationId: organization.Id, projectId: project.Id, type: Event.KnownTypes.Log, source: "test", occurrenceDate: SystemClock.OffsetNow);
         var context = await _pipeline.RunAsync(ev, organization, project);
         Assert.True(context.IsProcessed);
         Assert.False(context.HasError);
@@ -944,8 +945,7 @@ public sealed class EventPipelineTests : IntegrationTestsBase
         stack.Status = StackStatus.Discarded;
         stack = await _stackRepository.SaveAsync(stack, o => o.ImmediateConsistency());
 
-
-        ev = EventData.GenerateEvent(organizationId: TestConstants.OrganizationId, projectId: TestConstants.ProjectId, stackId: ev.StackId, type: Event.KnownTypes.Log, source: "test", occurrenceDate: SystemClock.OffsetNow);
+        ev = EventData.GenerateEvent(organizationId: organization.Id, projectId: project.Id, type: Event.KnownTypes.Log, source: "test", occurrenceDate: SystemClock.OffsetNow);
         context = await _pipeline.RunAsync(ev, organization, project);
         Assert.False(context.IsProcessed);
         Assert.False(context.HasError);
@@ -953,13 +953,93 @@ public sealed class EventPipelineTests : IntegrationTestsBase
         Assert.True(context.IsDiscarded);
         await RefreshDataAsync();
 
-        ev = EventData.GenerateEvent(organizationId: TestConstants.OrganizationId, projectId: TestConstants.ProjectId, type: Event.KnownTypes.Log, source: "test", occurrenceDate: SystemClock.OffsetNow);
+        ev = EventData.GenerateEvent(organizationId: organization.Id, projectId: project.Id, type: Event.KnownTypes.Log, source: "test", occurrenceDate: SystemClock.OffsetNow);
         context = await _pipeline.RunAsync(ev, organization, project);
         Assert.False(context.IsProcessed);
         Assert.False(context.HasError);
         Assert.True(context.IsCancelled);
         Assert.True(context.IsDiscarded);
+    }
+
+    [Theory]
+    [InlineData(StackStatus.Regressed, false, null, null)]
+    [InlineData(StackStatus.Fixed, true, "1.0.0", null)] // A fixed stack should not be marked as regressed if the event has no version.
+    [InlineData(StackStatus.Regressed, false, null, "1.0.0")]
+    [InlineData(StackStatus.Regressed, false, "1.0.0", "1.0.0")] // A fixed stack should not be marked as regressed if the event has the same version.
+    [InlineData(StackStatus.Fixed, true, "2.0.0", "1.0.0")]
+    [InlineData(StackStatus.Regressed, false, null, "1.0.1")]
+    [InlineData(StackStatus.Regressed, false, "1.0.0", "1.0.1")]
+    public async Task CanDiscardStackEventsBasedOnEventVersion(StackStatus expectedStatus, bool expectedDiscard, string? stackFixedInVersion, string? eventSemanticVersion)
+    {
+        var organization = await _organizationRepository.GetByIdAsync(TestConstants.OrganizationId, o => o.Cache());
+        var project = await _projectRepository.GetByIdAsync(TestConstants.ProjectId, o => o.Cache());
+
+        var ev = EventData.GenerateEvent(organizationId: organization.Id, projectId: project.Id, type: Event.KnownTypes.Log, source: "test", occurrenceDate: SystemClock.OffsetNow);
+        var context = await _pipeline.RunAsync(ev, organization, project);
+
+        var stack = context.Stack;
+        Assert.NotNull(stack);
+        Assert.Equal(StackStatus.Open, stack.Status);
+
+        Assert.True(context.IsProcessed);
+        Assert.False(context.HasError);
+        Assert.False(context.IsCancelled);
+        Assert.False(context.IsDiscarded);
+
+        var semanticVersionParser = GetService<SemanticVersionParser>();
+        var fixedInVersion = semanticVersionParser.Parse(stackFixedInVersion);
+        stack.MarkFixed(fixedInVersion);
+        await _stackRepository.SaveAsync(stack, o => o.ImmediateConsistency());
+
         await RefreshDataAsync();
+        ev = EventData.GenerateEvent(organizationId: organization.Id, projectId: project.Id, type: Event.KnownTypes.Log, source: "test", occurrenceDate: SystemClock.OffsetNow, semver: eventSemanticVersion);
+        context = await _pipeline.RunAsync(ev, organization, project);
+
+        stack = context.Stack;
+        Assert.NotNull(stack);
+        Assert.Equal(expectedStatus, stack.Status);
+        Assert.Equal(expectedDiscard, context.IsCancelled);
+        Assert.Equal(expectedDiscard, context.IsDiscarded);
+    }
+
+    [Theory]
+    [InlineData("1.0.0", null)] // A fixed stack should not be marked as regressed if the event has no version.
+    [InlineData("2.0.0", "1.0.0")]
+    public async Task WillNotDiscardStackEventsBasedOnEventVersionWithFreePlan(string stackFixedInVersion, string? eventSemanticVersion)
+    {
+        var organization = await _organizationRepository.GetByIdAsync(TestConstants.OrganizationId3, o => o.Cache());
+
+        var plans = GetService<BillingPlans>();
+        Assert.Equal(plans.FreePlan.Id, organization.PlanId);
+
+        var project = await _projectRepository.AddAsync(ProjectData.GenerateProject(organizationId: organization.Id), o => o.ImmediateConsistency().Cache());
+
+        var ev = EventData.GenerateEvent(organizationId: organization.Id, projectId: project.Id, type: Event.KnownTypes.Log, source: "test", occurrenceDate: SystemClock.OffsetNow);
+        var context = await _pipeline.RunAsync(ev, organization, project);
+
+        var stack = context.Stack;
+        Assert.NotNull(stack);
+        Assert.Equal(StackStatus.Open, stack.Status);
+
+        Assert.True(context.IsProcessed);
+        Assert.False(context.HasError);
+        Assert.False(context.IsCancelled);
+        Assert.False(context.IsDiscarded);
+
+        var semanticVersionParser = GetService<SemanticVersionParser>();
+        var fixedInVersion = semanticVersionParser.Parse(stackFixedInVersion);
+        stack.MarkFixed(fixedInVersion);
+        await _stackRepository.SaveAsync(stack, o => o.ImmediateConsistency());
+
+        await RefreshDataAsync();
+        ev = EventData.GenerateEvent(organizationId: organization.Id, projectId: project.Id, type: Event.KnownTypes.Log, source: "test", occurrenceDate: SystemClock.OffsetNow, semver: eventSemanticVersion);
+        context = await _pipeline.RunAsync(ev, organization, project);
+
+        stack = context.Stack;
+        Assert.NotNull(stack);
+        Assert.Equal(StackStatus.Fixed, stack.Status);
+        Assert.False(context.IsCancelled);
+        Assert.False(context.IsDiscarded);
     }
 
     [Theory]


### PR DESCRIPTION
- There is an optimization to only check the regressed status on only stacks with a status of `Fixed`. As you can't regress from any other version.
- If an organization has premium features and the stack is marked fixed and doesn't regress then **those events will be discarded and won't count towards limits**.


The one downside to this implementation is that if you mark a stack as fixed, you will not see any users who are still experiencing the error to reach out to them, as those events will be discarded.