### PR TITLE
Polish dashboards and saved views

### DIFF
--- a/src/Exceptionless.Core/Models/SavedView.cs
+++ b/src/Exceptionless.Core/Models/SavedView.cs
@@ -49,6 +49,12 @@ public record SavedView : IOwnedByOrganizationWithIdentity, IHaveDates
     /// <summary>Column display order per dashboard table, excluding utility columns.</summary>
     public List<string>? ColumnOrder { get; set; }
 
+    /// <summary>Whether dashboard statistic cards are shown for this view. Null means use the default.</summary>
+    public bool? ShowStats { get; set; }
+
+    /// <summary>Whether the dashboard chart is shown for this view. Null means use the default.</summary>
+    public bool? ShowChart { get; set; }
+
     /// <summary>Display name shown in the sidebar and picker.</summary>
     [Required]
     [MaxLength(100)]

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/event-detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/event-detail-sheet.svelte
@@ -35,9 +35,17 @@
 </script>
 
 <Sheet.Root onOpenChange={handleOpenChange} open={!!eventId}>
-    <Sheet.Content class="w-full overflow-y-scroll sm:max-w-full! md:w-5/6!">
+    <Sheet.Content
+        class="top-15.25! bottom-0! h-auto! w-full transform-gpu overflow-y-auto rounded-l-lg border-l shadow-2xl duration-150 ease-out will-change-transform sm:max-w-full! md:w-5/6!"
+        overlayProps={{ class: 'top-15.25! bg-black/5 supports-backdrop-filter:backdrop-blur-none!' }}
+    >
         <Sheet.Header>
-            <Sheet.Title>Event Details <Button href={resolvedHref} size="sm" title="Open in new window" variant="ghost"><ExternalLink /></Button></Sheet.Title>
+            <Sheet.Title class="flex items-center gap-2">
+                Event Details
+                <Button aria-label="Open event details in new window" href={resolvedHref} size="icon-sm" title="Open in new window" variant="ghost">
+                    <ExternalLink aria-hidden="true" />
+                </Button>
+            </Sheet.Title>
         </Sheet.Header>
         <div class="px-4">
             {#if eventId}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-dashboard-chart.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-dashboard-chart.svelte
@@ -31,7 +31,7 @@
         },
         stacks: {
             color: 'var(--chart-2)',
-            label: 'Unique Events (Stacks)'
+            label: 'Issues'
         }
     } satisfies Chart.ChartConfig;
 
@@ -39,7 +39,7 @@
         {
             color: chartConfig.stacks.color,
             key: 'stacks',
-            label: 'Unique Events (Stacks)'
+            label: 'Issues'
         },
         {
             color: chartConfig.events.color,
@@ -49,7 +49,7 @@
     ];
 </script>
 
-<div class="bg-card text-card-foreground rounded-lg border {className}">
+<Chart.Shell class={className}>
     {#if isLoading}
         <Skeleton class="h-16 w-full rounded" />
     {:else}
@@ -98,4 +98,4 @@
             </AreaChart>
         </Chart.Container>
     {/if}
-</div>
+</Chart.Shell>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-stack-chart.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-stack-chart.svelte
@@ -37,7 +37,7 @@
     ];
 </script>
 
