### PR TITLE
Account creation with token and AccountCreation false

### DIFF
--- a/src/Exceptionless.Web/ClientApp.angular/app/auth/signup-controller.js
+++ b/src/Exceptionless.Web/ClientApp.angular/app/auth/signup-controller.js
@@ -148,7 +148,7 @@
 
                 this.$onInit = function $onInit() {
                     vm._source = "app.auth.Signup";
-                    vm._canSignup = !!ENABLE_ACCOUNT_CREATION;
+                    vm._canSignup = !!ENABLE_ACCOUNT_CREATION || !!$stateParams.token;
                     vm.authenticate = authenticate;
                     vm.isExternalLoginEnabled = isExternalLoginEnabled;
                     vm.signup = signup;


### PR DESCRIPTION
The api already work this way.  You can sign up if EnableAccountCreation is true or if you have a valid token linked to an organization.  Currently the frontend wont submit when you enter with a token if EnableAccountCreation is false.

Here is the relevant api logic:

    private async Task<bool> IsAccountCreationEnabledAsync(string? token)
    {
        if (_authOptions.EnableAccountCreation)
            return true;`

         if (String.IsNullOrEmpty(token))
            return false;

        var organization = await _organizationRepository.GetByInviteTokenAsync(token);
        return organization is not null;
    }
 