### PR TITLE
Polish next UI saved views and sample data

### DIFF
--- a/src/Exceptionless.Core/Bootstrapper.cs
+++ b/src/Exceptionless.Core/Bootstrapper.cs
@@ -254,7 +254,7 @@ public class Bootstrapper
 
         var dataHelper = container.GetRequiredService<SampleDataService>();
         await dataHelper.CreateDataAsync();
-        await dataHelper.EnqueueSampleEventsAsync(eventCount: 100, daysBack: 7);
+        await dataHelper.EnqueueSampleEventsAsync();
     }
 
     public static void AddHostedJobs(IServiceCollection services, ILoggerFactory loggerFactory)

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/GenerateSampleEventsWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/GenerateSampleEventsWorkItemHandler.cs
@@ -48,14 +48,13 @@ public class GenerateSampleEventsWorkItemHandler : WorkItemHandlerBase
         var workItem = context.GetData<GenerateSampleEventsWorkItem>()!;
         int eventCount = Math.Clamp(workItem.EventCount, 1, 10000);
         int daysBack = Math.Clamp(workItem.DaysBack, 1, 365);
-        int acceptedDaysBack = Math.Min(daysBack, 3);
 
-        Log.LogInformation("Generating {EventCount} sample events over {DaysBack} days", eventCount, acceptedDaysBack);
-        await context.ReportProgressAsync(0, $"Generating {eventCount} sample events over {acceptedDaysBack} days");
+        Log.LogInformation("Generating {EventCount} sample events over {DaysBack} days", eventCount, daysBack);
+        await context.ReportProgressAsync(0, $"Generating {eventCount} sample events over {daysBack} days");
 
         var generator = new RandomEventGenerator(_timeProvider);
         var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
-        var minDate = utcNow.AddDays(-acceptedDaysBack);
+        var minDate = utcNow.AddDays(-daysBack);
 
         if (IsProjectScoped(workItem))
         {
@@ -98,7 +97,7 @@ public class GenerateSampleEventsWorkItemHandler : WorkItemHandlerBase
                 if (context.CancellationToken.IsCancellationRequested)
                     break;
 
-                await _eventPipeline.RunAsync(batch, organization, project);
+                await _eventPipeline.RunAsync(batch, organization, project, allowExtendedEventDateRange: true);
                 totalProcessed += batch.Length;
 
                 int percentage = (int)Math.Min(99, totalProcessed * 100.0 / eventCount);
@@ -141,7 +140,7 @@ public class GenerateSampleEventsWorkItemHandler : WorkItemHandlerBase
             if (context.CancellationToken.IsCancellationRequested)
                 break;
 
-            await _eventPipeline.RunAsync(batch, organization, project);
+            await _eventPipeline.RunAsync(batch, organization, project, allowExtendedEventDateRange: true);
             totalProcessed += batch.Length;
 
             int percentage = (int)Math.Min(99, totalProcessed * 100.0 / eventCount);

--- a/src/Exceptionless.Core/Models/SavedView.cs
+++ b/src/Exceptionless.Core/Models/SavedView.cs
@@ -10,6 +10,8 @@ namespace Exceptionless.Core.Models;
 /// </summary>
 public record SavedView : IOwnedByOrganizationWithIdentity, IHaveDates
 {
+    public const int MaxFilterDefinitionsLength = 100_000;
+
     // Identity
     [ObjectId]
     public string Id { get; set; } = null!;
@@ -38,14 +40,14 @@ public record SavedView : IOwnedByOrganizationWithIdentity, IHaveDates
     public string? Filter { get; set; }
 
     /// <summary>JSON array of structured filter objects for UI chip hydration.</summary>
-    [MaxLength(10000)]
+    [MaxLength(MaxFilterDefinitionsLength)]
     public string? FilterDefinitions { get; set; }
 
     /// <summary>Column visibility state per dashboard table, keyed by column id.</summary>
     public Dictionary<string, bool>? Columns { get; set; }
 
-    /// <summary>Whether this view loads automatically when navigating to the page.</summary>
-    public bool IsDefault { get; set; }
+    /// <summary>Column display order per dashboard table, excluding utility columns.</summary>
+    public List<string>? ColumnOrder { get; set; }
 
     /// <summary>Display name shown in the sidebar and picker.</summary>
     [Required]

--- a/src/Exceptionless.Core/Models/WorkItems/GenerateSampleEventsWorkItem.cs
+++ b/src/Exceptionless.Core/Models/WorkItems/GenerateSampleEventsWorkItem.cs
@@ -4,6 +4,6 @@ public record GenerateSampleEventsWorkItem
 {
     public string? OrganizationId { get; init; }
     public string? ProjectId { get; init; }
-    public int EventCount { get; init; } = 100;
+    public int EventCount { get; init; } = 250;
     public int DaysBack { get; init; } = 7;
 }

--- a/src/Exceptionless.Core/Pipeline/001_CheckEventDateAction.cs
+++ b/src/Exceptionless.Core/Pipeline/001_CheckEventDateAction.cs
@@ -24,7 +24,7 @@ public class CheckEventDateAction : EventPipelineActionBase
 
         // Discard events that are being submitted outside of the plan retention limit.
         double eventAgeInDays = _timeProvider.GetUtcNow().UtcDateTime.Subtract(ctx.Event.Date.UtcDateTime).TotalDays;
-        if (eventAgeInDays > 3 || ctx.Organization.RetentionDays > 0 && eventAgeInDays > ctx.Organization.RetentionDays)
+        if ((!ctx.AllowExtendedEventDateRange && eventAgeInDays > 3) || (ctx.Organization.RetentionDays > 0 && eventAgeInDays > ctx.Organization.RetentionDays))
         {
             _logger.LogInformation("Discarding event that occurred more than three days ago or outside of organization retention limit");
 

--- a/src/Exceptionless.Core/Pipeline/EventPipeline.cs
+++ b/src/Exceptionless.Core/Pipeline/EventPipeline.cs
@@ -11,14 +11,20 @@ public class EventPipeline : PipelineBase<EventContext, EventPipelineActionBase>
 {
     public EventPipeline(IServiceProvider serviceProvider, AppOptions options, ILoggerFactory loggerFactory) : base(serviceProvider, options, loggerFactory) { }
 
-    public Task<EventContext> RunAsync(PersistentEvent ev, Organization organization, Project project, EventPostInfo? epi = null)
+    public Task<EventContext> RunAsync(PersistentEvent ev, Organization organization, Project project, EventPostInfo? epi = null, bool allowExtendedEventDateRange = false)
     {
-        return RunAsync(new EventContext(ev, organization, project, epi));
+        return RunAsync(new EventContext(ev, organization, project, epi)
+        {
+            AllowExtendedEventDateRange = allowExtendedEventDateRange
+        });
     }
 
-    public Task<ICollection<EventContext>> RunAsync(IEnumerable<PersistentEvent> events, Organization organization, Project project, EventPostInfo? epi = null)
+    public Task<ICollection<EventContext>> RunAsync(IEnumerable<PersistentEvent> events, Organization organization, Project project, EventPostInfo? epi = null, bool allowExtendedEventDateRange = false)
     {
-        return RunAsync(events.Select(ev => new EventContext(ev, organization, project, epi)).ToList());
+        return RunAsync(events.Select(ev => new EventContext(ev, organization, project, epi)
+        {
+            AllowExtendedEventDateRange = allowExtendedEventDateRange
+        }).ToList());
     }
 
     public override async Task<ICollection<EventContext>> RunAsync(ICollection<EventContext> contexts)

--- a/src/Exceptionless.Core/Plugins/EventProcessor/EventContext.cs
+++ b/src/Exceptionless.Core/Plugins/EventProcessor/EventContext.cs
@@ -28,6 +28,7 @@ public class EventContext : ExtensibleObject, IPipelineContext
     public bool IsNew { get; set; }
     public bool IsRegression { get; set; }
     public bool IncludePrivateInformation { get; set; }
+    public bool AllowExtendedEventDateRange { get; set; }
     public string? SignatureHash { get; set; }
     public IDictionary<string, string> StackSignatureData { get; private set; }
 

--- a/src/Exceptionless.Core/Repositories/Configuration/Indexes/SavedViewIndex.cs
+++ b/src/Exceptionless.Core/Repositories/Configuration/Indexes/SavedViewIndex.cs
@@ -27,7 +27,6 @@ public sealed class SavedViewIndex : VersionedIndex<Models.SavedView>
                 .Keyword(f => f.Name(e => e.UpdatedByUserId))
                 .Text(f => f.Name(e => e.Name).Analyzer(KEYWORD_LOWERCASE_ANALYZER).AddKeywordField())
                 .Keyword(f => f.Name(e => e.ViewType))
-                .Boolean(f => f.Name(e => e.IsDefault))
                 .Number(f => f.Name(e => e.Version).Type(NumberType.Integer)));
     }
 

--- a/src/Exceptionless.Core/Utility/RandomEventGenerator.cs
+++ b/src/Exceptionless.Core/Utility/RandomEventGenerator.cs
@@ -26,6 +26,7 @@ public class RandomEventGenerator
         // Reserve ~20% of events for sessions
         int sessionCount = Math.Clamp(count / 5, 0, count);
         int regularCount = count - sessionCount;
+        int errorLogCount = Math.Clamp(regularCount / 10, regularCount > 0 ? 1 : 0, regularCount);
 
         for (int i = 0; i < regularCount; i++)
         {
@@ -36,7 +37,7 @@ public class RandomEventGenerator
                 Date = RandomData.GetDateTime(min, max)
             };
 
-            PopulateEvent(ev);
+            PopulateEvent(ev, i < errorLogCount ? "Error" : null);
             events.Add(ev);
         }
 
@@ -88,12 +89,12 @@ public class RandomEventGenerator
         return events;
     }
 
-    private void PopulateEvent(Event ev)
+    private void PopulateEvent(Event ev, string? logLevel = null)
     {
         ev.Data ??= new DataDictionary();
         ev.Tags ??= [];
 
-        ev.Type = EventTypes.Random()!;
+        ev.Type = String.IsNullOrEmpty(logLevel) ? EventTypes.Random()! : Event.KnownTypes.Log;
         switch (ev.Type)
         {
             case Event.KnownTypes.FeatureUsage:
@@ -104,8 +105,8 @@ public class RandomEventGenerator
                 break;
             case Event.KnownTypes.Log:
                 ev.Source = LogSources.Random();
-                ev.Message = LogMessages.Random();
-                string? level = LogLevels.Random();
+                string? level = logLevel ?? LogLevels.Random();
+                ev.Message = GetLogMessage(level);
                 if (!String.IsNullOrEmpty(level))
                     ev.Data[Event.KnownDataKeys.Level] = level;
                 break;
@@ -147,14 +148,21 @@ public class RandomEventGenerator
         if (ev.Type == Event.KnownTypes.Error)
         {
             // Pre-generate a limited set of errors so stacking occurs
-            _randomErrors ??= [.. Enumerable.Range(1, 15).Select(_ => GenerateError())];
-            _randomSimpleErrors ??= [.. Enumerable.Range(1, 10).Select(_ => GenerateSimpleError())];
+            _randomErrors ??= [.. Enumerable.Range(1, 5).Select(_ => GenerateError())];
+            _randomSimpleErrors ??= [.. Enumerable.Range(1, 3).Select(_ => GenerateSimpleError())];
 
             if (RandomData.GetBool())
                 ev.Data[Event.KnownDataKeys.Error] = _randomErrors.Random();
             else
                 ev.Data[Event.KnownDataKeys.SimpleError] = _randomSimpleErrors.Random();
         }
+    }
+
+    private static string? GetLogMessage(string? level)
+    {
+        return String.Equals(level, "Error", StringComparison.OrdinalIgnoreCase)
+            ? ErrorLogMessages.Random()
+            : LogMessages.Random();
     }
 
     private List<Error>? _randomErrors;
@@ -378,6 +386,15 @@ public class RandomEventGenerator
         "Connection pool exhausted, waiting for available connection",
         "Configuration reloaded from source",
         "Health check passed"
+    ];
+
+    private static readonly List<string> ErrorLogMessages =
+    [
+        "Failed to process event batch after retry limit was reached",
+        "Unhandled exception while processing background job",
+        "Unable to publish notification email",
+        "Database command failed while saving project usage",
+        "Elasticsearch request failed while searching events"
     ];
 
     private static readonly List<string> LogLevels =

--- a/src/Exceptionless.Core/Utility/SampleDataService.cs
+++ b/src/Exceptionless.Core/Utility/SampleDataService.cs
@@ -277,7 +277,7 @@ public class SampleDataService
         _logger.LogDebug("Created Internal Organization {OrganizationName} and Project {ProjectName}", organization.Name, project.Name);
     }
 