-<div class="bg-card text-card-foreground rounded-lg border {className}">
+<Chart.Shell class={className}>
     {#if isLoading}
         <Skeleton class="h-full w-full rounded-md" />
     {:else}
@@ -68,4 +68,4 @@
             </AreaChart>
         </Chart.Container>
     {/if}
-</div>
+</Chart.Shell>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-stats-dashboard.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-stats-dashboard.svelte
@@ -1,25 +1,23 @@
 <script lang="ts">
-    import Duration from '$comp/formatters/duration.svelte';
     import Number from '$comp/formatters/number.svelte';
     import * as Card from '$comp/ui/card';
     import { Skeleton } from '$comp/ui/skeleton';
     import * as Tooltip from '$comp/ui/tooltip';
-    import AreaChart from '@lucide/svelte/icons/area-chart';
-    import Clock from '@lucide/svelte/icons/clock';
+    import CalendarDays from '@lucide/svelte/icons/calendar-days';
     import Info from '@lucide/svelte/icons/info';
-    import LineChart from '@lucide/svelte/icons/trending-up';
-    import Users from '@lucide/svelte/icons/users';
-    import prettyMilliseconds from 'pretty-ms';
+    import Layers from '@lucide/svelte/icons/layers';
+    import Sparkles from '@lucide/svelte/icons/sparkles';
+    import TrendingUp from '@lucide/svelte/icons/trending-up';
 
     interface Props {
-        avgDuration?: number;
-        avgPerHour?: number;
+        eventsPerHour?: number;
         isLoading?: boolean;
-        totalSessions?: number;
-        totalUsers?: number;
+        newIssues?: number;
+        totalEvents?: number;
+        totalIssues?: number;
     }
 
-    let { avgDuration = 0, avgPerHour = 0, isLoading = false, totalSessions = 0, totalUsers = 0 }: Props = $props();
+    let { eventsPerHour = 0, isLoading = false, newIssues = 0, totalEvents = 0, totalIssues = 0 }: Props = $props();
 
     const metricCardClass =
         "relative h-[66px]! justify-between gap-1! overflow-hidden bg-card py-2! ring-[color-mix(in_oklab,var(--chart-1)_42%,transparent)] before:absolute before:inset-x-0 before:top-0 before:h-1 before:bg-[linear-gradient(90deg,var(--chart-1),var(--chart-2))] before:content-['']";
@@ -27,34 +25,31 @@
     const metricTitleClass = 'min-w-0 truncate text-xs font-semibold text-[color-mix(in_oklab,var(--chart-2)_82%,var(--foreground))]';
     const metricIconClass = 'size-3.5 shrink-0 text-[var(--chart-2)]';
     const metricValueClass = 'truncate text-lg leading-none font-bold text-[var(--chart-2)] tabular-nums sm:text-xl';
-
-    const compactAverageDuration = $derived(avgDuration > 0 ? prettyMilliseconds(avgDuration * 1000, { compact: true, secondsDecimalDigits: 0 }) : '—');
-    const preciseAverageDuration = $derived(avgDuration > 0 ? prettyMilliseconds(avgDuration * 1000, { secondsDecimalDigits: 0, unitCount: 2 }) : '—');
 </script>
 
 <div class="grid grid-cols-2 gap-2 sm:grid-cols-4">
     <Card.Root size="sm" class={metricCardClass}>
         <Card.Header class={metricHeaderClass}>
             <div class="flex min-w-0 items-center gap-1.5">
-                <AreaChart aria-hidden="true" class={metricIconClass} />
-                <Card.Title class={metricTitleClass}>Total</Card.Title>
+                <CalendarDays aria-hidden="true" class={metricIconClass} />
+                <Card.Title class={metricTitleClass}>Events</Card.Title>
             </div>
             <Tooltip.Root>
                 <Tooltip.Trigger
                     class="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded-sm outline-none focus-visible:ring-2"
-                    aria-label="About sessions"
+                    aria-label="About events"
                 >
                     <Info aria-hidden="true" class="size-3.5" />
                 </Tooltip.Trigger>
-                <Tooltip.Content sideOffset={6}>Total sessions matching the current filters.</Tooltip.Content>
+                <Tooltip.Content sideOffset={6}>Total event occurrences matching the current filters.</Tooltip.Content>
             </Tooltip.Root>
         </Card.Header>
         <Card.Content class="px-3">
             {#if isLoading}
-                <Skeleton class="h-6 w-16" />
+                <Skeleton class="h-5 w-16" />
             {:else}
                 <div class={metricValueClass}>
-                    <Number value={totalSessions} />
+                    <Number value={totalEvents} />
                 </div>
             {/if}
         </Card.Content>
@@ -63,25 +58,25 @@
     <Card.Root size="sm" class={metricCardClass}>
         <Card.Header class={metricHeaderClass}>
             <div class="flex min-w-0 items-center gap-1.5">
-                <LineChart aria-hidden="true" class={metricIconClass} />
-                <Card.Title class={metricTitleClass}>Avg/hr</Card.Title>
+                <Layers aria-hidden="true" class={metricIconClass} />
+                <Card.Title class={metricTitleClass}>Issues</Card.Title>
             </div>
             <Tooltip.Root>
                 <Tooltip.Trigger
                     class="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded-sm outline-none focus-visible:ring-2"
-                    aria-label="About average sessions per hour"
+                    aria-label="About issues"
                 >
                     <Info aria-hidden="true" class="size-3.5" />
                 </Tooltip.Trigger>
-                <Tooltip.Content sideOffset={6}>Average sessions per hour across the selected time range.</Tooltip.Content>
+                <Tooltip.Content sideOffset={6}>Unique issues matching the current filters.</Tooltip.Content>
             </Tooltip.Root>
         </Card.Header>
         <Card.Content class="px-3">
             {#if isLoading}
-                <Skeleton class="h-6 w-16" />
+                <Skeleton class="h-5 w-16" />
             {:else}
                 <div class={metricValueClass}>
-                    <Number value={avgPerHour} formatOptions={{ maximumFractionDigits: 1 }} />
+                    <Number value={totalIssues} />
                 </div>
             {/if}
         </Card.Content>
@@ -90,25 +85,25 @@
     <Card.Root size="sm" class={metricCardClass}>
         <Card.Header class={metricHeaderClass}>
             <div class="flex min-w-0 items-center gap-1.5">
-                <Users aria-hidden="true" class={metricIconClass} />
-                <Card.Title class={metricTitleClass}>Users</Card.Title>
+                <Sparkles aria-hidden="true" class={metricIconClass} />
+                <Card.Title class={metricTitleClass}>New Issues</Card.Title>
             </div>
             <Tooltip.Root>
                 <Tooltip.Trigger
                     class="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded-sm outline-none focus-visible:ring-2"
-                    aria-label="About users"
+                    aria-label="About new issues"
                 >
                     <Info aria-hidden="true" class="size-3.5" />
                 </Tooltip.Trigger>
-                <Tooltip.Content sideOffset={6}>Unique users seen in matching sessions.</Tooltip.Content>
+                <Tooltip.Content sideOffset={6}>Issues with their first occurrence in the selected time range.</Tooltip.Content>
             </Tooltip.Root>
         </Card.Header>
         <Card.Content class="px-3">
             {#if isLoading}
-                <Skeleton class="h-6 w-16" />
+                <Skeleton class="h-5 w-16" />
             {:else}
                 <div class={metricValueClass}>
-                    <Number value={totalUsers} />
+                    <Number value={newIssues} />
                 </div>
             {/if}
         </Card.Content>
@@ -117,78 +112,27 @@
     <Card.Root size="sm" class={metricCardClass}>
         <Card.Header class={metricHeaderClass}>
             <div class="flex min-w-0 items-center gap-1.5">
-                <Clock aria-hidden="true" class={metricIconClass} />
-                <Card.Title class={metricTitleClass} aria-label="Duration">
-                    <span class="duration-label-short">Dur.</span>
-                    <span class="duration-label-full">Duration</span>
-                </Card.Title>
+                <TrendingUp aria-hidden="true" class={metricIconClass} />
+                <Card.Title class={metricTitleClass}>Events/hr</Card.Title>
             </div>
             <Tooltip.Root>
                 <Tooltip.Trigger
                     class="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded-sm outline-none focus-visible:ring-2"
-                    aria-label="About average duration"
+                    aria-label="About events per hour"
                 >
                     <Info aria-hidden="true" class="size-3.5" />
                 </Tooltip.Trigger>
-                <Tooltip.Content sideOffset={6}>
-                    Average session duration.
-                    {#if avgDuration > 0}
-                        Full value: <Duration value={avgDuration * 1000} />.
-                    {/if}
-                </Tooltip.Content>
+                <Tooltip.Content sideOffset={6}>Average event occurrences per hour across the selected time range.</Tooltip.Content>
             </Tooltip.Root>
         </Card.Header>
         <Card.Content class="px-3">
             {#if isLoading}
-                <Skeleton class="h-6 w-16" />
+                <Skeleton class="h-5 w-16" />
             {:else}
-                <div class={[metricValueClass, 'duration-value-container']} aria-label={preciseAverageDuration}>
-                    <span class="duration-value-short">{compactAverageDuration}</span>
-                    <span class="duration-value-full">{preciseAverageDuration}</span>
+                <div class={metricValueClass}>
+                    <Number value={eventsPerHour} formatOptions={{ maximumFractionDigits: 1 }} />
                 </div>
             {/if}
         </Card.Content>
     </Card.Root>
 </div>
-
-<style>
-    .duration-label-full {
-        display: none;
-    }
-
-    .duration-label-short {
-        display: inline;
-    }
-
-    .duration-value-container {
-        container: duration-value / inline-size;
-    }
-
-    .duration-value-full {
-        display: none;
-    }
-
-    .duration-value-short {
-        display: inline;
-    }
-
-    @container card-header (min-width: 9rem) {
-        .duration-label-full {
-            display: inline;
-        }
-
-        .duration-label-short {
-            display: none;
-        }
-    }
-
-    @container duration-value (min-width: 6rem) {
-        .duration-value-full {
-            display: inline;
-        }
-
-        .duration-value-short {
-            display: none;
-        }
-    }
-</style>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
@@ -51,10 +51,10 @@
         onLoadView: (id: string) => void;
         onResetToSaved: () => void;
         savedViews: SavedView[];
-        showChart?: boolean;
-        showStats?: boolean;
         setShowChart?: (show: boolean) => void;
         setShowStats?: (show: boolean) => void;
+        showChart?: boolean;
+        showStats?: boolean;
         sort?: string;
         table: Table<StockFeatures, TData>;
         time?: string;
@@ -71,10 +71,10 @@
         onLoadView,
         onResetToSaved,
         savedViews,
-        showChart = true,
-        showStats = true,
         setShowChart,
         setShowStats,
+        showChart = true,
+        showStats = true,
         sort,
         table,
         time,

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
@@ -51,6 +51,10 @@
         onLoadView: (id: string) => void;
         onResetToSaved: () => void;
         savedViews: SavedView[];
+        showChart?: boolean;
+        showStats?: boolean;
+        setShowChart?: (show: boolean) => void;
+        setShowStats?: (show: boolean) => void;
         sort?: string;
         table: Table<StockFeatures, TData>;
         time?: string;
@@ -67,6 +71,10 @@
         onLoadView,
         onResetToSaved,
         savedViews,
+        showChart = true,
+        showStats = true,
+        setShowChart,
+        setShowStats,
         sort,
         table,
         time,
@@ -234,6 +242,8 @@
             is_private: isPrivate || undefined,
             name,
             organization_id: organizationId,
+            show_chart: showChart,
+            show_stats: showStats,
             sort: sort || undefined,
             time: time || undefined,
             view_type: view
@@ -273,6 +283,8 @@
             columns: columnVisibility,
             filter: currentFilterString || null,
             filter_definitions: serializeFilters(filters),
+            show_chart: showChart,
+            show_stats: showStats,
             sort: sort || null,
             time: time || null
         };
@@ -346,6 +358,36 @@
                 </DropdownMenu.Item>
             {/if}
         </DropdownMenu.Group>
+        {#if setShowStats || setShowChart}
+            <DropdownMenu.Separator />
+            <DropdownMenu.Group>
+                <DropdownMenu.Label>Display</DropdownMenu.Label>
+                {#if setShowStats}
+                    <DropdownMenu.CheckboxItem
+                        checked={showStats}
+                        onclick={(event) => {
+                            event.preventDefault();
+                            setShowStats(!showStats);
+                        }}
+                        onSelect={(event) => event.preventDefault()}
+                    >
+                        Stat boxes
+                    </DropdownMenu.CheckboxItem>
+                {/if}
+                {#if setShowChart}
+                    <DropdownMenu.CheckboxItem
+                        checked={showChart}
+                        onclick={(event) => {
+                            event.preventDefault();
+                            setShowChart(!showChart);
+                        }}
+                        onSelect={(event) => event.preventDefault()}
+                    >
+                        Chart
+                    </DropdownMenu.CheckboxItem>
+                {/if}
+            </DropdownMenu.Group>
+        {/if}
         {#if reorderableColumns.length > 0}
             <DropdownMenu.Separator />
             <DropdownMenu.Group>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -21,10 +21,14 @@ export interface UseSavedViewsOptions {
     filterCacheKey: (filter: null | string) => string;
     getColumnOrder?: () => ColumnOrderState;
     getColumnVisibility?: () => ColumnVisibilityState;
+    getShowChart?: () => boolean;
+    getShowStats?: () => boolean;
     getFilterDefinitions?: () => string;
     queryParams: SavedViewQueryParams;
     setColumnOrder?: (order: ColumnOrderState) => void;
     setColumnVisibility?: (visibility: ColumnVisibilityState) => void;
+    setShowChart?: (show: boolean) => void;
+    setShowStats?: (show: boolean) => void;
     updateFilterCache: (key: string, filters: IFilter[]) => void;
     view: string;
 }
@@ -90,6 +94,11 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
     }
 
+    function applyDisplayState(view: Pick<SavedView, 'show_chart' | 'show_stats'> | undefined): void {
+        options.setShowStats?.(view?.show_stats ?? true);
+        options.setShowChart?.(view?.show_chart ?? true);
+    }
+
     // Hydrate filters/columns when a saved view loads, or clear params if the view is no longer found.
     // lastLoadedViewId prevents re-hydration on background refetches (which would stomp user edits).
     let lastLoadedViewId = '';
@@ -103,6 +112,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             if (!savedId) {
                 if (lastLoadedViewId !== '') {
                     applyColumnState(undefined);
+                    applyDisplayState(undefined);
                 }
 
                 lastLoadedViewId = '';
@@ -148,6 +158,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         setSortQueryParam(options.queryParams, view.sort ?? null);
         setTimeQueryParam(options.queryParams, view.time ?? null);
         applyColumnState(view);
+        applyDisplayState(view);
     });
 
     // Detect if current filters or columns differ from the active saved view
@@ -181,6 +192,14 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return true;
         }
 
+        if (options.getShowStats && options.getShowStats() !== (view.show_stats ?? true)) {
+            return true;
+        }
+
+        if (options.getShowChart && options.getShowChart() !== (view.show_chart ?? true)) {
+            return true;
+        }
+
         return false;
     });
 
@@ -207,6 +226,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         setSortQueryParam(options.queryParams, view.sort ?? null);
         setTimeQueryParam(options.queryParams, view.time ?? null);
         applyColumnState(view);
+        applyDisplayState(view);
     }
 
     function handleClearSavedView() {
@@ -215,6 +235,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         setSortQueryParam(options.queryParams, null);
         setTimeQueryParam(options.queryParams, null);
         applyColumnState(undefined);
+        applyDisplayState(undefined);
     }
 
     return {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -21,9 +21,9 @@ export interface UseSavedViewsOptions {
     filterCacheKey: (filter: null | string) => string;
     getColumnOrder?: () => ColumnOrderState;
     getColumnVisibility?: () => ColumnVisibilityState;
+    getFilterDefinitions?: () => string;
     getShowChart?: () => boolean;
     getShowStats?: () => boolean;
-    getFilterDefinitions?: () => string;
     queryParams: SavedViewQueryParams;
     setColumnOrder?: (order: ColumnOrderState) => void;
     setColumnVisibility?: (visibility: ColumnVisibilityState) => void;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/sessions/components/sessions-dashboard-chart.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/sessions/components/sessions-dashboard-chart.svelte
@@ -49,7 +49,7 @@
     ];
 </script>
 
-<div class="bg-card text-card-foreground rounded-lg border shadow-sm {className}">
+<Chart.Shell class={className}>
     {#if isLoading}
         <Skeleton class="h-16 w-full rounded" />
     {:else}
@@ -98,4 +98,4 @@
             </AreaChart>
         </Chart.Container>
     {/if}
-</div>
+</Chart.Shell>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/chart/chart-shell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/chart/chart-shell.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="chart-shell"
+	class={cn("bg-card text-card-foreground rounded-lg border border-[color-mix(in_oklab,var(--chart-1)_42%,transparent)] shadow-sm", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/chart/index.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/chart/index.ts
@@ -1,6 +1,7 @@
 import ChartContainer from "./chart-container.svelte";
+import ChartShell from "./chart-shell.svelte";
 import ChartTooltip from "./chart-tooltip.svelte";
 
 export { getPayloadConfigFromPayload, type ChartConfig } from "./chart-utils.js";
 
-export { ChartContainer, ChartTooltip, ChartContainer as Container, ChartTooltip as Tooltip };
+export { ChartContainer, ChartShell, ChartTooltip, ChartContainer as Container, ChartShell as Shell, ChartTooltip as Tooltip };

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/sheet/sheet-content.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/sheet/sheet-content.svelte
@@ -17,10 +17,12 @@
 		class: className,
 		side = "right",
 		showCloseButton = true,
+		overlayProps,
 		portalProps,
 		children,
 		...restProps
 	}: WithoutChildrenOrChild<SheetPrimitive.ContentProps> & {
+		overlayProps?: WithoutChildrenOrChild<ComponentProps<typeof SheetOverlay>>;
 		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof SheetPortal>>;
 		side?: Side;
 		showCloseButton?: boolean;
@@ -29,7 +31,7 @@
 </script>
 
 <SheetPortal {...portalProps}>
-	<SheetOverlay />
+	<SheetOverlay {...overlayProps} />
 	<SheetPrimitive.Content
 		bind:ref
 		data-slot="sheet-content"

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
@@ -377,7 +377,7 @@ export interface UpdateSavedView {
   sort?: null | string;
   filter_definitions?: null | string;
   columns?: null | Record<string, boolean>;
-  column_order?: null | unknown[];
+  column_order?: string[] | null;
   show_stats?: null | boolean;
   show_chart?: null | boolean;
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
@@ -140,7 +140,9 @@ export interface NewSavedView {
   view_type: string;
   filter_definitions?: null | string;
   columns?: null | Record<string, boolean>;
-  column_order?: null | string[];
+  column_order?: string[] | null;
+  show_stats?: null | boolean;
+  show_chart?: null | boolean;
   /** If true, the view will only be visible to the current user. Defaults to false. */
   is_private?: null | boolean;
 }
@@ -219,7 +221,10 @@ export interface PersistentEvent {
   created_utc: string;
   /** Used to store primitive data type custom data values for searching the event. */
   idx?: null | Record<string, unknown>;
-  /** The event type (ie. error, log message, feature usage). Check KnownTypes for standard event types. */
+  /**
+   * The event type (ie. error, log message, feature usage). Check KnownTypes for standard event types.
+   * Nullable in transit; the pipeline infers a default before save. Validated as required on repository save.
+   */
   type?: null | string;
   /** The event source (ie. machine name, log name, feature name). */
   source?: null | string;
@@ -372,7 +377,9 @@ export interface UpdateSavedView {
   sort?: null | string;
   filter_definitions?: null | string;
   columns?: null | Record<string, boolean>;
-  column_order?: null | string[];
+  column_order?: null | unknown[];
+  show_stats?: null | boolean;
+  show_chart?: null | boolean;
 }
 
 /** A class the tracks changes (i.e. the Delta) for a particular TEntityType. */
@@ -564,7 +571,9 @@ export interface ViewSavedView {
   filter?: null | string;
   filter_definitions?: null | string;
   columns?: null | Record<string, boolean>;
-  column_order?: null | string[];
+  column_order?: string[] | null;
+  show_stats?: null | boolean;
+  show_chart?: null | boolean;
   name: string;
   time?: null | string;
   sort?: null | string;

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
@@ -424,7 +424,7 @@ export const UpdateSavedViewSchema = object({
     .nullable()
     .optional(),
   columns: record(string(), boolean()).nullable().optional(),
-  column_order: array(unknown()).nullable().optional(),
+  column_order: array(string()).nullable().optional(),
   show_stats: boolean().nullable().optional(),
   show_chart: boolean().nullable().optional(),
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
@@ -202,6 +202,8 @@ export const NewSavedViewSchema = object({
     .optional(),
   columns: record(string(), boolean()).nullable().optional(),
   column_order: array(string()).nullable().optional(),
+  show_stats: boolean().nullable().optional(),
+  show_chart: boolean().nullable().optional(),
   is_private: boolean().nullable().optional(),
 });
 export type NewSavedViewFormData = Infer<typeof NewSavedViewSchema>;
@@ -288,8 +290,7 @@ export const PersistentEventSchema = object({
   type: string()
     .min(1, "Type is required")
     .max(100, "Type must be at most 100 characters")
-    .nullable()
-    .optional(),
+    .nullable(),
   source: string()
     .min(1, "Source is required")
     .max(2000, "Source must be at most 2000 characters")
@@ -423,7 +424,9 @@ export const UpdateSavedViewSchema = object({
     .nullable()
     .optional(),
   columns: record(string(), boolean()).nullable().optional(),
-  column_order: array(string()).nullable().optional(),
+  column_order: array(unknown()).nullable().optional(),
+  show_stats: boolean().nullable().optional(),
+  show_chart: boolean().nullable().optional(),
 });
 export type UpdateSavedViewFormData = Infer<typeof UpdateSavedViewSchema>;
 
@@ -613,6 +616,8 @@ export const ViewSavedViewSchema = object({
     .optional(),
   columns: record(string(), boolean()).nullable().optional(),
   column_order: array(string()).nullable().optional(),
+  show_stats: boolean().nullable().optional(),
+  show_chart: boolean().nullable().optional(),
   name: string().min(1, "Name is required"),
   time: string().min(1, "Time is required").nullable().optional(),
   sort: string().min(1, "Sort is required").nullable().optional(),

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/navbar.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/navbar.svelte
@@ -27,7 +27,7 @@
 
                 <A variant="ghost" class="mr-14 ml-2 flex md:min-w-62.5 lg:ml-3 dark:text-white" href={resolve('/(app)')}>
                     {#if isMediumScreenQuery.current}
-                        <Logo class="absolute top-2.25 mr-3 h-11.25" />
+                        <Logo class="absolute top-1 mr-3 h-14" />
                     {:else}
                         <img alt="Exceptionless Logo" class="mr-3 h-8" src={logoSmall} />
                     {/if}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
@@ -1,9 +1,21 @@
 <script lang="ts">
+    import type { EventSummaryModel, StackSummaryModel, SummaryTemplateKeys } from '$features/events/components/summary/index';
+    import type { FetchClientResponse, ProblemDetails } from '@exceptionless/fetchclient';
+
+    import { resolve } from '$app/paths';
     import * as Command from '$comp/ui/command';
+    import { accessToken } from '$features/auth/index.svelte';
+    import { organization } from '$features/organizations/context.svelte';
     import { appKeyboardShortcuts, formatKeyboardShortcut, type ShortcutKey } from '$features/shared/keyboard-shortcuts';
+    import { DEFAULT_OFFSET } from '$shared/api/api.svelte';
+    import { useFetchClient } from '@exceptionless/fetchclient';
+    import Activity from '@lucide/svelte/icons/activity';
+    import Bug from '@lucide/svelte/icons/bug';
     import Building2 from '@lucide/svelte/icons/building-2';
     import CircleUserRound from '@lucide/svelte/icons/circle-user-round';
     import Keyboard from '@lucide/svelte/icons/keyboard';
+    import Search from '@lucide/svelte/icons/search';
+    import { createQuery } from '@tanstack/svelte-query';
 
     import type { NavigationItem } from '../../routes.svelte';
 
@@ -27,7 +39,84 @@
         routes: NavigationItem[];
     };
 
+    type CommandSearchResult = EventSummaryModel<SummaryTemplateKeys> | StackSummaryModel<SummaryTemplateKeys>;
+
+    const COMMAND_SEARCH_RESULT_LIMIT = 3;
+    const COMMAND_SEARCH_REQUEST_LIMIT = COMMAND_SEARCH_RESULT_LIMIT + 1;
+    const COMMAND_SEARCH_MIN_LENGTH = 2;
+    const COMMAND_SEARCH_TIME_RANGE = '[now-7d TO now]';
+
     let { open = $bindable(), openKeyboardShortcuts, openOrganizationSwitcher, openUserMenu, resetKey, routes }: Props = $props();
+    let searchText = $state('');
+    let debouncedSearchText = $state('');
+
+    const client = useFetchClient();
+    const hasSearchText = $derived(debouncedSearchText.length >= COMMAND_SEARCH_MIN_LENGTH);
+
+    $effect(() => {
+        const trimmedSearchText = searchText.trim();
+        if (trimmedSearchText.length < COMMAND_SEARCH_MIN_LENGTH) {
+            debouncedSearchText = '';
+            return;
+        }
+
+        const timeout = window.setTimeout(() => {
+            debouncedSearchText = trimmedSearchText;
+        }, 150);
+
+        return () => {
+            window.clearTimeout(timeout);
+        };
+    });
+
+    const eventSearchQuery = createQuery<FetchClientResponse<EventSummaryModel<SummaryTemplateKeys>[]>, ProblemDetails>(() => ({
+        enabled: () => open && !!accessToken.current && !!organization.current && hasSearchText,
+        queryFn: async ({ signal }: { signal: AbortSignal }) => {
+            return client.getJSON<EventSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organization.current}/events`, {
+                params: {
+                    ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
+                    filter: debouncedSearchText,
+                    limit: COMMAND_SEARCH_REQUEST_LIMIT,
+                    mode: 'summary',
+                    time: COMMAND_SEARCH_TIME_RANGE
+                },
+                signal
+            });
+        },
+        queryKey: ['navigation-command', 'events', organization.current, debouncedSearchText]
+    }));
+
+    const issueSearchQuery = createQuery<FetchClientResponse<StackSummaryModel<SummaryTemplateKeys>[]>, ProblemDetails>(() => ({
+        enabled: () => open && !!accessToken.current && !!organization.current && hasSearchText,
+        queryFn: async ({ signal }: { signal: AbortSignal }) => {
+            return client.getJSON<StackSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organization.current}/events`, {
+                params: {
+                    ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
+                    filter: debouncedSearchText,
+                    limit: COMMAND_SEARCH_REQUEST_LIMIT,
+                    mode: 'stack_frequent',
+                    time: COMMAND_SEARCH_TIME_RANGE
+                },
+                signal
+            });
+        },
+        queryKey: ['navigation-command', 'issues', organization.current, debouncedSearchText]
+    }));
+
+    const eventMatches = $derived((eventSearchQuery.data?.data ?? []).slice(0, COMMAND_SEARCH_RESULT_LIMIT));
+    const issueMatches = $derived((issueSearchQuery.data?.data ?? []).slice(0, COMMAND_SEARCH_RESULT_LIMIT));
+    const hasMoreEventMatches = $derived((eventSearchQuery.data?.data?.length ?? 0) > COMMAND_SEARCH_RESULT_LIMIT);
+    const hasMoreIssueMatches = $derived((issueSearchQuery.data?.data?.length ?? 0) > COMMAND_SEARCH_RESULT_LIMIT);
+    const showEventSearchResults = $derived(eventSearchQuery.isPending || eventMatches.length > 0 || hasMoreEventMatches);
+    const showIssueSearchResults = $derived(issueSearchQuery.isPending || issueMatches.length > 0 || hasMoreIssueMatches);
+    const showRemoteSearchResults = $derived(showEventSearchResults || showIssueSearchResults);
+
+    $effect(() => {
+        if (resetKey >= 0) {
+            searchText = '';
+            debouncedSearchText = '';
+        }
+    });
 
     function getCommandGroup(route: NavigationItem): string {
         return route.group === 'Dashboards' ? route.title : route.group;
@@ -40,6 +129,61 @@
     function getCommandValue(...parts: Array<string | undefined>): string {
         return parts.filter(Boolean).join(' ');
     }
+
+    function filterCommandItem(value: string, search: string, keywords?: string[]): number {
+        const normalizedSearch = search.trim().toLocaleLowerCase();
+        if (!normalizedSearch) {
+            return 1;
+        }
+
+        const searchableText = [value, ...(keywords ?? [])].join(' ').toLocaleLowerCase();
+        return searchableText.includes(normalizedSearch) ? 1 : 0;
+    }
+
+    function buildSearchHref(path: string, searchText: string): string {
+        const params = new URLSearchParams({
+            filter: searchText,
+            limit: '20',
+            time: ''
+        });
+
+        return `${path}?${params.toString()}`;
+    }
+
+    function getResultTitle(result: CommandSearchResult): string {
+        if ('title' in result && result.title) {
+            return result.title;
+        }
+
+        const data = result.data as Record<string, unknown>;
+        const values = [data.Type, data.Method, data.Source, data.Name, data.Message, data.Path].filter(
+            (value): value is string => typeof value === 'string' && value.length > 0
+        );
+
+        return values.join(' ') || result.id;
+    }
+
+    function getResultDescription(result: CommandSearchResult): string | undefined {
+        const data = result.data as Record<string, unknown>;
+        const values = [data.Identity, data.Source, data.Path].filter((value): value is string => typeof value === 'string' && value.length > 0);
+
+        return values.join(' · ') || undefined;
+    }
+
+    function getResultValue(group: 'Event' | 'Issue', result: CommandSearchResult): string {
+        return getCommandValue(group, debouncedSearchText, getResultTitle(result), getResultDescription(result), result.id);
+    }
+
+    function getEventHref(result: CommandSearchResult): string {
+        return resolve('/(app)/event/[eventId]', { eventId: result.id });
+    }
+
+    function getIssueHref(result: CommandSearchResult): string {
+        return resolve('/(app)/issues/[stackId]', { stackId: result.id });
+    }
+
+    const eventSearchHref = $derived(buildSearchHref(resolve('/(app)'), debouncedSearchText));
+    const issueSearchHref = $derived(buildSearchHref(resolve('/(app)/issues'), debouncedSearchText));
 
     const commandRoutes = $derived(
         routes.flatMap((route) => {
@@ -108,10 +252,72 @@
 </script>
 
 {#key resetKey}
-    <Command.Dialog bind:open>
-        <Command.Input placeholder="Search or jump to..." />
+    <Command.Dialog bind:open filter={filterCommandItem}>
+        <Command.Input bind:value={searchText} placeholder="Search or jump to..." />
         <Command.List>
             <Command.Empty>No results found.</Command.Empty>
+            {#if hasSearchText && showRemoteSearchResults}
+                {#if showEventSearchResults}
+                    <Command.Group heading="Events" value="Search Events">
+                        {#if eventSearchQuery.isPending}
+                            <Command.Item disabled value={`Searching events ${debouncedSearchText}`}>
+                                <Activity />
+                                <span>Searching events...</span>
+                            </Command.Item>
+                        {:else}
+                            {#each eventMatches as event (event.id)}
+                                <Command.LinkItem href={getEventHref(event)} onclick={closeCommandWindow} value={getResultValue('Event', event)}>
+                                    <Activity />
+                                    <div class="flex min-w-0 flex-col">
+                                        <span class="truncate">{getResultTitle(event)}</span>
+                                        {#if getResultDescription(event)}
+                                            <span class="text-muted-foreground truncate text-xs">{getResultDescription(event)}</span>
+                                        {/if}
+                                    </div>
+                                </Command.LinkItem>
+                            {/each}
+                            {#if hasMoreEventMatches}
+                                <Command.LinkItem href={eventSearchHref} onclick={closeCommandWindow} value={`View all events ${debouncedSearchText}`}>
+                                    <Search />
+                                    <span>View all matching events</span>
+                                </Command.LinkItem>
+                            {/if}
+                        {/if}
+                    </Command.Group>
+                {/if}
+                {#if showEventSearchResults && showIssueSearchResults}
+                    <Command.Separator />
+                {/if}
+                {#if showIssueSearchResults}
+                    <Command.Group heading="Issues" value="Search Issues">
+                        {#if issueSearchQuery.isPending}
+                            <Command.Item disabled value={`Searching issues ${debouncedSearchText}`}>
+                                <Bug />
+                                <span>Searching issues...</span>
+                            </Command.Item>
+                        {:else}
+                            {#each issueMatches as issue (issue.id)}
+                                <Command.LinkItem href={getIssueHref(issue)} onclick={closeCommandWindow} value={getResultValue('Issue', issue)}>
+                                    <Bug />
+                                    <div class="flex min-w-0 flex-col">
+                                        <span class="truncate">{getResultTitle(issue)}</span>
+                                        {#if getResultDescription(issue)}
+                                            <span class="text-muted-foreground truncate text-xs">{getResultDescription(issue)}</span>
+                                        {/if}
+                                    </div>
+                                </Command.LinkItem>
+                            {/each}
+                            {#if hasMoreIssueMatches}
+                                <Command.LinkItem href={issueSearchHref} onclick={closeCommandWindow} value={`View all issues ${debouncedSearchText}`}>
+                                    <Search />
+                                    <span>View all matching issues</span>
+                                </Command.LinkItem>
+                            {/if}
+                        {/if}
+                    </Command.Group>
+                {/if}
+                <Command.Separator />
+            {/if}
             {#each Object.entries(groupedRoutes) as [group, items], index (group)}
                 <Command.Group heading={group}>
                     {#each items as route (route.href)}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+page.svelte
@@ -12,6 +12,7 @@
     import { getOrganizationCountQuery } from '$features/events/api.svelte';
     import EventDetailSheet from '$features/events/components/event-detail-sheet.svelte';
     import EventsDashboardChart from '$features/events/components/events-dashboard-chart.svelte';
+    import EventsStatsDashboard from '$features/events/components/events-stats-dashboard.svelte';
     import { DateFilter, ProjectFilter, StatusFilter } from '$features/events/components/filters';
     import {
         applyTimeFilter,
@@ -92,15 +93,21 @@
     });
 
     const VIEW = 'events';
+    let showStats = $state(true);
+    let showChart = $state(true);
     const savedViewsState = useSavedViews({
         defaultColumnVisibility: defaultEventColumnVisibility,
         filterCacheKey,
         getColumnOrder: () => table.store.state.columnOrder,
         getColumnVisibility: () => table.store.state.columnVisibility,
         getFilterDefinitions: () => serializeFilters(filters ?? []),
+        getShowChart: () => showChart,
+        getShowStats: () => showStats,
         queryParams,
         setColumnOrder: (v) => table.setColumnOrder(v),
         setColumnVisibility: (v) => table.setColumnVisibility(v),
+        setShowChart: (v) => (showChart = v),
+        setShowStats: (v) => (showStats = v),
         updateFilterCache,
         view: VIEW
     });
@@ -297,6 +304,22 @@
         }));
     });
 
+    const stats = $derived.by(() => {
+        const aggregations = chartDataQuery.data?.aggregations;
+        const timeRange = parseDateMathRange(getQueryTime() || undefined);
+        const totalEvents = agg.sum(aggregations, 'sum_count')?.value ?? chartDataQuery.data?.total ?? 0;
+        const totalIssues = agg.cardinality(aggregations, 'cardinality_stack')?.value ?? 0;
+        const newIssues = agg.terms<boolean>(aggregations, 'terms_first')?.buckets[0]?.total ?? 0;
+        const hours = Math.max((timeRange.end.getTime() - timeRange.start.getTime()) / 3_600_000, 1);
+
+        return {
+            eventsPerHour: totalEvents / hours,
+            newIssues,
+            totalEvents,
+            totalIssues
+        };
+    });
+
     function onRangeSelect(start: Date, end: Date) {
         onFilterChanged(new DateFilter('date', toDateMathRange(start, end)));
     }
@@ -322,6 +345,10 @@
                     onClearSavedView={savedViewsState.handleClearSavedView}
                     onResetToSaved={savedViewsState.handleResetToSaved}
                     savedViews={savedViewsState.savedViews}
+                    {showChart}
+                    {showStats}
+                    setShowChart={(v) => (showChart = v)}
+                    setShowStats={(v) => (showStats = v)}
                     sort={queryParams.sort ?? undefined}
                     {table}
                     time={queryParams.time ?? undefined}
@@ -338,7 +365,19 @@
     </div>
 
     <div class="flex flex-col gap-y-4">
-        <EventsDashboardChart data={chartData()} isLoading={chartDataQuery.isLoading && !chartDataQuery.isSuccess} {onRangeSelect} />
+        {#if showStats}
+            <EventsStatsDashboard
+                eventsPerHour={stats.eventsPerHour}
+                isLoading={chartDataQuery.isLoading && !chartDataQuery.isSuccess}
+                newIssues={stats.newIssues}
+                totalEvents={stats.totalEvents}
+                totalIssues={stats.totalIssues}
+            />
+        {/if}
+
+        {#if showChart}
+            <EventsDashboardChart data={chartData()} isLoading={chartDataQuery.isLoading && !chartDataQuery.isSuccess} {onRangeSelect} />
+        {/if}
 
         <EventsDataTable bind:limit={queryParams.limit!} isLoading={clientStatus.isLoading} {rowClick} {rowHref} {table}>
             {#snippet footerChildren()}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/issues/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/issues/+page.svelte
@@ -12,6 +12,7 @@
     import EventDetailSheet from '$features/events/components/event-detail-sheet.svelte';
     import EventsDashboardChart from '$features/events/components/events-dashboard-chart.svelte';
     import { DateFilter, ProjectFilter, StatusFilter, TypeFilter } from '$features/events/components/filters';
+    import EventsStatsDashboard from '$features/events/components/events-stats-dashboard.svelte';
     import {
         applyTimeFilter,
         buildFilterCacheKey,
@@ -106,14 +107,20 @@
     });
 
     const VIEW = 'issues';
+    let showStats = $state(true);
+    let showChart = $state(true);
     const savedViewsState = useSavedViews({
         filterCacheKey,
         getColumnOrder: () => table.store.state.columnOrder,
         getColumnVisibility: () => table.store.state.columnVisibility,
         getFilterDefinitions: () => serializeFilters(filters ?? []),
+        getShowChart: () => showChart,
+        getShowStats: () => showStats,
         queryParams,
         setColumnOrder: (v) => table.setColumnOrder(v),
         setColumnVisibility: (v) => table.setColumnVisibility(v),
+        setShowChart: (v) => (showChart = v),
+        setShowStats: (v) => (showStats = v),
         updateFilterCache,
         view: VIEW
     });
@@ -310,6 +317,22 @@
         }));
     });
 
+    const stats = $derived.by(() => {
+        const aggregations = chartDataQuery.data?.aggregations;
+        const timeRange = parseDateMathRange(queryParams.time);
+        const totalEvents = agg.sum(aggregations, 'sum_count')?.value ?? chartDataQuery.data?.total ?? 0;
+        const totalIssues = agg.cardinality(aggregations, 'cardinality_stack')?.value ?? 0;
+        const newIssues = agg.terms<boolean>(aggregations, 'terms_first')?.buckets[0]?.total ?? 0;
+        const hours = Math.max((timeRange.end.getTime() - timeRange.start.getTime()) / 3_600_000, 1);
+
+        return {
+            eventsPerHour: totalEvents / hours,
+            newIssues,
+            totalEvents,
+            totalIssues
+        };
+    });
+
     function onRangeSelect(start: Date, end: Date) {
         onFilterChanged(new DateFilter('date', toDateMathRange(start, end)));
     }
@@ -335,6 +358,10 @@
                     onClearSavedView={savedViewsState.handleClearSavedView}
                     onResetToSaved={savedViewsState.handleResetToSaved}
                     savedViews={savedViewsState.savedViews}
+                    {showChart}
+                    {showStats}
+                    setShowChart={(v) => (showChart = v)}
+                    setShowStats={(v) => (showStats = v)}
                     {table}
                     time={queryParams.time ?? undefined}
                     view={VIEW}
@@ -350,7 +377,19 @@
     </div>
 
     <div class="flex flex-col gap-y-4">
-        <EventsDashboardChart data={chartData()} isLoading={clientStatus.isLoading || chartDataQuery.isLoading} {onRangeSelect} />
+        {#if showStats}
+            <EventsStatsDashboard
+                eventsPerHour={stats.eventsPerHour}
+                isLoading={chartDataQuery.isLoading && !chartDataQuery.isSuccess}
+                newIssues={stats.newIssues}
+                totalEvents={stats.totalEvents}
+                totalIssues={stats.totalIssues}
+            />
+        {/if}
+
+        {#if showChart}
+            <EventsDashboardChart data={chartData()} isLoading={clientStatus.isLoading || chartDataQuery.isLoading} {onRangeSelect} />
+        {/if}
 
         <EventsDataTable bind:limit={queryParams.limit!} isLoading={clientStatus.isLoading} {rowClick} {rowHref} {table}>
             {#snippet footerChildren()}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/issues/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/issues/+page.svelte
@@ -11,8 +11,8 @@
     import { type GetEventsParams, getOrganizationCountQuery, getStackEventsQuery } from '$features/events/api.svelte';
     import EventDetailSheet from '$features/events/components/event-detail-sheet.svelte';
     import EventsDashboardChart from '$features/events/components/events-dashboard-chart.svelte';
-    import { DateFilter, ProjectFilter, StatusFilter, TypeFilter } from '$features/events/components/filters';
     import EventsStatsDashboard from '$features/events/components/events-stats-dashboard.svelte';
+    import { DateFilter, ProjectFilter, StatusFilter, TypeFilter } from '$features/events/components/filters';
     import {
         applyTimeFilter,
         buildFilterCacheKey,

--- a/src/Exceptionless.Web/Models/SavedView/NewSavedView.cs
+++ b/src/Exceptionless.Web/Models/SavedView/NewSavedView.cs
@@ -54,6 +54,10 @@ public record NewSavedView : IOwnedByOrganization, IValidatableObject
     [MaxLength(50)]
     public List<string>? ColumnOrder { get; set; }
 
+    public bool? ShowStats { get; set; }
+
+    public bool? ShowChart { get; set; }
+
     /// <summary>If true, the view will only be visible to the current user. Defaults to false.</summary>
     public bool? IsPrivate { get; set; }
 

--- a/src/Exceptionless.Web/Models/SavedView/UpdateSavedView.cs
+++ b/src/Exceptionless.Web/Models/SavedView/UpdateSavedView.cs
@@ -19,6 +19,8 @@ public class UpdateSavedView : IValidatableObject
     public Dictionary<string, bool>? Columns { get; set; }
     [MaxLength(50)]
     public List<string>? ColumnOrder { get; set; }
+    public bool? ShowStats { get; set; }
+    public bool? ShowChart { get; set; }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {

--- a/src/Exceptionless.Web/Models/SavedView/ViewSavedView.cs
+++ b/src/Exceptionless.Web/Models/SavedView/ViewSavedView.cs
@@ -24,6 +24,8 @@ public record ViewSavedView : IIdentity, IHaveDates
     public string? FilterDefinitions { get; set; }
     public Dictionary<string, bool>? Columns { get; set; }
     public List<string>? ColumnOrder { get; set; }
+    public bool? ShowStats { get; set; }
+    public bool? ShowChart { get; set; }
     public string Name { get; set; } = null!;
     public string? Time { get; set; }
     public string? Sort { get; set; }

--- a/src/Exceptionless.Web/Utility/OpenApi/DeltaSchemaTransformer.cs
+++ b/src/Exceptionless.Web/Utility/OpenApi/DeltaSchemaTransformer.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using Exceptionless.Core.Extensions;
 using Microsoft.AspNetCore.OpenApi;
@@ -40,6 +41,7 @@ public class DeltaSchemaTransformer : IOpenApiSchemaTransformer
 
             // Apply data annotations from the inner type's property
             DataAnnotationHelper.ApplyToSchema(propertySchema, property);
+            ApplyArrayAnnotations(propertySchema, property);
 
             string propertyName = property.Name.ToLowerUnderscoredWords();
             schema.Properties[propertyName] = propertySchema;
@@ -133,9 +135,10 @@ public class DeltaSchemaTransformer : IOpenApiSchemaTransformer
                 schema.AdditionalProperties = CreateSchemaForType(valueType, false);
             }
         }
-        else if (type.IsArray || (type.IsGenericType && typeof(System.Collections.IEnumerable).IsAssignableFrom(type)))
+        else if (TryGetEnumerableElementType(type, out var elementType))
         {
             schemaType |= JsonSchemaType.Array;
+            schema.Items = CreateSchemaForType(elementType, false);
         }
         else
         {
@@ -144,5 +147,41 @@ public class DeltaSchemaTransformer : IOpenApiSchemaTransformer
 
         schema.Type = schemaType;
         return schema;
+    }
+
+    private static void ApplyArrayAnnotations(OpenApiSchema schema, PropertyInfo property)
+    {
+        if (!schema.Type.HasValue || (schema.Type.Value & JsonSchemaType.Array) != JsonSchemaType.Array)
+        {
+            return;
+        }
+
+        var maxLength = property.GetCustomAttribute<MaxLengthAttribute>();
+        if (maxLength is { Length: > -1 })
+        {
+            schema.MaxItems = maxLength.Length;
+        }
+    }
+
+    private static bool TryGetEnumerableElementType(Type type, out Type elementType)
+    {
+        if (type.IsArray)
+        {
+            elementType = type.GetElementType() ?? typeof(object);
+            return true;
+        }
+
+        if (type == typeof(string) || !typeof(System.Collections.IEnumerable).IsAssignableFrom(type))
+        {
+            elementType = typeof(object);
+            return false;
+        }
+
+        var enumerableType = type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+            ? type
+            : type.GetInterfaces().FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+
+        elementType = enumerableType?.GetGenericArguments()[0] ?? typeof(object);
+        return true;
     }
 }

--- a/tests/Exceptionless.Tests/Controllers/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Controllers/Data/openapi.json
@@ -16,7 +16,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost/"
+      "url": "https://localhost:7111/"
     }
   ],
   "paths": {
@@ -440,7 +440,7 @@
           "Token"
         ],
         "summary": "Create for organization",
-        "description": "This is a helper action that makes it easier to create a token for a specific organization.\nYou may also specify a scope when creating a token. There are three valid scopes: client, user and admin.",
+        "description": "This is a helper action that makes it easier to create a token for a specific organization.\r\nYou may also specify a scope when creating a token. There are three valid scopes: client, user and admin.",
         "parameters": [
           {
             "name": "organizationId",
@@ -564,7 +564,7 @@
           "Token"
         ],
         "summary": "Create for project",
-        "description": "This is a helper action that makes it easier to create a token for a specific project.\nYou may also specify a scope when creating a token. There are three valid scopes: client, user and admin.",
+        "description": "This is a helper action that makes it easier to create a token for a specific project.\r\nYou may also specify a scope when creating a token. There are three valid scopes: client, user and admin.",
         "parameters": [
           {
             "name": "projectId",
@@ -1071,7 +1071,7 @@
           "Auth"
         ],
         "summary": "Login",
-        "description": "Log in with your email address and password to generate a token scoped with your users roles.\n\n```{ \"email\": \"noreply@exceptionless.io\", \"password\": \"exceptionless\" }```\n\nThis token can then be used to access the api. You can use this token in the header (bearer authentication)\nor append it onto the query string: ?access_token=MY_TOKEN\n\nPlease note that you can also use this token on the documentation site by placing it in the\nheaders api_key input box.",
+        "description": "Log in with your email address and password to generate a token scoped with your users roles.\r\n\r\n```{ \"email\": \"noreply@exceptionless.io\", \"password\": \"exceptionless\" }```\r\n\r\nThis token can then be used to access the api. You can use this token in the header (bearer authentication)\r\nor append it onto the query string: ?access_token=MY_TOKEN\r\n\r\nPlease note that you can also use this token on the documentation site by placing it in the\r\nheaders api_key input box.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -1928,7 +1928,7 @@
           "Event"
         ],
         "summary": "Submit event by POST",
-        "description": "      You can create an event by posting any uncompressed or compressed (gzip or deflate) string or json object. If we know how to handle it\n      we will create a new event. If none of the JSON properties match the event object then we will create a new event and place your JSON\n      object into the events data collection.\n\n      You can also post a multi-line string. We automatically split strings by the \\n character and create a new log event for every line.\n\n      Simple event:\n      ```{ \"message\": \"Exceptionless is amazing!\" }```\n\n      Simple log event with user identity:\n      ```{\n    \"type\": \"log\",\n    \"message\": \"Exceptionless is amazing!\",\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\n    \"@user\":{ \"identity\":\"123456789\", \"name\": \"Test User\" }\n}```\n\n      Multiple events from string content:\n      ```Exceptionless is amazing!\nExceptionless is really amazing!```\n\n      Simple error:\n      ```{\n    \"type\": \"error\",\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\n    \"@simple_error\": {\n        \"message\": \"Simple Exception\",\n        \"type\": \"System.Exception\",\n        \"stack_trace\": \"   at Client.Tests.ExceptionlessClientTests.CanSubmitSimpleException() in ExceptionlessClientTests.cs:line 77\"\n    }\n}```",
+        "description": "      You can create an event by posting any uncompressed or compressed (gzip or deflate) string or json object. If we know how to handle it\r\n      we will create a new event. If none of the JSON properties match the event object then we will create a new event and place your JSON\r\n      object into the events data collection.\r\n\r\n      You can also post a multi-line string. We automatically split strings by the \\n character and create a new log event for every line.\r\n\r\n      Simple event:\r\n      ```{ \"message\": \"Exceptionless is amazing!\" }```\r\n\r\n      Simple log event with user identity:\r\n      ```{\r\n    \"type\": \"log\",\r\n    \"message\": \"Exceptionless is amazing!\",\r\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\r\n    \"@user\":{ \"identity\":\"123456789\", \"name\": \"Test User\" }\r\n}```\r\n\r\n      Multiple events from string content:\r\n      ```Exceptionless is amazing!\r\nExceptionless is really amazing!```\r\n\r\n      Simple error:\r\n      ```{\r\n    \"type\": \"error\",\r\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\r\n    \"@simple_error\": {\r\n        \"message\": \"Simple Exception\",\r\n        \"type\": \"System.Exception\",\r\n        \"stack_trace\": \"   at Client.Tests.ExceptionlessClientTests.CanSubmitSimpleException() in ExceptionlessClientTests.cs:line 77\"\r\n    }\r\n}```",
         "parameters": [
           {
             "name": "userAgent",
@@ -2214,7 +2214,7 @@
           "Event"
         ],
         "summary": "Submit event by POST for a specific project",
-        "description": "      You can create an event by posting any uncompressed or compressed (gzip or deflate) string or json object. If we know how to handle it\n      we will create a new event. If none of the JSON properties match the event object then we will create a new event and place your JSON\n      object into the events data collection.\n\n      You can also post a multi-line string. We automatically split strings by the \\n character and create a new log event for every line.\n\n      Simple event:\n      ```{ \"message\": \"Exceptionless is amazing!\" }```\n\n      Simple log event with user identity:\n      ```{\n    \"type\": \"log\",\n    \"message\": \"Exceptionless is amazing!\",\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\n    \"@user\":{ \"identity\":\"123456789\", \"name\": \"Test User\" }\n}```\n\n      Multiple events from string content:\n      ```Exceptionless is amazing!\nExceptionless is really amazing!```\n\n      Simple error:\n      ```{\n    \"type\": \"error\",\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\n    \"@simple_error\": {\n        \"message\": \"Simple Exception\",\n        \"type\": \"System.Exception\",\n        \"stack_trace\": \"   at Client.Tests.ExceptionlessClientTests.CanSubmitSimpleException() in ExceptionlessClientTests.cs:line 77\"\n    }\n}```",
+        "description": "      You can create an event by posting any uncompressed or compressed (gzip or deflate) string or json object. If we know how to handle it\r\n      we will create a new event. If none of the JSON properties match the event object then we will create a new event and place your JSON\r\n      object into the events data collection.\r\n\r\n      You can also post a multi-line string. We automatically split strings by the \\n character and create a new log event for every line.\r\n\r\n      Simple event:\r\n      ```{ \"message\": \"Exceptionless is amazing!\" }```\r\n\r\n      Simple log event with user identity:\r\n      ```{\r\n    \"type\": \"log\",\r\n    \"message\": \"Exceptionless is amazing!\",\r\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\r\n    \"@user\":{ \"identity\":\"123456789\", \"name\": \"Test User\" }\r\n}```\r\n\r\n      Multiple events from string content:\r\n      ```Exceptionless is amazing!\r\nExceptionless is really amazing!```\r\n\r\n      Simple error:\r\n      ```{\r\n    \"type\": \"error\",\r\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\r\n    \"@simple_error\": {\r\n        \"message\": \"Simple Exception\",\r\n        \"type\": \"System.Exception\",\r\n        \"stack_trace\": \"   at Client.Tests.ExceptionlessClientTests.CanSubmitSimpleException() in ExceptionlessClientTests.cs:line 77\"\r\n    }\r\n}```",
         "parameters": [
           {
             "name": "projectId",
@@ -3547,7 +3547,7 @@
           "Event"
         ],
         "summary": "Submit event by GET",
-        "description": "You can submit an event using an HTTP GET and query string parameters. Any unknown query string parameters will be added to the extended data of the event.\n\nFeature usage named build with a duration of 10:\n```/events/submit?access_token=YOUR_API_KEY&amp;type=usage&amp;source=build&amp;value=10```\n\nLog with message, geo and extended data\n```/events/submit?access_token=YOUR_API_KEY&amp;type=log&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
+        "description": "You can submit an event using an HTTP GET and query string parameters. Any unknown query string parameters will be added to the extended data of the event.\r\n\r\nFeature usage named build with a duration of 10:\r\n```/events/submit?access_token=YOUR_API_KEY&amp;type=usage&amp;source=build&amp;value=10```\r\n\r\nLog with message, geo and extended data\r\n```/events/submit?access_token=YOUR_API_KEY&amp;type=log&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
         "parameters": [
           {
             "name": "type",
@@ -3681,7 +3681,7 @@
           "Event"
         ],
         "summary": "Submit event type by GET",
-        "description": "You can submit an event using an HTTP GET and query string parameters.\n\nFeature usage event named build with a value of 10:\n```/events/submit/usage?access_token=YOUR_API_KEY&amp;source=build&amp;value=10```\n\nLog event with message, geo and extended data\n```/events/submit/log?access_token=YOUR_API_KEY&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
+        "description": "You can submit an event using an HTTP GET and query string parameters.\r\n\r\nFeature usage event named build with a value of 10:\r\n```/events/submit/usage?access_token=YOUR_API_KEY&amp;source=build&amp;value=10```\r\n\r\nLog event with message, geo and extended data\r\n```/events/submit/log?access_token=YOUR_API_KEY&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
         "parameters": [
           {
             "name": "type",
@@ -3817,7 +3817,7 @@
           "Event"
         ],
         "summary": "Submit event type by GET for a specific project",
-        "description": "You can submit an event using an HTTP GET and query string parameters.\n\nFeature usage named build with a duration of 10:\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=usage&amp;source=build&amp;value=10```\n\nLog with message, geo and extended data\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=log&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
+        "description": "You can submit an event using an HTTP GET and query string parameters.\r\n\r\nFeature usage named build with a duration of 10:\r\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=usage&amp;source=build&amp;value=10```\r\n\r\nLog with message, geo and extended data\r\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=log&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
         "parameters": [
           {
             "name": "projectId",
@@ -3953,7 +3953,7 @@
           "Event"
         ],
         "summary": "Submit event type by GET for a specific project",
-        "description": "You can submit an event using an HTTP GET and query string parameters.\n\nFeature usage named build with a duration of 10:\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=usage&amp;source=build&amp;value=10```\n\nLog with message, geo and extended data\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=log&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
+        "description": "You can submit an event using an HTTP GET and query string parameters.\r\n\r\nFeature usage named build with a duration of 10:\r\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=usage&amp;source=build&amp;value=10```\r\n\r\nLog with message, geo and extended data\r\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=log&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
         "parameters": [
           {
             "name": "projectId",
@@ -4683,7 +4683,7 @@
           "Organization"
         ],
         "summary": "Change plan",
-        "description": "Upgrades or downgrades the organization's plan.\nAccepts parameters via JSON body (preferred) or query string (legacy).",
+        "description": "Upgrades or downgrades the organization's plan.\r\nAccepts parameters via JSON body (preferred) or query string (legacy).",
         "parameters": [
           {
             "name": "id",
@@ -7929,6 +7929,18 @@
               "type": "string"
             }
           },
+          "show_stats": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "show_chart": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
           "is_private": {
             "type": [
               "null",
@@ -8152,7 +8164,7 @@
               "null",
               "string"
             ],
-            "description": "The event type (ie. error, log message, feature usage). Check KnownTypes for standard event types.\nNullable in transit; the pipeline infers a default before save. Validated as required on repository save."
+            "description": "The event type (ie. error, log message, feature usage). Check KnownTypes for standard event types.\r\nNullable in transit; the pipeline infers a default before save. Validated as required on repository save."
           },
           "source": {
             "maxLength": 2000,
@@ -8586,6 +8598,18 @@
             "type": [
               "null",
               "array"
+            ]
+          },
+          "show_stats": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "show_chart": {
+            "type": [
+              "null",
+              "boolean"
             ]
           }
         },
@@ -9260,6 +9284,18 @@
             "items": {
               "type": "string"
             }
+          },
+          "show_stats": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "show_chart": {
+            "type": [
+              "null",
+              "boolean"
+            ]
           },
           "name": {
             "type": "string"

--- a/tests/Exceptionless.Tests/Controllers/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Controllers/Data/openapi.json
@@ -8595,10 +8595,14 @@
             }
           },
           "column_order": {
+            "maxItems": 50,
             "type": [
               "null",
               "array"
-            ]
+            ],
+            "items": {
+              "type": "string"
+            }
           },
           "show_stats": {
             "type": [

--- a/tests/Exceptionless.Tests/Controllers/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Controllers/Data/openapi.json
@@ -16,7 +16,7 @@
   },
   "servers": [
     {
-      "url": "https://localhost:7111/"
+      "url": "http://localhost/"
     }
   ],
   "paths": {


### PR DESCRIPTION
## Summary
- Polish the event detail sheet, command palette search, navbar logo, and shared dashboard chart shell
- Add compact dashboard stat cards for sessions and events/issues
- Add saved-view column order/display preferences for stat boxes and charts

## Validation
- npm run check
- Live browser verification in Aspire for dashboard chart/stat toggles and menu alignment
- OpenAPI baseline regenerated from local Aspire

## Notes
- Aspire is expected to remain running for local `/next` validation.