### PR TITLE
Update payment address

### DIFF
--- a/src/Exceptionless.Web/ClientApp.angular/app/payment/payment.tpl.html
+++ b/src/Exceptionless.Web/ClientApp.angular/app/payment/payment.tpl.html
@@ -5,9 +5,10 @@
             <div class="col-sm-5">
                 <img src="/img/exceptionless.png" alt="logo" />
                 <address>
-                    <strong>Exceptionless</strong><br />
-                    5250 Hwy 78, Suite 750-324<br />
-                    Sachse, TX 75048<br />
+                    <strong>CodeSmith Tools, LLC</strong><br />
+                    5473 Blair Rd Ste 100<br />
+                    PMB 66994<br />
+                    Dallas, TX 75231-4227<br />
                 </address>
             </div>
             <div class="col-sm-7">

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/payment/[id]/+page@.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/payment/[id]/+page@.svelte
@@ -61,9 +61,10 @@
                 <div class="flex flex-col items-start space-y-4">
                     <Logo class="mx-0 h-16" />
                     <address class="text-muted-foreground text-sm not-italic">
-                        <strong class="text-foreground">Exceptionless</strong><br />
-                        5250 Hwy 78, Suite 750-324<br />
-                        Sachse, TX 75048<br />
+                        <strong class="text-foreground">CodeSmith Tools, LLC</strong><br />
+                        5473 Blair Rd Ste 100<br />
+                        PMB 66994<br />
+                        Dallas, TX 75231-4227<br />
                     </address>
                 </div>
             </div>


### PR DESCRIPTION
Updates the mailing address shown on invoice/payment pages to the current CodeSmith Tools, LLC address.

## Summary
- Replaces the old Exceptionless Sachse address in the legacy Angular payment template.
- Replaces the same address in the Svelte payment page.

## Validation
- `npm run build` passed.
- `git diff --check` passed.
- Searched frontend source and regenerated app output for the old address fragments; no matches remain.