-    public async Task EnqueueSampleEventsAsync(int eventCount = 100, int daysBack = 7)
+    public async Task EnqueueSampleEventsAsync(int eventCount = 250, int daysBack = 7)
     {
         await _workItemQueue.EnqueueAsync(new GenerateSampleEventsWorkItem
         {
@@ -287,7 +287,7 @@ public class SampleDataService
         _logger.LogInformation("Enqueued sample event generation: {EventCount} events over {DaysBack} days", eventCount, daysBack);
     }
 
-    public async Task<string> EnqueueSampleEventsAsync(string organizationId, string projectId, int eventCount = 100, int daysBack = 7)
+    public async Task<string> EnqueueSampleEventsAsync(string organizationId, string projectId, int eventCount = 250, int daysBack = 7)
     {
         string workItemId = await _workItemQueue.EnqueueAsync(new GenerateSampleEventsWorkItem
         {

--- a/src/Exceptionless.Web/ClientApp/src/app.css
+++ b/src/Exceptionless.Web/ClientApp/src/app.css
@@ -44,12 +44,12 @@
     --sidebar-border: var(--border);
     --sidebar-ring: var(--ring);
 
-    --chart-1: #7bb662; /* Total (green, light) */
-    --chart-2: #56b4e9; /* Blocked (blue, light) */
-    --chart-3: #d47a00; /* Discarded – hsl(32 100% 42%) */
-    --chart-4: #ffd64d; /* Too Big  – hsl(46 100% 65%) */
-    --chart-5: #d9d9d9; /* Total in Organization (magenta, light) */
-    --chart-6: #c62828; /* material-red-700: deep red for light mode */
+    --chart-1: #72c928; /* Total / events: classic Exceptionless green */
+    --chart-2: #43a047; /* Secondary series: deeper green */
+    --chart-3: #f0ad4e; /* Discarded / regressed: warm amber */
+    --chart-4: #f7d34a; /* Ignored / too big: golden yellow */
+    --chart-5: #8a8f98; /* Organization total / snoozed: neutral gray */
+    --chart-6: #d9534f; /* Limit / destructive: classic red */
 }
 
 .dark {
@@ -91,12 +91,12 @@
     --sidebar-border: var(--border);
     --sidebar-ring: var(--ring);
 
-    --chart-1: #a4d56f; /* Total (green, dark) */
-    --chart-2: #8fdbff; /* Blocked (blue, dark) */
-    --chart-3: #ff9e3d; /* Discarded – hsl(30 100% 62%) */
-    --chart-4: #ffea70; /* Too Big  – hsl(48 100% 70%) */
-    --chart-5: #5a5a5a; /* Total in Organization (magenta, dark) */
-    --chart-6: #ff5c5c; /* hsl(0 100% 66%): bright red for dark mode */
+    --chart-1: #91dc45; /* Total / events: classic Exceptionless green */
+    --chart-2: #5fc263; /* Secondary series: deeper green */
+    --chart-3: #ffbd63; /* Discarded / regressed: warm amber */
+    --chart-4: #ffe16a; /* Ignored / too big: golden yellow */
+    --chart-5: #a4abb5; /* Organization total / snoozed: neutral gray */
+    --chart-6: #ff746f; /* Limit / destructive: classic red */
 }
 
 @theme inline {
@@ -207,6 +207,10 @@
 }
 
 /* HACK: Need to figure out why this is needed for range selection. */
+[data-slot='chart'] .lc-area-path {
+    fill-opacity: 0.16;
+}
+
 .lc-brush-range {
     @apply bg-primary/10 border-primary border-2;
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/extended-data-item.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/extended-data-item.svelte
@@ -127,12 +127,12 @@
                         <DropdownMenu.GroupHeading>Actions</DropdownMenu.GroupHeading>
                         <DropdownMenu.Separator />
                         {#if canToggle}
-                            <DropdownMenu.Item onclick={onToggleView} title="Toggle between raw and structured view">
+                            <DropdownMenu.Item onclick={onToggleView} title="Toggle Between Raw and Structured View">
                                 <ToggleLeft class="mr-2 size-4" />
                                 Toggle View
                             </DropdownMenu.Item>
                         {/if}
-                        <DropdownMenu.Item onclick={copyToClipboard} title="Copy to clipboard">
+                        <DropdownMenu.Item onclick={copyToClipboard} title="Copy to Clipboard">
                             <Copy class="mr-2 size-4" />
                             Copy to Clipboard
                         </DropdownMenu.Item>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/log-level.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/log-level.svelte
@@ -10,16 +10,20 @@
 
     let { level }: Props = $props();
 
-    function getLogLevelVariant(level: LogLevel | null): 'default' | 'destructive' | 'outline' | 'secondary' {
+    function getLogLevelVariant(level: LogLevel | null): 'default' | 'destructive' | 'info' | 'outline' | 'secondary' | 'yellow' {
         if (level === 'trace' || level === 'debug') {
             return 'secondary';
         }
 
         if (level === 'info') {
-            return 'default';
+            return 'info';
         }
 
-        if (level === 'warn' || level === 'error') {
+        if (level === 'warn') {
+            return 'yellow';
+        }
+
+        if (level === 'error') {
             return 'destructive';
         }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/options.svelte.ts
@@ -4,15 +4,24 @@ import NumberFormatter from '$comp/formatters/number.svelte';
 import TimeAgo from '$comp/formatters/time-ago.svelte';
 import { Checkbox } from '$comp/ui/checkbox';
 import { nameof } from '$lib/utils';
-import { type ColumnDef, renderComponent, type StockFeatures } from '@tanstack/svelte-table';
+import { type ColumnDef, type ColumnVisibilityState, renderComponent, type StockFeatures } from '@tanstack/svelte-table';
 
 import type { GetEventsMode } from '../../api.svelte';
 import type { EventSummaryModel, StackSummaryModel, SummaryModel, SummaryTemplateKeys } from '../summary/index';
 
+import LogLevel from '../log-level.svelte';
 import Summary from '../summary/summary.svelte';
 import EventsUserIdentitySummaryCell from './events-user-identity-summary-cell.svelte';
 import StackStatusCell from './stack-status-cell.svelte';
 import StackUsersSummaryCell from './stack-users-summary-cell.svelte';
+
+export const defaultEventColumnVisibility: ColumnVisibilityState = {
+    level: false,
+    message: false,
+    name: false,
+    source: false,
+    type: false
+};
 
 export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKeys>>(
     mode: GetEventsMode = 'summary'
@@ -43,8 +52,11 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
         },
         {
             cell: (prop) => renderComponent(Summary, { showStatus: false, summary: prop.row.original }),
-            enableHiding: false,
-            header: 'Summary'
+            header: 'Summary',
+            id: 'summary',
+            meta: {
+                class: 'w-full'
+            }
         }
     ];
 
@@ -53,7 +65,6 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
         columns.push(
             {
                 cell: (prop) => renderComponent(EventsUserIdentitySummaryCell, { summary: prop.row.original }),
-                enableSorting: false,
                 header: 'User',
                 id: 'user',
                 meta: {
@@ -67,6 +78,53 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
                 id: 'date',
                 meta: {
                     class: 'w-36'
+                }
+            },
+            {
+                accessorFn: (row) => getSummaryDataValue(row, 'Message'),
+                cell: (prop) => formatTextColumn(prop.getValue()),
+                enableSorting: false,
+                header: 'Message',
+                id: 'message',
+                meta: {
+                    class: 'w-full'
+                }
+            },
+            {
+                accessorFn: (row) => getSummaryDataValue(row, 'Type'),
+                cell: (prop) => formatTextColumn(prop.getValue()),
+                header: 'Type',
+                id: 'type',
+                meta: {
+                    class: 'w-36'
+                }
+            },
+            {
+                accessorFn: (row) => getSource(row),
+                cell: (prop) => formatTextColumn(prop.getValue()),
+                header: 'Source',
+                id: 'source',
+                meta: {
+                    class: 'w-40'
+                }
+            },
+            {
+                accessorFn: (row) => getSummaryDataValue(row, 'Name'),
+                cell: (prop) => formatTextColumn(prop.getValue()),
+                enableSorting: false,
+                header: 'Name',
+                id: 'name',
+                meta: {
+                    class: 'w-40'
+                }
+            },
+            {
+                accessorFn: (row) => getSummaryDataValue(row, 'Level'),
+                cell: (prop) => renderComponent(LogLevel, { level: prop.getValue<string | undefined>() }),
+                header: 'Level',
+                id: 'level',
+                meta: {
+                    class: 'w-[4.5rem] min-w-[4.5rem] max-w-[4.5rem] px-1 text-center'
                 }
             }
         );
@@ -125,4 +183,17 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
     }
 
     return columns;
+}
+
+function formatTextColumn(value: unknown): string {
+    return typeof value === 'string' && value.length > 0 ? value : '—';
+}
+
+function getSource<TSummaryModel extends SummaryModel<SummaryTemplateKeys>>(summary: TSummaryModel): string | undefined {
+    return getSummaryDataValue(summary, 'SourceShortName') ?? getSummaryDataValue(summary, 'Source');
+}
+
+function getSummaryDataValue<TSummaryModel extends SummaryModel<SummaryTemplateKeys>>(summary: TSummaryModel, key: string): string | undefined {
+    const value = (summary.data as Record<string, unknown>)[key];
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/stack-status-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/stack-status-cell.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
     import type { StackStatus } from '$features/stacks/models';
 
-    import StackStatusBadge from '$features/stacks/components/stack-status-badge.svelte';
+    import { stackStatuses } from '$features/stacks/options';
 
     interface Props {
         value: StackStatus;
     }
 
     let { value }: Props = $props();
+
+    const label = $derived(stackStatuses.find((option) => option.value === value)?.label ?? value);
 </script>
 
 {#if value}
-    <div class="flex w-[100px] items-center">
-        <StackStatusBadge status={value} />
-    </div>
+    <span>{label}</span>
 {/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/impersonate-organization-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/impersonate-organization-dialog.svelte
@@ -251,7 +251,7 @@
                 </Select.Root>
 
                 {#if hasFilters}
-                    <Button variant="ghost" size="sm" onclick={resetFilters} class="h-8 text-xs">Reset filters</Button>
+                    <Button variant="ghost" size="sm" onclick={resetFilters} class="h-8 text-xs">Reset Filters</Button>
                 {/if}
             </div>
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.svelte.ts
@@ -144,15 +144,7 @@ export function syncSavedViewCaches(queryClient: QueryClient, savedView: SavedVi
 }
 
 export function upsertSavedViewCache(cachedViews: SavedView[] | undefined, savedView: SavedView): SavedView[] {
-    const views = savedView.is_default
-        ? (cachedViews ?? []).map((view) => {
-              if (view.id === savedView.id || view.view_type !== savedView.view_type || !view.is_default) {
-                  return view;
-              }
-
-              return { ...view, is_default: false };
-          })
-        : (cachedViews ?? []);
+    const views = cachedViews ?? [];
     const savedViewIndex = views.findIndex((view) => view.id === savedView.id);
 
     if (savedViewIndex === -1) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/save-view-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/save-view-dialog.svelte
@@ -12,7 +12,7 @@
         duplicateView?: SavedView;
         onClose: () => void;
         onLoadView: (id: string) => void;
-        onSave: (name: string, isPrivate: boolean, isDefault: boolean) => Promise<void>;
+        onSave: (name: string, isPrivate: boolean) => Promise<void>;
         open: boolean;
         saving: boolean;
     }
@@ -21,13 +21,11 @@
 
     let saveName = $state('');
     let isPrivate = $state(false);
-    let isDefault = $state(false);
 
     $effect(() => {
         if (open) {
             saveName = '';
             isPrivate = false;
-            isDefault = false;
         }
     });
 
@@ -36,7 +34,7 @@
             return;
         }
 
-        await onSave(saveName.trim(), isPrivate, isDefault);
+        await onSave(saveName.trim(), isPrivate);
     }
 </script>
 
@@ -77,25 +75,8 @@
                     <Label for="view-private" class="text-sm">Private</Label>
                     <Muted>Only visible to you</Muted>
                 </div>
-                <Switch
-                    id="view-private"
-                    bind:checked={isPrivate}
-                    onCheckedChange={(checked) => {
-                        if (checked) {
-                            isDefault = false;
-                        }
-                    }}
-                />
+                <Switch id="view-private" bind:checked={isPrivate} />
             </div>
-            {#if !isPrivate}
-                <div class="flex items-center justify-between">
-                    <div>
-                        <Label for="view-default" class="text-sm">Set as default</Label>
-                        <Muted>Auto-loads for everyone on page visit</Muted>
-                    </div>
-                    <Switch id="view-default" bind:checked={isDefault} />
-                </div>
-            {/if}
             <Dialog.Footer>
                 <Button variant="outline" onclick={onClose}>Cancel</Button>
                 <Button type="submit" disabled={!saveName.trim() || saving}>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
@@ -14,6 +14,7 @@
     import { toFilter } from '$features/events/components/filters/helpers.svelte';
     import { serializeFilters } from '$features/events/components/filters/helpers.svelte';
     import { organization } from '$features/organizations/context.svelte';
+    import GripVertical from '@lucide/svelte/icons/grip-vertical';
     import Pencil from '@lucide/svelte/icons/pencil';
     import Plus from '@lucide/svelte/icons/plus';
     import Save from '@lucide/svelte/icons/save';
@@ -42,6 +43,7 @@
 
     interface Props {
         activeSavedView?: SavedView;
+        columnOrder?: string[];
         columnVisibility?: Record<string, boolean>;
         filters: IFilter[];
         isModified: boolean;
@@ -55,12 +57,26 @@
         view: string;
     }
 
-    let { activeSavedView, columnVisibility, filters, isModified, onClearSavedView, onLoadView, onResetToSaved, savedViews, sort, table, time, view }: Props =
-        $props();
+    let {
+        activeSavedView,
+        columnOrder,
+        columnVisibility,
+        filters,
+        isModified,
+        onClearSavedView,
+        onLoadView,
+        onResetToSaved,
+        savedViews,
+        sort,
+        table,
+        time,
+        view
+    }: Props = $props();
 
     let isSaveDialogOpen = $state(false);
     let isRenameDialogOpen = $state(false);
     let isDeleteDialogOpen = $state(false);
+    let draggedColumnId = $state<null | string>(null);
     let viewToDelete = $state<null | SavedView>(null);
 
     const organizationId = $derived(organization.current);
@@ -116,6 +132,8 @@
 
     const activeView = $derived(activeSavedView);
     const hideableColumns = $derived(table.getAllLeafColumns().filter((column) => column.getCanHide()));
+    const reorderableColumns = $derived(table.getAllLeafColumns().filter((column) => column.id !== 'select'));
+    const visibleHideableColumnCount = $derived(hideableColumns.filter((column) => column.getIsVisible()).length);
 
     async function openSaveDialog() {
         await tick();
@@ -127,23 +145,92 @@
         isRenameDialogOpen = true;
     }
 
+    function canToggleColumn(column: (typeof hideableColumns)[number]): boolean {
+        return !column.getIsVisible() || visibleHideableColumnCount > 1;
+    }
+
+    function toggleColumn(column: (typeof hideableColumns)[number]): void {
+        if (canToggleColumn(column)) {
+            column.toggleVisibility();
+        }
+    }
+
+    function getColumnLabel(column: (typeof reorderableColumns)[number]): string {
+        if (typeof column.columnDef.header === 'string') {
+            return column.columnDef.header;
+        }
+
+        return column.id.replace(/[_-]/g, ' ').replace(/\w\S*/g, (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
+    }
+
+    function getSavedColumnOrder(): string[] | undefined {
+        const currentColumnIds = new Set(table.getAllLeafColumns().map((column) => column.id));
+        const savedColumnOrder = (columnOrder ?? []).filter((columnId) => columnId !== 'select' && currentColumnIds.has(columnId));
+
+        return savedColumnOrder.length > 0 ? savedColumnOrder : undefined;
+    }
+
+    function handleColumnDragEnd(): void {
+        draggedColumnId = null;
+    }
+
+    function handleColumnDragOver(event: DragEvent, targetColumnId: string): void {
+        event.preventDefault();
+        if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = 'move';
+        }
+
+        if (draggedColumnId && draggedColumnId !== targetColumnId) {
+            moveColumn(draggedColumnId, targetColumnId);
+        }
+    }
+
+    function handleColumnDragStart(event: DragEvent, columnId: string): void {
+        draggedColumnId = columnId;
+        if (event.dataTransfer) {
+            event.dataTransfer.effectAllowed = 'move';
+            event.dataTransfer.setData('text/plain', columnId);
+        }
+    }
+
+    function moveColumn(columnId: string, targetColumnId: string): void {
+        const columnIds = reorderableColumns.map((column) => column.id);
+        const columnIndex = columnIds.indexOf(columnId);
+        const targetIndex = columnIds.indexOf(targetColumnId);
+        if (columnIndex === -1 || targetIndex < 0 || targetIndex >= columnIds.length) {
+            return;
+        }
+
+        const [movedColumnId] = columnIds.splice(columnIndex, 1);
+        if (!movedColumnId) {
+            return;
+        }
+
+        columnIds.splice(targetIndex, 0, movedColumnId);
+
+        const allColumnIds = table.getAllLeafColumns().map((column) => column.id);
+        const extraColumnIds = allColumnIds.filter((id) => id !== 'select' && !columnIds.includes(id));
+        table.setColumnOrder(['select', ...columnIds, ...extraColumnIds]);
+    }
+
     async function openDeleteDialog(savedView: SavedView) {
         viewToDelete = savedView;
         await tick();
         isDeleteDialogOpen = true;
     }
 
-    async function handleSave(name: string, isPrivate: boolean, isDefault: boolean) {
+    async function handleSave(name: string, isPrivate: boolean) {
         if (!organizationId) {
             return;
         }
 
         const filterDefinitions = serializeFilters(filters);
+        const savedColumnOrder = getSavedColumnOrder();
         const body: NewSavedView = {
+            column_order: savedColumnOrder,
             columns: columnVisibility,
             filter: currentFilterString || undefined,
             filter_definitions: filterDefinitions,
-            is_default: isDefault || undefined,
             is_private: isPrivate || undefined,
             name,
             organization_id: organizationId,
@@ -182,6 +269,7 @@
         }
 
         const body: UpdateSavedView = {
+            column_order: getSavedColumnOrder() ?? null,
             columns: columnVisibility,
             filter: currentFilterString || null,
             filter_definitions: serializeFilters(filters),
@@ -223,7 +311,7 @@
 <DropdownMenu.Root>
     <DropdownMenu.Trigger>
         {#snippet child({ props })}
-            <Button {...props} class="gap-x-1.5 px-3" size="lg" variant="outline" title="Manage view settings">
+            <Button {...props} class="gap-x-1.5 px-3" size="lg" variant="outline" title="Manage View Settings">
                 <SlidersHorizontal class="size-4" aria-hidden="true" />
                 <span>View</span>
             </Button>
@@ -249,7 +337,7 @@
                 </DropdownMenu.Item>
                 <DropdownMenu.Item disabled={!isModified} onclick={onResetToSaved}>
                     <Undo2 class="mr-2 size-4" aria-hidden="true" />
-                    Reset to saved
+                    Reset to Saved
                 </DropdownMenu.Item>
                 <DropdownMenu.Separator />
                 <DropdownMenu.Item class="text-destructive" onclick={() => openDeleteDialog(activeView)}>
@@ -258,15 +346,49 @@
                 </DropdownMenu.Item>
             {/if}
         </DropdownMenu.Group>
-        {#if hideableColumns.length > 0}
+        {#if reorderableColumns.length > 0}
             <DropdownMenu.Separator />
             <DropdownMenu.Group>
                 <DropdownMenu.Label>Columns</DropdownMenu.Label>
-                {#each hideableColumns as column (column.id)}
-                    <DropdownMenu.CheckboxItem checked={column.getIsVisible()} onclick={() => column.toggleVisibility()}>
-                        {column.columnDef.header}
-                    </DropdownMenu.CheckboxItem>
-                {/each}
+                <div role="list">
+                    {#each reorderableColumns as column (column.id)}
+                        <div
+                            class={[
+                                'group/column flex cursor-grab items-center gap-1 rounded-md py-0.5 pr-1.5 active:cursor-grabbing',
+                                draggedColumnId === column.id && 'bg-accent/70'
+                            ]}
+                            draggable="true"
+                            ondragend={handleColumnDragEnd}
+                            ondragover={(event) => handleColumnDragOver(event, column.id)}
+                            ondragstart={(event) => handleColumnDragStart(event, column.id)}
+                            role="listitem"
+                        >
+                            {#if column.getCanHide()}
+                                <DropdownMenu.CheckboxItem
+                                    checked={column.getIsVisible()}
+                                    class="min-w-0 flex-1"
+                                    disabled={!canToggleColumn(column)}
+                                    onclick={(event) => {
+                                        event.preventDefault();
+                                        toggleColumn(column);
+                                    }}
+                                    onSelect={(event) => event.preventDefault()}
+                                >
+                                    <span class="truncate">{getColumnLabel(column)}</span>
+                                </DropdownMenu.CheckboxItem>
+                            {:else}
+                                <span class="flex min-w-0 flex-1 items-center gap-1.5 px-1.5 py-1 text-sm">
+                                    <span class="mr-2 size-4" aria-hidden="true"></span>
+                                    <span class="truncate">{getColumnLabel(column)}</span>
+                                </span>
+                            {/if}
+                            <GripVertical
+                                class="text-muted-foreground/60 size-4 shrink-0 opacity-0 transition-opacity group-focus-within/column:opacity-100 group-hover/column:opacity-100"
+                                aria-hidden="true"
+                            />
+                        </div>
+                    {/each}
+                </div>
             </DropdownMenu.Group>
         {/if}
     </DropdownMenu.Content>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -1,5 +1,5 @@
 import type { IFilter } from '$comp/faceted-filter';
-import type { ColumnVisibilityState } from '@tanstack/svelte-table';
+import type { ColumnOrderState, ColumnVisibilityState } from '@tanstack/svelte-table';
 
 import { deserializeFilters } from '$features/events/components/filters/helpers.svelte';
 import { organization } from '$features/organizations/context.svelte';
@@ -17,10 +17,13 @@ export interface SavedViewQueryParams {
 }
 
 export interface UseSavedViewsOptions {
+    defaultColumnVisibility?: ColumnVisibilityState;
     filterCacheKey: (filter: null | string) => string;
+    getColumnOrder?: () => ColumnOrderState;
     getColumnVisibility?: () => ColumnVisibilityState;
     getFilterDefinitions?: () => string;
     queryParams: SavedViewQueryParams;
+    setColumnOrder?: (order: ColumnOrderState) => void;
     setColumnVisibility?: (visibility: ColumnVisibilityState) => void;
     updateFilterCache: (key: string, filters: IFilter[]) => void;
     view: string;
@@ -77,11 +80,19 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
     const activeSavedView = $derived(savedViewsListQuery.data?.find((v) => v.id === options.queryParams.saved));
 
+    function applyColumnState(view: Pick<SavedView, 'column_order' | 'columns'> | undefined): void {
+        if (options.setColumnVisibility) {
+            options.setColumnVisibility(view?.columns ?? {});
+        }
+
+        if (options.setColumnOrder) {
+            options.setColumnOrder(view?.column_order ?? []);
+        }
+    }
+
     // Hydrate filters/columns when a saved view loads, or clear params if the view is no longer found.
     // lastLoadedViewId prevents re-hydration on background refetches (which would stomp user edits).
-    let lastLoadedViewId = '';
-    let hasAutoRestored = false;
-    let lastAutoRestoredOrganizationId = '';
+    let lastLoadedViewId: string | undefined;
     $effect(() => {
         const savedId = options.queryParams.saved;
         const isLoading = savedViewsListQuery.isLoading;
@@ -90,6 +101,10 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
         if (!savedId || isLoading || !views) {
             if (!savedId) {
+                if (lastLoadedViewId !== '') {
+                    applyColumnState(undefined);
+                }
+
                 lastLoadedViewId = '';
             }
 
@@ -110,7 +125,6 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             options.queryParams.filter = null;
             setSortQueryParam(options.queryParams, null);
             setTimeQueryParam(options.queryParams, null);
-            hasAutoRestored = false;
             return;
         }
 
@@ -133,52 +147,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         options.queryParams.filter = view.filter ?? null;
         setSortQueryParam(options.queryParams, view.sort ?? null);
         setTimeQueryParam(options.queryParams, view.time ?? null);
-
-        if (view.columns && options.setColumnVisibility) {
-            options.setColumnVisibility(view.columns);
-        }
-    });
-
-    // Auto-load default saved view when navigating to page without explicit params
-    $effect(() => {
-        const organizationId = organization.current;
-        const views = savedViewsListQuery.data;
-        if (!organizationId) {
-            return;
-        }
-
-        if (organizationId !== lastAutoRestoredOrganizationId) {
-            hasAutoRestored = false;
-            lastAutoRestoredOrganizationId = organizationId;
-        }
-
-        if (hasAutoRestored) {
-            return;
-        }
-
-        // Don't lock out the auto-restore while the feature flag is still resolving
-        // or the views list hasn't loaded yet. Without this guard the effect fires
-        // while the query is disabled (isLoading=false but data=undefined) and marks
-        // hasAutoRestored=true before any view data is available.
-        if (!isEnabled || savedViewsListQuery.isLoading) {
-            return;
-        }
-
-        hasAutoRestored = true;
-
-        const search = window.location.search;
-        const hasExplicitParams =
-            /[?&]saved(?:[=&]|$)/.test(search) || /[?&]filter(?:[=&]|$)/.test(search) || /[?&]sort(?:[=&]|$)/.test(search) || /[?&]time(?:[=&]|$)/.test(search);
-        if (hasExplicitParams) {
-            return;
-        }
-
-        untrack(() => {
-            const defaultView = views?.find((v) => v.is_default);
-            if (defaultView) {
-                options.queryParams.saved = defaultView.id;
-            }
-        });
+        applyColumnState(view);
     });
 
     // Detect if current filters or columns differ from the active saved view
@@ -204,7 +173,11 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return true;
         }
 
-        if (options.getColumnVisibility && !columnsEqual(options.getColumnVisibility(), view.columns)) {
+        if (options.getColumnVisibility && !columnsEqual(options.getColumnVisibility(), view.columns, options.defaultColumnVisibility)) {
+            return true;
+        }
+
+        if (options.getColumnOrder && !columnOrderEqual(options.getColumnOrder(), view.column_order)) {
             return true;
         }
 
@@ -233,9 +206,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         options.queryParams.filter = view.filter ?? null;
         setSortQueryParam(options.queryParams, view.sort ?? null);
         setTimeQueryParam(options.queryParams, view.time ?? null);
-        if (view.columns && options.setColumnVisibility) {
-            options.setColumnVisibility(view.columns);
-        }
+        applyColumnState(view);
     }
 
     function handleClearSavedView() {
@@ -243,9 +214,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         options.queryParams.filter = null;
         setSortQueryParam(options.queryParams, null);
         setTimeQueryParam(options.queryParams, null);
-        if (options.setColumnVisibility) {
-            options.setColumnVisibility({});
-        }
+        applyColumnState(undefined);
     }
 
     return {
@@ -270,9 +239,26 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     };
 }
 
-function columnsEqual(a: ColumnVisibilityState | undefined, b: null | Record<string, boolean> | undefined): boolean {
-    const aEntries = Object.entries(a ?? {}).sort(([k1], [k2]) => k1.localeCompare(k2));
-    const bEntries = Object.entries(b ?? {}).sort(([k1], [k2]) => k1.localeCompare(k2));
+function columnOrderEqual(a: ColumnOrderState | undefined, b: null | string[] | undefined): boolean {
+    const normalize = (value: null | string[] | undefined) => (value ?? []).filter((columnId) => columnId !== 'select');
+    const aOrder = normalize(a);
+    const bOrder = normalize(b);
+
+    if (aOrder.length !== bOrder.length) {
+        return false;
+    }
+
+    return aOrder.every((columnId, index) => columnId === bOrder[index]);
+}
+
+function columnsEqual(
+    a: ColumnVisibilityState | undefined,
+    b: null | Record<string, boolean> | undefined,
+    defaultColumnVisibility: ColumnVisibilityState = {}
+): boolean {
+    const normalize = (value: ColumnVisibilityState | null | undefined) => ({ ...defaultColumnVisibility, ...(value ?? {}) });
+    const aEntries = Object.entries(normalize(a)).sort(([k1], [k2]) => k1.localeCompare(k2));
+    const bEntries = Object.entries(normalize(b)).sort(([k1], [k2]) => k1.localeCompare(k2));
 
     if (aEntries.length !== bEntries.length) {
         return false;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -92,7 +92,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
     // Hydrate filters/columns when a saved view loads, or clear params if the view is no longer found.
     // lastLoadedViewId prevents re-hydration on background refetches (which would stomp user edits).
-    let lastLoadedViewId: string | undefined;
+    let lastLoadedViewId = '';
     $effect(() => {
         const savedId = options.queryParams.saved;
         const isLoading = savedViewsListQuery.isLoading;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { SavedView } from './models';
 
-import { invalidateSavedViewQueries, queryKeys, SAVED_VIEW_REFRESH_DELAY_MS, syncSavedViewCaches, upsertSavedViewCache } from './api.svelte';
+import { invalidateSavedViewQueries, queryKeys, SAVED_VIEW_REFRESH_DELAY_MS, syncSavedViewCaches } from './api.svelte';
 import { type SavedViewQueryParams, setSortQueryParam, setTimeQueryParam, supportsSortQueryParam, supportsTimeQueryParam } from './use-saved-views.svelte';
 
 const TEST_ORG_ID = '507f1f77bcf86cd799439011';
@@ -16,13 +16,13 @@ afterEach(() => {
 
 function buildSavedView({ id, name, ...overrides }: Partial<SavedView> & Pick<SavedView, 'id' | 'name'>): SavedView {
     return {
+        column_order: null,
         columns: {},
         created_by_user_id: TEST_USER_ID,
         created_utc: new Date().toISOString(),
         filter: null,
         filter_definitions: null,
         id,
-        is_default: false,
         name,
         organization_id: TEST_ORG_ID,
         sort: null,
@@ -344,21 +344,6 @@ describe('useSavedViews', () => {
             // Assert
             expect(queryClient.getQueryData<SavedView[]>(queryKeys.view(TEST_ORG_ID, 'issues'))).toEqual([updatedView, otherView]);
             expect(queryClient.getQueryData<SavedView[]>(queryKeys.organization(TEST_ORG_ID))).toEqual([updatedView, otherView]);
-        });
-
-        it('keeps only one default per saved-view type in the cached list', () => {
-            // Arrange
-            const currentDefault = buildSavedView({ id: 'view-1', is_default: true, name: 'Current Default' });
-            const otherIssuesView = buildSavedView({ id: 'view-2', name: 'Other Issues View' });
-            const streamDefault = buildSavedView({ id: 'view-3', is_default: true, name: 'Stream Default', view_type: 'stream' });
-            const newDefault = buildSavedView({ id: 'view-4', is_default: true, name: 'New Default' });
-
-            // Act
-            const updatedViews = upsertSavedViewCache([currentDefault, otherIssuesView, streamDefault], newDefault);
-
-            // Assert
-            expect(updatedViews.filter((view) => view.view_type === 'issues' && view.is_default)).toEqual([newDefault]);
-            expect(updatedViews.filter((view) => view.view_type === 'stream' && view.is_default)).toEqual([streamDefault]);
         });
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
@@ -20,27 +20,53 @@
 
     let { children, rowClick, rowHref, table }: Props = $props();
 
+    const selectColumnClass = 'w-8 min-w-8 max-w-8';
+
     function getHeaderColumnClass(header: Header<StockFeatures, TData, unknown>) {
-        const metaClass = (header.column.columnDef.meta as { class?: string })?.class || '';
+        if (header.column.id === 'select') {
+            return selectColumnClass;
+        }
+
+        const metaClass = getMetaClass(header.column.columnDef.meta);
         if (!metaClass) {
             return '';
         }
 
-        if (metaClass.includes('text-right')) {
-            return [metaClass, 'justify-end'].join(' ');
+        const className = getVisibleDataColumnCount() === 1 ? removeWidthClasses(metaClass) : metaClass;
+        if (className.includes('text-right')) {
+            return [className, 'justify-end'].join(' ');
         }
 
-        return metaClass;
+        if (className.includes('text-center')) {
+            return [className, 'justify-center'].join(' ');
+        }
+
+        return className;
     }
 
     function getCellClass(cell: Cell<StockFeatures, TData, unknown>) {
         if (cell.column.id === 'select') {
-            return;
+            return selectColumnClass;
         }
 
-        const metaClass = (cell.column.columnDef.meta as { class?: string })?.class ?? '';
-        const classes = rowClick ? ['cursor-pointer', 'truncate', 'max-w-sm', metaClass] : ['truncate', 'max-w-sm', metaClass];
+        const isOnlyDataColumn = getVisibleDataColumnCount() === 1;
+        const metaClass = isOnlyDataColumn ? removeWidthClasses(getMetaClass(cell.column.columnDef.meta)) : getMetaClass(cell.column.columnDef.meta);
+        const classes = rowClick
+            ? ['cursor-pointer', 'truncate', !isOnlyDataColumn && 'max-w-sm', metaClass]
+            : ['truncate', !isOnlyDataColumn && 'max-w-sm', metaClass];
         return classes.filter(Boolean).join(' ');
+    }
+
+    function getMetaClass(meta: unknown): string {
+        return (meta as { class?: string })?.class ?? '';
+    }
+
+    function getVisibleDataColumnCount(): number {
+        return table.getVisibleLeafColumns().filter((column) => column.id !== 'select').length;
+    }
+
+    function isWidthClass(className: string): boolean {
+        return /^(?:max-w|min-w|w)-/.test(className);
     }
 
     function onCellClick(event: MouseEvent, cell: Cell<StockFeatures, TData, unknown>): void {
@@ -72,6 +98,13 @@
 
         // Call the row click handler, passing the event so consumer can override if needed
         rowClick(cell.row.original, event);
+    }
+
+    function removeWidthClasses(className: string): string {
+        return className
+            .split(' ')
+            .filter((part) => !isWidthClass(part))
+            .join(' ');
     }
 </script>
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-view-options.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-view-options.svelte
@@ -16,6 +16,19 @@
     }
 
     let { size = 'icon', table }: Props = $props();
+
+    const hideableColumns = $derived(table.getAllLeafColumns().filter((column) => column.getCanHide()));
+    const visibleHideableColumnCount = $derived(hideableColumns.filter((column) => column.getIsVisible()).length);
+
+    function canToggleColumn(column: (typeof hideableColumns)[number]): boolean {
+        return !column.getIsVisible() || visibleHideableColumnCount > 1;
+    }
+
+    function toggleColumn(column: (typeof hideableColumns)[number]): void {
+        if (canToggleColumn(column)) {
+            column.toggleVisibility();
+        }
+    }
 </script>
 
 <DropdownMenu.Root>
@@ -30,12 +43,10 @@
         <DropdownMenu.Group>
             <DropdownMenu.Label>Toggle columns</DropdownMenu.Label>
             <DropdownMenu.Separator />
-            {#each table.getAllLeafColumns() as column (column.id)}
-                {#if column.getCanHide()}
-                    <DropdownMenu.CheckboxItem checked={column.getIsVisible()} onclick={() => column.toggleVisibility()}>
-                        {column.columnDef.header}
-                    </DropdownMenu.CheckboxItem>
-                {/if}
+            {#each hideableColumns as column (column.id)}
+                <DropdownMenu.CheckboxItem checked={column.getIsVisible()} disabled={!canToggleColumn(column)} onclick={() => toggleColumn(column)}>
+                    {column.columnDef.header}
+                </DropdownMenu.CheckboxItem>
             {/each}
         </DropdownMenu.Group>
     </DropdownMenu.Content>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/faceted-filter/faceted-filter-actions.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/faceted-filter/faceted-filter-actions.svelte
@@ -16,10 +16,10 @@
 <div class="flex flex-col">
     <Separator />
     {#if showClear}
-        <Button class="justify-center text-center" variant="ghost" onclick={clear}>Clear filter</Button>
+        <Button class="justify-center text-center" variant="ghost" onclick={clear}>Clear Filter</Button>
     {/if}
     {#if toggleHidden}
-        <Button class="justify-center text-center" variant="ghost" onclick={toggleHidden}>{hidden ? 'Show filter' : 'Hide filter'}</Button>
+        <Button class="justify-center text-center" variant="ghost" onclick={toggleHidden}>{hidden ? 'Show Filter' : 'Hide Filter'}</Button>
     {/if}
-    <Button class="justify-center text-center" variant="ghost" onclick={remove}>Remove filter</Button>
+    <Button class="justify-center text-center" variant="ghost" onclick={remove}>Remove Filter</Button>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/faceted-filter/faceted-filter-builder.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/faceted-filter/faceted-filter-builder.svelte
@@ -2,6 +2,7 @@
     import type { KeywordFilter } from '$features/events/components/filters';
     import type { Snippet } from 'svelte';
 
+    import { Badge } from '$comp/ui/badge';
     import { Button } from '$comp/ui/button';
     import * as Command from '$comp/ui/command';
     import * as Popover from '$comp/ui/popover';
@@ -54,6 +55,7 @@
     });
 
     const hiddenFilterCount = $derived(filters.filter((filter) => filter.hidden).length);
+    const hiddenFilterLabel = $derived(`${hiddenFilterCount} Hidden ${hiddenFilterCount === 1 ? 'Filter' : 'Filters'}`);
     const hasFilters = $derived(filters.length > 0);
     const visibleFacets = $derived(facets.filter((facet) => !facet.filter.hidden || showHiddenFilters));
 
@@ -184,13 +186,22 @@
         {#snippet child({ props })}
             <Button
                 {...props}
-                class={[!hasFilters && 'gap-x-1 px-3']}
+                class={['relative', !hasFilters && 'gap-x-1 px-3']}
                 size={hasFilters ? 'icon-lg' : 'lg'}
                 variant="outline"
-                title="Add and manage filters"
-                aria-label="Add and manage filters"
+                title="Add and Manage Filters"
+                aria-label={hiddenFilterCount > 0 ? `Add and Manage Filters. ${hiddenFilterLabel}.` : 'Add and Manage Filters'}
             >
                 <Circle class={[hasFilters ? 'size-4' : 'mr-2 size-4']} aria-hidden="true" />
+                {#if hiddenFilterCount > 0}
+                    <Badge
+                        variant="secondary"
+                        class="absolute -top-1 -right-1 h-4 min-w-4 rounded-full px-1 text-[10px] leading-none shadow-sm"
+                        aria-hidden="true"
+                    >
+                        {hiddenFilterCount}
+                    </Badge>
+                {/if}
                 {#if !hasFilters}
                     Filter
                 {/if}
@@ -211,7 +222,7 @@
                 {#if search}
                     <Command.Group>
                         <Command.Item value={CREATE_KEYWORD_FILTER_COMMAND_ITEM} onSelect={onCreateKeywordFromSearch}>
-                            Create keyword filter: "{search}"
+                            Create Keyword Filter: "{search}"
                         </Command.Item>
                     </Command.Group>
                 {/if}
@@ -221,11 +232,11 @@
             <Separator />
             {#if hiddenFilterCount > 0}
                 <Button class="justify-center text-center" variant="ghost" onclick={toggleHiddenFilters}>
-                    {showHiddenFilters ? 'Hide hidden filters' : `Show hidden filters (${hiddenFilterCount})`}
+                    {showHiddenFilters ? 'Hide Hidden Filters' : `Show ${hiddenFilterLabel}`}
                 </Button>
             {/if}
             {#if filters.some((f) => f.type !== 'date')}
-                <Button class="justify-center text-center" variant="ghost" onclick={onRemoveAll}>Clear filters</Button>
+                <Button class="justify-center text-center" variant="ghost" onclick={onRemoveAll}>Clear Filters</Button>
             {/if}
             <Button class="justify-center text-center" variant="ghost" onclick={onClose}>Close</Button>
         </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/notification/notification.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/notification/notification.svelte
@@ -15,7 +15,7 @@
                 default: 'border-l-border bg-background text-foreground',
                 destructive: 'border-l-red-500 bg-red-50 text-red-900 dark:bg-red-900/30 dark:text-red-200',
                 impersonation: 'border-l-violet-500 bg-violet-50 text-violet-900 dark:bg-violet-900/30 dark:text-violet-200',
-                information: 'border-l-blue-500 bg-blue-50 text-blue-900 dark:bg-blue-900/30 dark:text-blue-200',
+                information: 'border-l-primary bg-[#dff0d8] text-[#3c763d] dark:bg-[#dff0d8] dark:text-[#3c763d]',
                 success: 'border-l-green-500 bg-green-50 text-green-900 dark:bg-green-900/30 dark:text-green-200',
                 warning: 'border-l-yellow-500 bg-yellow-50 text-yellow-900 dark:bg-yellow-900/30 dark:text-yellow-200'
             }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/badge/badge.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/badge/badge.svelte
@@ -13,6 +13,8 @@
 				link: "text-primary underline-offset-4 hover:underline",
 				// Custom semantic color variants — adapted to new [a]:hover: selector format
 				red: "bg-red-100 text-red-700 [a]:hover:bg-red-200 border-transparent focus-visible:ring-red-400 dark:bg-red-900/30 dark:text-red-300 dark:[a]:hover:bg-red-900/50",
+				info: "bg-primary/10 text-foreground border-transparent [a]:hover:bg-primary/15 focus-visible:ring-primary/30 dark:bg-primary/15 dark:[a]:hover:bg-primary/20",
+				yellow: "bg-yellow-100 text-yellow-700 [a]:hover:bg-yellow-200 border-transparent focus-visible:ring-yellow-400 dark:bg-yellow-900/30 dark:text-yellow-300 dark:[a]:hover:bg-yellow-900/50",
 				amber: "bg-amber-100 text-amber-700 [a]:hover:bg-amber-200 border-transparent focus-visible:ring-amber-400 dark:bg-amber-900/30 dark:text-amber-300 dark:[a]:hover:bg-amber-900/50",
 				orange: "bg-orange-100 text-orange-700 [a]:hover:bg-orange-200 border-transparent focus-visible:ring-orange-400 dark:bg-orange-900/30 dark:text-orange-300 dark:[a]:hover:bg-orange-900/50",
 			},

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/button/button.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/button/button.svelte
@@ -3,14 +3,17 @@
 	import type { HTMLAnchorAttributes, HTMLButtonAttributes } from "svelte/elements";
 	import { type VariantProps, tv } from "tailwind-variants";
 
+	const primaryActionVariant =
+		"bg-[#4f9630] text-white hover:bg-[#427f28] focus-visible:border-[#427f28] focus-visible:ring-[#4f9630]/20 dark:bg-[#4f9630] dark:hover:bg-[#427f28]";
+
 	export const buttonVariants = tv({
 		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
-				default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+				default: primaryActionVariant,
 				outline: "border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground",
 				secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
-				success: "bg-green-600 text-white hover:bg-green-700 focus-visible:border-green-700 focus-visible:ring-green-600/20 dark:bg-green-600 dark:hover:bg-green-700",
+				success: primaryActionVariant,
 				ghost: "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",
 				destructive: "bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30",
 				link: "text-primary underline-offset-4 hover:underline",
@@ -21,10 +24,10 @@
 				sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
 				lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
 				xl: "h-10 gap-2 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
-				icon: "size-8",
-				"icon-xs": "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
-				"icon-sm": "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
-				"icon-lg": "size-9",
+				icon: "size-8 [&_svg]:stroke-[2.5]",
+				"icon-xs": "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3 [&_svg]:stroke-[2.5]",
+				"icon-sm": "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg [&_svg]:stroke-[2.5]",
+				"icon-lg": "size-9 [&_svg]:stroke-[2.5]",
 			},
 		},
 		defaultVariants: {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/command/command-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/command/command-dialog.svelte
@@ -36,7 +36,7 @@
 	</Dialog.Header>
 	<Dialog.Content
 		class={cn("top-1.5 translate-y-0 overflow-hidden p-0 shadow-2xl sm:max-w-5xl", className)}
-		overlayClass="bg-black/15 supports-backdrop-filter:backdrop-blur-none"
+		overlayClass="bg-black/20 supports-backdrop-filter:backdrop-blur-none"
 		{preventScroll}
 		{showCloseButton}
 		{portalProps}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/command/command-shortcut.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/command/command-shortcut.svelte
@@ -1,20 +1,23 @@
 <script lang="ts">
-	import { cn, type WithElementRef } from "$lib/utils.js";
-	import type { HTMLAttributes } from "svelte/elements";
+    import { cn, type WithElementRef } from "$lib/utils.js";
+    import type { HTMLAttributes } from "svelte/elements";
 
-	let {
-		ref = $bindable(null),
-		class: className,
-		children,
-		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLSpanElement>> = $props();
+    let {
+        ref = $bindable(null),
+        class: className,
+        children,
+        ...restProps
+    }: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
 </script>
 
-<span
-	bind:this={ref}
-	data-slot="command-shortcut"
-	class={cn("text-muted-foreground group-data-selected/command-item:text-foreground ml-auto text-xs tracking-widest", className)}
-	{...restProps}
+<kbd
+    bind:this={ref}
+    data-slot="command-shortcut"
+    class={cn(
+        "border-border bg-muted text-muted-foreground group-data-selected/command-item:bg-background group-data-selected/command-item:text-foreground ml-auto h-5 w-fit min-w-5 gap-1 rounded-sm border px-1 font-sans text-xs font-medium [&_svg:not([class*='size-'])]:size-3 pointer-events-none inline-flex items-center justify-center select-none",
+        className
+    )}
+    {...restProps}
 >
-	{@render children?.()}
-</span>
+    {@render children?.()}
+</kbd>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
@@ -23,14 +23,14 @@
 	bind:indeterminate
 	data-slot="dropdown-menu-checkbox-item"
 	class={cn(
-		"focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm whitespace-nowrap data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm whitespace-nowrap data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className
 	)}
 	{...restProps}
 >
 	{#snippet children({ checked, indeterminate })}
 		<span
-			class="absolute right-2 flex items-center justify-center pointer-events-none"
+			class="mr-2 flex size-4 items-center justify-center pointer-events-none"
 			data-slot="dropdown-menu-checkbox-item-indicator"
 		>
 			{#if indeterminate}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/dropdown-menu/dropdown-menu-item.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/dropdown-menu/dropdown-menu-item.svelte
@@ -20,7 +20,7 @@
 	data-inset={inset}
 	data-variant={variant}
 	class={cn(
-		"focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm whitespace-nowrap data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 group/dropdown-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"focus:bg-accent focus:text-accent-foreground data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground not-data-[variant=destructive]:data-highlighted:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm whitespace-nowrap data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 group/dropdown-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		className
 	)}
 	{...restProps}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/keyboard-shortcuts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/keyboard-shortcuts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatKeyboardShortcutForPlatform } from './keyboard-shortcuts';
+import { appKeyboardShortcuts, formatKeyboardShortcutForPlatform, isKeyboardShortcut } from './keyboard-shortcuts';
 
 describe('formatKeyboardShortcutForPlatform', () => {
     it('should format modifier shortcuts for Apple platforms', () => {
@@ -13,5 +13,20 @@ describe('formatKeyboardShortcutForPlatform', () => {
         expect(formatKeyboardShortcutForPlatform(['Mod', 'K'], false)).toBe('⌃K');
         expect(formatKeyboardShortcutForPlatform(['Shift', 'Mod', 'Q'], false)).toBe('⇧⌃Q');
         expect(formatKeyboardShortcutForPlatform(['Alt'], false)).toBe('⎇');
+    });
+
+    it('should format single key shortcuts', () => {
+        expect(formatKeyboardShortcutForPlatform(appKeyboardShortcuts.switchOrganization.keys, false)).toBe('O');
+        expect(formatKeyboardShortcutForPlatform(appKeyboardShortcuts.userMenu.keys, false)).toBe('U');
+        expect(formatKeyboardShortcutForPlatform(appKeyboardShortcuts.keyboardShortcuts.keys, false)).toBe('?');
+    });
+
+    it('should match shortcut keys case-insensitively', () => {
+        expect(isKeyboardShortcut({ key: 'o' } as KeyboardEvent, appKeyboardShortcuts.switchOrganization)).toBe(true);
+        expect(isKeyboardShortcut({ key: 'O' } as KeyboardEvent, appKeyboardShortcuts.switchOrganization)).toBe(true);
+        expect(isKeyboardShortcut({ key: 'p' } as KeyboardEvent, appKeyboardShortcuts.switchOrganization)).toBe(false);
+        expect(isKeyboardShortcut({ key: 'u' } as KeyboardEvent, appKeyboardShortcuts.userMenu)).toBe(true);
+        expect(isKeyboardShortcut({ key: 'U' } as KeyboardEvent, appKeyboardShortcuts.userMenu)).toBe(true);
+        expect(isKeyboardShortcut({ key: '?' } as KeyboardEvent, appKeyboardShortcuts.keyboardShortcuts)).toBe(true);
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/keyboard-shortcuts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/keyboard-shortcuts.ts
@@ -1,15 +1,33 @@
 const applePlatformPattern = /Mac|iPhone|iPad|iPod/i;
 
-type ShortcutKey = 'Alt' | 'Mod' | 'Shift' | string;
+export type KeyboardShortcut = {
+    key: string;
+    keys: readonly ShortcutKey[];
+};
 
-export function formatKeyboardShortcut(keys: ShortcutKey[]): string {
+export type ShortcutKey = 'Alt' | 'Mod' | 'Shift' | string;
+
+export const appKeyboardShortcuts = {
+    allEvents: { key: 'e', keys: ['E'] },
+    commandPalette: { key: '/', keys: ['/'] },
+    issues: { key: 'i', keys: ['I'] },
+    keyboardShortcuts: { key: '?', keys: ['?'] },
+    switchOrganization: { key: 'o', keys: ['O'] },
+    userMenu: { key: 'u', keys: ['U'] }
+} as const satisfies Record<string, KeyboardShortcut>;
+
+export function formatKeyboardShortcut(keys: readonly ShortcutKey[]): string {
     return formatKeyboardShortcutForPlatform(keys, isApplePlatform());
 }
 
-export function formatKeyboardShortcutForPlatform(keys: ShortcutKey[], isApplePlatformValue: boolean): string {
+export function formatKeyboardShortcutForPlatform(keys: readonly ShortcutKey[], isApplePlatformValue: boolean): string {
     const formattedKeys = keys.map((key) => formatShortcutKey(key, isApplePlatformValue));
 
     return formattedKeys.join('');
+}
+
+export function isKeyboardShortcut(event: KeyboardEvent, shortcut: KeyboardShortcut): boolean {
+    return event.key.toLowerCase() === shortcut.key;
 }
 
 function formatShortcutKey(key: ShortcutKey, isApplePlatformValue: boolean): string {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
@@ -2,6 +2,7 @@ import type { FetchClientResponse } from '@exceptionless/fetchclient';
 
 import {
     type ColumnDef,
+    type ColumnOrderState,
     type ColumnSort,
     type ColumnVisibilityState,
     createCoreRowModel,
@@ -25,6 +26,7 @@ export interface TableConfiguration<TData extends RowData, TPaginationStrategy e
     columnPersistenceKey: string;
     columns: ColumnDef<StockFeatures, TData, unknown>[];
     configureOptions?: (options: TableOptions<StockFeatures, TData>) => TableOptions<StockFeatures, TData>;
+    defaultColumnOrder?: ColumnOrderState;
     defaultColumnVisibility?: ColumnVisibilityState;
     paginationStrategy: TPaginationStrategy;
     queryData?: TData[];
@@ -70,10 +72,18 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
 
     // Use the persistKey if provided, otherwise default to events-column-visibility
     const visibilityKey = configuration.columnPersistenceKey ? `${configuration.columnPersistenceKey}-column-visibility` : 'events-column-visibility';
-    const [columnVisibility, setColumnVisibility] = createPersistedTableState(
+    const [persistedColumnVisibility, setColumnVisibility] = createPersistedTableState(
         visibilityKey,
         configuration.defaultColumnVisibility ?? <ColumnVisibilityState>{}
     );
+    const columnVisibility = () => ({ ...configuration.defaultColumnVisibility, ...persistedColumnVisibility() });
+
+    const orderKey = configuration.columnPersistenceKey ? `${configuration.columnPersistenceKey}-column-order` : 'events-column-order';
+    const [persistedColumnOrder, setPersistedColumnOrder] = createPersistedTableState(orderKey, configuration.defaultColumnOrder ?? <ColumnOrderState>[]);
+    const columnOrder = () => sanitizeColumnOrder(persistedColumnOrder(), columns());
+    const setColumnOrder = (updaterOrValue: Updater<ColumnOrderState>) => {
+        setPersistedColumnOrder(updaterOrValue instanceof Function ? updaterOrValue(resolveColumnOrder(columnOrder(), columns())) : updaterOrValue);
+    };
 
     // Initialize pagination state from parameters
     const initialPageIndex =
@@ -243,6 +253,7 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
         set meta(value) {
             setMetaImpl(value);
         },
+        onColumnOrderChange: setColumnOrder,
         onColumnVisibilityChange: setColumnVisibility,
         onPaginationChange,
         onRowSelectionChange: setRowSelection,
@@ -251,6 +262,9 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
             return pageCount();
         },
         state: {
+            get columnOrder() {
+                return columnOrder();
+            },
             get columnVisibility() {
                 return columnVisibility();
             },
@@ -342,6 +356,21 @@ function createTableState<T>(initialValue: T): [() => T, (updater: Updater<T>) =
     ];
 }
 
+function getColumnIds<TData extends RowData>(columns: ColumnDef<StockFeatures, TData, unknown>[]): string[] {
+    return columns.flatMap((column) => {
+        const columnDefinition = column as { accessorKey?: number | string; columns?: ColumnDef<StockFeatures, TData, unknown>[]; id?: string };
+        if (columnDefinition.columns) {
+            return getColumnIds(columnDefinition.columns);
+        }
+
+        if (columnDefinition.id) {
+            return [columnDefinition.id];
+        }
+
+        return typeof columnDefinition.accessorKey === 'string' ? [columnDefinition.accessorKey] : [];
+    });
+}
+
 function hasSortQueryParameter(parameters: TablePagingParameters): parameters is TableCursorPagingParameters | TableOffsetPagingParameters {
     return Object.prototype.hasOwnProperty.call(parameters, 'sort');
 }
@@ -360,6 +389,18 @@ function parseSortString(sort: string | undefined): ColumnSort[] {
             id: value.startsWith('-') ? value.slice(1) : value
         }))
         .filter((value) => value.id.length > 0);
+}
+
+function resolveColumnOrder<TData extends RowData>(columnOrder: ColumnOrderState, columns: ColumnDef<StockFeatures, TData, unknown>[]): ColumnOrderState {
+    const defaultColumnOrder = getColumnIds(columns);
+    const explicitColumnOrder = columnOrder.filter((columnId, index) => defaultColumnOrder.includes(columnId) && columnOrder.indexOf(columnId) === index);
+    const nextColumnOrder = [...explicitColumnOrder, ...defaultColumnOrder.filter((columnId) => !explicitColumnOrder.includes(columnId))];
+
+    return defaultColumnOrder.includes('select') ? ['select', ...nextColumnOrder.filter((columnId) => columnId !== 'select')] : nextColumnOrder;
+}
+
+function sanitizeColumnOrder<TData extends RowData>(columnOrder: ColumnOrderState, columns: ColumnDef<StockFeatures, TData, unknown>[]): ColumnOrderState {
+    return columnOrder.length === 0 ? columnOrder : resolveColumnOrder(columnOrder, columns);
 }
 
 function serializeSortState(sorting: ColumnSort[]): string | undefined {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/table/options.svelte.ts
@@ -61,7 +61,7 @@ export function getColumns(onTagClick?: (tag: string) => void): ColumnDef<StockF
         },
         {
             accessorKey: nameof<Stack>('status'),
-            cell: (prop) => renderComponent(StackStatusCell, { value: prop.getValue<string>() }),
+            cell: (prop) => renderComponent(StackStatusCell, { value: prop.getValue<Stack['status']>() }),
             header: 'Status',
             id: 'status',
             meta: {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/table/stack-status-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/table/stack-status-cell.svelte
@@ -1,29 +1,15 @@
 <script lang="ts">
-    import { Badge } from '$comp/ui/badge';
+    import type { StackStatus } from '$features/stacks/models';
+
+    import { stackStatuses } from '$features/stacks/options';
 
     interface Props {
-        value: string;
+        value: StackStatus;
     }
 
     let { value }: Props = $props();
 
-    const statusLabels: Record<string, string> = {
-        discarded: 'Discarded',
-        fixed: 'Fixed',
-        ignored: 'Ignored',
-        open: 'Open',
-        regressed: 'Regressed',
-        snoozed: 'Snoozed'
-    };
-
-    const statusVariants: Record<string, 'default' | 'destructive' | 'outline' | 'secondary'> = {
-        discarded: 'destructive',
-        fixed: 'secondary',
-        ignored: 'destructive',
-        open: 'default',
-        regressed: 'destructive',
-        snoozed: 'secondary'
-    };
+    const label = $derived(stackStatuses.find((option) => option.value === value)?.label ?? value);
 </script>
 
-<Badge variant={statusVariants[value] ?? 'outline'}>{statusLabels[value] ?? value}</Badge>
+<span>{label}</span>

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
@@ -140,8 +140,7 @@ export interface NewSavedView {
   view_type: string;
   filter_definitions?: null | string;
   columns?: null | Record<string, boolean>;
-  /** If true, this view will be the default for its view type. Defaults to false. */
-  is_default?: null | boolean;
+  column_order?: null | string[];
   /** If true, the view will only be visible to the current user. Defaults to false. */
   is_private?: null | boolean;
 }
@@ -368,12 +367,12 @@ export interface UpdateProject {
 /** A class the tracks changes (i.e. the Delta) for a particular TEntityType. */
 export interface UpdateSavedView {
   name?: null | string;
-  is_default?: null | boolean;
   filter?: null | string;
   time?: null | string;
   sort?: null | string;
   filter_definitions?: null | string;
   columns?: null | Record<string, boolean>;
+  column_order?: null | string[];
 }
 
 /** A class the tracks changes (i.e. the Delta) for a particular TEntityType. */
@@ -565,7 +564,7 @@ export interface ViewSavedView {
   filter?: null | string;
   filter_definitions?: null | string;
   columns?: null | Record<string, boolean>;
-  is_default: boolean;
+  column_order?: null | string[];
   name: string;
   time?: null | string;
   sort?: null | string;

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
@@ -197,11 +197,11 @@ export const NewSavedViewSchema = object({
   view_type: string().min(1, "View type is required"),
   filter_definitions: string()
     .min(1, "Filter definitions is required")
-    .max(10000, "Filter definitions must be at most 10000 characters")
+    .max(100000, "Filter definitions must be at most 100000 characters")
     .nullable()
     .optional(),
   columns: record(string(), boolean()).nullable().optional(),
-  is_default: boolean().nullable().optional(),
+  column_order: array(string()).nullable().optional(),
   is_private: boolean().nullable().optional(),
 });
 export type NewSavedViewFormData = Infer<typeof NewSavedViewSchema>;
@@ -415,7 +415,6 @@ export type UpdateProjectFormData = Infer<typeof UpdateProjectSchema>;
 
 export const UpdateSavedViewSchema = object({
   name: string().min(1, "Name is required").nullable().optional(),
-  is_default: boolean().nullable().optional(),
   filter: string().min(1, "Filter is required").nullable().optional(),
   time: string().min(1, "Time is required").nullable().optional(),
   sort: string().min(1, "Sort is required").nullable().optional(),
@@ -424,6 +423,7 @@ export const UpdateSavedViewSchema = object({
     .nullable()
     .optional(),
   columns: record(string(), boolean()).nullable().optional(),
+  column_order: array(string()).nullable().optional(),
 });
 export type UpdateSavedViewFormData = Infer<typeof UpdateSavedViewSchema>;
 
@@ -612,7 +612,7 @@ export const ViewSavedViewSchema = object({
     .nullable()
     .optional(),
   columns: record(string(), boolean()).nullable().optional(),
-  is_default: boolean(),
+  column_order: array(string()).nullable().optional(),
   name: string().min(1, "Name is required"),
   time: string().min(1, "Time is required").nullable().optional(),
   sort: string().min(1, "Sort is required").nullable().optional(),

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/keyboard-shortcuts-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/keyboard-shortcuts-dialog.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+    import { Muted } from '$comp/typography';
+    import * as Dialog from '$comp/ui/dialog';
+    import * as Kbd from '$comp/ui/kbd';
+    import { appKeyboardShortcuts, formatKeyboardShortcut, type ShortcutKey } from '$features/shared/keyboard-shortcuts';
+
+    type ShortcutRow = {
+        action: string;
+        shortcuts: readonly (readonly ShortcutKey[])[];
+    };
+
+    type ShortcutSection = {
+        rows: readonly ShortcutRow[];
+        title: string;
+    };
+
+    type Props = {
+        open: boolean;
+    };
+
+    let { open = $bindable() }: Props = $props();
+
+    const shortcutSections: ShortcutSection[] = [
+        {
+            rows: [
+                { action: 'Go to Issues', shortcuts: [appKeyboardShortcuts.issues.keys] },
+                { action: 'Go to All Events', shortcuts: [appKeyboardShortcuts.allEvents.keys] },
+                { action: 'Show Keyboard Shortcuts', shortcuts: [appKeyboardShortcuts.keyboardShortcuts.keys] }
+            ],
+            title: 'Navigation'
+        },
+        {
+            rows: [
+                { action: 'Open Organization Switcher', shortcuts: [appKeyboardShortcuts.switchOrganization.keys] },
+                { action: 'Open User Menu', shortcuts: [appKeyboardShortcuts.userMenu.keys] }
+            ],
+            title: 'Menus'
+        },
+        {
+            rows: [
+                { action: 'Open Command Palette', shortcuts: [appKeyboardShortcuts.commandPalette.keys] },
+                { action: 'Open Selected Command', shortcuts: [['Enter']] },
+                { action: 'Close Command Palette', shortcuts: [['Esc']] }
+            ],
+            title: 'Command Palette'
+        },
+        {
+            rows: [
+                { action: 'Open Selected Row', shortcuts: [['Enter']] },
+                { action: 'Toggle Selected Row', shortcuts: [['Space']] },
+                { action: 'Close Menus and Popovers', shortcuts: [['Esc']] }
+            ],
+            title: 'Lists and Tables'
+        }
+    ];
+
+    function shortcutLabel(keys: readonly ShortcutKey[]): string {
+        return formatKeyboardShortcut(keys);
+    }
+</script>
+
+<Dialog.Root bind:open>
+    <Dialog.Content
+        preventScroll={false}
+        overlayClass="bg-black/20 supports-backdrop-filter:backdrop-blur-none"
+        class="max-h-[min(42rem,calc(100vh-2rem))] gap-0 overflow-hidden p-0 sm:max-w-3xl"
+    >
+        <Dialog.Header class="border-b px-4 py-3 sm:px-5">
+            <Dialog.Title class="text-base">Keyboard Shortcuts</Dialog.Title>
+            <Dialog.Description>
+                <Muted class="text-xs">Quick actions available from the app shell.</Muted>
+            </Dialog.Description>
+        </Dialog.Header>
+
+        <div class="grid gap-4 overflow-y-auto p-4 md:grid-cols-2 md:p-5">
+            {#each shortcutSections as section (section.title)}
+                <section aria-labelledby={`shortcut-section-${section.title.toLowerCase().replaceAll(' ', '-')}`} class="overflow-hidden rounded-md border">
+                    <h2
+                        id={`shortcut-section-${section.title.toLowerCase().replaceAll(' ', '-')}`}
+                        class="bg-muted/60 border-b px-3 py-2 text-sm font-semibold"
+                    >
+                        {section.title}
+                    </h2>
+                    <div class="divide-y">
+                        {#each section.rows as row (row.action)}
+                            <div class="grid min-h-10 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2.5 text-sm">
+                                <span class="min-w-0 leading-5">{row.action}</span>
+                                <div class="flex items-center gap-1.5">
+                                    {#each row.shortcuts as shortcut, index (shortcut.join('+'))}
+                                        {#if index > 0}
+                                            <span class="text-muted-foreground text-xs">or</span>
+                                        {/if}
+                                        <Kbd.Group>
+                                            <Kbd.Root>{shortcutLabel(shortcut)}</Kbd.Root>
+                                        </Kbd.Group>
+                                    {/each}
+                                </div>
+                            </div>
+                        {/each}
+                    </div>
+                </section>
+            {/each}
+        </div>
+    </Dialog.Content>
+</Dialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar-organization-switcher.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar-organization-switcher.svelte
@@ -5,7 +5,6 @@
     import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';
     import DelayedRender from '$comp/delayed-render.svelte';
-    import { A } from '$comp/typography';
     import * as Avatar from '$comp/ui/avatar/index';
     import * as DropdownMenu from '$comp/ui/dropdown-menu/index';
     import * as Sidebar from '$comp/ui/sidebar/index';
@@ -20,20 +19,45 @@
     import Plus from '@lucide/svelte/icons/plus';
     import Settings from '@lucide/svelte/icons/settings';
     import UserRoundSearch from '@lucide/svelte/icons/user-round-search';
+    import { tick } from 'svelte';
 
     type Props = HTMLAttributes<HTMLUListElement> & {
         currentOrganizationId: string | undefined;
         impersonatedOrganization: undefined | ViewOrganization;
         isLoading: boolean;
+        open?: boolean;
         organizations: undefined | ViewOrganization[];
     };
 
-    let { class: className, currentOrganizationId = $bindable(), impersonatedOrganization, isLoading, organizations = [] }: Props = $props();
+    let {
+        class: className,
+        currentOrganizationId = $bindable(),
+        impersonatedOrganization,
+        isLoading,
+        open = $bindable(false),
+        organizations = []
+    }: Props = $props();
 
     const sidebar = useSidebar();
     const activeOrganization = $derived(impersonatedOrganization ?? organizations.find((organization) => organization.id === currentOrganizationId));
     const isImpersonating = $derived(!!impersonatedOrganization);
+    let menuContentElement = $state<HTMLElement | null>(null);
     let openImpersonateDialog = $state(false);
+
+    $effect(() => {
+        if (open) {
+            void focusActiveOrganizationItem();
+        }
+    });
+
+    async function focusActiveOrganizationItem(): Promise<void> {
+        await tick();
+        await new Promise<void>((resolve) => window.setTimeout(resolve));
+        (
+            menuContentElement?.querySelector<HTMLElement>('[data-current-organization="true"]') ??
+            menuContentElement?.querySelector<HTMLElement>('[data-slot="dropdown-menu-item"]')
+        )?.focus();
+    }
 
     function onOrganizationSelected(organization: ViewOrganization): void {
         if (sidebar.isMobile) {
@@ -56,12 +80,16 @@
         await goto(resolve('/(app)'));
         currentOrganizationId = organizations[0]?.id;
     }
+
+    async function navigateTo(href: string): Promise<void> {
+        await goto(href);
+    }
 </script>
 
 {#if organizations.length > 0 || isImpersonating}
     <Sidebar.Menu class={className}>
         <Sidebar.MenuItem>
-            <DropdownMenu.Root>
+            <DropdownMenu.Root bind:open>
                 <DropdownMenu.Trigger>
                     {#snippet child({ props })}
                         <Sidebar.MenuButton
@@ -96,6 +124,7 @@
                     {/snippet}
                 </DropdownMenu.Trigger>
                 <DropdownMenu.Content
+                    bind:ref={menuContentElement}
                     class="w-(--bits-dropdown-menu-anchor-width) min-w-64 rounded-lg"
                     align="start"
                     side={sidebar.isMobile ? 'bottom' : 'right'}
@@ -106,8 +135,8 @@
                         {#each organizations as organization (organization.name)}
                             <DropdownMenu.Item
                                 onSelect={() => onOrganizationSelected(organization)}
-                                data-active={organization.id === currentOrganizationId && !isImpersonating}
-                                class="data-[active=true]:bg-accent data-[active=true]:text-accent-foreground gap-2 p-2"
+                                data-current-organization={organization.id === currentOrganizationId && !isImpersonating ? 'true' : undefined}
+                                class="gap-2 p-2"
                             >
                                 <Avatar.Root class="size-6 rounded-lg border" title={organization.name}>
                                     <Avatar.Fallback class="rounded-lg">{getInitials(organization.name)}</Avatar.Fallback>
@@ -120,31 +149,25 @@
                             <div class="bg-background flex size-6 items-center justify-center rounded-md border">
                                 <UserRoundSearch class="size-4" aria-hidden="true" />
                             </div>
-                            No organizations available
+                            No Organizations Available
                         </DropdownMenu.Item>
                     {/if}
                     <DropdownMenu.Separator />
                     {#if activeOrganization?.id}
-                        <DropdownMenu.Item>
-                            <A
-                                variant="ghost"
-                                href={resolve('/(app)/organization/[organizationId]/manage', { organizationId: activeOrganization.id })}
-                                class="flex w-full items-center gap-2"
-                            >
-                                <div class="bg-background flex size-6 items-center justify-center rounded-md border">
-                                    <Settings class="size-4" aria-hidden="true" />
-                                </div>
-                                <span class="text-muted-foreground font-medium">Manage Organization</span>
-                            </A>
+                        <DropdownMenu.Item
+                            onSelect={() => void navigateTo(resolve('/(app)/organization/[organizationId]/manage', { organizationId: activeOrganization.id }))}
+                        >
+                            <div class="bg-background flex size-6 items-center justify-center rounded-md border">
+                                <Settings class="size-4" aria-hidden="true" />
+                            </div>
+                            <span class="text-muted-foreground font-medium">Manage Organization</span>
                         </DropdownMenu.Item>
                     {/if}
-                    <DropdownMenu.Item>
-                        <A variant="ghost" href={resolve('/(app)/organization/add')} class="flex w-full items-center gap-2">
-                            <div class="bg-background flex size-6 items-center justify-center rounded-md border">
-                                <Plus class="size-4" aria-hidden="true" />
-                            </div>
-                            <span class="text-muted-foreground font-medium">Add organization</span>
-                        </A>
+                    <DropdownMenu.Item onSelect={() => void navigateTo(resolve('/(app)/organization/add'))}>
+                        <div class="bg-background flex size-6 items-center justify-center rounded-md border">
+                            <Plus class="size-4" aria-hidden="true" />
+                        </div>
+                        <span class="text-muted-foreground font-medium">Add Organization</span>
                     </DropdownMenu.Item>
                     <GlobalUser>
                         <DropdownMenu.Separator />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar-user.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar-user.svelte
@@ -3,9 +3,9 @@
     import type { Gravatar } from '$features/users/gravatar.svelte';
     import type { ViewCurrentUser } from '$features/users/models';
 
+    import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';
     import GitHubIcon from '$comp/icons/GitHubIcon.svelte';
-    import { A } from '$comp/typography';
     import * as Avatar from '$comp/ui/avatar/index';
     import { Badge } from '$comp/ui/badge';
     import * as DropdownMenu from '$comp/ui/dropdown-menu/index';
@@ -30,12 +30,24 @@
         intercomUnreadCount: number;
         isChatEnabled: boolean;
         isLoading: boolean;
+        open?: boolean;
         openChat: () => void;
+        openKeyboardShortcuts: () => Promise<void> | void;
         organizations?: ViewOrganization[];
         user: undefined | ViewCurrentUser;
     }
 
-    let { gravatar, intercomUnreadCount = 0, isChatEnabled, isLoading, openChat, organizations = [], user }: Props = $props();
+    let {
+        gravatar,
+        intercomUnreadCount = 0,
+        isChatEnabled,
+        isLoading,
+        open = $bindable(false),
+        openChat,
+        openKeyboardShortcuts,
+        organizations = [],
+        user
+    }: Props = $props();
     const sidebar = useSidebar();
     const currentOrganizationId = $derived(organizations.find((organizationItem) => organizationItem.id === organization.current)?.id);
 
@@ -52,6 +64,21 @@
     function onChatClick() {
         onMenuClick();
         openChat();
+    }
+
+    function onKeyboardShortcutsClick() {
+        onMenuClick();
+        void openKeyboardShortcuts();
+    }
+
+    function navigateTo(href: string): void {
+        onMenuClick();
+        void goto(href);
+    }
+
+    function openExternalLink(href: string): void {
+        onMenuClick();
+        window.open(href, '_blank', 'noopener,noreferrer');
     }
 </script>
 
@@ -78,7 +105,7 @@
                 >
                     <Help class="size-4" aria-hidden="true" />
                     <div class="grid flex-1 gap-0.5 text-left">
-                        <span class="text-sm leading-none font-medium">Chat with support</span>
+                        <span class="text-sm leading-none font-medium">Chat with Support</span>
                     </div>
                     {#if intercomUnreadCount > 0}
                         <Sidebar.MenuBadge>{getUnreadCountLabel(intercomUnreadCount)}</Sidebar.MenuBadge>
@@ -89,7 +116,7 @@
     {/if}
     <Sidebar.Menu>
         <Sidebar.MenuItem>
-            <DropdownMenu.Root>
+            <DropdownMenu.Root bind:open>
                 <DropdownMenu.Trigger>
                     {#snippet child({ props })}
                         <Sidebar.MenuButton size="lg" class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground" {...props}>
@@ -134,43 +161,31 @@
                     <DropdownMenu.Separator />
 
                     <DropdownMenu.Group>
-                        <DropdownMenu.Item>
+                        <DropdownMenu.Item onSelect={() => navigateTo(resolve('/(app)/account/manage'))}>
                             <BadgeCheck />
-                            <A variant="ghost" href={resolve('/(app)/account/manage')} class="w-full" onclick={onMenuClick}>Account</A>
+                            <span class="w-full">Account</span>
                         </DropdownMenu.Item>
-                        <DropdownMenu.Item>
+                        <DropdownMenu.Item onSelect={() => navigateTo(resolve('/(app)/account/notifications'))}>
                             <Bell />
-                            <A variant="ghost" href={resolve('/(app)/account/notifications')} class="w-full" onclick={onMenuClick}>Notifications</A>
+                            <span class="w-full">Notifications</span>
                         </DropdownMenu.Item>
                         {#if currentOrganizationId}
-                            <DropdownMenu.Item>
+                            <DropdownMenu.Item
+                                onSelect={() => navigateTo(resolve('/(app)/organization/[organizationId]/manage', { organizationId: currentOrganizationId }))}
+                            >
                                 <Settings />
-                                <A
-                                    variant="ghost"
-                                    href={resolve('/(app)/organization/[organizationId]/manage', { organizationId: currentOrganizationId })}
-                                    class="flex w-full items-center gap-2"
-                                    onclick={onMenuClick}
-                                >
-                                    Manage Organization
-                                </A>
+                                <span class="w-full">Manage Organization</span>
                             </DropdownMenu.Item>
-                            <DropdownMenu.Item>
+                            <DropdownMenu.Item
+                                onSelect={() => navigateTo(resolve('/(app)/organization/[organizationId]/billing', { organizationId: currentOrganizationId }))}
+                            >
                                 <CreditCard />
-                                <A
-                                    variant="ghost"
-                                    href={resolve('/(app)/organization/[organizationId]/billing', { organizationId: currentOrganizationId })}
-                                    class="flex w-full items-center gap-2"
-                                    onclick={onMenuClick}
-                                >
-                                    Billing
-                                </A>
+                                <span class="w-full">Billing</span>
                             </DropdownMenu.Item>
                         {:else}
-                            <DropdownMenu.Item>
+                            <DropdownMenu.Item onSelect={() => navigateTo(resolve('/(app)/organization/add'))}>
                                 <Plus />
-                                <A variant="ghost" href={resolve('/(app)/organization/add')} class="flex w-full items-center gap-2" onclick={onMenuClick}>
-                                    Add organization
-                                </A>
+                                <span class="w-full">Add Organization</span>
                             </DropdownMenu.Item>
                         {/if}
                     </DropdownMenu.Group>
@@ -189,32 +204,32 @@
                                     {/if}
                                 </DropdownMenu.Item>
                             {/if}
-                            <DropdownMenu.Item>
+                            <DropdownMenu.Item onSelect={() => openExternalLink(documentationHref)}>
                                 <BookOpen />
-                                <A variant="ghost" href={documentationHref} target="_blank" class="w-full">Documentation</A>
+                                <span class="w-full">Documentation</span>
                             </DropdownMenu.Item>
-                            <DropdownMenu.Item>
+                            <DropdownMenu.Item onSelect={() => openExternalLink(supportIssuesHref)}>
                                 <Help />
-                                <A variant="ghost" href={supportIssuesHref} target="_blank" class="w-full">Support</A>
+                                <span class="w-full">Support</span>
                             </DropdownMenu.Item>
-                            <DropdownMenu.Item>
+                            <DropdownMenu.Item onSelect={() => openExternalLink(githubRepositoryHref)}>
                                 <GitHubIcon />
-                                <A variant="ghost" href={githubRepositoryHref} target="_blank" class="w-full">GitHub</A>
+                                <span class="w-full">GitHub</span>
                             </DropdownMenu.Item>
-                            <DropdownMenu.Item>
+                            <DropdownMenu.Item onSelect={() => openExternalLink(apiReferenceHref)}>
                                 <Braces />
-                                <A variant="ghost" href={apiReferenceHref} target="_blank" class="w-full">API Reference</A>
+                                <span class="w-full">API Reference</span>
                             </DropdownMenu.Item>
-                            <DropdownMenu.Item>
+                            <DropdownMenu.Item onSelect={onKeyboardShortcutsClick}>
                                 <BookOpen />
-                                Keyboard shortcuts
+                                <span class="w-full">Keyboard Shortcuts</span>
                             </DropdownMenu.Item>
                         </DropdownMenu.SubContent>
                     </DropdownMenu.Sub>
                     <DropdownMenu.Separator />
-                    <DropdownMenu.Item>
+                    <DropdownMenu.Item onSelect={() => navigateTo(resolve('/(auth)/logout'))}>
                         <LogOut />
-                        <A variant="ghost" href={resolve('/(auth)/logout')} class="w-full">Log out</A>
+                        <span class="w-full">Log Out</span>
                     </DropdownMenu.Item>
                 </DropdownMenu.Content>
             </DropdownMenu.Root>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar.svelte
@@ -15,12 +15,12 @@
 
     import type { NavigationItem } from '../../../routes.svelte';
 
-    function isSavedItemActive(savedItem: { href: string; isDefault?: boolean }, routeHref: string): boolean {
+    function isSavedItemActive(savedItem: { href: string }, routeHref: string): boolean {
         const savedId = new URL(savedItem.href, page.url.origin).searchParams.get('saved');
         const activeSavedParam = page.url.searchParams.get('saved');
         const isOnRoute = routeHref === page.url.pathname;
 
-        return isOnRoute && (savedItem.isDefault ? !activeSavedParam || activeSavedParam === savedId : activeSavedParam === savedId);
+        return isOnRoute && activeSavedParam === savedId;
     }
 
     function isPathActive(href: string): boolean {
@@ -31,15 +31,23 @@
         return group === 'Settings' || group.endsWith(' Settings');
     }
 
-    function isChildItemActive(childItem: { href: string; isDefault?: boolean }, routeHref: string): boolean {
+    function isChildItemActive(childItem: { href: string }, routeHref: string): boolean {
         const childUrl = new URL(childItem.href, page.url.origin);
         const hasSavedViewParam = childUrl.searchParams.has('saved');
 
-        if (hasSavedViewParam || childItem.isDefault !== undefined) {
+        if (hasSavedViewParam) {
             return isSavedItemActive(childItem, routeHref);
         }
 
         return isPathActive(childUrl.pathname);
+    }
+
+    function isSavedViewChild(childItem: { href: string }): boolean {
+        return new URL(childItem.href, page.url.origin).searchParams.has('saved');
+    }
+
+    function hasSavedViewChildren(route: NavigationItem): boolean {
+        return route.children?.some((childItem) => isSavedViewChild(childItem)) ?? false;
     }
 
     function isRouteActive(route: NavigationItem): boolean {
@@ -86,6 +94,8 @@
     const isIconCollapsed = $derived(sidebar.state === 'collapsed' && !sidebar.isMobile);
     let hoverMenuId = $state<string | undefined>(undefined);
     let hoverMenuCloseTimeout = $state<ReturnType<typeof setTimeout> | undefined>(undefined);
+    let expandedRouteHrefs = $state<Record<string, boolean>>({});
+    let settingsExpanded = $state<boolean | undefined>(undefined);
 
     function onMenuClick() {
         if (sidebar.isMobile) {
@@ -147,6 +157,51 @@
         onMenuClick();
     }
 
+    function isRouteGroupOpen(route: NavigationItem): boolean {
+        const routeHref = String(route.href);
+
+        return expandedRouteHrefs[routeHref] ?? isRouteActive(route);
+    }
+
+    function setRouteGroupOpen(route: NavigationItem, open: boolean): void {
+        const routeHref = String(route.href);
+        expandedRouteHrefs = {
+            ...expandedRouteHrefs,
+            [routeHref]: open
+        };
+    }
+
+    function isSettingsOpen(): boolean {
+        return settingsExpanded ?? settingsIsActive;
+    }
+
+    $effect(() => {
+        let nextExpandedRouteHrefs = expandedRouteHrefs;
+        let hasExpandedRouteChanges = false;
+
+        for (const route of dashboardRoutes) {
+            const routeHref = String(route.href);
+            if (!route.children?.length || !isRouteActive(route) || nextExpandedRouteHrefs[routeHref] !== undefined) {
+                continue;
+            }
+
+            if (!hasExpandedRouteChanges) {
+                nextExpandedRouteHrefs = { ...nextExpandedRouteHrefs };
+                hasExpandedRouteChanges = true;
+            }
+
+            nextExpandedRouteHrefs[routeHref] = true;
+        }
+
+        if (hasExpandedRouteChanges) {
+            expandedRouteHrefs = nextExpandedRouteHrefs;
+        }
+
+        if (settingsIsActive && settingsExpanded === undefined) {
+            settingsExpanded = true;
+        }
+    });
+
     onDestroy(() => {
         if (hoverMenuCloseTimeout) {
             clearTimeout(hoverMenuCloseTimeout);
@@ -167,6 +222,7 @@
                     {@const Icon = route.icon}
                     {#if isIconCollapsed}
                         {#if route.children?.length}
+                            {@const hasSavedViews = hasSavedViewChildren(route)}
                             {@const menuId = `route:${route.href}`}
                             <DropdownMenu.Root open={isHoverMenuOpen(menuId)} onOpenChange={(open) => onHoverMenuOpenChange(menuId, open)}>
                                 <DropdownMenu.Trigger>
@@ -186,12 +242,14 @@
                                     onmouseenter={() => openHoverMenu(menuId)}
                                     onmouseleave={() => closeHoverMenu(menuId)}
                                 >
-                                    <DropdownMenu.Item>
-                                        <A variant="ghost" href={route.href} class="w-full" onclick={onFlyoutLinkClick}>
-                                            {route.title}
-                                        </A>
-                                    </DropdownMenu.Item>
-                                    <DropdownMenu.Separator />
+                                    {#if !hasSavedViews}
+                                        <DropdownMenu.Item>
+                                            <A variant="ghost" href={route.href} class="w-full" onclick={onFlyoutLinkClick}>
+                                                {route.title}
+                                            </A>
+                                        </DropdownMenu.Item>
+                                        <DropdownMenu.Separator />
+                                    {/if}
                                     {#each route.children as savedItem (savedItem.href)}
                                         <DropdownMenu.Item>
                                             <A variant="ghost" href={savedItem.href} class="w-full" onclick={onFlyoutLinkClick}>
@@ -214,27 +272,38 @@
                             </Sidebar.MenuItem>
                         {/if}
                     {:else if route.children?.length}
-                        <Collapsible.Root open={isRouteActive(route)} class="group/collapsible">
+                        {@const hasSavedViews = hasSavedViewChildren(route)}
+                        <Collapsible.Root open={isRouteGroupOpen(route)} onOpenChange={(open) => setRouteGroupOpen(route, open)} class="group/collapsible">
                             {#snippet child({ props: collapsibleProps })}
                                 <Sidebar.MenuItem {...collapsibleProps}>
                                     <Collapsible.Trigger>
                                         {#snippet child({ props: triggerProps })}
                                             <Sidebar.MenuButton {...triggerProps}>
                                                 {#snippet child({ props: buttonProps })}
-                                                    <A
-                                                        variant="ghost"
-                                                        href={route.href}
-                                                        title={route.title}
-                                                        onclick={onMenuClick}
-                                                        class="flex min-w-0 flex-1 items-center gap-2"
-                                                        {...buttonProps}
-                                                    >
-                                                        <Icon />
-                                                        <span>{route.title}</span>
-                                                        <ChevronRight
-                                                            class="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
-                                                        />
-                                                    </A>
+                                                    {#if hasSavedViews}
+                                                        <button type="button" title={route.title} {...buttonProps}>
+                                                            <Icon />
+                                                            <span>{route.title}</span>
+                                                            <ChevronRight
+                                                                class="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
+                                                            />
+                                                        </button>
+                                                    {:else}
+                                                        <A
+                                                            variant="ghost"
+                                                            href={route.href}
+                                                            title={route.title}
+                                                            onclick={onMenuClick}
+                                                            class="flex min-w-0 flex-1 items-center gap-2"
+                                                            {...buttonProps}
+                                                        >
+                                                            <Icon />
+                                                            <span>{route.title}</span>
+                                                            <ChevronRight
+                                                                class="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
+                                                            />
+                                                        </A>
+                                                    {/if}
                                                 {/snippet}
                                             </Sidebar.MenuButton>
                                         {/snippet}
@@ -306,7 +375,7 @@
                         </DropdownMenu.Content>
                     </DropdownMenu.Root>
                 {:else}
-                    <Collapsible.Root open={settingsIsActive} class="group/collapsible">
+                    <Collapsible.Root open={isSettingsOpen()} onOpenChange={(open) => (settingsExpanded = open)} class="group/collapsible">
                         {#snippet child({ props })}
                             <Sidebar.MenuItem {...props}>
                                 <Collapsible.Trigger>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
     import * as Command from '$comp/ui/command';
+    import { appKeyboardShortcuts, formatKeyboardShortcut, type ShortcutKey } from '$features/shared/keyboard-shortcuts';
+    import Building2 from '@lucide/svelte/icons/building-2';
+    import CircleUserRound from '@lucide/svelte/icons/circle-user-round';
+    import Keyboard from '@lucide/svelte/icons/keyboard';
 
     import type { NavigationItem } from '../../routes.svelte';
 
@@ -9,11 +13,21 @@
         icon: NavigationItem['icon'];
         openInNewTab?: boolean;
         parentTitle?: string;
+        shortcut?: readonly ShortcutKey[];
         title: string;
         value: string;
     };
 
-    let { open = $bindable(), resetKey, routes }: { open: boolean; resetKey: number; routes: NavigationItem[] } = $props();
+    type Props = {
+        open: boolean;
+        openKeyboardShortcuts: () => Promise<void> | void;
+        openOrganizationSwitcher: () => Promise<void> | void;
+        openUserMenu: () => Promise<void> | void;
+        resetKey: number;
+        routes: NavigationItem[];
+    };
+
+    let { open = $bindable(), openKeyboardShortcuts, openOrganizationSwitcher, openUserMenu, resetKey, routes }: Props = $props();
 
     function getCommandGroup(route: NavigationItem): string {
         return route.group === 'Dashboards' ? route.title : route.group;
@@ -21,6 +35,10 @@
 
     function getCommandTitle(route: NavigationItem): string {
         return route.group === 'Dashboards' ? `All ${route.title}` : route.title;
+    }
+
+    function getCommandValue(...parts: Array<string | undefined>): string {
+        return parts.filter(Boolean).join(' ');
     }
 
     const commandRoutes = $derived(
@@ -33,8 +51,9 @@
                     href: route.href,
                     icon: route.icon,
                     openInNewTab: route.openInNewTab,
+                    shortcut: route.shortcut,
                     title,
-                    value: `${route.title} ${title} ${route.href}`
+                    value: getCommandValue(group, route.title, title)
                 }
             ];
 
@@ -46,7 +65,7 @@
                         icon: route.icon,
                         parentTitle: route.group === 'Dashboards' ? undefined : route.title,
                         title: child.title,
-                        value: `${route.title} ${child.title} ${child.href}`
+                        value: getCommandValue(group, route.title, child.title)
                     }))
                 );
             }
@@ -70,6 +89,21 @@
 
     function closeCommandWindow() {
         open = false;
+    }
+
+    async function switchOrganization(): Promise<void> {
+        closeCommandWindow();
+        await openOrganizationSwitcher();
+    }
+
+    async function openCurrentUserMenu(): Promise<void> {
+        closeCommandWindow();
+        await openUserMenu();
+    }
+
+    async function openKeyboardShortcutsDialog(): Promise<void> {
+        closeCommandWindow();
+        await openKeyboardShortcuts();
     }
 </script>
 
@@ -98,9 +132,35 @@
                                     <span class="text-muted-foreground text-xs">{route.parentTitle}</span>
                                 {/if}
                             </div>
+                            {#if route.shortcut}
+                                <Command.Shortcut>{formatKeyboardShortcut(route.shortcut)}</Command.Shortcut>
+                            {/if}
                         </Command.LinkItem>
                     {/each}
                 </Command.Group>
+                {#if group === 'Sessions'}
+                    <Command.Separator />
+                    <Command.Group heading="Organizations">
+                        <Command.Item value="Switch Organization organizations org" onSelect={() => void switchOrganization()}>
+                            <Building2 />
+                            <span>Switch Organization</span>
+                            <Command.Shortcut>{formatKeyboardShortcut(appKeyboardShortcuts.switchOrganization.keys)}</Command.Shortcut>
+                        </Command.Item>
+                    </Command.Group>
+                    <Command.Separator />
+                    <Command.Group heading="User">
+                        <Command.Item value="Open User Menu account profile current user" onSelect={() => void openCurrentUserMenu()}>
+                            <CircleUserRound />
+                            <span>Open User Menu</span>
+                            <Command.Shortcut>{formatKeyboardShortcut(appKeyboardShortcuts.userMenu.keys)}</Command.Shortcut>
+                        </Command.Item>
+                        <Command.Item value="Keyboard Shortcuts help shortcuts" onSelect={() => void openKeyboardShortcutsDialog()}>
+                            <Keyboard />
+                            <span>Keyboard Shortcuts</span>
+                            <Command.Shortcut>{formatKeyboardShortcut(appKeyboardShortcuts.keyboardShortcuts.keys)}</Command.Shortcut>
+                        </Command.Item>
+                    </Command.Group>
+                {/if}
                 {#if index !== Object.keys(groupedRoutes).length - 1}
                     <Command.Separator />
                 {/if}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
@@ -21,6 +21,7 @@
     import { premiumPage } from '$features/organizations/premium-page.svelte';
     import { invalidateProjectQueries } from '$features/projects/api.svelte';
     import { getSavedViewsQuery, invalidateSavedViewQueries } from '$features/saved-views/api.svelte';
+    import { appKeyboardShortcuts, isKeyboardShortcut } from '$features/shared/keyboard-shortcuts';
     import { invalidateStackQueries } from '$features/stacks/api.svelte';
     import { invalidateTokenQueries } from '$features/tokens/api.svelte';
     import { getMeQuery, invalidateUserQueries } from '$features/users/api.svelte';
@@ -30,9 +31,11 @@
     import { WebSocketClient } from '$features/websockets/web-socket-client.svelte';
     import { useMiddleware } from '@exceptionless/fetchclient';
     import { useQueryClient } from '@tanstack/svelte-query';
+    import { tick } from 'svelte';
     import { fade } from 'svelte/transition';
 
     import { type NavigationItemContext, routes } from '../routes.svelte';
+    import KeyboardShortcutsDialog from './(components)/keyboard-shortcuts-dialog.svelte';
     import Footer from './(components)/layouts/footer.svelte';
     import Navbar from './(components)/layouts/navbar.svelte';
     import SidebarOrganizationSwitcher from './(components)/layouts/sidebar-organization-switcher.svelte';
@@ -50,6 +53,9 @@
     const sidebar = useSidebar();
     let isCommandOpen = $state(false);
     let commandResetKey = $state(0);
+    let isKeyboardShortcutsOpen = $state(false);
+    let isOrganizationSwitcherOpen = $state(false);
+    let isUserMenuOpen = $state(false);
 
     // Auto-reset premium page state on navigation so pages don't need cleanup
     beforeNavigate(() => {
@@ -59,6 +65,30 @@
     function openCommandPalette(): void {
         commandResetKey += 1;
         isCommandOpen = true;
+    }
+
+    async function openOrganizationSwitcher(): Promise<void> {
+        isCommandOpen = false;
+        isKeyboardShortcutsOpen = false;
+        isUserMenuOpen = false;
+        await tick();
+        isOrganizationSwitcherOpen = true;
+    }
+
+    async function openUserMenu(): Promise<void> {
+        isCommandOpen = false;
+        isKeyboardShortcutsOpen = false;
+        isOrganizationSwitcherOpen = false;
+        await tick();
+        isUserMenuOpen = true;
+    }
+
+    async function openKeyboardShortcuts(): Promise<void> {
+        isCommandOpen = false;
+        isOrganizationSwitcherOpen = false;
+        isUserMenuOpen = false;
+        await tick();
+        isKeyboardShortcutsOpen = true;
     }
 
     useMiddleware(async (ctx, next) => {
@@ -154,18 +184,58 @@
         }
     });
 
-    // WebSocket + keyboard shortcut — only depends on token, not navigation
+    // WebSocket + keyboard shortcuts — only depends on token, not navigation
     $effect(() => {
         const currentToken = accessToken.current;
 
         function handleKeydown(e: KeyboardEvent) {
-            if (e.defaultPrevented || e.ctrlKey || e.metaKey || e.altKey || isEditableElement(e.target)) {
+            if (
+                e.defaultPrevented ||
+                e.ctrlKey ||
+                e.metaKey ||
+                e.altKey ||
+                isCommandOpen ||
+                isKeyboardShortcutsOpen ||
+                isOrganizationSwitcherOpen ||
+                isUserMenuOpen ||
+                isEditableElement(e.target)
+            ) {
                 return;
             }
 
-            if (e.key === '/') {
+            if (isKeyboardShortcut(e, appKeyboardShortcuts.commandPalette)) {
                 e.preventDefault();
                 openCommandPalette();
+                return;
+            }
+
+            if (isKeyboardShortcut(e, appKeyboardShortcuts.switchOrganization)) {
+                e.preventDefault();
+                void openOrganizationSwitcher();
+                return;
+            }
+
+            if (isKeyboardShortcut(e, appKeyboardShortcuts.userMenu)) {
+                e.preventDefault();
+                void openUserMenu();
+                return;
+            }
+
+            if (isKeyboardShortcut(e, appKeyboardShortcuts.allEvents)) {
+                e.preventDefault();
+                void goto(resolve('/(app)'));
+                return;
+            }
+
+            if (isKeyboardShortcut(e, appKeyboardShortcuts.issues)) {
+                e.preventDefault();
+                void goto(resolve('/(app)/issues'));
+                return;
+            }
+
+            if (isKeyboardShortcut(e, appKeyboardShortcuts.keyboardShortcuts)) {
+                e.preventDefault();
+                void openKeyboardShortcuts();
             }
         }
 
@@ -173,7 +243,7 @@
             return;
         }
 
-        document.addEventListener('keydown', handleKeydown);
+        document.addEventListener('keydown', handleKeydown, { capture: true });
 
         const ws = new WebSocketClient();
         ws.onMessage = onMessage;
@@ -190,7 +260,7 @@
         };
 
         return () => {
-            document.removeEventListener('keydown', handleKeydown);
+            document.removeEventListener('keydown', handleKeydown, { capture: true });
             ws?.close();
         };
     });
@@ -353,31 +423,11 @@
                 return route;
             }
 
-            const defaultView = viewSavedViews.find((savedView: SavedView) => savedView.is_default);
-            const nonDefaultViews = viewSavedViews.filter((savedView: SavedView) => !savedView.is_default);
-
-            // Only show submenu if there are non-default views
-            if (nonDefaultViews.length === 0) {
-                return { ...route, children: route.children, defaultViewId: defaultView?.id, view: viewKey };
-            }
-
-            // Show all views sorted: default first, then alphabetically by name
-            const sortedViews = [...viewSavedViews].sort((a, b) => {
-                if (a.is_default && !b.is_default) {
-                    return -1;
-                }
-
-                if (!a.is_default && b.is_default) {
-                    return 1;
-                }
-
-                return a.name.localeCompare(b.name);
-            });
+            const sortedViews = [...viewSavedViews].sort((a, b) => a.name.localeCompare(b.name));
 
             const children = [
                 ...sortedViews.map((savedView) => ({
                     href: buildSavedViewHref(route.href, savedView),
-                    isDefault: savedView.is_default,
                     title: savedView.name
                 })),
                 ...(route.children ?? [])
@@ -386,7 +436,6 @@
             return {
                 ...route,
                 children,
-                defaultViewId: defaultView?.id,
                 view: viewKey
             };
         });
@@ -412,18 +461,37 @@
                 isLoading={organizationsQuery.isLoading}
                 {organizations}
                 {impersonatedOrganization}
+                bind:open={isOrganizationSwitcherOpen}
                 bind:currentOrganizationId={organization.current}
             />
         {/snippet}
 
         {#snippet footer()}
-            <SidebarUser {isChatEnabled} isLoading={meQuery.isLoading} user={meQuery.data} {gravatar} {organizations} {openChat} {intercomUnreadCount} />
+            <SidebarUser
+                {isChatEnabled}
+                isLoading={meQuery.isLoading}
+                user={meQuery.data}
+                {gravatar}
+                {organizations}
+                {openChat}
+                {openKeyboardShortcuts}
+                {intercomUnreadCount}
+                bind:open={isUserMenuOpen}
+            />
         {/snippet}
     </Sidebar>
     <div class="flex min-h-screen min-w-0 flex-1 pt-16">
         <div class="text-secondary-foreground flex min-h-full min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto">
             <main class="flex-1 px-4 pt-4">
-                <NavigationCommand bind:open={isCommandOpen} resetKey={commandResetKey} routes={filteredRoutes} />
+                <NavigationCommand
+                    bind:open={isCommandOpen}
+                    {openKeyboardShortcuts}
+                    {openOrganizationSwitcher}
+                    {openUserMenu}
+                    resetKey={commandResetKey}
+                    routes={filteredRoutes}
+                />
+                <KeyboardShortcutsDialog bind:open={isKeyboardShortcutsOpen} />
 
                 {#if showOrganizationNotifications.current}
                     <OrganizationNotifications {isChatEnabled} {openChat} {requiresPremium} premiumFeatureName={premiumPage.current} class="mb-4" />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+page.svelte
@@ -27,7 +27,7 @@
     import OrganizationDefaultsFacetedFilterBuilder from '$features/events/components/filters/organization-defaults-faceted-filter-builder.svelte';
     import EventsBulkActionsDropdownMenu from '$features/events/components/table/events-bulk-actions-dropdown-menu.svelte';
     import EventsDataTable from '$features/events/components/table/events-data-table.svelte';
-    import { getColumns } from '$features/events/components/table/options.svelte';
+    import { defaultEventColumnVisibility, getColumns } from '$features/events/components/table/options.svelte';
     import { organization } from '$features/organizations/context.svelte';
     import SavedViewPicker from '$features/saved-views/components/saved-view-picker.svelte';
     import { useSavedViews } from '$features/saved-views/use-saved-views.svelte';
@@ -93,10 +93,13 @@
 
     const VIEW = 'events';
     const savedViewsState = useSavedViews({
+        defaultColumnVisibility: defaultEventColumnVisibility,
         filterCacheKey,
+        getColumnOrder: () => table.store.state.columnOrder,
         getColumnVisibility: () => table.store.state.columnVisibility,
         getFilterDefinitions: () => serializeFilters(filters ?? []),
         queryParams,
+        setColumnOrder: (v) => table.setColumnOrder(v),
         setColumnVisibility: (v) => table.setColumnVisibility(v),
         updateFilterCache,
         view: VIEW
@@ -185,6 +188,7 @@
             get columns() {
                 return getColumns<EventSummaryModel<SummaryTemplateKeys>>(eventsQueryParameters.mode);
             },
+            defaultColumnVisibility: defaultEventColumnVisibility,
             paginationStrategy: 'cursor',
             get queryData() {
                 return clientResponse?.data ?? [];
@@ -261,7 +265,11 @@
                 return eventsQueryParameters.time;
             }
         },
-        route: { organizationId: organization.current }
+        route: {
+            get organizationId() {
+                return organization.current;
+            }
+        }
     });
 
     const chartData = $derived(() => {
@@ -306,6 +314,7 @@
             {#if savedViewsState.isEnabled}
                 <SavedViewPicker
                     activeSavedView={savedViewsState.activeSavedView}
+                    columnOrder={table.store.state.columnOrder}
                     columnVisibility={table.store.state.columnVisibility}
                     filters={filters ?? []}
                     isModified={savedViewsState.isModified}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/issues/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/issues/+page.svelte
@@ -108,9 +108,11 @@
     const VIEW = 'issues';
     const savedViewsState = useSavedViews({
         filterCacheKey,
+        getColumnOrder: () => table.store.state.columnOrder,
         getColumnVisibility: () => table.store.state.columnVisibility,
         getFilterDefinitions: () => serializeFilters(filters ?? []),
         queryParams,
+        setColumnOrder: (v) => table.setColumnOrder(v),
         setColumnVisibility: (v) => table.setColumnVisibility(v),
         updateFilterCache,
         view: VIEW
@@ -273,7 +275,11 @@
                 return eventsQueryParameters.time;
             }
         },
-        route: { organizationId: organization.current }
+        route: {
+            get organizationId() {
+                return organization.current;
+            }
+        }
     });
 
     const chartData = $derived(() => {
@@ -321,6 +327,7 @@
             {#if savedViewsState.isEnabled}
                 <SavedViewPicker
                     activeSavedView={savedViewsState.activeSavedView}
+                    columnOrder={table.store.state.columnOrder}
                     columnVisibility={table.store.state.columnVisibility}
                     filters={filters ?? []}
                     isModified={savedViewsState.isModified}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/integrations/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/integrations/+page.svelte
@@ -215,9 +215,8 @@
             {#snippet toolbarChildren()}
                 <div class="flex-1"></div>
                 <DataTableViewOptions size="icon-lg" {table} />
-                <Button size="icon-lg" onclick={() => (showAddWebhookDialog = true)} title="Add Webhook">
-                    <Plus class="size-4" aria-hidden="true" />
-                    <span class="sr-only">Add Webhook</span>
+                <Button size="icon-lg" onclick={() => (showAddWebhookDialog = true)} title="Add Webhook" aria-label="Add Webhook">
+                    <Plus aria-hidden="true" />
                 </Button>
             {/snippet}
         </WebhooksDataTable>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/routes.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/routes.svelte.ts
@@ -1,6 +1,7 @@
 import { resolve } from '$app/paths';
 import GitHubIcon from '$comp/icons/GitHubIcon.svelte';
 import { apiReferenceHref, documentationHref, githubRepositoryHref, supportIssuesHref } from '$features/shared/help-links';
+import { appKeyboardShortcuts } from '$features/shared/keyboard-shortcuts';
 import Documentation from '@lucide/svelte/icons/book-open';
 import ApiDocumentations from '@lucide/svelte/icons/braces';
 import Issues from '@lucide/svelte/icons/bug';
@@ -20,15 +21,17 @@ export function routes(): NavigationItem[] {
     const items = [
         {
             group: 'Dashboards',
-            href: resolve('/(app)'),
-            icon: Events,
-            title: 'Events'
+            href: resolve('/(app)/issues'),
+            icon: Issues,
+            shortcut: appKeyboardShortcuts.issues.keys,
+            title: 'Issues'
         },
         {
             group: 'Dashboards',
-            href: resolve('/(app)/issues'),
-            icon: Issues,
-            title: 'Issues'
+            href: resolve('/(app)'),
+            icon: Events,
+            shortcut: appKeyboardShortcuts.allEvents.keys,
+            title: 'Events'
         },
         {
             group: 'Dashboards',

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -25,7 +25,7 @@
         updateFilterCache
     } from '$features/events/components/filters/helpers.svelte';
     import OrganizationDefaultsFacetedFilterBuilder from '$features/events/components/filters/organization-defaults-faceted-filter-builder.svelte';
-    import { getColumns } from '$features/events/components/table/options.svelte';
+    import { defaultEventColumnVisibility, getColumns } from '$features/events/components/table/options.svelte';
     import { organization } from '$features/organizations/context.svelte';
     import SavedViewPicker from '$features/saved-views/components/saved-view-picker.svelte';
     import { useSavedViews } from '$features/saved-views/use-saved-views.svelte';
@@ -80,10 +80,13 @@
 
     const VIEW = 'stream';
     const savedViewsState = useSavedViews({
+        defaultColumnVisibility: defaultEventColumnVisibility,
         filterCacheKey,
+        getColumnOrder: () => table.store.state.columnOrder,
         getColumnVisibility: () => table.store.state.columnVisibility,
         getFilterDefinitions: () => serializeFilters(filters ?? []),
         queryParams,
+        setColumnOrder: (v) => table.setColumnOrder(v),
         setColumnVisibility: (v) => table.setColumnVisibility(v),
         updateFilterCache,
         view: VIEW
@@ -171,6 +174,7 @@
                 options.manualSorting = false;
                 return options;
             },
+            defaultColumnVisibility: defaultEventColumnVisibility,
             paginationStrategy: 'cursor',
             get queryData() {
                 return queryData;
@@ -280,6 +284,7 @@
             {#if savedViewsState.isEnabled}
                 <SavedViewPicker
                     activeSavedView={savedViewsState.activeSavedView}
+                    columnOrder={table.store.state.columnOrder}
                     columnVisibility={table.store.state.columnVisibility}
                     filters={filters ?? []}
                     isModified={savedViewsState.isModified}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(auth)/login/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(auth)/login/+page.svelte
@@ -55,129 +55,148 @@
             }
         }
     }));
+
+    function prefillDevCredentials(): void {
+        form.setFieldValue('email', 'admin@exceptionless.test');
+        form.setFieldValue('password', 'tester');
+    }
 </script>
 
-<Card.Root class="mx-auto w-sm">
-    <Card.Header>
-        <Logo />
-    </Card.Header>
-    <Card.Content>
-        <form
-            onsubmit={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                form.handleSubmit();
-            }}
-        >
-            <form.Subscribe selector={(state) => state.errors}>
-                {#snippet children(errors)}
-                    <ErrorMessage message={getFormErrorMessages(errors)}></ErrorMessage>
-                {/snippet}
-            </form.Subscribe>
-            {#if dev}
-                <Muted class="mb-2 block text-center text-xs">Default credentials: <strong>admin@exceptionless.test</strong> / <strong>tester</strong></Muted>
+<div class="mx-auto flex w-[calc(100vw-2rem)] max-w-lg flex-col items-center">
+    <Card.Root class="w-full">
+        <Card.Header>
+            <Logo />
+        </Card.Header>
+        <Card.Content>
+            <form
+                onsubmit={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    form.handleSubmit();
+                }}
+            >
+                <form.Subscribe selector={(state) => state.errors}>
+                    {#snippet children(errors)}
+                        <ErrorMessage message={getFormErrorMessages(errors)}></ErrorMessage>
+                    {/snippet}
+                </form.Subscribe>
+                {#if dev}
+                    <div class="mb-2 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 text-center text-xs">
+                        <Muted class="block">
+                            Default credentials: <strong>admin@exceptionless.test</strong> / <strong>tester</strong>
+                        </Muted>
+                        <Button type="button" variant="link" size="xs" class="h-auto px-0 py-0 text-xs" onclick={prefillDevCredentials}>Use</Button>
+                    </div>
+                {/if}
+                <form.Field name="email">
+                    {#snippet children(field)}
+                        <Field.Field data-invalid={ariaInvalid(field)}>
+                            <Field.Label for={field.name}>Email</Field.Label>
+                            <Input
+                                id={field.name}
+                                name={field.name}
+                                type={dev ? 'text' : 'email'}
+                                placeholder="Enter email address"
+                                autocomplete="email"
+                                required
+                                tabindex={1}
+                                value={field.state.value}
+                                onblur={field.handleBlur}
+                                oninput={(e) => field.handleChange(e.currentTarget.value)}
+                                aria-invalid={ariaInvalid(field)}
+                            />
+                            <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
+                        </Field.Field>
+                    {/snippet}
+                </form.Field>
+                <form.Field name="password">
+                    {#snippet children(field)}
+                        <Field.Field data-invalid={ariaInvalid(field)}>
+                            <Field.Label for={field.name}
+                                >Password <Muted class="float-right"><A href={resolve('/(auth)/forgot-password')} tabindex={6}>Forgot password?</A></Muted
+                                ></Field.Label
+                            >
+                            <Input
+                                id={field.name}
+                                name={field.name}
+                                type="password"
+                                placeholder="Enter password"
+                                autocomplete="current-password"
+                                maxlength={100}
+                                minlength={6}
+                                required
+                                tabindex={2}
+                                value={field.state.value}
+                                onblur={field.handleBlur}
+                                oninput={(e) => field.handleChange(e.currentTarget.value)}
+                                aria-invalid={ariaInvalid(field)}
+                            />
+                            <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
+                        </Field.Field>
+                    {/snippet}
+                </form.Field>
+                <form.Subscribe selector={(state) => state.isSubmitting}>
+                    {#snippet children(isSubmitting)}
+                        <div class={enableAccountCreation ? 'mt-4 grid grid-cols-2 gap-3' : 'mt-4'}>
+                            <Button type="submit" class="w-full" tabindex={3} disabled={isSubmitting}>
+                                {#if isSubmitting}
+                                    <Spinner /> Logging in...
+                                {:else}
+                                    Login
+                                {/if}
+                            </Button>
+                            {#if enableAccountCreation}
+                                <Button variant="secondary" href={resolve('/(auth)/signup')} class="w-full" tabindex={4}>Signup</Button>
+                            {/if}
+                        </div>
+                    {/snippet}
+                </form.Subscribe>
+            </form>
+
+            {#if enableOAuthLogin}
+                <div class="my-4 flex w-full items-center">
+                    <hr class="w-full" />
+                    <P class="px-3">OR</P>
+                    <hr class="w-full" />
+                </div>
+                <div class="auto-cols-2 grid grid-flow-col grid-rows-2 gap-4">
+                    {#if microsoftClientId}
+                        <Button aria-label="Login with Microsoft" tabindex={4} onclick={() => liveLogin(redirectUrl)}>
+                            <MicrosoftIcon class="size-4" /> Microsoft
+                        </Button>
+                    {/if}
+                    {#if googleClientId}
+                        <Button aria-label="Login with Google" tabindex={4} onclick={() => googleLogin(redirectUrl)}>
+                            <GoogleIcon class="size-4" /> Google
+                        </Button>
+                    {/if}
+                    {#if facebookClientId}
+                        <Button aria-label="Login with Facebook" tabindex={4} onclick={() => facebookLogin(redirectUrl)}>
+                            <FacebookIcon class="size-4" /> Facebook
+                        </Button>
+                    {/if}
+                    {#if gitHubClientId}
+                        <Button aria-label="Login with GitHub" tabindex={4} onclick={() => githubLogin(redirectUrl)}>
+                            <GitHubIcon class="size-4" /> GitHub
+                        </Button>
+                    {/if}
+                </div>
             {/if}
-            <form.Field name="email">
-                {#snippet children(field)}
-                    <Field.Field data-invalid={ariaInvalid(field)}>
-                        <Field.Label for={field.name}>Email</Field.Label>
-                        <Input
-                            id={field.name}
-                            name={field.name}
-                            type={dev ? 'text' : 'email'}
-                            placeholder="Enter email address"
-                            autocomplete="email"
-                            required
-                            tabindex={1}
-                            value={field.state.value}
-                            onblur={field.handleBlur}
-                            oninput={(e) => field.handleChange(e.currentTarget.value)}
-                            aria-invalid={ariaInvalid(field)}
-                        />
-                        <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
-                    </Field.Field>
-                {/snippet}
-            </form.Field>
-            <form.Field name="password">
-                {#snippet children(field)}
-                    <Field.Field data-invalid={ariaInvalid(field)}>
-                        <Field.Label for={field.name}
-                            >Password <Muted class="float-right"><A href={resolve('/(auth)/forgot-password')} tabindex={6}>Forgot password?</A></Muted
-                            ></Field.Label
-                        >
-                        <Input
-                            id={field.name}
-                            name={field.name}
-                            type="password"
-                            placeholder="Enter password"
-                            autocomplete="current-password"
-                            maxlength={100}
-                            minlength={6}
-                            required
-                            tabindex={2}
-                            value={field.state.value}
-                            onblur={field.handleBlur}
-                            oninput={(e) => field.handleChange(e.currentTarget.value)}
-                            aria-invalid={ariaInvalid(field)}
-                        />
-                        <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
-                    </Field.Field>
-                {/snippet}
-            </form.Field>
-            <form.Subscribe selector={(state) => state.isSubmitting}>
-                {#snippet children(isSubmitting)}
-                    <Button type="submit" class="mt-4 w-full" tabindex={3} disabled={isSubmitting}>
-                        {#if isSubmitting}
-                            <Spinner /> Logging in...
-                        {:else}
-                            Login
-                        {/if}
-                    </Button>
-                {/snippet}
-            </form.Subscribe>
-        </form>
 
-        {#if enableOAuthLogin}
-            <div class="my-4 flex w-full items-center">
-                <hr class="w-full" />
-                <P class="px-3">OR</P>
-                <hr class="w-full" />
-            </div>
-            <div class="auto-cols-2 grid grid-flow-col grid-rows-2 gap-4">
-                {#if microsoftClientId}
-                    <Button aria-label="Login with Microsoft" tabindex={4} onclick={() => liveLogin(redirectUrl)}>
-                        <MicrosoftIcon class="size-4" /> Microsoft
-                    </Button>
-                {/if}
-                {#if googleClientId}
-                    <Button aria-label="Login with Google" tabindex={4} onclick={() => googleLogin(redirectUrl)}>
-                        <GoogleIcon class="size-4" /> Google
-                    </Button>
-                {/if}
-                {#if facebookClientId}
-                    <Button aria-label="Login with Facebook" tabindex={4} onclick={() => facebookLogin(redirectUrl)}>
-                        <FacebookIcon class="size-4" /> Facebook
-                    </Button>
-                {/if}
-                {#if gitHubClientId}
-                    <Button aria-label="Login with GitHub" tabindex={4} onclick={() => githubLogin(redirectUrl)}>
-                        <GitHubIcon class="size-4" /> GitHub
-                    </Button>
-                {/if}
-            </div>
-        {/if}
+            {#if enableAccountCreation}
+                <P class="text-center text-sm">
+                    Not a member?
+                    <A href={resolve('/(auth)/signup')} tabindex={5}>Start a free trial</A>
+                </P>
+            {/if}
+        </Card.Content>
+    </Card.Root>
 
-        {#if enableAccountCreation}
-            <P class="text-center text-sm">
-                Not a member?
-                <A href={resolve('/(auth)/signup')} tabindex={5}>Start a free trial</A>
-            </P>
-
-            <P class="text-center text-sm">
-                By signing up, you agree to our <A href="https://exceptionless.com/privacy" target="_blank">Privacy Policy</A>
-                and
-                <A href="https://exceptionless.com/terms" target="_blank">Terms of Service</A>.
-            </P>
-        {/if}
-    </Card.Content>
-</Card.Root>
+    {#if enableAccountCreation}
+        <P class="text-muted-foreground mt-3! px-4 text-center text-sm">
+            By signing up, you agree to our <A href="https://exceptionless.com/privacy" target="_blank">Privacy Policy</A>
+            and
+            <A href="https://exceptionless.com/terms" target="_blank">Terms of Service</A>.
+        </P>
+    {/if}
+</div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(auth)/routes.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(auth)/routes.svelte.ts
@@ -18,7 +18,7 @@ export function routes(): NavigationItem[] {
             href: resolve('/(auth)/logout'),
             icon: LogOut,
             show: (context: NavigationItemContext) => context.authenticated,
-            title: 'Log out'
+            title: 'Log Out'
         }
     ];
 }

--- a/src/Exceptionless.Web/ClientApp/src/routes/routes.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/routes.svelte.ts
@@ -1,4 +1,5 @@
 import type { ResolvedPathname } from '$app/types';
+import type { ShortcutKey } from '$features/shared/keyboard-shortcuts';
 import type { ViewCurrentUser } from '$features/users/models';
 import type { Icon } from '@lucide/svelte';
 import type { Component } from 'svelte';
@@ -8,17 +9,16 @@ import { routes as authRoutes } from './(auth)/routes.svelte';
 
 export type NavigationChild = {
     href: string;
-    isDefault?: boolean;
     title: string;
 };
 
 export type NavigationItem = {
     children?: NavigationChild[];
-    defaultViewId?: string;
     group: string;
     href: ResolvedPathname | string;
     icon: Component | typeof Icon;
     openInNewTab?: boolean;
+    shortcut?: readonly ShortcutKey[];
     show?: (context: NavigationItemContext) => boolean;
     title: string;
     view?: string;

--- a/src/Exceptionless.Web/Controllers/AdminController.cs
+++ b/src/Exceptionless.Web/Controllers/AdminController.cs
@@ -439,7 +439,7 @@ public class AdminController : ExceptionlessApiController
     }
 
     [HttpPost("generate-sample-events")]
-    public async Task<IActionResult> GenerateSampleEventsAsync(int eventCount = 100, int daysBack = 7)
+    public async Task<IActionResult> GenerateSampleEventsAsync(int eventCount = 250, int daysBack = 7)
     {
         if (eventCount < 1 || eventCount > 10000)
         {

--- a/src/Exceptionless.Web/Controllers/SavedViewController.cs
+++ b/src/Exceptionless.Web/Controllers/SavedViewController.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Exceptionless.Core.Authorization;
 using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Models;
@@ -109,12 +110,6 @@ public class SavedViewController : RepositoryApiController<ISavedViewRepository,
         if (!IsInOrganization(organizationId))
             return BadRequest();
 
-        if (savedView.IsPrivate is true && savedView.IsDefault is true)
-        {
-            ModelState.AddModelError(nameof(NewSavedView.IsDefault), "Private views cannot be set as the default. Default views are organization-wide.");
-            return ValidationProblem(ModelState);
-        }
-
         savedView.OrganizationId = organizationId;
         if (savedView.IsPrivate is true)
             savedView.UserId = CurrentUser.Id;
@@ -187,15 +182,6 @@ public class SavedViewController : RepositoryApiController<ISavedViewRepository,
         if (original.UserId is not null && original.UserId != CurrentUser.Id && !User.IsInRole(AuthorizationRoles.GlobalAdmin))
             return PermissionResult.DenyWithNotFound(original.Id);
 
-        // Private views cannot be set as the default
-        if (original.UserId is not null
-            && changes.GetChangedPropertyNames().Contains(nameof(UpdateSavedView.IsDefault))
-            && changes.TryGetPropertyValue(nameof(UpdateSavedView.IsDefault), out object? isDefaultValue)
-            && isDefaultValue is true)
-        {
-            return PermissionResult.DenyWithStatus(StatusCodes.Status422UnprocessableEntity, "Private views cannot be set as the default. Default views are organization-wide.");
-        }
-
         // Delta<T> bypasses IValidatableObject — enforce data-annotation and custom validation manually.
         var changedNames = changes.GetChangedPropertyNames();
 
@@ -210,7 +196,7 @@ public class SavedViewController : RepositoryApiController<ISavedViewRepository,
             ?? ValidateStringLength<UpdateSavedView>(changes, changedNames, nameof(UpdateSavedView.Filter), 2000)
             ?? ValidateStringLength<UpdateSavedView>(changes, changedNames, nameof(UpdateSavedView.Time), 100)
             ?? ValidateStringLength<UpdateSavedView>(changes, changedNames, nameof(UpdateSavedView.Sort), 100)
-            ?? ValidateStringLength<UpdateSavedView>(changes, changedNames, nameof(UpdateSavedView.FilterDefinitions), 10000);
+            ?? ValidateStringLength<UpdateSavedView>(changes, changedNames, nameof(UpdateSavedView.FilterDefinitions), SavedView.MaxFilterDefinitionsLength);
         if (lengthResult is not null)
             return lengthResult;
 
@@ -222,15 +208,12 @@ public class SavedViewController : RepositoryApiController<ISavedViewRepository,
             return PermissionResult.DenyWithStatus(StatusCodes.Status422UnprocessableEntity, "FilterDefinitions must be a valid JSON array.");
         }
 
-        if (changedNames.Contains(nameof(UpdateSavedView.Columns)))
+        if (changedNames.Contains(nameof(UpdateSavedView.Columns)) || changedNames.Contains(nameof(UpdateSavedView.ColumnOrder)))
         {
             var patchedChanges = new UpdateSavedView();
             changes.Patch(patchedChanges);
 
-            if (patchedChanges.Columns is not null && patchedChanges.Columns.Count > 50)
-                return PermissionResult.DenyWithStatus(StatusCodes.Status422UnprocessableEntity, "Columns cannot exceed 50 items.");
-
-            var validationError = NewSavedView.ValidateColumnKeys(original.ViewType, patchedChanges.Columns).FirstOrDefault();
+            var validationError = ValidateColumns(original.ViewType, patchedChanges);
             if (validationError is not null)
             {
                 return PermissionResult.DenyWithStatus(StatusCodes.Status422UnprocessableEntity, validationError.ErrorMessage ?? "Invalid column keys.");
@@ -252,45 +235,32 @@ public class SavedViewController : RepositoryApiController<ISavedViewRepository,
         return null;
     }
 
-    protected override async Task<SavedView> AddModelAsync(SavedView value)
+    private static ValidationResult? ValidateColumns(string viewType, UpdateSavedView changes)
+    {
+        if (changes.Columns is not null && changes.Columns.Count > 50)
+            return new ValidationResult("Columns cannot exceed 50 items.", [nameof(UpdateSavedView.Columns)]);
+
+        if (changes.ColumnOrder is not null && changes.ColumnOrder.Count > 50)
+            return new ValidationResult("ColumnOrder cannot exceed 50 items.", [nameof(UpdateSavedView.ColumnOrder)]);
+
+        return NewSavedView.ValidateColumnKeys(viewType, changes.Columns)
+            .Concat(NewSavedView.ValidateColumnOrder(viewType, changes.ColumnOrder))
+            .FirstOrDefault();
+    }
+
+    protected override Task<SavedView> AddModelAsync(SavedView value)
     {
         value.CreatedByUserId = CurrentUser.Id;
         value.Version = 1;
 
-        if (value.IsDefault)
-            await ClearDefaultAsync(value.OrganizationId, value.ViewType);
-
-        return await base.AddModelAsync(value);
+        return base.AddModelAsync(value);
     }
 
-    protected override async Task<SavedView> UpdateModelAsync(SavedView original, Delta<UpdateSavedView> changes)
+    protected override Task<SavedView> UpdateModelAsync(SavedView original, Delta<UpdateSavedView> changes)
     {
         original.UpdatedByUserId = CurrentUser.Id;
 
-        if (changes.GetChangedPropertyNames().Contains(nameof(UpdateSavedView.IsDefault))
-            && changes.TryGetPropertyValue(nameof(UpdateSavedView.IsDefault), out object? isDefaultValue)
-            && isDefaultValue is true)
-        {
-            await ClearDefaultAsync(original.OrganizationId, original.ViewType);
-        }
-
-        return await base.UpdateModelAsync(original, changes);
-    }
-
-    private async Task ClearDefaultAsync(string organizationId, string viewType)
-    {
-        var existing = await _repository.GetByViewAsync(organizationId, viewType, o => o.ImmediateConsistency().PageLimit(MaxViewsPerOrganization));
-        var defaults = existing.Documents.Where(savedView => savedView.IsDefault && savedView.UserId is null).ToList();
-
-        if (defaults.Count > 0)
-        {
-            foreach (var defaultView in defaults)
-            {
-                defaultView.IsDefault = false;
-            }
-
-            await _repository.SaveAsync(defaults, o => o.ImmediateConsistency());
-        }
+        return base.UpdateModelAsync(original, changes);
     }
 
     protected override async Task<PermissionResult> CanDeleteAsync(SavedView value)

--- a/src/Exceptionless.Web/Models/SavedView/NewSavedView.cs
+++ b/src/Exceptionless.Web/Models/SavedView/NewSavedView.cs
@@ -15,9 +15,9 @@ public record NewSavedView : IOwnedByOrganization, IValidatableObject
     public static readonly IReadOnlyDictionary<string, IReadOnlySet<string>> ValidColumnIds =
         new Dictionary<string, IReadOnlySet<string>>
         {
-            ["events"] = new HashSet<string> { "user", "date" },
-            ["issues"] = new HashSet<string> { "status", "users", "events", "first", "last" },
-            ["stream"] = new HashSet<string> { "user", "date" }
+            ["events"] = new HashSet<string> { "summary", "user", "date", "message", "type", "source", "name", "level" },
+            ["issues"] = new HashSet<string> { "summary", "status", "users", "events", "first", "last" },
+            ["stream"] = new HashSet<string> { "summary", "user", "date", "message", "type", "source", "name", "level" }
         };
 
     /// <summary>Union of all valid column IDs across all views.</summary>
@@ -45,14 +45,14 @@ public record NewSavedView : IOwnedByOrganization, IValidatableObject
     [Required]
     public string ViewType { get; set; } = null!;
 
-    [MaxLength(10000)]
+    [MaxLength(SavedView.MaxFilterDefinitionsLength)]
     public string? FilterDefinitions { get; set; }
 
     [MaxLength(50)]
     public Dictionary<string, bool>? Columns { get; set; }
 
-    /// <summary>If true, this view will be the default for its view type. Defaults to false.</summary>
-    public bool? IsDefault { get; set; }
+    [MaxLength(50)]
+    public List<string>? ColumnOrder { get; set; }
 
     /// <summary>If true, the view will only be visible to the current user. Defaults to false.</summary>
     public bool? IsPrivate { get; set; }
@@ -83,6 +83,11 @@ public record NewSavedView : IOwnedByOrganization, IValidatableObject
         {
             yield return error;
         }
+
+        foreach (var error in ValidateColumnOrder(ViewType, ColumnOrder))
+        {
+            yield return error;
+        }
     }
 
     internal static IEnumerable<ValidationResult> ValidateColumnKeys(string? view, Dictionary<string, bool>? columns)
@@ -102,6 +107,36 @@ public record NewSavedView : IOwnedByOrganization, IValidatableObject
             yield return new ValidationResult(
                 $"Column key '{key}' is not a valid column. Valid columns are: {String.Join(", ", validKeys.Order())}.",
                 [nameof(Columns)]
+            );
+        }
+    }
+
+    internal static IEnumerable<ValidationResult> ValidateColumnOrder(string? view, IReadOnlyCollection<string>? columnOrder)
+    {
+        if (columnOrder is null || columnOrder.Count == 0)
+        {
+            yield break;
+        }
+
+        var validKeys = view is not null && ValidColumnIds.TryGetValue(view, out var viewKeys)
+            ? viewKeys
+            : AllValidColumnIds;
+
+        var invalidKeys = columnOrder.Where(key => !validKeys.Contains(key)).Distinct();
+        foreach (var key in invalidKeys)
+        {
+            yield return new ValidationResult(
+                $"Column order key '{key}' is not a valid column. Valid columns are: {String.Join(", ", validKeys.Order())}.",
+                [nameof(ColumnOrder)]
+            );
+        }
+
+        var duplicateKeys = columnOrder.GroupBy(key => key).Where(group => group.Count() > 1).Select(group => group.Key);
+        foreach (var key in duplicateKeys)
+        {
+            yield return new ValidationResult(
+                $"Column order key '{key}' cannot be repeated.",
+                [nameof(ColumnOrder)]
             );
         }
     }

--- a/src/Exceptionless.Web/Models/SavedView/UpdateSavedView.cs
+++ b/src/Exceptionless.Web/Models/SavedView/UpdateSavedView.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Exceptionless.Core.Models;
 
 namespace Exceptionless.Web.Models;
 
@@ -6,17 +7,18 @@ public class UpdateSavedView : IValidatableObject
 {
     [MaxLength(100)]
     public string? Name { get; set; }
-    public bool? IsDefault { get; set; }
     [MaxLength(2000)]
     public string? Filter { get; set; }
     [MaxLength(100)]
     public string? Time { get; set; }
     [MaxLength(100)]
     public string? Sort { get; set; }
-    [MaxLength(10000)]
+    [MaxLength(SavedView.MaxFilterDefinitionsLength)]
     public string? FilterDefinitions { get; set; }
     [MaxLength(50)]
     public Dictionary<string, bool>? Columns { get; set; }
+    [MaxLength(50)]
+    public List<string>? ColumnOrder { get; set; }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
@@ -29,6 +31,11 @@ public class UpdateSavedView : IValidatableObject
         }
 
         foreach (var error in NewSavedView.ValidateColumnKeys(null, Columns))
+        {
+            yield return error;
+        }
+
+        foreach (var error in NewSavedView.ValidateColumnOrder(null, ColumnOrder))
         {
             yield return error;
         }

--- a/src/Exceptionless.Web/Models/SavedView/ViewSavedView.cs
+++ b/src/Exceptionless.Web/Models/SavedView/ViewSavedView.cs
@@ -23,7 +23,7 @@ public record ViewSavedView : IIdentity, IHaveDates
     public string? Filter { get; set; }
     public string? FilterDefinitions { get; set; }
     public Dictionary<string, bool>? Columns { get; set; }
-    public bool IsDefault { get; set; }
+    public List<string>? ColumnOrder { get; set; }
     public string Name { get; set; } = null!;
     public string? Time { get; set; }
     public string? Sort { get; set; }

--- a/tests/Exceptionless.Tests/Controllers/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Controllers/Data/openapi.json
@@ -7903,7 +7903,7 @@
             "type": "string"
           },
           "filter_definitions": {
-            "maxLength": 10000,
+            "maxLength": 100000,
             "type": [
               "null",
               "string"
@@ -7919,12 +7919,15 @@
               "type": "boolean"
             }
           },
-          "is_default": {
+          "column_order": {
+            "maxItems": 50,
             "type": [
               "null",
-              "boolean"
+              "array"
             ],
-            "description": "If true, this view will be the default for its view type. Defaults to false."
+            "items": {
+              "type": "string"
+            }
           },
           "is_private": {
             "type": [
@@ -8546,12 +8549,6 @@
               "string"
             ]
           },
-          "is_default": {
-            "type": [
-              "null",
-              "boolean"
-            ]
-          },
           "filter": {
             "type": [
               "null",
@@ -8584,6 +8581,12 @@
             "additionalProperties": {
               "type": "boolean"
             }
+          },
+          "column_order": {
+            "type": [
+              "null",
+              "array"
+            ]
           }
         },
         "description": "A class the tracks changes (i.e. the Delta) for a particular TEntityType."
@@ -9184,7 +9187,6 @@
           "id",
           "organization_id",
           "created_by_user_id",
-          "is_default",
           "name",
           "version",
           "view_type",
@@ -9250,8 +9252,14 @@
               "type": "boolean"
             }
           },
-          "is_default": {
-            "type": "boolean"
+          "column_order": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
           },
           "name": {
             "type": "string"

--- a/tests/Exceptionless.Tests/Controllers/SavedViewControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/SavedViewControllerTests.cs
@@ -43,7 +43,8 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
             Time = "[now-7D TO now]",
             Sort = "-date",
             ViewType = "events",
-            FilterDefinitions = """[{"type":"keyword","value":"status:open"}]"""
+            FilterDefinitions = """[{"type":"keyword","value":"status:open"}]""",
+            ColumnOrder = ["summary", "date", "user"]
         };
 
         // Act
@@ -65,6 +66,7 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
         Assert.Equal("[now-7D TO now]", result.Time);
         Assert.Equal("-date", result.Sort);
         Assert.Equal("events", result.ViewType);
+        Assert.Equal(["summary", "date", "user"], result.ColumnOrder);
         Assert.NotNull(result.FilterDefinitions);
         Assert.Equal(1, result.Version);
         Assert.NotNull(result.CreatedByUserId);
@@ -77,6 +79,7 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
         Assert.NotNull(savedView);
         Assert.Equal("Production Errors", savedView.Name);
         Assert.Equal("-date", savedView.Sort);
+        Assert.Equal(["summary", "date", "user"], savedView.ColumnOrder);
     }
 
     [Fact]
@@ -750,7 +753,7 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
         Assert.NotNull(await _savedViewRepository.GetByIdAsync(organizationWide.Id));
     }
 
-    private async Task<ViewSavedView?> CreateSavedViewAsync(string name, string filter, string view, bool isPrivate = false, bool isDefault = false)
+    private async Task<ViewSavedView?> CreateSavedViewAsync(string name, string filter, string view, bool isPrivate = false)
     {
         var newView = new NewSavedView
         {
@@ -758,7 +761,6 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
             Name = name,
             Filter = filter,
             ViewType = view,
-            IsDefault = isDefault,
             IsPrivate = isPrivate
         };
 
@@ -773,115 +775,6 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
 
         await RefreshDataAsync();
         return result;
-    }
-
-    // IsDefault tests
-
-    [Fact]
-    public async Task PostAsync_WithIsDefault_SetsIsDefaultOnSavedView()
-    {
-        // Arrange & Act
-        var created = await CreateSavedViewAsync("Default Events", "status:open", "events", isDefault: true);
-
-        // Assert
-        Assert.NotNull(created);
-        Assert.True(created.IsDefault);
-    }
-
-    [Fact]
-    public async Task PostAsync_WithoutIsDefault_DefaultsToFalse()
-    {
-        // Arrange & Act
-        var created = await CreateSavedViewAsync("Not Default", "status:open", "events");
-
-        // Assert
-        Assert.NotNull(created);
-        Assert.False(created.IsDefault);
-    }
-
-    [Fact]
-    public async Task PostAsync_NewDefault_ClearsPreviousDefault()
-    {
-        // Arrange
-        var first = await CreateSavedViewAsync("First Default", "status:open", "events", isDefault: true);
-        Assert.NotNull(first);
-        Assert.True(first.IsDefault);
-
-        // Act - create another default for same view
-        var second = await CreateSavedViewAsync("Second Default", "status:regressed", "events", isDefault: true);
-        Assert.NotNull(second);
-        Assert.True(second.IsDefault);
-
-        // Assert - first should no longer be default
-        var firstReloaded = await _savedViewRepository.GetByIdAsync(first.Id);
-        Assert.NotNull(firstReloaded);
-        Assert.False(firstReloaded.IsDefault);
-    }
-
-    [Fact]
-    public async Task PostAsync_NewDefaultForDifferentView_DoesNotClearOtherViewDefault()
-    {
-        // Arrange
-        var eventsDefault = await CreateSavedViewAsync("Events Default", "status:open", "events", isDefault: true);
-        Assert.NotNull(eventsDefault);
-
-        // Act - create default for issues view
-        var issuesDefault = await CreateSavedViewAsync("Issues Default", "status:regressed", "issues", isDefault: true);
-        Assert.NotNull(issuesDefault);
-
-        // Assert - events default should be unaffected
-        var eventsReloaded = await _savedViewRepository.GetByIdAsync(eventsDefault.Id);
-        Assert.NotNull(eventsReloaded);
-        Assert.True(eventsReloaded.IsDefault);
-    }
-
-    [Fact]
-    public async Task PatchAsync_SetIsDefault_ClearsPreviousDefault()
-    {
-        // Arrange
-        var first = await CreateSavedViewAsync("First", "status:open", "events", isDefault: true);
-        var second = await CreateSavedViewAsync("Second", "status:regressed", "events");
-        Assert.NotNull(first);
-        Assert.NotNull(second);
-
-        // Act - set second as default via PATCH
-        var updated = await SendRequestAsAsync<ViewSavedView>(r => r
-            .Patch()
-            .AsGlobalAdminUser()
-            .AppendPaths("saved-views", second.Id)
-            .Content(new UpdateSavedView { IsDefault = true })
-            .StatusCodeShouldBeOk()
-        );
-
-        // Assert
-        Assert.NotNull(updated);
-        Assert.True(updated.IsDefault);
-
-        var firstReloaded = await _savedViewRepository.GetByIdAsync(first.Id);
-        Assert.NotNull(firstReloaded);
-        Assert.False(firstReloaded.IsDefault);
-    }
-
-    [Fact]
-    public async Task PatchAsync_UnsetIsDefault_RemovesDefault()
-    {
-        // Arrange
-        var created = await CreateSavedViewAsync("Default View", "status:open", "events", isDefault: true);
-        Assert.NotNull(created);
-        Assert.True(created.IsDefault);
-
-        // Act
-        var updated = await SendRequestAsAsync<ViewSavedView>(r => r
-            .Patch()
-            .AsGlobalAdminUser()
-            .AppendPaths("saved-views", created.Id)
-            .Content(new UpdateSavedView { IsDefault = false })
-            .StatusCodeShouldBeOk()
-        );
-
-        // Assert
-        Assert.NotNull(updated);
-        Assert.False(updated.IsDefault);
     }
 
     // CanUpdateAsync permission tests
@@ -969,25 +862,6 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
         );
     }
 
-    [Fact]
-    public async Task PostAsync_IsDefaultResponse_IncludesIsDefaultField()
-    {
-        // Arrange & Act
-        var created = await CreateSavedViewAsync("Check Response", "status:open", "events", isDefault: true);
-        Assert.NotNull(created);
-
-        // Act - fetch back via GET
-        var fetched = await SendRequestAsAsync<ViewSavedView>(r => r
-            .AsGlobalAdminUser()
-            .AppendPaths("saved-views", created.Id)
-            .StatusCodeShouldBeOk()
-        );
-
-        // Assert
-        Assert.NotNull(fetched);
-        Assert.True(fetched.IsDefault);
-    }
-
     // Security tests
 
     [Fact]
@@ -1040,7 +914,7 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
             Name = "Long FilterDefs",
             Filter = "status:open",
             ViewType = "events",
-            FilterDefinitions = new string('x', 10001)
+            FilterDefinitions = $"[\"{new string('x', SavedView.MaxFilterDefinitionsLength)}\"]"
         };
 
         return SendRequestAsync(r => r
@@ -1254,133 +1128,15 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
         );
     }
 
-    // Private views cannot be default tests
-
     [Fact]
-    public Task PostAsync_PrivateAndDefault_ReturnsUnprocessableEntity()
-    {
-        // Arrange
-        var newView = new NewSavedView
-        {
-            OrganizationId = SampleDataService.TEST_ORG_ID,
-            Name = "Private Default",
-            Filter = "status:open",
-            ViewType = "events",
-            IsDefault = true,
-            IsPrivate = true
-        };
-
-        // Act & Assert - private + default should be rejected with 422
-        return SendRequestAsync(r => r
-            .Post()
-            .AsGlobalAdminUser()
-            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views")
-            .Content(newView)
-            .StatusCodeShouldBeUnprocessableEntity()
-        );
-    }
-
-    [Fact]
-    public async Task PostAsync_PrivateWithoutDefault_Succeeds()
+    public async Task PostAsync_PrivateView_Succeeds()
     {
         // Arrange & Act
-        var created = await CreateSavedViewAsync("Private Non-Default", "status:open", "events", isPrivate: true);
+        var created = await CreateSavedViewAsync("Private View", "status:open", "events", isPrivate: true);
 
         // Assert
         Assert.NotNull(created);
-        Assert.False(created.IsDefault);
         Assert.NotNull(created.UserId);
-    }
-
-    [Fact]
-    public async Task PatchAsync_PrivateViewSetDefault_ReturnsUnprocessableEntity()
-    {
-        // Arrange - create a private view
-        var privateView = await CreateSavedViewAsync("Private View", "status:open", "events", isPrivate: true);
-        Assert.NotNull(privateView);
-        Assert.NotNull(privateView.UserId);
-
-        // Act & Assert - trying to set a private view as default should fail with 422
-        await SendRequestAsync(r => r
-            .Patch()
-            .AsGlobalAdminUser()
-            .AppendPaths("saved-views", privateView.Id)
-            .Content(new UpdateSavedView { IsDefault = true })
-            .StatusCodeShouldBeUnprocessableEntity()
-        );
-
-        // Verify it's still not default
-        var reloaded = await _savedViewRepository.GetByIdAsync(privateView.Id);
-        Assert.NotNull(reloaded);
-        Assert.False(reloaded.IsDefault);
-    }
-
-    [Fact]
-    public async Task PostAsync_OrganizationWideDefault_DoesNotAffectPrivateViews()
-    {
-        // Arrange - create a private view (not default)
-        var privateView = await CreateSavedViewAsync("My Private", "status:open", "events", isPrivate: true);
-        Assert.NotNull(privateView);
-
-        // Act - create an organization-wide default
-        var organizationDefault = await CreateSavedViewAsync("Organization Default", "status:regressed", "events", isDefault: true);
-        Assert.NotNull(organizationDefault);
-        Assert.True(organizationDefault.IsDefault);
-
-        // Assert - private view should be unaffected
-        var privateReloaded = await _savedViewRepository.GetByIdAsync(privateView.Id);
-        Assert.NotNull(privateReloaded);
-        Assert.False(privateReloaded.IsDefault);
-    }
-
-    [Fact]
-    public async Task PostAsync_DefaultForDifferentViews_AreIndependent()
-    {
-        // Arrange & Act - create defaults for different views
-        var eventsDefault = await CreateSavedViewAsync("Events Default", "status:open", "events", isDefault: true);
-        var issuesDefault = await CreateSavedViewAsync("Issues Default", "status:regressed", "issues", isDefault: true);
-        var streamDefault = await CreateSavedViewAsync("Stream Default", "type:error", "stream", isDefault: true);
-
-        // Assert - all should be independently default
-        Assert.NotNull(eventsDefault);
-        Assert.NotNull(issuesDefault);
-        Assert.NotNull(streamDefault);
-        Assert.True(eventsDefault.IsDefault);
-        Assert.True(issuesDefault.IsDefault);
-        Assert.True(streamDefault.IsDefault);
-
-        // Verify by reloading
-        var eventsReloaded = await _savedViewRepository.GetByIdAsync(eventsDefault.Id);
-        var issuesReloaded = await _savedViewRepository.GetByIdAsync(issuesDefault.Id);
-        var streamReloaded = await _savedViewRepository.GetByIdAsync(streamDefault.Id);
-        Assert.True(eventsReloaded!.IsDefault);
-        Assert.True(issuesReloaded!.IsDefault);
-        Assert.True(streamReloaded!.IsDefault);
-    }
-
-    [Fact]
-    public async Task PatchAsync_UnsetDefault_OnlyAffectsTargetView()
-    {
-        // Arrange - set defaults for two views
-        var eventsDefault = await CreateSavedViewAsync("Events Default", "status:open", "events", isDefault: true);
-        var issuesDefault = await CreateSavedViewAsync("Issues Default", "status:regressed", "issues", isDefault: true);
-        Assert.NotNull(eventsDefault);
-        Assert.NotNull(issuesDefault);
-
-        // Act - unset events default
-        await SendRequestAsAsync<ViewSavedView>(r => r
-            .Patch()
-            .AsGlobalAdminUser()
-            .AppendPaths("saved-views", eventsDefault.Id)
-            .Content(new UpdateSavedView { IsDefault = false })
-            .StatusCodeShouldBeOk()
-        );
-
-        // Assert - issues default should be unaffected
-        var eventsReloaded = await _savedViewRepository.GetByIdAsync(eventsDefault.Id);
-        var issuesReloaded = await _savedViewRepository.GetByIdAsync(issuesDefault.Id);
-        Assert.False(eventsReloaded!.IsDefault);
-        Assert.True(issuesReloaded!.IsDefault);
     }
 
     [Fact]
@@ -1435,9 +1191,48 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
                 OrganizationId = SampleDataService.TEST_ORG_ID,
                 Name = "Valid Columns",
                 ViewType = "events",
-                Columns = new Dictionary<string, bool> { ["user"] = true, ["date"] = false }
+                Columns = new Dictionary<string, bool> { ["summary"] = true, ["level"] = false, ["message"] = false }
             })
             .StatusCodeShouldBeCreated()
+        );
+    }
+
+    [Fact]
+    public Task PostAsync_InvalidColumnOrderKey_ReturnsUnprocessableEntity()
+    {
+        // Arrange & Act & Assert
+        return SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views")
+            .Content(new NewSavedView
+            {
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                Name = "Bad Column Order",
+                ViewType = "events",
+                ColumnOrder = ["summary", "status"]
+            })
+            .StatusCodeShouldBeUnprocessableEntity()
+        );
+    }
+
+    [Fact]
+    public async Task PatchAsync_DuplicateColumnOrderKey_ReturnsUnprocessableEntity()
+    {
+        // Arrange
+        var created = await CreateSavedViewAsync("Patch Column Order Test", "status:open", "events");
+        Assert.NotNull(created);
+
+        // Act & Assert
+        await SendRequestAsync(r => r
+            .Patch()
+            .AsGlobalAdminUser()
+            .AppendPaths("saved-views", created.Id)
+            .Content(new UpdateSavedView
+            {
+                ColumnOrder = ["summary", "summary"]
+            })
+            .StatusCodeShouldBeUnprocessableEntity()
         );
     }
 

--- a/tests/Exceptionless.Tests/Mapping/SavedViewMapperTests.cs
+++ b/tests/Exceptionless.Tests/Mapping/SavedViewMapperTests.cs
@@ -28,7 +28,7 @@ public sealed class SavedViewMapperTests
             ViewType = "issues",
             FilterDefinitions = "[{\"type\":\"status\",\"values\":[\"open\",\"regressed\"]}]",
             Columns = new Dictionary<string, bool> { ["status"] = true, ["users"] = false },
-            IsDefault = true
+            ColumnOrder = ["summary", "status", "users"]
         };
 
         // Act
@@ -45,7 +45,7 @@ public sealed class SavedViewMapperTests
         Assert.NotNull(result.Columns);
         Assert.True(result.Columns["status"]);
         Assert.False(result.Columns["users"]);
-        Assert.True(result.IsDefault);
+        Assert.Equal(["summary", "status", "users"], result.ColumnOrder);
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public sealed class SavedViewMapperTests
         Assert.Null(result.Time);
         Assert.Null(result.FilterDefinitions);
         Assert.Null(result.Columns);
-        Assert.False(result.IsDefault);
+        Assert.Null(result.ColumnOrder);
     }
 
     [Fact]
@@ -107,7 +107,7 @@ public sealed class SavedViewMapperTests
             Filter = "status:open",
             FilterDefinitions = "[{\"type\":\"status\",\"values\":[\"open\"]}]",
             Columns = new Dictionary<string, bool> { ["status"] = true },
-            IsDefault = false,
+            ColumnOrder = ["summary", "status"],
             Name = "My View",
             Time = "[now-30d TO now]",
             Sort = "-last",
@@ -130,7 +130,7 @@ public sealed class SavedViewMapperTests
         Assert.Equal("[{\"type\":\"status\",\"values\":[\"open\"]}]", result.FilterDefinitions);
         Assert.NotNull(result.Columns);
         Assert.True(result.Columns["status"]);
-        Assert.False(result.IsDefault);
+        Assert.Equal(["summary", "status"], result.ColumnOrder);
         Assert.Equal("My View", result.Name);
         Assert.Equal("[now-30d TO now]", result.Time);
         Assert.Equal("-last", result.Sort);
@@ -163,6 +163,7 @@ public sealed class SavedViewMapperTests
         Assert.Null(result.Filter);
         Assert.Null(result.FilterDefinitions);
         Assert.Null(result.Columns);
+        Assert.Null(result.ColumnOrder);
         Assert.Null(result.Time);
         Assert.Null(result.Sort);
     }

--- a/tests/Exceptionless.Tests/Pipeline/CheckEventDateActionTests.cs
+++ b/tests/Exceptionless.Tests/Pipeline/CheckEventDateActionTests.cs
@@ -1,0 +1,103 @@
+using Exceptionless.Core;
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Pipeline;
+using Exceptionless.Core.Plugins.EventProcessor;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Exceptionless.Tests.Pipeline;
+
+public class CheckEventDateActionTests
+{
+    [Fact]
+    public async Task ProcessAsync_WithEventOlderThanThreeDays_DiscardsEvent()
+    {
+        // Arrange
+        var utcNow = new DateTimeOffset(2026, 5, 20, 12, 0, 0, TimeSpan.Zero);
+        var context = CreateContext(utcNow.AddDays(-4), retentionDays: 7);
+        var action = CreateAction(utcNow);
+
+        // Act
+        await action.ProcessAsync(context);
+
+        // Assert
+        Assert.True(context.IsCancelled);
+        Assert.True(context.IsDiscarded);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithExtendedDateRangeAndEventWithinRetention_KeepsEvent()
+    {
+        // Arrange
+        var utcNow = new DateTimeOffset(2026, 5, 20, 12, 0, 0, TimeSpan.Zero);
+        var context = CreateContext(utcNow.AddDays(-7), retentionDays: 7);
+        context.AllowExtendedEventDateRange = true;
+        var action = CreateAction(utcNow);
+
+        // Act
+        await action.ProcessAsync(context);
+
+        // Assert
+        Assert.False(context.IsCancelled);
+        Assert.False(context.IsDiscarded);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithExtendedDateRangeAndEventOutsideRetention_DiscardsEvent()
+    {
+        // Arrange
+        var utcNow = new DateTimeOffset(2026, 5, 20, 12, 0, 0, TimeSpan.Zero);
+        var context = CreateContext(utcNow.AddDays(-8), retentionDays: 7);
+        context.AllowExtendedEventDateRange = true;
+        var action = CreateAction(utcNow);
+
+        // Act
+        await action.ProcessAsync(context);
+
+        // Assert
+        Assert.True(context.IsCancelled);
+        Assert.True(context.IsDiscarded);
+    }
+
+    private static CheckEventDateAction CreateAction(DateTimeOffset utcNow)
+    {
+        return new CheckEventDateAction(new FixedTimeProvider(utcNow), CreateOptions(), NullLoggerFactory.Instance);
+    }
+
+    private static EventContext CreateContext(DateTimeOffset eventDate, int retentionDays)
+    {
+        var ev = new PersistentEvent { Date = eventDate };
+        var organization = new Organization { RetentionDays = retentionDays };
+        var project = new Project();
+
+        return new EventContext(ev, organization, project);
+    }
+
+    private static AppOptions CreateOptions()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [nameof(AppOptions.BaseURL)] = "http://localhost"
+            })
+            .Build();
+
+        return AppOptions.ReadFromConfiguration(configuration);
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _utcNow;
+
+        public FixedTimeProvider(DateTimeOffset utcNow)
+        {
+            _utcNow = utcNow;
+        }
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            return _utcNow;
+        }
+    }
+}

--- a/tests/Exceptionless.Tests/Utility/RandomEventGeneratorTests.cs
+++ b/tests/Exceptionless.Tests/Utility/RandomEventGeneratorTests.cs
@@ -1,0 +1,57 @@
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Models.Data;
+using Exceptionless.Core.Utility;
+using Xunit;
+
+namespace Exceptionless.Tests.Utility;
+
+public class RandomEventGeneratorTests
+{
+    [Fact]
+    public void Generate_WithRegularEvents_IncludesErrorLevelLogEvent()
+    {
+        // Arrange
+        var generator = new Exceptionless.Core.Utility.RandomEventGenerator(TimeProvider.System);
+
+        // Act
+        var events = generator.Generate("organization", "project", 10);
+
+        // Assert
+        Assert.Contains(events, generatedEvent =>
+            generatedEvent.Type == Event.KnownTypes.Log &&
+            generatedEvent.Data is not null &&
+            generatedEvent.Data.TryGetValue(Event.KnownDataKeys.Level, out object? level) &&
+            String.Equals(level as string, "Error", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Generate_WithErrorEvents_ReusesStackSignatures()
+    {
+        // Arrange
+        var generator = new Exceptionless.Core.Utility.RandomEventGenerator(TimeProvider.System);
+
+        // Act
+        var signatures = generator.Generate("organization", "project", 200)
+            .Select(GetErrorSignature)
+            .Where(signature => !String.IsNullOrEmpty(signature))
+            .ToList();
+
+        // Assert
+        Assert.True(signatures.Count > 8);
+        Assert.True(signatures.Distinct().Count() < signatures.Count);
+    }
+
+    private static string? GetErrorSignature(Event ev)
+    {
+        if (ev.Data is null)
+            return null;
+
+        if (ev.Data.TryGetValue(Event.KnownDataKeys.Error, out object? errorValue) && errorValue is Error error)
+            return new ErrorSignature(error, System.Text.Json.JsonSerializerOptions.Web).SignatureHash;
+
+        if (ev.Data.TryGetValue(Event.KnownDataKeys.SimpleError, out object? simpleErrorValue) && simpleErrorValue is SimpleError simpleError)
+            return $"{simpleError.Type}:{simpleError.StackTrace}";
+
+        return null;
+    }
+}

--- a/tests/http/saved-views.http
+++ b/tests/http/saved-views.http
@@ -47,7 +47,7 @@ Content-Type: application/json
         "user": true,
         "date": true
     },
-    "is_default": false
+    "column_order": ["summary", "user", "date"]
 }
 
 ###
@@ -68,7 +68,7 @@ Content-Type: application/json
         "user": true,
         "date": true
     },
-    "is_default": false,
+    "column_order": ["summary", "date", "user"],
     "is_private": true
 }
 
@@ -84,7 +84,8 @@ Content-Type: application/json
 {
     "name": "Open Events (Last 30d)",
     "time": "[now-30d TO now]",
-    "sort": "date"
+    "sort": "date",
+    "column_order": ["summary", "date", "user"]
 }
 
 ### Delete saved view


### PR DESCRIPTION
## Summary
- Add saved-view column visibility/order support and remove the undeployed default-view behavior.
- Polish the next UI table, navigation, command palette, keyboard shortcut, and related shared component interactions.
- Improve generated sample data by increasing defaults, making error events stack together more often, and allowing sample generation to span the requested retention-backed date range.

## Validation
- `dotnet build /property:GenerateFullPaths=true /consoleloggerparameters:NoSummary`
- `dotnet test -- --filter-class Exceptionless.Tests.Pipeline.CheckEventDateActionTests`
- `dotnet test -- --filter-class Exceptionless.Tests.Utility.RandomEventGeneratorTests`
- `npm run check`
- `npm run lint`
- `git diff --check`