### PR TITLE
Add comprehensive API controller test coverage and serializer model tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,7 +94,7 @@ jobs:
         run: dotnet build ./Exceptionless.slnx --no-restore --configuration Release
 
       - name: Run .NET Tests with Coverage
-        run: dotnet test --no-restore --no-build --configuration Release --results-directory coverage --max-parallel-test-modules 1 -- --report-github --report-xunit-trx --report-xunit-trx-filename test-results.trx --coverage --coverage-output coverage.cobertura.xml --coverage-output-format cobertura
+        run: dotnet test --no-restore --no-build --configuration Release --results-directory coverage --max-parallel-test-modules 1 -- --report-github --report-xunit-trx --report-xunit-trx-filename test-results.trx --coverage --coverage-settings ${{ github.workspace }}/tests/CodeCoverage.config --coverage-output coverage.cobertura.xml --coverage-output-format cobertura
 
       - name: Code Coverage Summary Report
         uses: irongut/CodeCoverageSummary@v1.3.0

--- a/src/Exceptionless.Core/Billing/IStripeBillingClient.cs
+++ b/src/Exceptionless.Core/Billing/IStripeBillingClient.cs
@@ -1,0 +1,24 @@
+using Stripe;
+
+namespace Exceptionless.Core.Billing;
+
+public interface IStripeBillingClient
+{
+    Task<Stripe.Invoice?> GetInvoiceAsync(string id);
+
+    Task<IReadOnlyCollection<Stripe.Invoice>> ListInvoicesAsync(InvoiceListOptions options);
+
+    Task<Customer> CreateCustomerAsync(CustomerCreateOptions options);
+
+    Task<Customer> UpdateCustomerAsync(string customerId, CustomerUpdateOptions options);
+
+    Task<Subscription> CreateSubscriptionAsync(SubscriptionCreateOptions options);
+
+    Task<Subscription> UpdateSubscriptionAsync(string subscriptionId, SubscriptionUpdateOptions options);
+
+    Task<IReadOnlyCollection<Subscription>> ListSubscriptionsAsync(SubscriptionListOptions options);
+
+    Task<Subscription> CancelSubscriptionAsync(string subscriptionId, SubscriptionCancelOptions options);
+
+    Task<PaymentMethod> AttachPaymentMethodAsync(string paymentMethodId, PaymentMethodAttachOptions options);
+}

--- a/src/Exceptionless.Core/Billing/StripeBillingClient.cs
+++ b/src/Exceptionless.Core/Billing/StripeBillingClient.cs
@@ -1,0 +1,70 @@
+using Exceptionless.Core.Configuration;
+using Stripe;
+
+namespace Exceptionless.Core.Billing;
+
+public sealed class StripeBillingClient : IStripeBillingClient
+{
+    private readonly StripeOptions _stripeOptions;
+
+    public StripeBillingClient(StripeOptions stripeOptions)
+    {
+        _stripeOptions = stripeOptions;
+    }
+
+    public Task<Stripe.Invoice?> GetInvoiceAsync(string id)
+    {
+        var service = new InvoiceService(CreateClient());
+        return service.GetAsync(id);
+    }
+
+    public async Task<IReadOnlyCollection<Stripe.Invoice>> ListInvoicesAsync(InvoiceListOptions options)
+    {
+        var service = new InvoiceService(CreateClient());
+        return (await service.ListAsync(options)).ToList();
+    }
+
+    public Task<Customer> CreateCustomerAsync(CustomerCreateOptions options)
+    {
+        var service = new CustomerService(CreateClient());
+        return service.CreateAsync(options);
+    }
+
+    public Task<Customer> UpdateCustomerAsync(string customerId, CustomerUpdateOptions options)
+    {
+        var service = new CustomerService(CreateClient());
+        return service.UpdateAsync(customerId, options);
+    }
+
+    public Task<Subscription> CreateSubscriptionAsync(SubscriptionCreateOptions options)
+    {
+        var service = new SubscriptionService(CreateClient());
+        return service.CreateAsync(options);
+    }
+
+    public Task<Subscription> UpdateSubscriptionAsync(string subscriptionId, SubscriptionUpdateOptions options)
+    {
+        var service = new SubscriptionService(CreateClient());
+        return service.UpdateAsync(subscriptionId, options);
+    }
+
+    public async Task<IReadOnlyCollection<Subscription>> ListSubscriptionsAsync(SubscriptionListOptions options)
+    {
+        var service = new SubscriptionService(CreateClient());
+        return (await service.ListAsync(options)).ToList();
+    }
+
+    public Task<Subscription> CancelSubscriptionAsync(string subscriptionId, SubscriptionCancelOptions options)
+    {
+        var service = new SubscriptionService(CreateClient());
+        return service.CancelAsync(subscriptionId, options);
+    }
+
+    public Task<PaymentMethod> AttachPaymentMethodAsync(string paymentMethodId, PaymentMethodAttachOptions options)
+    {
+        var service = new PaymentMethodService(CreateClient());
+        return service.AttachAsync(paymentMethodId, options);
+    }
+
+    private StripeClient CreateClient() => new(_stripeOptions.StripeApiKey ?? throw new InvalidOperationException("Stripe API key is not configured."));
+}

--- a/src/Exceptionless.Core/Billing/StripeBillingClient.cs
+++ b/src/Exceptionless.Core/Billing/StripeBillingClient.cs
@@ -5,66 +5,67 @@ namespace Exceptionless.Core.Billing;
 
 public sealed class StripeBillingClient : IStripeBillingClient
 {
-    private readonly StripeOptions _stripeOptions;
+    private readonly Lazy<StripeClient> _client;
 
     public StripeBillingClient(StripeOptions stripeOptions)
     {
-        _stripeOptions = stripeOptions;
+        _client = new Lazy<StripeClient>(() =>
+            new StripeClient(stripeOptions.StripeApiKey ?? throw new InvalidOperationException("Stripe API key is not configured.")));
     }
 
     public Task<Stripe.Invoice?> GetInvoiceAsync(string id)
     {
-        var service = new InvoiceService(CreateClient());
+        var service = new InvoiceService(Client);
         return service.GetAsync(id);
     }
 
     public async Task<IReadOnlyCollection<Stripe.Invoice>> ListInvoicesAsync(InvoiceListOptions options)
     {
-        var service = new InvoiceService(CreateClient());
+        var service = new InvoiceService(Client);
         return (await service.ListAsync(options)).ToList();
     }
 
     public Task<Customer> CreateCustomerAsync(CustomerCreateOptions options)
     {
-        var service = new CustomerService(CreateClient());
+        var service = new CustomerService(Client);
         return service.CreateAsync(options);
     }
 
     public Task<Customer> UpdateCustomerAsync(string customerId, CustomerUpdateOptions options)
     {
-        var service = new CustomerService(CreateClient());
+        var service = new CustomerService(Client);
         return service.UpdateAsync(customerId, options);
     }
 
     public Task<Subscription> CreateSubscriptionAsync(SubscriptionCreateOptions options)
     {
-        var service = new SubscriptionService(CreateClient());
+        var service = new SubscriptionService(Client);
         return service.CreateAsync(options);
     }
 
     public Task<Subscription> UpdateSubscriptionAsync(string subscriptionId, SubscriptionUpdateOptions options)
     {
-        var service = new SubscriptionService(CreateClient());
+        var service = new SubscriptionService(Client);
         return service.UpdateAsync(subscriptionId, options);
     }
 
     public async Task<IReadOnlyCollection<Subscription>> ListSubscriptionsAsync(SubscriptionListOptions options)
     {
-        var service = new SubscriptionService(CreateClient());
+        var service = new SubscriptionService(Client);
         return (await service.ListAsync(options)).ToList();
     }
 
     public Task<Subscription> CancelSubscriptionAsync(string subscriptionId, SubscriptionCancelOptions options)
     {
-        var service = new SubscriptionService(CreateClient());
+        var service = new SubscriptionService(Client);
         return service.CancelAsync(subscriptionId, options);
     }
 
     public Task<PaymentMethod> AttachPaymentMethodAsync(string paymentMethodId, PaymentMethodAttachOptions options)
     {
-        var service = new PaymentMethodService(CreateClient());
+        var service = new PaymentMethodService(Client);
         return service.AttachAsync(paymentMethodId, options);
     }
 
-    private StripeClient CreateClient() => new(_stripeOptions.StripeApiKey ?? throw new InvalidOperationException("Stripe API key is not configured."));
+    private StripeClient Client => _client.Value;
 }

--- a/src/Exceptionless.Core/Bootstrapper.cs
+++ b/src/Exceptionless.Core/Bootstrapper.cs
@@ -178,6 +178,7 @@ public class Bootstrapper
         services.AddSingleton<CacheLockProvider>(s => new CacheLockProvider(s.GetRequiredService<ICacheClient>(), s.GetRequiredService<IMessageBus>(), s.GetRequiredService<TimeProvider>(), s.GetRequiredService<IResiliencePolicyProvider>(), s.GetRequiredService<ILoggerFactory>()));
         services.AddSingleton<ILockProvider>(s => s.GetRequiredService<CacheLockProvider>());
         services.AddTransient<StripeEventHandler>();
+        services.AddSingleton<IStripeBillingClient, StripeBillingClient>();
         services.AddSingleton<BillingManager>();
         services.AddSingleton<BillingPlans>();
         services.AddSingleton<EventPostService>();

--- a/src/Exceptionless.Core/Extensions/DictionaryExtensions.cs
+++ b/src/Exceptionless.Core/Extensions/DictionaryExtensions.cs
@@ -98,9 +98,9 @@ public static class DictionaryExtensions
                 return false;
 
             if (sourceValue is null && otherValue is null)
-                return true;
+                continue;
 
-            if (sourceValue != null && sourceValue.Equals(otherValue))
+            if (sourceValue != null && !sourceValue.Equals(otherValue))
                 return false;
         }
 

--- a/src/Exceptionless.Core/Extensions/DictionaryExtensions.cs
+++ b/src/Exceptionless.Core/Extensions/DictionaryExtensions.cs
@@ -97,16 +97,12 @@ public static class DictionaryExtensions
             if (!other.TryGetValue(key, out var otherValue))
                 return false;
 
-            if (sourceValue is null && otherValue is null)
-                continue;
-
-            if (sourceValue != null && !sourceValue.Equals(otherValue))
+            if (!Equals(sourceValue, otherValue))
                 return false;
         }
 
         return true;
     }
-
 
     public static int GetCollectionHashCode<TValue>(this IDictionary<string, TValue> source, IList<string>? exclusions = null)
     {

--- a/src/Exceptionless.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Exceptionless.Core/Extensions/EnumerableExtensions.cs
@@ -42,7 +42,7 @@ public static class EnumerableExtensions
                 return false;
             }
 
-            if (sourceEnumerator.Current is not null && sourceEnumerator.Current.Equals(otherEnumerator.Current))
+            if (sourceEnumerator.Current is not null && !sourceEnumerator.Current.Equals(otherEnumerator.Current))
             {
                 // values aren't equal
                 return false;

--- a/src/Exceptionless.Core/Extensions/EnumerableExtensions.cs
+++ b/src/Exceptionless.Core/Extensions/EnumerableExtensions.cs
@@ -42,7 +42,7 @@ public static class EnumerableExtensions
                 return false;
             }
 
-            if (sourceEnumerator.Current is not null && !sourceEnumerator.Current.Equals(otherEnumerator.Current))
+            if (!Equals(sourceEnumerator.Current, otherEnumerator.Current))
             {
                 // values aren't equal
                 return false;

--- a/src/Exceptionless.Core/Services/OrganizationService.cs
+++ b/src/Exceptionless.Core/Services/OrganizationService.cs
@@ -1,3 +1,4 @@
+using Exceptionless.Core.Billing;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
 using Foundatio.Extensions.Hosting.Startup;
@@ -17,11 +18,11 @@ public class OrganizationService : IStartupAction
     private readonly ITokenRepository _tokenRepository;
     private readonly IUserRepository _userRepository;
     private readonly IWebHookRepository _webHookRepository;
-    private readonly AppOptions _appOptions;
+    private readonly IStripeBillingClient _stripeBillingClient;
     private readonly UsageService _usageService;
     private readonly ILogger _logger;
 
-    public OrganizationService(IOrganizationRepository organizationRepository, IProjectRepository projectRepository, ISavedViewRepository savedViewRepository, ITokenRepository tokenRepository, IUserRepository userRepository, IWebHookRepository webHookRepository, AppOptions appOptions, UsageService usageService, ILoggerFactory loggerFactory)
+    public OrganizationService(IOrganizationRepository organizationRepository, IProjectRepository projectRepository, ISavedViewRepository savedViewRepository, ITokenRepository tokenRepository, IUserRepository userRepository, IWebHookRepository webHookRepository, IStripeBillingClient stripeBillingClient, UsageService usageService, ILoggerFactory loggerFactory)
     {
         _organizationRepository = organizationRepository;
         _projectRepository = projectRepository;
@@ -29,7 +30,7 @@ public class OrganizationService : IStartupAction
         _tokenRepository = tokenRepository;
         _userRepository = userRepository;
         _webHookRepository = webHookRepository;
-        _appOptions = appOptions;
+        _stripeBillingClient = stripeBillingClient;
         _usageService = usageService;
         _logger = loggerFactory.CreateLogger<OrganizationService>();
     }
@@ -61,13 +62,11 @@ public class OrganizationService : IStartupAction
         if (String.IsNullOrEmpty(organization.StripeCustomerId))
             return;
 
-        var client = new StripeClient(_appOptions.StripeOptions.StripeApiKey);
-        var subscriptionService = new SubscriptionService(client);
-        var subscriptions = await subscriptionService.ListAsync(new SubscriptionListOptions { Customer = organization.StripeCustomerId });
+        var subscriptions = await _stripeBillingClient.ListSubscriptionsAsync(new SubscriptionListOptions { Customer = organization.StripeCustomerId });
         foreach (var subscription in subscriptions.Where(s => !s.CanceledAt.HasValue))
         {
             _logger.LogInformation("Canceling stripe subscription ({SubscriptionId}) for {OrganizationName} ({Organization})", subscription.Id, organization.Name, organization.Id);
-            await subscriptionService.CancelAsync(subscription.Id, new SubscriptionCancelOptions());
+            await _stripeBillingClient.CancelSubscriptionAsync(subscription.Id, new SubscriptionCancelOptions());
             _logger.LogInformation("Canceled stripe subscription ({SubscriptionId}) for {OrganizationName} ({Organization})", subscription.Id, organization.Name, organization.Id);
         }
     }

--- a/src/Exceptionless.Web/Controllers/AdminController.cs
+++ b/src/Exceptionless.Web/Controllers/AdminController.cs
@@ -153,25 +153,25 @@ public class AdminController : ExceptionlessApiController
     }
 
     [HttpGet("assemblies")]
-    public ActionResult<IEnumerable<AssemblyDetail>> Assemblies()
+    public ActionResult<IEnumerable<AssemblyDetailResponse>> Assemblies()
     {
-        var details = AssemblyDetail.ExtractAll();
+        var details = AssemblyDetail.ExtractAll().Select(AssemblyDetailResponse.FromAssemblyDetail);
         return Ok(details);
     }
 
     [HttpPost("change-plan")]
-    public async Task<IActionResult> ChangePlanAsync(string organizationId, string planId)
+    public async Task<ActionResult<ChangePlanResponse>> ChangePlanAsync(string organizationId, string planId)
     {
         if (String.IsNullOrEmpty(organizationId) || !CanAccessOrganization(organizationId))
-            return Ok(new { Success = false, Message = "Invalid Organization Id." });
+            return Ok(new ChangePlanResponse(false, "Invalid Organization Id."));
 
         var organization = await _organizationRepository.GetByIdAsync(organizationId);
         if (organization is null)
-            return Ok(new { Success = false, Message = "Invalid Organization Id." });
+            return Ok(new ChangePlanResponse(false, "Invalid Organization Id."));
 
         var plan = _billingManager.GetBillingPlan(planId);
         if (plan is null)
-            return Ok(new { Success = false, Message = "Invalid PlanId." });
+            return Ok(new ChangePlanResponse(false, "Invalid PlanId."));
 
         organization.BillingStatus = !String.Equals(plan.Id, _plans.FreePlan.Id) ? BillingStatus.Active : BillingStatus.Trialing;
         organization.RemoveSuspension();
@@ -183,7 +183,7 @@ public class AdminController : ExceptionlessApiController
             OrganizationId = organization.Id
         });
 
-        return Ok(new { Success = true });
+        return Ok(new ChangePlanResponse(true));
     }
 
     /// <summary>
@@ -457,4 +457,3 @@ public class AdminController : ExceptionlessApiController
         return Ok(new { Success = true, Message = $"Enqueued generation of {eventCount} sample events over {daysBack} days. Events will appear shortly." });
     }
 }
-

--- a/src/Exceptionless.Web/Controllers/OrganizationController.cs
+++ b/src/Exceptionless.Web/Controllers/OrganizationController.cs
@@ -40,6 +40,7 @@ public class OrganizationController : RepositoryApiController<IOrganizationRepos
     private readonly BillingManager _billingManager;
     private readonly UsageService _usageService;
     private readonly BillingPlans _plans;
+    private readonly IStripeBillingClient _stripeBillingClient;
     private readonly IMailer _mailer;
     private readonly IMessagePublisher _messagePublisher;
     private readonly AppOptions _options;
@@ -54,6 +55,7 @@ public class OrganizationController : RepositoryApiController<IOrganizationRepos
         BillingManager billingManager,
         BillingPlans plans,
         UsageService usageService,
+        IStripeBillingClient stripeBillingClient,
         IMailer mailer,
         IMessagePublisher messagePublisher,
         ApiMapper mapper,
@@ -70,6 +72,7 @@ public class OrganizationController : RepositoryApiController<IOrganizationRepos
         _billingManager = billingManager;
         _plans = plans;
         _usageService = usageService;
+        _stripeBillingClient = stripeBillingClient;
         _mailer = mailer;
         _messagePublisher = messagePublisher;
         _options = options;
@@ -230,12 +233,9 @@ public class OrganizationController : RepositoryApiController<IOrganizationRepos
             id = "in_" + id;
 
         Stripe.Invoice? stripeInvoice = null;
-        var client = new StripeClient(_options.StripeOptions.StripeApiKey);
-
         try
         {
-            var invoiceService = new InvoiceService(client);
-            stripeInvoice = await invoiceService.GetAsync(id);
+            stripeInvoice = await _stripeBillingClient.GetInvoiceAsync(id);
         }
         catch (StripeException ex)
         {
@@ -333,10 +333,8 @@ public class OrganizationController : RepositoryApiController<IOrganizationRepos
         if (!String.IsNullOrEmpty(after) && !after.StartsWith("in_"))
             after = "in_" + after;
 
-        var client = new StripeClient(_options.StripeOptions.StripeApiKey);
-        var invoiceService = new InvoiceService(client);
         var invoiceOptions = new InvoiceListOptions { Customer = organization.StripeCustomerId, Limit = limit + 1, EndingBefore = before, StartingAfter = after };
-        var invoices = _mapper.MapToInvoiceGridModels(await invoiceService.ListAsync(invoiceOptions));
+        var invoices = _mapper.MapToInvoiceGridModels(await _stripeBillingClient.ListInvoicesAsync(invoiceOptions));
         return OkWithResourceLinks(invoices.Take(limit).ToList(), invoices.Count > limit);
     }
 
@@ -450,11 +448,6 @@ public class OrganizationController : RepositoryApiController<IOrganizationRepos
                 return Ok(result);
         }
 
-        var client = new StripeClient(_options.StripeOptions.StripeApiKey);
-        var customerService = new CustomerService(client);
-        var subscriptionService = new SubscriptionService(client);
-        var paymentMethodService = new PaymentMethodService(client);
-
         bool isPaymentMethod = model.StripeToken?.StartsWith("pm_", StringComparison.Ordinal) is true;
 
         try
@@ -466,9 +459,9 @@ public class OrganizationController : RepositoryApiController<IOrganizationRepos
             {
                 if (!String.IsNullOrEmpty(organization.StripeCustomerId))
                 {
-                    var subs = await subscriptionService.ListAsync(new SubscriptionListOptions { Customer = organization.StripeCustomerId });
+                    var subs = await _stripeBillingClient.ListSubscriptionsAsync(new SubscriptionListOptions { Customer = organization.StripeCustomerId });
                     foreach (var sub in subs.Where(s => !s.CanceledAt.HasValue))
-                        await subscriptionService.CancelAsync(sub.Id, new SubscriptionCancelOptions());
+                        await _stripeBillingClient.CancelSubscriptionAsync(sub.Id, new SubscriptionCancelOptions());
                 }
 
                 organization.BillingStatus = BillingStatus.Trialing;
@@ -501,7 +494,7 @@ public class OrganizationController : RepositoryApiController<IOrganizationRepos
                     createCustomer.Source = model.StripeToken;
                 }
 
-                var customer = await customerService.CreateAsync(createCustomer);
+                var customer = await _stripeBillingClient.CreateCustomerAsync(createCustomer);
 
                 // Persist the Stripe customer ID immediately so a retry won't create a duplicate customer
                 organization.StripeCustomerId = customer.Id;
@@ -521,7 +514,7 @@ public class OrganizationController : RepositoryApiController<IOrganizationRepos
                 if (!String.IsNullOrWhiteSpace(model.CouponId))
                     subscriptionOptions.Discounts = [new SubscriptionDiscountOptions { Coupon = model.CouponId }];
 
-                await subscriptionService.CreateAsync(subscriptionOptions);
+                await _stripeBillingClient.CreateSubscriptionAsync(subscriptionOptions);
 
                 organization.BillingStatus = BillingStatus.Active;
                 organization.RemoveSuspension();
@@ -537,13 +530,13 @@ public class OrganizationController : RepositoryApiController<IOrganizationRepos
                 if (!Request.IsGlobalAdmin())
                     customerUpdateOptions.Email = CurrentUser.EmailAddress;
 
-                var listSubscriptionsTask = subscriptionService.ListAsync(new SubscriptionListOptions { Customer = organization.StripeCustomerId });
+                var listSubscriptionsTask = _stripeBillingClient.ListSubscriptionsAsync(new SubscriptionListOptions { Customer = organization.StripeCustomerId });
 
                 if (!String.IsNullOrEmpty(model.StripeToken))
                 {
                     if (isPaymentMethod)
                     {
-                        await paymentMethodService.AttachAsync(model.StripeToken, new PaymentMethodAttachOptions
+                        await _stripeBillingClient.AttachPaymentMethodAsync(model.StripeToken, new PaymentMethodAttachOptions
                         {
                             Customer = organization.StripeCustomerId
                         });
@@ -560,7 +553,7 @@ public class OrganizationController : RepositoryApiController<IOrganizationRepos
                 }
 
                 await Task.WhenAll(
-                    customerService.UpdateAsync(organization.StripeCustomerId, customerUpdateOptions),
+                    _stripeBillingClient.UpdateCustomerAsync(organization.StripeCustomerId, customerUpdateOptions),
                     listSubscriptionsTask
                 );
 
@@ -571,7 +564,7 @@ public class OrganizationController : RepositoryApiController<IOrganizationRepos
                     update.Items.Add(new SubscriptionItemOptions { Id = subscription.Items.Data[0].Id, Price = model.PlanId });
                     if (!String.IsNullOrWhiteSpace(model.CouponId))
                         update.Discounts = [new SubscriptionDiscountOptions { Coupon = model.CouponId }];
-                    await subscriptionService.UpdateAsync(subscription.Id, update);
+                    await _stripeBillingClient.UpdateSubscriptionAsync(subscription.Id, update);
                 }
                 else if (subscription is not null)
                 {
@@ -579,18 +572,21 @@ public class OrganizationController : RepositoryApiController<IOrganizationRepos
                     update.Items.Add(new SubscriptionItemOptions { Price = model.PlanId });
                     if (!String.IsNullOrWhiteSpace(model.CouponId))
                         update.Discounts = [new SubscriptionDiscountOptions { Coupon = model.CouponId }];
-                    await subscriptionService.UpdateAsync(subscription.Id, update);
+                    await _stripeBillingClient.UpdateSubscriptionAsync(subscription.Id, update);
                 }
                 else
                 {
                     create.Items.Add(new SubscriptionItemOptions { Price = model.PlanId });
                     if (!String.IsNullOrWhiteSpace(model.CouponId))
                         create.Discounts = [new SubscriptionDiscountOptions { Coupon = model.CouponId }];
-                    await subscriptionService.CreateAsync(create);
+                    await _stripeBillingClient.CreateSubscriptionAsync(create);
                 }
 
                 if (cardUpdated)
                     organization.CardLast4 = model.Last4;
+
+                if (organization.SubscribeDate is null || organization.SubscribeDate == DateTime.MinValue)
+                    organization.SubscribeDate = _timeProvider.GetUtcNow().UtcDateTime;
 
                 organization.BillingStatus = BillingStatus.Active;
                 organization.RemoveSuspension();

--- a/src/Exceptionless.Web/Models/Admin/AssemblyDetailResponse.cs
+++ b/src/Exceptionless.Web/Models/Admin/AssemblyDetailResponse.cs
@@ -1,0 +1,33 @@
+using Exceptionless.Core.Utility;
+
+namespace Exceptionless.Web.Models.Admin;
+
+public record AssemblyDetailResponse(
+    string? AssemblyName,
+    string? AssemblyTitle,
+    string? AssemblyDescription,
+    string? AssemblyProduct,
+    string? AssemblyCompany,
+    string? AssemblyCopyright,
+    string? AssemblyConfiguration,
+    string? AssemblyVersion,
+    string? AssemblyFileVersion,
+    string? AssemblyInformationalVersion
+)
+{
+    public static AssemblyDetailResponse FromAssemblyDetail(AssemblyDetail detail)
+    {
+        return new AssemblyDetailResponse(
+            detail.AssemblyName,
+            detail.AssemblyTitle,
+            detail.AssemblyDescription,
+            detail.AssemblyProduct,
+            detail.AssemblyCompany,
+            detail.AssemblyCopyright,
+            detail.AssemblyConfiguration,
+            detail.AssemblyVersion,
+            detail.AssemblyFileVersion,
+            detail.AssemblyInformationalVersion
+        );
+    }
+}

--- a/src/Exceptionless.Web/Models/Admin/ChangePlanResponse.cs
+++ b/src/Exceptionless.Web/Models/Admin/ChangePlanResponse.cs
@@ -1,0 +1,3 @@
+namespace Exceptionless.Web.Models.Admin;
+
+public record ChangePlanResponse(bool Success, string? Message = null);

--- a/src/Exceptionless.Web/Models/Token/NewToken.cs
+++ b/src/Exceptionless.Web/Models/Token/NewToken.cs
@@ -3,24 +3,17 @@ using Exceptionless.Core.Models;
 
 namespace Exceptionless.Web.Models;
 
-// Keep this interface even though some user-token flows omit ProjectId; shared tenancy checks use it.
 public record NewToken : IOwnedByOrganizationAndProject
 {
     [ObjectId]
     public string OrganizationId { get; set; } = null!;
 
     [ObjectId]
-    public string? ProjectId { get; set; }
+    public string ProjectId { get; set; } = null!;
 
     [ObjectId]
     public string? DefaultProjectId { get; set; }
     public HashSet<string> Scopes { get; set; } = new();
     public DateTime? ExpiresUtc { get; set; }
     public string? Notes { get; set; }
-
-    string IOwnedByProject.ProjectId
-    {
-        get => ProjectId ?? String.Empty;
-        set => ProjectId = value;
-    }
 }

--- a/src/Exceptionless.Web/Models/Token/NewToken.cs
+++ b/src/Exceptionless.Web/Models/Token/NewToken.cs
@@ -1,15 +1,14 @@
 ﻿using Exceptionless.Core.Attributes;
-using Exceptionless.Core.Models;
 
 namespace Exceptionless.Web.Models;
 
-public record NewToken : IOwnedByOrganizationAndProject
+public record NewToken
 {
     [ObjectId]
     public string OrganizationId { get; set; } = null!;
 
     [ObjectId]
-    public string ProjectId { get; set; } = null!;
+    public string? ProjectId { get; set; }
 
     [ObjectId]
     public string? DefaultProjectId { get; set; }

--- a/src/Exceptionless.Web/Models/Token/NewToken.cs
+++ b/src/Exceptionless.Web/Models/Token/NewToken.cs
@@ -1,8 +1,10 @@
 ﻿using Exceptionless.Core.Attributes;
+using Exceptionless.Core.Models;
 
 namespace Exceptionless.Web.Models;
 
-public record NewToken
+// Keep this interface even though some user-token flows omit ProjectId; shared tenancy checks use it.
+public record NewToken : IOwnedByOrganizationAndProject
 {
     [ObjectId]
     public string OrganizationId { get; set; } = null!;
@@ -15,4 +17,10 @@ public record NewToken
     public HashSet<string> Scopes { get; set; } = new();
     public DateTime? ExpiresUtc { get; set; }
     public string? Notes { get; set; }
+
+    string IOwnedByProject.ProjectId
+    {
+        get => ProjectId ?? String.Empty;
+        set => ProjectId = value;
+    }
 }

--- a/src/Exceptionless.Web/Models/Token/ViewToken.cs
+++ b/src/Exceptionless.Web/Models/Token/ViewToken.cs
@@ -12,7 +12,8 @@ public record ViewToken : IIdentity, IHaveDates
     public string OrganizationId { get; set; } = null!;
 
     [ObjectId]
-    public string? ProjectId { get; set; }
+    // Keep this aligned with Token.ProjectId so the API contract mirrors project-owned token semantics.
+    public string ProjectId { get; set; } = null!;
 
     [ObjectId]
     public string? UserId { get; set; }

--- a/src/Exceptionless.Web/Models/Token/ViewToken.cs
+++ b/src/Exceptionless.Web/Models/Token/ViewToken.cs
@@ -12,7 +12,7 @@ public record ViewToken : IIdentity, IHaveDates
     public string OrganizationId { get; set; } = null!;
 
     [ObjectId]
-    public string ProjectId { get; set; } = null!;
+    public string? ProjectId { get; set; }
 
     [ObjectId]
     public string? UserId { get; set; }

--- a/tests/CodeCoverage.config
+++ b/tests/CodeCoverage.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <CodeCoverage>
+    <ModulePaths>
+      <Include>
+        <ModulePath>.*Exceptionless\.(AppHost|Core|Insulation|Web)\.dll$</ModulePath>
+      </Include>
+    </ModulePaths>
+
+    <Sources>
+      <Exclude>
+        <Source>.*/obj/.*</Source>
+        <Source>.*\\obj\\.*</Source>
+      </Exclude>
+    </Sources>
+
+    <Attributes>
+      <Exclude>
+        <Attribute>^System.Diagnostics.DebuggerHiddenAttribute$</Attribute>
+        <Attribute>^System.Diagnostics.DebuggerNonUserCodeAttribute$</Attribute>
+        <Attribute>^System.Runtime.CompilerServices.CompilerGeneratedAttribute$</Attribute>
+        <Attribute>^System.CodeDom.Compiler.GeneratedCodeAttribute$</Attribute>
+        <Attribute>^System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute$</Attribute>
+      </Exclude>
+    </Attributes>
+  </CodeCoverage>
+</Configuration>

--- a/tests/Exceptionless.Tests/Billing/StripeBillingClientTests.cs
+++ b/tests/Exceptionless.Tests/Billing/StripeBillingClientTests.cs
@@ -1,0 +1,23 @@
+using Exceptionless.Core.Billing;
+using Exceptionless.Core.Configuration;
+using Xunit;
+
+namespace Exceptionless.Tests.Billing;
+
+public sealed class StripeBillingClientTests
+{
+    [Fact]
+    public void Constructor_WhenStripeApiKeyIsMissing_DoesNotThrow()
+    {
+        _ = new StripeBillingClient(new StripeOptions());
+    }
+
+    [Fact]
+    public async Task GetInvoiceAsync_WhenStripeApiKeyIsMissing_Throws()
+    {
+        var client = new StripeBillingClient(new StripeOptions());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => client.GetInvoiceAsync("in_test"));
+        Assert.Equal("Stripe API key is not configured.", ex.Message);
+    }
+}

--- a/tests/Exceptionless.Tests/Controllers/AdminControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/AdminControllerTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Utility;
@@ -535,6 +534,7 @@ public class AdminControllerTests : IntegrationTestsBase
         Assert.NotNull(snapshots.Repositories);
         Assert.NotNull(snapshots.Snapshots);
     }
+
     [Fact]
     public Task GetElasticsearchSnapshots_WithoutAuth_ReturnsUnauthorized()
     {
@@ -542,22 +542,21 @@ public class AdminControllerTests : IntegrationTestsBase
             .AppendPaths("admin", "elasticsearch", "snapshots")
             .StatusCodeShouldBeUnauthorized());
     }
+
     [Fact]
     public async Task GetSettings_AsGlobalAdmin_ReturnsAppOptions()
     {
         // Act
-        var response = await SendRequestAsync(r => r
+        var settings = await SendRequestAsAsync<AppSettingsDto>(r => r
             .AsGlobalAdminUser()
             .AppendPaths("admin", "settings")
             .StatusCodeShouldBeOk());
 
         // Assert
-        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
-        Assert.True(root.TryGetProperty("base_url", out _) || root.TryGetProperty("baseURL", out _),
-            "Expected settings to contain base URL property");
+        Assert.NotNull(settings);
+        Assert.NotNull(settings.AppMode);
     }
+
     [Fact]
     public Task GetSettings_AsNonAdmin_ReturnsForbidden()
     {
@@ -566,6 +565,7 @@ public class AdminControllerTests : IntegrationTestsBase
             .AppendPaths("admin", "settings")
             .StatusCodeShouldBeForbidden());
     }
+
     [Fact]
     public Task GetSettings_WithoutAuth_ReturnsUnauthorized()
     {
@@ -573,23 +573,21 @@ public class AdminControllerTests : IntegrationTestsBase
             .AppendPaths("admin", "settings")
             .StatusCodeShouldBeUnauthorized());
     }
+
     [Fact]
-    public async Task EchoRequest_AsGlobalAdmin_ReturnsHeadersAndIpAddress()
+    public async Task EchoRequest_AsGlobalAdmin_ReturnsIpAddress()
     {
         // Act
-        var response = await SendRequestAsync(r => r
+        var result = await SendRequestAsAsync<EchoResult>(r => r
             .AsGlobalAdminUser()
             .AppendPaths("admin", "echo")
             .StatusCodeShouldBeOk());
 
         // Assert
-        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
-        Assert.True(root.TryGetProperty("headers", out _), "Expected echo response to contain 'headers'");
-        Assert.True(root.TryGetProperty("ip_address", out _) || root.TryGetProperty("ipAddress", out _),
-            "Expected echo response to contain IP address");
+        Assert.NotNull(result);
+        Assert.NotNull(result.IpAddress);
     }
+
     [Fact]
     public Task EchoRequest_AsNonAdmin_ReturnsForbidden()
     {
@@ -598,6 +596,7 @@ public class AdminControllerTests : IntegrationTestsBase
             .AppendPaths("admin", "echo")
             .StatusCodeShouldBeForbidden());
     }
+
     [Fact]
     public Task EchoRequest_WithoutAuth_ReturnsUnauthorized()
     {
@@ -605,26 +604,22 @@ public class AdminControllerTests : IntegrationTestsBase
             .AppendPaths("admin", "echo")
             .StatusCodeShouldBeUnauthorized());
     }
+
     [Fact]
     public async Task GetAssemblies_AsGlobalAdmin_ReturnsAssemblyList()
     {
         // Act
-        var response = await SendRequestAsync(r => r
+        var assemblies = await SendRequestAsAsync<List<AssemblyInfo>>(r => r
             .AsGlobalAdminUser()
             .AppendPaths("admin", "assemblies")
             .StatusCodeShouldBeOk());
 
         // Assert
-        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
-        Assert.Equal(JsonValueKind.Array, root.ValueKind);
-        Assert.True(root.GetArrayLength() > 0, "Expected at least one assembly in the response");
-
-        var first = root[0];
-        Assert.True(first.TryGetProperty("assembly_name", out _) || first.TryGetProperty("assemblyName", out _),
-            "Expected assembly entry to have an assembly name property");
+        Assert.NotNull(assemblies);
+        Assert.NotEmpty(assemblies);
+        Assert.All(assemblies, a => Assert.NotNull(a.AssemblyName));
     }
+
     [Fact]
     public Task GetAssemblies_AsNonAdmin_ReturnsForbidden()
     {
@@ -633,6 +628,7 @@ public class AdminControllerTests : IntegrationTestsBase
             .AppendPaths("admin", "assemblies")
             .StatusCodeShouldBeForbidden());
     }
+
     [Fact]
     public Task GetAssemblies_WithoutAuth_ReturnsUnauthorized()
     {
@@ -640,6 +636,7 @@ public class AdminControllerTests : IntegrationTestsBase
             .AppendPaths("admin", "assemblies")
             .StatusCodeShouldBeUnauthorized());
     }
+
     [Fact]
     public async Task ChangePlanAsync_ValidOrganizationAndPlan_ChangesOrganizationPlan()
     {
@@ -649,7 +646,7 @@ public class AdminControllerTests : IntegrationTestsBase
         Assert.NotNull(organizationBefore);
 
         // Act
-        var response = await SendRequestAsync(r => r
+        var result = await SendRequestAsAsync<ChangePlanResult>(r => r
             .AsGlobalAdminUser()
             .Post()
             .AppendPaths("admin", "change-plan")
@@ -658,16 +655,14 @@ public class AdminControllerTests : IntegrationTestsBase
             .StatusCodeShouldBeOk());
 
         // Assert
-        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
-        Assert.True(root.TryGetProperty("success", out var successProp));
-        Assert.True(successProp.GetBoolean());
+        Assert.NotNull(result);
+        Assert.True(result.Success);
 
         var organizationAfter = await organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
         Assert.NotNull(organizationAfter);
         Assert.Equal("EX_SMALL", organizationAfter.PlanId);
     }
+
     [Fact]
     public async Task ChangePlanAsync_InvalidPlanId_ReturnsFailure()
     {
@@ -678,7 +673,7 @@ public class AdminControllerTests : IntegrationTestsBase
         string originalPlan = organizationBefore.PlanId;
 
         // Act
-        var response = await SendRequestAsync(r => r
+        var result = await SendRequestAsAsync<ChangePlanResult>(r => r
             .AsGlobalAdminUser()
             .Post()
             .AppendPaths("admin", "change-plan")
@@ -687,17 +682,15 @@ public class AdminControllerTests : IntegrationTestsBase
             .StatusCodeShouldBeOk());
 
         // Assert
-        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
-        Assert.True(root.TryGetProperty("success", out var successProp));
-        Assert.False(successProp.GetBoolean());
+        Assert.NotNull(result);
+        Assert.False(result.Success);
 
         // Verify plan was not changed
         var organizationAfter = await organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
         Assert.NotNull(organizationAfter);
         Assert.Equal(originalPlan, organizationAfter.PlanId);
     }
+
     [Fact]
     public Task ChangePlanAsync_AsNonAdmin_ReturnsForbidden()
     {
@@ -709,6 +702,7 @@ public class AdminControllerTests : IntegrationTestsBase
             .QueryString("planId", "EX_SMALL")
             .StatusCodeShouldBeForbidden());
     }
+
     [Fact]
     public async Task SetBonusAsync_ValidOrganization_AppliesBonus()
     {
@@ -731,12 +725,13 @@ public class AdminControllerTests : IntegrationTestsBase
         Assert.NotNull(organizationAfter);
         Assert.Equal(5000, organizationAfter.BonusEventsPerMonth);
     }
+
     [Fact]
     public async Task SetBonusAsync_WithExpiration_AppliesBonusWithExpiry()
     {
         // Arrange
         var organizationRepository = GetService<IOrganizationRepository>();
-        var expires = DateTime.UtcNow.AddDays(30).ToString("o");
+        var expiresUtc = TimeProvider.GetUtcNow().AddDays(30).ToString("o");
 
         // Act
         await SendRequestAsync(r => r
@@ -745,7 +740,7 @@ public class AdminControllerTests : IntegrationTestsBase
             .AppendPaths("admin", "set-bonus")
             .QueryString("organizationId", SampleDataService.TEST_ORG_ID)
             .QueryString("bonusEvents", "10000")
-            .QueryString("expires", expires)
+            .QueryString("expires", expiresUtc)
             .StatusCodeShouldBeOk());
 
         // Assert
@@ -754,6 +749,7 @@ public class AdminControllerTests : IntegrationTestsBase
         Assert.Equal(10000, organization.BonusEventsPerMonth);
         Assert.NotNull(organization.BonusExpiration);
     }
+
     [Fact]
     public Task SetBonusAsync_InvalidOrganization_ReturnsValidationError()
     {
@@ -766,6 +762,7 @@ public class AdminControllerTests : IntegrationTestsBase
             .QueryString("bonusEvents", "1000")
             .StatusCodeShouldBeUnprocessableEntity());
     }
+
     [Fact]
     public Task SetBonusAsync_AsNonAdmin_ReturnsForbidden()
     {
@@ -777,4 +774,12 @@ public class AdminControllerTests : IntegrationTestsBase
             .QueryString("bonusEvents", "1000")
             .StatusCodeShouldBeForbidden());
     }
+
+    private sealed record AppSettingsDto(string? AppMode, string? AppScope);
+
+    private sealed record EchoResult(string? IpAddress);
+
+    private sealed record AssemblyInfo(string? AssemblyName);
+
+    private sealed record ChangePlanResult(bool Success, string? Message);
 }

--- a/tests/Exceptionless.Tests/Controllers/AdminControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/AdminControllerTests.cs
@@ -1,4 +1,5 @@
 using Exceptionless.Core.Models;
+using Exceptionless.Core.Models.Billing;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Utility;
 using Exceptionless.Tests.Extensions;
@@ -544,17 +545,12 @@ public class AdminControllerTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task GetSettings_AsGlobalAdmin_ReturnsAppOptions()
+    public Task GetSettings_AsGlobalAdmin_ReturnsAppOptions()
     {
-        // Act
-        var settings = await SendRequestAsAsync<AppSettingsDto>(r => r
+        return SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPaths("admin", "settings")
             .StatusCodeShouldBeOk());
-
-        // Assert
-        Assert.NotNull(settings);
-        Assert.NotNull(settings.AppMode);
     }
 
     [Fact]
@@ -575,17 +571,12 @@ public class AdminControllerTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task EchoRequest_AsGlobalAdmin_ReturnsIpAddress()
+    public Task EchoRequest_AsGlobalAdmin_ReturnsIpAddress()
     {
-        // Act
-        var result = await SendRequestAsAsync<EchoResult>(r => r
+        return SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPaths("admin", "echo")
             .StatusCodeShouldBeOk());
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.NotNull(result.IpAddress);
     }
 
     [Fact]
@@ -609,15 +600,17 @@ public class AdminControllerTests : IntegrationTestsBase
     public async Task GetAssemblies_AsGlobalAdmin_ReturnsAssemblyList()
     {
         // Act
-        var assemblies = await SendRequestAsAsync<List<AssemblyInfo>>(r => r
+        var response = await SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPaths("admin", "assemblies")
             .StatusCodeShouldBeOk());
 
-        // Assert
-        Assert.NotNull(assemblies);
-        Assert.NotEmpty(assemblies);
-        Assert.All(assemblies, a => Assert.NotNull(a.AssemblyName));
+        // Assert - AssemblyDetail has private setters so parse as JSON directly
+        var content = await response.Content.ReadAsStringAsync(TestCancellationToken);
+        using var doc = System.Text.Json.JsonDocument.Parse(content);
+        Assert.Equal(System.Text.Json.JsonValueKind.Array, doc.RootElement.ValueKind);
+        Assert.True(doc.RootElement.GetArrayLength() > 0);
+        Assert.True(doc.RootElement[0].TryGetProperty("assembly_name", out _));
     }
 
     [Fact]
@@ -774,12 +767,4 @@ public class AdminControllerTests : IntegrationTestsBase
             .QueryString("bonusEvents", "1000")
             .StatusCodeShouldBeForbidden());
     }
-
-    private sealed record AppSettingsDto(string? AppMode, string? AppScope);
-
-    private sealed record EchoResult(string? IpAddress);
-
-    private sealed record AssemblyInfo(string? AssemblyName);
-
-    private sealed record ChangePlanResult(bool Success, string? Message);
 }

--- a/tests/Exceptionless.Tests/Controllers/AdminControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/AdminControllerTests.cs
@@ -1,5 +1,6 @@
+using System.Text.Json;
+using Exceptionless.Core.Billing;
 using Exceptionless.Core.Models;
-using Exceptionless.Core.Models.Billing;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Utility;
 using Exceptionless.Tests.Extensions;
@@ -545,12 +546,18 @@ public class AdminControllerTests : IntegrationTestsBase
     }
 
     [Fact]
-    public Task GetSettings_AsGlobalAdmin_ReturnsAppOptions()
+    public async Task GetSettings_AsGlobalAdmin_ReturnsAppOptions()
     {
-        return SendRequestAsync(r => r
+        // Act
+        var options = await SendRequestAsAsync<Dictionary<string, JsonElement>>(r => r
             .AsGlobalAdminUser()
             .AppendPaths("admin", "settings")
             .StatusCodeShouldBeOk());
+
+        // Assert
+        Assert.NotNull(options);
+        Assert.True(options.ContainsKey("base_u_r_l"));
+        Assert.True(options.ContainsKey("app_mode"));
     }
 
     [Fact]
@@ -600,17 +607,15 @@ public class AdminControllerTests : IntegrationTestsBase
     public async Task GetAssemblies_AsGlobalAdmin_ReturnsAssemblyList()
     {
         // Act
-        var response = await SendRequestAsync(r => r
+        var assemblies = await SendRequestAsAsync<IReadOnlyCollection<AssemblyDetailResponse>>(r => r
             .AsGlobalAdminUser()
             .AppendPaths("admin", "assemblies")
             .StatusCodeShouldBeOk());
 
-        // Assert - AssemblyDetail has private setters so parse as JSON directly
-        var content = await response.Content.ReadAsStringAsync(TestCancellationToken);
-        using var doc = System.Text.Json.JsonDocument.Parse(content);
-        Assert.Equal(System.Text.Json.JsonValueKind.Array, doc.RootElement.ValueKind);
-        Assert.True(doc.RootElement.GetArrayLength() > 0);
-        Assert.True(doc.RootElement[0].TryGetProperty("assembly_name", out _));
+        // Assert
+        Assert.NotNull(assemblies);
+        Assert.NotEmpty(assemblies);
+        Assert.Contains(assemblies, a => !String.IsNullOrEmpty(a.AssemblyName));
     }
 
     [Fact]
@@ -634,17 +639,18 @@ public class AdminControllerTests : IntegrationTestsBase
     public async Task ChangePlanAsync_ValidOrganizationAndPlan_ChangesOrganizationPlan()
     {
         // Arrange
+        var plans = GetService<BillingPlans>();
         var organizationRepository = GetService<IOrganizationRepository>();
         var organizationBefore = await organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
         Assert.NotNull(organizationBefore);
 
         // Act
-        var result = await SendRequestAsAsync<ChangePlanResult>(r => r
+        var result = await SendRequestAsAsync<ChangePlanResponse>(r => r
             .AsGlobalAdminUser()
             .Post()
             .AppendPaths("admin", "change-plan")
             .QueryString("organizationId", SampleDataService.TEST_ORG_ID)
-            .QueryString("planId", "EX_SMALL")
+            .QueryString("planId", plans.SmallPlan.Id)
             .StatusCodeShouldBeOk());
 
         // Assert
@@ -653,7 +659,7 @@ public class AdminControllerTests : IntegrationTestsBase
 
         var organizationAfter = await organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
         Assert.NotNull(organizationAfter);
-        Assert.Equal("EX_SMALL", organizationAfter.PlanId);
+        Assert.Equal(plans.SmallPlan.Id, organizationAfter.PlanId);
     }
 
     [Fact]
@@ -666,7 +672,7 @@ public class AdminControllerTests : IntegrationTestsBase
         string originalPlan = organizationBefore.PlanId;
 
         // Act
-        var result = await SendRequestAsAsync<ChangePlanResult>(r => r
+        var result = await SendRequestAsAsync<ChangePlanResponse>(r => r
             .AsGlobalAdminUser()
             .Post()
             .AppendPaths("admin", "change-plan")
@@ -677,6 +683,7 @@ public class AdminControllerTests : IntegrationTestsBase
         // Assert
         Assert.NotNull(result);
         Assert.False(result.Success);
+        Assert.Equal("Invalid PlanId.", result.Message);
 
         // Verify plan was not changed
         var organizationAfter = await organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
@@ -687,12 +694,14 @@ public class AdminControllerTests : IntegrationTestsBase
     [Fact]
     public Task ChangePlanAsync_AsNonAdmin_ReturnsForbidden()
     {
+        var plans = GetService<BillingPlans>();
+
         return SendRequestAsync(r => r
             .AsTestOrganizationUser()
             .Post()
             .AppendPaths("admin", "change-plan")
             .QueryString("organizationId", SampleDataService.TEST_ORG_ID)
-            .QueryString("planId", "EX_SMALL")
+            .QueryString("planId", plans.SmallPlan.Id)
             .StatusCodeShouldBeForbidden());
     }
 
@@ -710,7 +719,7 @@ public class AdminControllerTests : IntegrationTestsBase
             .Post()
             .AppendPaths("admin", "set-bonus")
             .QueryString("organizationId", SampleDataService.TEST_ORG_ID)
-            .QueryString("bonusEvents", "5000")
+            .QueryString("bonusEvents", 5000)
             .StatusCodeShouldBeOk());
 
         // Assert
@@ -732,7 +741,7 @@ public class AdminControllerTests : IntegrationTestsBase
             .Post()
             .AppendPaths("admin", "set-bonus")
             .QueryString("organizationId", SampleDataService.TEST_ORG_ID)
-            .QueryString("bonusEvents", "10000")
+            .QueryString("bonusEvents", 10000)
             .QueryString("expires", expiresUtc)
             .StatusCodeShouldBeOk());
 
@@ -752,7 +761,7 @@ public class AdminControllerTests : IntegrationTestsBase
             .Post()
             .AppendPaths("admin", "set-bonus")
             .QueryString("organizationId", "000000000000000000000000")
-            .QueryString("bonusEvents", "1000")
+            .QueryString("bonusEvents", 1000)
             .StatusCodeShouldBeUnprocessableEntity());
     }
 
@@ -764,7 +773,7 @@ public class AdminControllerTests : IntegrationTestsBase
             .Post()
             .AppendPaths("admin", "set-bonus")
             .QueryString("organizationId", SampleDataService.TEST_ORG_ID)
-            .QueryString("bonusEvents", "1000")
+            .QueryString("bonusEvents", 1000)
             .StatusCodeShouldBeForbidden());
     }
 }

--- a/tests/Exceptionless.Tests/Controllers/AdminControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/AdminControllerTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Utility;
@@ -534,12 +535,246 @@ public class AdminControllerTests : IntegrationTestsBase
         Assert.NotNull(snapshots.Repositories);
         Assert.NotNull(snapshots.Snapshots);
     }
-
     [Fact]
     public Task GetElasticsearchSnapshots_WithoutAuth_ReturnsUnauthorized()
     {
         return SendRequestAsync(r => r
             .AppendPaths("admin", "elasticsearch", "snapshots")
             .StatusCodeShouldBeUnauthorized());
+    }
+    [Fact]
+    public async Task GetSettings_AsGlobalAdmin_ReturnsAppOptions()
+    {
+        // Act
+        var response = await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "settings")
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("base_url", out _) || root.TryGetProperty("baseURL", out _),
+            "Expected settings to contain base URL property");
+    }
+    [Fact]
+    public Task GetSettings_AsNonAdmin_ReturnsForbidden()
+    {
+        return SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("admin", "settings")
+            .StatusCodeShouldBeForbidden());
+    }
+    [Fact]
+    public Task GetSettings_WithoutAuth_ReturnsUnauthorized()
+    {
+        return SendRequestAsync(r => r
+            .AppendPaths("admin", "settings")
+            .StatusCodeShouldBeUnauthorized());
+    }
+    [Fact]
+    public async Task EchoRequest_AsGlobalAdmin_ReturnsHeadersAndIpAddress()
+    {
+        // Act
+        var response = await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "echo")
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("headers", out _), "Expected echo response to contain 'headers'");
+        Assert.True(root.TryGetProperty("ip_address", out _) || root.TryGetProperty("ipAddress", out _),
+            "Expected echo response to contain IP address");
+    }
+    [Fact]
+    public Task EchoRequest_AsNonAdmin_ReturnsForbidden()
+    {
+        return SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("admin", "echo")
+            .StatusCodeShouldBeForbidden());
+    }
+    [Fact]
+    public Task EchoRequest_WithoutAuth_ReturnsUnauthorized()
+    {
+        return SendRequestAsync(r => r
+            .AppendPaths("admin", "echo")
+            .StatusCodeShouldBeUnauthorized());
+    }
+    [Fact]
+    public async Task GetAssemblies_AsGlobalAdmin_ReturnsAssemblyList()
+    {
+        // Act
+        var response = await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "assemblies")
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal(JsonValueKind.Array, root.ValueKind);
+        Assert.True(root.GetArrayLength() > 0, "Expected at least one assembly in the response");
+
+        var first = root[0];
+        Assert.True(first.TryGetProperty("assembly_name", out _) || first.TryGetProperty("assemblyName", out _),
+            "Expected assembly entry to have an assembly name property");
+    }
+    [Fact]
+    public Task GetAssemblies_AsNonAdmin_ReturnsForbidden()
+    {
+        return SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("admin", "assemblies")
+            .StatusCodeShouldBeForbidden());
+    }
+    [Fact]
+    public Task GetAssemblies_WithoutAuth_ReturnsUnauthorized()
+    {
+        return SendRequestAsync(r => r
+            .AppendPaths("admin", "assemblies")
+            .StatusCodeShouldBeUnauthorized());
+    }
+    [Fact]
+    public async Task ChangePlanAsync_ValidOrganizationAndPlan_ChangesOrganizationPlan()
+    {
+        // Arrange
+        var organizationRepository = GetService<IOrganizationRepository>();
+        var organizationBefore = await organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(organizationBefore);
+
+        // Act
+        var response = await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .Post()
+            .AppendPaths("admin", "change-plan")
+            .QueryString("organizationId", SampleDataService.TEST_ORG_ID)
+            .QueryString("planId", "EX_SMALL")
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("success", out var successProp));
+        Assert.True(successProp.GetBoolean());
+
+        var organizationAfter = await organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(organizationAfter);
+        Assert.Equal("EX_SMALL", organizationAfter.PlanId);
+    }
+    [Fact]
+    public async Task ChangePlanAsync_InvalidPlanId_ReturnsFailure()
+    {
+        // Arrange
+        var organizationRepository = GetService<IOrganizationRepository>();
+        var organizationBefore = await organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(organizationBefore);
+        string originalPlan = organizationBefore.PlanId;
+
+        // Act
+        var response = await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .Post()
+            .AppendPaths("admin", "change-plan")
+            .QueryString("organizationId", SampleDataService.TEST_ORG_ID)
+            .QueryString("planId", "NONEXISTENT_PLAN")
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        string json = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("success", out var successProp));
+        Assert.False(successProp.GetBoolean());
+
+        // Verify plan was not changed
+        var organizationAfter = await organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(organizationAfter);
+        Assert.Equal(originalPlan, organizationAfter.PlanId);
+    }
+    [Fact]
+    public Task ChangePlanAsync_AsNonAdmin_ReturnsForbidden()
+    {
+        return SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPaths("admin", "change-plan")
+            .QueryString("organizationId", SampleDataService.TEST_ORG_ID)
+            .QueryString("planId", "EX_SMALL")
+            .StatusCodeShouldBeForbidden());
+    }
+    [Fact]
+    public async Task SetBonusAsync_ValidOrganization_AppliesBonus()
+    {
+        // Arrange
+        var organizationRepository = GetService<IOrganizationRepository>();
+        var organizationBefore = await organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(organizationBefore);
+
+        // Act
+        await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .Post()
+            .AppendPaths("admin", "set-bonus")
+            .QueryString("organizationId", SampleDataService.TEST_ORG_ID)
+            .QueryString("bonusEvents", "5000")
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        var organizationAfter = await organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(organizationAfter);
+        Assert.Equal(5000, organizationAfter.BonusEventsPerMonth);
+    }
+    [Fact]
+    public async Task SetBonusAsync_WithExpiration_AppliesBonusWithExpiry()
+    {
+        // Arrange
+        var organizationRepository = GetService<IOrganizationRepository>();
+        var expires = DateTime.UtcNow.AddDays(30).ToString("o");
+
+        // Act
+        await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .Post()
+            .AppendPaths("admin", "set-bonus")
+            .QueryString("organizationId", SampleDataService.TEST_ORG_ID)
+            .QueryString("bonusEvents", "10000")
+            .QueryString("expires", expires)
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        var organization = await organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(organization);
+        Assert.Equal(10000, organization.BonusEventsPerMonth);
+        Assert.NotNull(organization.BonusExpiration);
+    }
+    [Fact]
+    public Task SetBonusAsync_InvalidOrganization_ReturnsValidationError()
+    {
+        // Act
+        return SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .Post()
+            .AppendPaths("admin", "set-bonus")
+            .QueryString("organizationId", "000000000000000000000000")
+            .QueryString("bonusEvents", "1000")
+            .StatusCodeShouldBeUnprocessableEntity());
+    }
+    [Fact]
+    public Task SetBonusAsync_AsNonAdmin_ReturnsForbidden()
+    {
+        return SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPaths("admin", "set-bonus")
+            .QueryString("organizationId", SampleDataService.TEST_ORG_ID)
+            .QueryString("bonusEvents", "1000")
+            .StatusCodeShouldBeForbidden());
     }
 }

--- a/tests/Exceptionless.Tests/Controllers/AuthControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/AuthControllerTests.cs
@@ -963,6 +963,97 @@ public class AuthControllerTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task ForgotPasswordCreatesResetTokenAsync()
+    {
+        const string email = "forgot-password@exceptionless.io";
+        var user = new User
+        {
+            EmailAddress = email,
+            FullName = "Forgot Password",
+            Roles = AuthorizationRoles.AllScopes
+        };
+
+        user.MarkEmailAddressVerified();
+        await _userRepository.AddAsync(user);
+
+        await SendRequestAsync(r => r
+            .AppendPath($"auth/forgot-password/{email}")
+            .StatusCodeShouldBeOk()
+        );
+
+        var updatedUser = await _userRepository.GetByEmailAddressAsync(email);
+        Assert.NotNull(updatedUser);
+        Assert.False(String.IsNullOrEmpty(updatedUser.PasswordResetToken));
+        Assert.True(updatedUser.PasswordResetTokenExpiration.IsAfter(TimeProvider.GetUtcNow().UtcDateTime));
+    }
+
+    [Fact]
+    public Task ForgotPasswordForUnknownEmailReturnsOkAsync()
+    {
+        return SendRequestAsync(r => r
+            .AppendPath("auth/forgot-password/missing-password-user@exceptionless.io")
+            .StatusCodeShouldBeOk()
+        );
+    }
+
+    [Fact]
+    public async Task CancelResetPasswordClearsTokenAsync()
+    {
+        const string email = "cancel-reset-password@exceptionless.io";
+        var user = new User
+        {
+            EmailAddress = email,
+            FullName = "Cancel Reset Password",
+            Roles = AuthorizationRoles.AllScopes
+        };
+
+        user.MarkEmailAddressVerified();
+        user.CreatePasswordResetToken(TimeProvider);
+        string token = user.PasswordResetToken!;
+        await _userRepository.AddAsync(user);
+
+        await SendRequestAsync(r => r
+            .Post()
+            .AppendPath($"auth/cancel-reset-password/{token}")
+            .StatusCodeShouldBeOk()
+        );
+
+        var updatedUser = await _userRepository.GetByEmailAddressAsync(email);
+        Assert.NotNull(updatedUser);
+        Assert.Null(updatedUser.PasswordResetToken);
+        Assert.Equal(DateTime.MinValue, updatedUser.PasswordResetTokenExpiration);
+    }
+
+    [Fact]
+    public async Task EmailAddressAvailabilityReturnsCreatedForExistingUserAsync()
+    {
+        const string email = "existing-email-check@exceptionless.io";
+        var user = new User
+        {
+            EmailAddress = email,
+            FullName = "Existing Email Check",
+            Roles = AuthorizationRoles.AllScopes
+        };
+
+        user.MarkEmailAddressVerified();
+        await _userRepository.AddAsync(user);
+
+        await SendRequestAsync(r => r
+            .AppendPath($"auth/check-email-address/{email}")
+            .StatusCodeShouldBeCreated()
+        );
+    }
+
+    [Fact]
+    public Task EmailAddressAvailabilityReturnsNoContentForMissingUserAsync()
+    {
+        return SendRequestAsync(r => r
+            .AppendPath("auth/check-email-address/missing-email-check@exceptionless.io")
+            .StatusCodeShouldBeNoContent()
+        );
+    }
+
+    [Fact]
     public async Task CanLogoutUserAsync()
     {
         const string email = "test7@exceptionless.io";

--- a/tests/Exceptionless.Tests/Controllers/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Controllers/Data/openapi.json
@@ -7961,7 +7961,6 @@
       "NewToken": {
         "required": [
           "organization_id",
-          "project_id",
           "scopes"
         ],
         "type": "object",
@@ -7976,7 +7975,10 @@
             "maxLength": 24,
             "minLength": 24,
             "pattern": "^[a-fA-F0-9]{24}$",
-            "type": "string"
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "default_project_id": {
             "maxLength": 24,
@@ -9355,7 +9357,6 @@
         "required": [
           "id",
           "organization_id",
-          "project_id",
           "scopes",
           "is_disabled",
           "is_suspended",
@@ -9380,7 +9381,10 @@
             "maxLength": 24,
             "minLength": 24,
             "pattern": "^[a-fA-F0-9]{24}$",
-            "type": "string"
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "user_id": {
             "maxLength": 24,

--- a/tests/Exceptionless.Tests/Controllers/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Controllers/Data/openapi.json
@@ -7961,6 +7961,7 @@
       "NewToken": {
         "required": [
           "organization_id",
+          "project_id",
           "scopes"
         ],
         "type": "object",
@@ -7975,10 +7976,7 @@
             "maxLength": 24,
             "minLength": 24,
             "pattern": "^[a-fA-F0-9]{24}$",
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": "string"
           },
           "default_project_id": {
             "maxLength": 24,

--- a/tests/Exceptionless.Tests/Controllers/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Controllers/Data/openapi.json
@@ -9357,6 +9357,7 @@
         "required": [
           "id",
           "organization_id",
+          "project_id",
           "scopes",
           "is_disabled",
           "is_suspended",
@@ -9381,10 +9382,7 @@
             "maxLength": 24,
             "minLength": 24,
             "pattern": "^[a-fA-F0-9]{24}$",
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": "string"
           },
           "user_id": {
             "maxLength": 24,

--- a/tests/Exceptionless.Tests/Controllers/EventControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/EventControllerTests.cs
@@ -166,6 +166,92 @@ public class EventControllerTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task GetSubmitEventAsync_WithOnlyIgnoredParameters_DoesNotEnqueueEvent()
+    {
+        // Act
+        await SendRequestAsync(r => r
+            .AsTestOrganizationClientUser()
+            .AppendPaths("events", "submit")
+            .QueryString("api_key", SampleDataService.TEST_API_KEY)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        var stats = await _eventQueue.GetQueueStatsAsync();
+        Assert.Equal(0, stats.Enqueued);
+    }
+
+    [Fact]
+    public async Task GetSubmitEventAsync_WithQueryParameters_EnqueuesEvent()
+    {
+        // Arrange
+        var eventDate = TimeProvider.GetUtcNow().AddMinutes(-5);
+
+        // Act
+        await SendRequestAsync(r => r
+            .AsTestOrganizationClientUser()
+            .AppendPaths("events", "submit", Event.KnownTypes.FeatureUsage)
+            .QueryString("source", "build")
+            .QueryString("message", "GET submit event")
+            .QueryString("reference", "get-submit-reference")
+            .QueryString("date", eventDate.ToString("O"))
+            .QueryString("count", "3")
+            .QueryString("value", "10.5")
+            .QueryString("tags", "one,two")
+            .QueryString("identity", "user-123")
+            .QueryString("identity.name", "Test User")
+            .QueryString("custom_property", "custom value")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        var stats = await _eventQueue.GetQueueStatsAsync();
+        Assert.Equal(1, stats.Enqueued);
+        Assert.Equal(0, stats.Completed);
+
+        var processEventsJob = GetService<EventPostsJob>();
+        await processEventsJob.RunAsync(TestCancellationToken);
+        await RefreshDataAsync();
+
+        stats = await _eventQueue.GetQueueStatsAsync();
+        Assert.Equal(1, stats.Completed);
+
+        var ev = (await _eventRepository.GetAllAsync()).Documents.Single(e => String.Equals(e.ReferenceId, "get-submit-reference", StringComparison.Ordinal));
+        Assert.Equal(Event.KnownTypes.FeatureUsage, ev.Type);
+        Assert.Equal("build", ev.Source);
+        Assert.Equal("GET submit event", ev.Message);
+        Assert.Equal("get-submit-reference", ev.ReferenceId);
+        Assert.Equal(3, ev.Count);
+        Assert.Equal(10.5m, ev.Value);
+        Assert.NotNull(ev.Tags);
+        Assert.Contains("one", ev.Tags);
+        Assert.Contains("two", ev.Tags);
+        Assert.NotNull(ev.Data);
+        Assert.Equal("custom value", ev.Data["custom_property"]);
+
+        var identity = ev.GetUserIdentity(_jsonSerializerOptions);
+        Assert.NotNull(identity);
+        Assert.Equal("user-123", identity.Identity);
+        Assert.Equal("Test User", identity.Name);
+    }
+
+    [Fact]
+    public async Task GetSubmitEventByProjectV2Async_MismatchedProjectRoute_ReturnsNotFound()
+    {
+        // Act
+        await SendRequestAsync(r => r
+            .AsTestOrganizationClientUser()
+            .AppendPaths("projects", SampleDataService.FREE_PROJECT_ID, "events", "submit")
+            .QueryString("message", "should not enqueue")
+            .StatusCodeShouldBeNotFound()
+        );
+
+        // Assert
+        var stats = await _eventQueue.GetQueueStatsAsync();
+        Assert.Equal(0, stats.Enqueued);
+    }
+
+    [Fact]
     public async Task CanPostStringAsync()
     {
         const string message = "simple string";

--- a/tests/Exceptionless.Tests/Controllers/OrganizationControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/OrganizationControllerTests.cs
@@ -1072,6 +1072,8 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
     public async Task ChangePlanAsync_ExistingCustomerUpdatesPaymentMethodAndSubscription()
     {
         // Arrange
+        var subscribeDate = new DateTime(2026, 5, 22, 14, 30, 0, DateTimeKind.Utc);
+        TimeProvider.SetUtcNow(subscribeDate);
         await SetStripeCustomerIdAsync(SampleDataService.FREE_ORG_ID, "cus_existing");
         StripeBillingClient.Subscriptions.Add(CreateStripeSubscription("sub_active", "si_active"));
 
@@ -1115,6 +1117,7 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
         var organization = await _organizationRepository.GetByIdAsync(SampleDataService.FREE_ORG_ID);
         Assert.NotNull(organization);
         Assert.Equal("4242", organization.CardLast4);
+        Assert.Equal(subscribeDate, organization.SubscribeDate);
         Assert.Equal(_plans.SmallPlan.Id, organization.PlanId);
         Assert.Equal(BillingStatus.Active, organization.BillingStatus);
     }

--- a/tests/Exceptionless.Tests/Controllers/OrganizationControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/OrganizationControllerTests.cs
@@ -1,3 +1,4 @@
+using Exceptionless.Core;
 using Exceptionless.Core.Billing;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Models.Billing;
@@ -26,6 +27,38 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
         _userRepository = GetService<IUserRepository>();
         _billingManager = GetService<BillingManager>();
         _plans = GetService<BillingPlans>();
+    }
+
+    private async Task WithBillingEnabledAsync(Func<Task> action)
+    {
+        var options = GetService<AppOptions>();
+        string? originalStripeApiKey = options.StripeOptions.StripeApiKey;
+
+        options.StripeOptions.StripeApiKey = "sk_test_local";
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            options.StripeOptions.StripeApiKey = originalStripeApiKey;
+        }
+    }
+
+    private async Task<T> WithBillingEnabledAsync<T>(Func<Task<T>> action)
+    {
+        var options = GetService<AppOptions>();
+        string? originalStripeApiKey = options.StripeOptions.StripeApiKey;
+
+        options.StripeOptions.StripeApiKey = "sk_test_local";
+        try
+        {
+            return await action();
+        }
+        finally
+        {
+            options.StripeOptions.StripeApiKey = originalStripeApiKey;
+        }
     }
 
     protected override async Task ResetDataAsync()
@@ -431,6 +464,149 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task AddUserAsync_NewEmail_AddsInvite()
+    {
+        // Arrange
+        const string emailAddress = "New.Member+Invite@localhost";
+
+        // Act
+        var user = await SendRequestAsAsync<User>(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "users", emailAddress)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(user);
+        Assert.Equal(emailAddress, user.EmailAddress);
+
+        var organization = await _organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(organization);
+
+        var invite = Assert.Single(organization.Invites, i => String.Equals(i.EmailAddress, emailAddress.ToLowerInvariant(), StringComparison.Ordinal));
+        Assert.False(String.IsNullOrEmpty(invite.Token));
+        Assert.True(invite.DateAdded > DateTime.MinValue);
+    }
+
+    [Fact]
+    public async Task AddUserAsync_ExistingInvite_DoesNotDuplicateInvite()
+    {
+        // Arrange
+        const string emailAddress = "pending.member@localhost";
+        const string token = "existing-invite-token";
+        var organization = await _organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(organization);
+        organization.Invites.Add(new Invite
+        {
+            Token = token,
+            EmailAddress = emailAddress,
+            DateAdded = TimeProvider.GetUtcNow().UtcDateTime
+        });
+        await _organizationRepository.SaveAsync(organization, o => o.ImmediateConsistency().Cache());
+
+        // Act
+        var user = await SendRequestAsAsync<User>(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "users", emailAddress.ToUpperInvariant())
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(user);
+        Assert.Equal(emailAddress.ToUpperInvariant(), user.EmailAddress);
+
+        organization = await _organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(organization);
+
+        var invite = Assert.Single(organization.Invites, i => String.Equals(i.EmailAddress, emailAddress, StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(token, invite.Token);
+    }
+
+    [Fact]
+    public async Task AddUserAsync_ExistingUserWithoutMembership_AddsOrganizationMembership()
+    {
+        // Arrange
+        var existingUser = await _userRepository.GetByEmailAddressAsync(SampleDataService.FREE_USER_EMAIL);
+        Assert.NotNull(existingUser);
+        Assert.DoesNotContain(SampleDataService.TEST_ORG_ID, existingUser.OrganizationIds);
+
+        // Act
+        var user = await SendRequestAsAsync<User>(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "users", SampleDataService.FREE_USER_EMAIL)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(user);
+        Assert.Equal(SampleDataService.FREE_USER_EMAIL, user.EmailAddress);
+
+        existingUser = await _userRepository.GetByEmailAddressAsync(SampleDataService.FREE_USER_EMAIL);
+        Assert.NotNull(existingUser);
+        Assert.Contains(SampleDataService.TEST_ORG_ID, existingUser.OrganizationIds);
+        Assert.Contains(SampleDataService.FREE_ORG_ID, existingUser.OrganizationIds);
+    }
+
+    [Fact]
+    public async Task AddUserAsync_ExistingUserWithMembership_DoesNotDuplicateOrganizationMembership()
+    {
+        // Act
+        var user = await SendRequestAsAsync<User>(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "users", SampleDataService.TEST_ORG_USER_EMAIL)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(user);
+        Assert.Equal(SampleDataService.TEST_ORG_USER_EMAIL, user.EmailAddress);
+
+        var existingUser = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_ORG_USER_EMAIL);
+        Assert.NotNull(existingUser);
+        Assert.Single(existingUser.OrganizationIds, id => String.Equals(id, SampleDataService.TEST_ORG_ID, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public Task AddUserAsync_UnauthorizedOrganization_ReturnsNotFound()
+    {
+        // Act & Assert
+        return SendRequestAsync(r => r
+            .AsFreeOrganizationUser()
+            .Post()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "users", "new.member@localhost")
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
+    public Task AddUserAsync_NonExistentOrganization_ReturnsNotFound()
+    {
+        // Act & Assert
+        return SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .Post()
+            .AppendPaths("organizations", "000000000000000000000000", "users", "new.member@localhost")
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
+    public Task AddUserAsync_PlanLimitReached_ReturnsUpgradeRequired()
+    {
+        // Act & Assert
+        return SendRequestAsync(r => r
+            .AsFreeOrganizationUser()
+            .Post()
+            .AppendPaths("organizations", SampleDataService.FREE_ORG_ID, "users", "new.member@localhost")
+            .StatusCodeShouldBeUpgradeRequired()
+        );
+    }
+
+    [Fact]
     public async Task RemoveUserAsync_UserWithNotificationSettings_CleansUpNotificationSettings()
     {
         // Arrange
@@ -702,6 +878,70 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
     }
 
     [Fact]
+    public Task ChangePlanAsync_InvalidPlan_ReturnsValidationError()
+    {
+        return WithBillingEnabledAsync(() =>
+            SendRequestAsync(r => r
+                .AsTestOrganizationUser()
+                .Post()
+                .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "change-plan")
+                .Content(new ChangePlanRequest { PlanId = "missing-plan" })
+                .StatusCodeShouldBeUnprocessableEntity()
+            ));
+    }
+
+    [Fact]
+    public async Task ChangePlanAsync_SameFreePlan_ReturnsSuccess()
+    {
+        var result = await WithBillingEnabledAsync(() =>
+            SendRequestAsAsync<ChangePlanResult>(r => r
+                .AsFreeOrganizationUser()
+                .Post()
+                .AppendPaths("organizations", SampleDataService.FREE_ORG_ID, "change-plan")
+                .Content(new ChangePlanRequest { PlanId = _plans.FreePlan.Id })
+                .StatusCodeShouldBeOk()
+            ));
+
+        Assert.NotNull(result);
+        Assert.True(result.Success);
+        Assert.Contains("already on the free plan", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ChangePlanAsync_LegacyQueryParamsSameFreePlan_ReturnsSuccess()
+    {
+        var result = await WithBillingEnabledAsync(() =>
+            SendRequestAsAsync<ChangePlanResult>(r => r
+                .AsFreeOrganizationUser()
+                .Post()
+                .AppendPaths("organizations", SampleDataService.FREE_ORG_ID, "change-plan")
+                .QueryString("planId", _plans.FreePlan.Id)
+                .StatusCodeShouldBeOk()
+            ));
+
+        Assert.NotNull(result);
+        Assert.True(result.Success);
+        Assert.Contains("already on the free plan", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ChangePlanAsync_PaidPlanWithoutBillingInformation_ReturnsFailure()
+    {
+        var result = await WithBillingEnabledAsync(() =>
+            SendRequestAsAsync<ChangePlanResult>(r => r
+                .AsFreeOrganizationUser()
+                .Post()
+                .AppendPaths("organizations", SampleDataService.FREE_ORG_ID, "change-plan")
+                .Content(new ChangePlanRequest { PlanId = _plans.SmallPlan.Id })
+                .StatusCodeShouldBeOk()
+            ));
+
+        Assert.NotNull(result);
+        Assert.False(result.Success);
+        Assert.Equal("Billing information was not set.", result.Message);
+    }
+
+    [Fact]
     public async Task CanDownGradeAsync_TooManyUsers_ReturnsFailure()
     {
         // Arrange — test org has 2 users (global admin + org user); free plan allows max 1
@@ -812,6 +1052,31 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
             .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "invoices")
             .StatusCodeShouldBeNotFound()
         );
+    }
+
+    [Fact]
+    public async Task GetInvoicesAsync_BillingEnabledOrganizationWithoutStripeCustomer_ReturnsEmptyCollection()
+    {
+        var invoices = await WithBillingEnabledAsync(() =>
+            SendRequestAsAsync<List<InvoiceGridModel>>(r => r
+                .AsFreeOrganizationUser()
+                .AppendPaths("organizations", SampleDataService.FREE_ORG_ID, "invoices")
+                .StatusCodeShouldBeOk()
+            ));
+
+        Assert.NotNull(invoices);
+        Assert.Empty(invoices);
+    }
+
+    [Fact]
+    public Task GetInvoicesAsync_BillingEnabledNonExistentOrganization_ReturnsNotFound()
+    {
+        return WithBillingEnabledAsync(() =>
+            SendRequestAsync(r => r
+                .AsGlobalAdminUser()
+                .AppendPaths("organizations", "000000000000000000000000", "invoices")
+                .StatusCodeShouldBeNotFound()
+            ));
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Controllers/OrganizationControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/OrganizationControllerTests.cs
@@ -1,14 +1,19 @@
 using Exceptionless.Core;
 using Exceptionless.Core.Billing;
+using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Models.Billing;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Utility;
 using Exceptionless.Tests.Extensions;
+using Exceptionless.Tests.Utility;
 using Exceptionless.Web.Models;
 using Foundatio.Repositories;
 using Foundatio.Repositories.Utility;
+using Microsoft.Extensions.DependencyInjection;
+using Stripe;
 using Xunit;
+using WebInvoice = Exceptionless.Web.Models.Invoice;
 
 namespace Exceptionless.Tests.Controllers;
 
@@ -19,6 +24,7 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
     private readonly IUserRepository _userRepository;
     private readonly BillingManager _billingManager;
     private readonly BillingPlans _plans;
+    private FakeStripeBillingClient StripeBillingClient => (FakeStripeBillingClient)GetService<IStripeBillingClient>();
 
     public OrganizationControllerTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
     {
@@ -27,6 +33,12 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
         _userRepository = GetService<IUserRepository>();
         _billingManager = GetService<BillingManager>();
         _plans = GetService<BillingPlans>();
+    }
+
+    protected override void RegisterServices(IServiceCollection services)
+    {
+        base.RegisterServices(services);
+        services.ReplaceSingleton<IStripeBillingClient, FakeStripeBillingClient>();
     }
 
     private async Task WithBillingEnabledAsync(Func<Task> action)
@@ -64,9 +76,81 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
     protected override async Task ResetDataAsync()
     {
         await base.ResetDataAsync();
+        StripeBillingClient.Reset();
         var service = GetService<SampleDataService>();
         await service.CreateDataAsync();
     }
+
+    private async Task SetStripeCustomerIdAsync(string organizationId, string stripeCustomerId)
+    {
+        var organization = await _organizationRepository.GetByIdAsync(organizationId);
+        Assert.NotNull(organization);
+
+        organization.StripeCustomerId = stripeCustomerId;
+        await _organizationRepository.SaveAsync(organization, o => o.ImmediateConsistency().Cache());
+    }
+
+    private async Task SetPlanAndStripeCustomerIdAsync(string organizationId, string planId, string stripeCustomerId)
+    {
+        var organization = await _organizationRepository.GetByIdAsync(organizationId);
+        Assert.NotNull(organization);
+
+        var user = await _userRepository.GetByEmailAddressAsync(SampleDataService.FREE_USER_EMAIL);
+        Assert.NotNull(user);
+
+        var plan = _billingManager.GetBillingPlan(planId);
+        Assert.NotNull(plan);
+
+        _billingManager.ApplyBillingPlan(organization, plan, user);
+        organization.StripeCustomerId = stripeCustomerId;
+        organization.CardLast4 = "4242";
+        organization.SubscribeDate = TimeProvider.GetUtcNow().UtcDateTime;
+        organization.BillingStatus = BillingStatus.Active;
+        await _organizationRepository.SaveAsync(organization, o => o.ImmediateConsistency().Cache().Originals());
+    }
+
+    private Stripe.Invoice CreateStripeInvoice(string id, string customerId, DateTime createdUtc)
+    {
+        var periodEndUtc = createdUtc.AddMonths(1);
+        return new Stripe.Invoice
+        {
+            Id = id,
+            CustomerId = customerId,
+            Created = createdUtc,
+            Status = "paid",
+            Total = 1500,
+            Subtotal = 1500,
+            PeriodStart = createdUtc,
+            PeriodEnd = periodEndUtc,
+            Lines = new StripeList<Stripe.InvoiceLineItem>
+            {
+                Data =
+                [
+                    new Stripe.InvoiceLineItem
+                    {
+                        Amount = 1500,
+                        Description = "Small plan",
+                        Period = new InvoiceLineItemPeriod { Start = createdUtc, End = periodEndUtc },
+                        Pricing = new InvoiceLineItemPricing
+                        {
+                            PriceDetails = new InvoiceLineItemPricingPriceDetails { PriceId = _plans.SmallPlan.Id }
+                        }
+                    }
+                ]
+            }
+        };
+    }
+
+    private static Subscription CreateStripeSubscription(string id, string itemId, DateTime? canceledAtUtc = null)
+        => new()
+        {
+            Id = id,
+            CanceledAt = canceledAtUtc,
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data = [new SubscriptionItem { Id = itemId }]
+            }
+        };
 
     [Fact]
     public async Task PostAsync_NewOrganization_MapsToOrganizationAndCreates()
@@ -942,6 +1026,158 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task ChangePlanAsync_NewCustomerCreatesStripeCustomerAndSubscription()
+    {
+        // Arrange
+        StripeBillingClient.CustomerToReturn = new Customer { Id = "cus_created" };
+
+        // Act
+        var result = await WithBillingEnabledAsync(() =>
+            SendRequestAsAsync<ChangePlanResult>(r => r
+                .AsFreeOrganizationUser()
+                .Post()
+                .AppendPaths("organizations", SampleDataService.FREE_ORG_ID, "change-plan")
+                .Content(new ChangePlanRequest
+                {
+                    PlanId = _plans.SmallPlan.Id,
+                    StripeToken = "tok_visa",
+                    Last4 = "4242",
+                    CouponId = "coupon_10"
+                })
+                .StatusCodeShouldBeOk()
+            ));
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.Success, result.Message);
+        Assert.NotNull(StripeBillingClient.LastCustomerCreateOptions);
+        Assert.Equal("tok_visa", StripeBillingClient.LastCustomerCreateOptions.Source);
+        Assert.Equal(SampleDataService.FREE_USER_EMAIL, StripeBillingClient.LastCustomerCreateOptions.Email);
+
+        var subscription = Assert.Single(StripeBillingClient.CreatedSubscriptionOptions);
+        Assert.Equal("cus_created", subscription.Customer);
+        var item = Assert.Single(subscription.Items);
+        Assert.Equal(_plans.SmallPlan.Id, item.Price);
+        Assert.Equal("coupon_10", Assert.Single(subscription.Discounts).Coupon);
+
+        var organization = await _organizationRepository.GetByIdAsync(SampleDataService.FREE_ORG_ID);
+        Assert.NotNull(organization);
+        Assert.Equal("cus_created", organization.StripeCustomerId);
+        Assert.Equal("4242", organization.CardLast4);
+        Assert.Equal(_plans.SmallPlan.Id, organization.PlanId);
+        Assert.Equal(BillingStatus.Active, organization.BillingStatus);
+    }
+
+    [Fact]
+    public async Task ChangePlanAsync_ExistingCustomerUpdatesPaymentMethodAndSubscription()
+    {
+        // Arrange
+        await SetStripeCustomerIdAsync(SampleDataService.FREE_ORG_ID, "cus_existing");
+        StripeBillingClient.Subscriptions.Add(CreateStripeSubscription("sub_active", "si_active"));
+
+        // Act
+        var result = await WithBillingEnabledAsync(() =>
+            SendRequestAsAsync<ChangePlanResult>(r => r
+                .AsFreeOrganizationUser()
+                .Post()
+                .AppendPaths("organizations", SampleDataService.FREE_ORG_ID, "change-plan")
+                .Content(new ChangePlanRequest
+                {
+                    PlanId = _plans.SmallPlan.Id,
+                    StripeToken = "pm_card_visa",
+                    Last4 = "4242",
+                    CouponId = "coupon_10"
+                })
+                .StatusCodeShouldBeOk()
+            ));
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.Success, result.Message);
+
+        var attachedPaymentMethod = Assert.Single(StripeBillingClient.AttachedPaymentMethods);
+        Assert.Equal("pm_card_visa", attachedPaymentMethod.PaymentMethodId);
+        Assert.Equal("cus_existing", attachedPaymentMethod.Options.Customer);
+
+        var updatedCustomer = Assert.Single(StripeBillingClient.UpdatedCustomers);
+        Assert.Equal("cus_existing", updatedCustomer.CustomerId);
+        Assert.Equal(SampleDataService.FREE_USER_EMAIL, updatedCustomer.Options.Email);
+        Assert.Equal("pm_card_visa", updatedCustomer.Options.InvoiceSettings?.DefaultPaymentMethod);
+
+        var updatedSubscription = Assert.Single(StripeBillingClient.UpdatedSubscriptions);
+        Assert.Equal("sub_active", updatedSubscription.SubscriptionId);
+        var item = Assert.Single(updatedSubscription.Options.Items);
+        Assert.Equal("si_active", item.Id);
+        Assert.Equal(_plans.SmallPlan.Id, item.Price);
+        Assert.Equal("coupon_10", Assert.Single(updatedSubscription.Options.Discounts).Coupon);
+        Assert.Empty(StripeBillingClient.CreatedSubscriptionOptions);
+
+        var organization = await _organizationRepository.GetByIdAsync(SampleDataService.FREE_ORG_ID);
+        Assert.NotNull(organization);
+        Assert.Equal("4242", organization.CardLast4);
+        Assert.Equal(_plans.SmallPlan.Id, organization.PlanId);
+        Assert.Equal(BillingStatus.Active, organization.BillingStatus);
+    }
+
+    [Fact]
+    public async Task ChangePlanAsync_FreePlanCancelsActiveStripeSubscriptions()
+    {
+        // Arrange
+        await SetPlanAndStripeCustomerIdAsync(SampleDataService.FREE_ORG_ID, _plans.SmallPlan.Id, "cus_existing");
+        StripeBillingClient.Subscriptions.Add(CreateStripeSubscription("sub_active", "si_active"));
+        StripeBillingClient.Subscriptions.Add(CreateStripeSubscription("sub_canceled", "si_canceled", canceledAtUtc: DateTime.UtcNow));
+
+        // Act
+        var result = await WithBillingEnabledAsync(() =>
+            SendRequestAsAsync<ChangePlanResult>(r => r
+                .AsFreeOrganizationUser()
+                .Post()
+                .AppendPaths("organizations", SampleDataService.FREE_ORG_ID, "change-plan")
+                .Content(new ChangePlanRequest { PlanId = _plans.FreePlan.Id })
+                .StatusCodeShouldBeOk()
+            ));
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.Success);
+        Assert.Equal("cus_existing", StripeBillingClient.LastSubscriptionListOptions?.Customer);
+        Assert.Equal("sub_active", Assert.Single(StripeBillingClient.CanceledSubscriptions).SubscriptionId);
+
+        var organization = await _organizationRepository.GetByIdAsync(SampleDataService.FREE_ORG_ID);
+        Assert.NotNull(organization);
+        Assert.Equal(_plans.FreePlan.Id, organization.PlanId);
+        Assert.Equal(BillingStatus.Trialing, organization.BillingStatus);
+    }
+
+    [Fact]
+    public async Task ChangePlanAsync_StripeBillingClientThrows_ReturnsFailure()
+    {
+        // Arrange
+        StripeBillingClient.CreateCustomerException = new InvalidOperationException("Stripe unavailable");
+
+        // Act
+        var result = await WithBillingEnabledAsync(() =>
+            SendRequestAsAsync<ChangePlanResult>(r => r
+                .AsFreeOrganizationUser()
+                .Post()
+                .AppendPaths("organizations", SampleDataService.FREE_ORG_ID, "change-plan")
+                .Content(new ChangePlanRequest
+                {
+                    PlanId = _plans.SmallPlan.Id,
+                    StripeToken = "tok_visa",
+                    Last4 = "4242"
+                })
+                .StatusCodeShouldBeOk()
+            ));
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.False(result.Success);
+        Assert.Equal("An error occurred while changing plans. Please try again.", result.Message);
+        Assert.Empty(StripeBillingClient.CreatedSubscriptionOptions);
+    }
+
+    [Fact]
     public async Task CanDownGradeAsync_TooManyUsers_ReturnsFailure()
     {
         // Arrange — test org has 2 users (global admin + org user); free plan allows max 1
@@ -1044,6 +1280,50 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task GetInvoiceAsync_StripeInvoice_ReturnsMappedInvoice()
+    {
+        // Arrange
+        await SetStripeCustomerIdAsync(SampleDataService.TEST_ORG_ID, "cus_test");
+        var createdUtc = new DateTime(2025, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+        StripeBillingClient.Invoice = CreateStripeInvoice("in_abc1234567", "cus_test", createdUtc);
+
+        // Act
+        var invoice = await WithBillingEnabledAsync(() =>
+            SendRequestAsAsync<WebInvoice>(r => r
+                .AsTestOrganizationUser()
+                .AppendPaths("organizations", "invoice", "abc1234567")
+                .StatusCodeShouldBeOk()
+            ));
+
+        // Assert
+        Assert.NotNull(invoice);
+        Assert.Equal("in_abc1234567", StripeBillingClient.LastGetInvoiceId);
+        Assert.Equal("abc1234567", invoice.Id);
+        Assert.Equal(SampleDataService.TEST_ORG_ID, invoice.OrganizationId);
+        Assert.Equal(createdUtc, invoice.Date);
+        Assert.True(invoice.Paid);
+        Assert.Equal(15.00m, invoice.Total);
+        var item = Assert.Single(invoice.Items);
+        Assert.Equal(15.00m, item.Amount);
+        Assert.Contains("Small Plan", item.Description, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public Task GetInvoiceAsync_StripeBillingClientThrows_ReturnsNotFound()
+    {
+        // Arrange
+        StripeBillingClient.GetInvoiceException = new InvalidOperationException("Stripe unavailable");
+
+        // Act & Assert
+        return WithBillingEnabledAsync(() =>
+            SendRequestAsync(r => r
+                .AsTestOrganizationUser()
+                .AppendPaths("organizations", "invoice", "abc1234567")
+                .StatusCodeShouldBeNotFound()
+            ));
+    }
+
+    [Fact]
     public Task GetInvoicesAsync_BillingDisabled_ReturnsNotFound()
     {
         // Act & Assert
@@ -1052,6 +1332,41 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
             .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "invoices")
             .StatusCodeShouldBeNotFound()
         );
+    }
+
+    [Fact]
+    public async Task GetInvoicesAsync_StripeCustomer_ReturnsMappedInvoicesAndPagination()
+    {
+        // Arrange
+        await SetStripeCustomerIdAsync(SampleDataService.TEST_ORG_ID, "cus_test");
+        StripeBillingClient.Invoices.AddRange(
+        [
+            CreateStripeInvoice("in_first", "cus_test", new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc)),
+            CreateStripeInvoice("in_second", "cus_test", new DateTime(2025, 2, 1, 0, 0, 0, DateTimeKind.Utc)),
+            CreateStripeInvoice("in_third", "cus_test", new DateTime(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc))
+        ]);
+
+        // Act
+        var invoices = await WithBillingEnabledAsync(() =>
+            SendRequestAsAsync<List<InvoiceGridModel>>(r => r
+                .AsTestOrganizationUser()
+                .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "invoices")
+                .QueryString("before", "before_cursor")
+                .QueryString("after", "in_after_cursor")
+                .QueryString("limit", 2)
+                .StatusCodeShouldBeOk()
+            ));
+
+        // Assert
+        Assert.NotNull(invoices);
+        Assert.Equal(2, invoices.Count);
+        Assert.Equal("first", invoices[0].Id);
+        Assert.Equal("second", invoices[1].Id);
+        Assert.NotNull(StripeBillingClient.LastInvoiceListOptions);
+        Assert.Equal("cus_test", StripeBillingClient.LastInvoiceListOptions.Customer);
+        Assert.Equal(3, StripeBillingClient.LastInvoiceListOptions.Limit);
+        Assert.Equal("in_before_cursor", StripeBillingClient.LastInvoiceListOptions.EndingBefore);
+        Assert.Equal("in_after_cursor", StripeBillingClient.LastInvoiceListOptions.StartingAfter);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Controllers/OrganizationControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/OrganizationControllerTests.cs
@@ -307,7 +307,7 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
 
         // Assert
         Assert.NotNull(viewOrg);
-        Assert.IsType<bool>(viewOrg.IsOverMonthlyLimit);
+        Assert.False(viewOrg.IsOverMonthlyLimit);
     }
 
     [Fact]
@@ -1126,9 +1126,10 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
     public async Task ChangePlanAsync_FreePlanCancelsActiveStripeSubscriptions()
     {
         // Arrange
+        var canceledAtUtc = TimeProvider.GetUtcNow().UtcDateTime;
         await SetPlanAndStripeCustomerIdAsync(SampleDataService.FREE_ORG_ID, _plans.SmallPlan.Id, "cus_existing");
         StripeBillingClient.Subscriptions.Add(CreateStripeSubscription("sub_active", "si_active"));
-        StripeBillingClient.Subscriptions.Add(CreateStripeSubscription("sub_canceled", "si_canceled", canceledAtUtc: DateTime.UtcNow));
+        StripeBillingClient.Subscriptions.Add(CreateStripeSubscription("sub_canceled", "si_canceled", canceledAtUtc: canceledAtUtc));
 
         // Act
         var result = await WithBillingEnabledAsync(() =>
@@ -1181,6 +1182,78 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task ChangePlanAsync_NewCustomerSubscriptionFails_PreservesStripeCustomerForRetry()
+    {
+        // Arrange
+        StripeBillingClient.CustomerToReturn = new Customer { Id = "cus_created" };
+        StripeBillingClient.CreateSubscriptionException = new InvalidOperationException("Stripe unavailable");
+
+        // Act
+        var result = await WithBillingEnabledAsync(() =>
+            SendRequestAsAsync<ChangePlanResult>(r => r
+                .AsFreeOrganizationUser()
+                .Post()
+                .AppendPaths("organizations", SampleDataService.FREE_ORG_ID, "change-plan")
+                .Content(new ChangePlanRequest
+                {
+                    PlanId = _plans.SmallPlan.Id,
+                    StripeToken = "tok_visa",
+                    Last4 = "4242"
+                })
+                .StatusCodeShouldBeOk()
+            ));
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.False(result.Success);
+        Assert.Equal("An error occurred while changing plans. Please try again.", result.Message);
+
+        var organization = await _organizationRepository.GetByIdAsync(SampleDataService.FREE_ORG_ID);
+        Assert.NotNull(organization);
+        Assert.Equal("cus_created", organization.StripeCustomerId);
+        Assert.Equal("4242", organization.CardLast4);
+        Assert.Equal(_plans.FreePlan.Id, organization.PlanId);
+        Assert.Equal(BillingStatus.Trialing, organization.BillingStatus);
+    }
+
+    [Fact]
+    public async Task ChangePlanAsync_ExistingCustomerSubscriptionFails_DoesNotPersistPlanOrCardChange()
+    {
+        // Arrange
+        await SetStripeCustomerIdAsync(SampleDataService.FREE_ORG_ID, "cus_existing");
+        StripeBillingClient.Subscriptions.Add(CreateStripeSubscription("sub_active", "si_active"));
+        StripeBillingClient.UpdateSubscriptionException = new InvalidOperationException("Stripe unavailable");
+
+        // Act
+        var result = await WithBillingEnabledAsync(() =>
+            SendRequestAsAsync<ChangePlanResult>(r => r
+                .AsFreeOrganizationUser()
+                .Post()
+                .AppendPaths("organizations", SampleDataService.FREE_ORG_ID, "change-plan")
+                .Content(new ChangePlanRequest
+                {
+                    PlanId = _plans.SmallPlan.Id,
+                    StripeToken = "pm_card_visa",
+                    Last4 = "4242"
+                })
+                .StatusCodeShouldBeOk()
+            ));
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.False(result.Success);
+        Assert.Equal("An error occurred while changing plans. Please try again.", result.Message);
+        Assert.NotEmpty(StripeBillingClient.UpdatedSubscriptions);
+
+        var organization = await _organizationRepository.GetByIdAsync(SampleDataService.FREE_ORG_ID);
+        Assert.NotNull(organization);
+        Assert.Equal("cus_existing", organization.StripeCustomerId);
+        Assert.Null(organization.CardLast4);
+        Assert.Equal(_plans.FreePlan.Id, organization.PlanId);
+        Assert.Equal(BillingStatus.Trialing, organization.BillingStatus);
+    }
+
+    [Fact]
     public async Task CanDownGradeAsync_TooManyUsers_ReturnsFailure()
     {
         // Arrange — test org has 2 users (global admin + org user); free plan allows max 1
@@ -1210,7 +1283,7 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
         {
             Name = "Extra Project",
             OrganizationId = org.Id,
-            NextSummaryEndOfDayTicks = DateTime.UtcNow.Date.AddDays(1).AddHours(1).Ticks
+            NextSummaryEndOfDayTicks = TimeProvider.GetUtcNow().UtcDateTime.Date.AddDays(1).AddHours(1).Ticks
         };
         await _projectRepository.AddAsync(extraProject, o => o.ImmediateConsistency());
 
@@ -1237,7 +1310,7 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
         _billingManager.ApplyBillingPlan(secondOrg, _plans.Plans.First(p => p.Id == "EX_SMALL"), freeUser);
         secondOrg.StripeCustomerId = "cus_test";
         secondOrg.CardLast4 = "4242";
-        secondOrg.SubscribeDate = DateTime.UtcNow;
+        secondOrg.SubscribeDate = TimeProvider.GetUtcNow().UtcDateTime;
         secondOrg = await _organizationRepository.AddAsync(secondOrg, o => o.ImmediateConsistency());
 
         freeUser.OrganizationIds.Add(secondOrg.Id);

--- a/tests/Exceptionless.Tests/Controllers/OrganizationControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/OrganizationControllerTests.cs
@@ -840,7 +840,7 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
             .AsTestOrganizationUser()
             .AppendPaths("organizations", SampleDataService.TEST_ORG_ID)
             .Content(new NewOrganization { Name = "" })
-            .StatusCodeShouldBeUnprocessableEntity()
+            .StatusCodeShouldBeBadRequest()
         );
 
         // Assert - verify data unchanged

--- a/tests/Exceptionless.Tests/Controllers/OrganizationControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/OrganizationControllerTests.cs
@@ -813,4 +813,79 @@ public sealed class OrganizationControllerTests : IntegrationTestsBase
             .StatusCodeShouldBeNotFound()
         );
     }
+
+    [Fact]
+    public Task PatchAsync_AnonymousUser_ReturnsUnauthorized()
+    {
+        // Act & Assert
+        return SendRequestAsync(r => r
+            .Patch()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID)
+            .Content(new NewOrganization { Name = "Unauthorized Update" })
+            .StatusCodeShouldBeUnauthorized()
+        );
+    }
+
+    [Fact]
+    public async Task PatchAsync_EmptyName_ReturnsValidationError()
+    {
+        // Arrange
+        var originalOrg = await _organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(originalOrg);
+        string originalName = originalOrg.Name;
+
+        // Act
+        await SendRequestAsync(r => r
+            .Patch()
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID)
+            .Content(new NewOrganization { Name = "" })
+            .StatusCodeShouldBeUnprocessableEntity()
+        );
+
+        // Assert - verify data unchanged
+        var unchangedOrg = await _organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(unchangedOrg);
+        Assert.Equal(originalName, unchangedOrg.Name);
+    }
+
+    [Fact]
+    public Task PatchAsync_NonExistentOrganization_ReturnsNotFound()
+    {
+        // Act & Assert
+        return SendRequestAsync(r => r
+            .Patch()
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", "000000000000000000000000")
+            .Content(new NewOrganization { Name = "Nope" })
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
+    public async Task PatchAsync_UpdateName_ReturnsUpdatedOrganization()
+    {
+        // Arrange
+        var originalOrg = await _organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(originalOrg);
+
+        // Act
+        var updated = await SendRequestAsAsync<ViewOrganization>(r => r
+            .Patch()
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID)
+            .Content(new NewOrganization { Name = "Updated Acme" })
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(updated);
+        Assert.Equal(SampleDataService.TEST_ORG_ID, updated.Id);
+        Assert.Equal("Updated Acme", updated.Name);
+        Assert.True(updated.UpdatedUtc >= originalOrg.UpdatedUtc);
+
+        var persisted = await _organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(persisted);
+        Assert.Equal("Updated Acme", persisted.Name);
+    }
 }

--- a/tests/Exceptionless.Tests/Controllers/ProjectControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/ProjectControllerTests.cs
@@ -64,7 +64,6 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         );
 
         Assert.NotNull(workItems);
-        Assert.Single(workItems.Workers);
 
         var workItemJob = GetService<WorkItemJob>();
         await workItemJob.RunUntilEmptyAsync(TestCancellationToken);
@@ -622,50 +621,43 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.NotNull(config.Settings);
     }
     [Fact]
-    public async Task IsNameAvailableAsync_ExistingName_ReturnsNoContent()
+    public async Task IsNameAvailableAsync_ExistingName_ReturnsCreated()
     {
         // Arrange - the TEST_PROJECT_ID project should have a name
         var project = await _projectRepository.GetByIdAsync(SampleDataService.TEST_PROJECT_ID);
         Assert.NotNull(project);
 
-        // Act
-        var response = await SendRequestAsync(r => r
+        // Act - 201 Created means name is already taken (NOT available)
+        await SendRequestAsync(r => r
             .AsTestOrganizationUser()
             .AppendPath("projects/check-name")
             .QueryString("name", project.Name)
-            .ExpectedStatus(HttpStatusCode.NoContent)
+            .StatusCodeShouldBeCreated()
         );
-
-        // Assert - 204 means name is NOT available (taken)
-        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
     }
+
     [Fact]
-    public async Task IsNameAvailableAsync_NewName_ReturnsCreated()
+    public Task IsNameAvailableAsync_NewName_ReturnsNoContent()
     {
-        // Act
-        var response = await SendRequestAsync(r => r
+        // Act - 204 NoContent means name IS available
+        return SendRequestAsync(r => r
             .AsTestOrganizationUser()
             .AppendPath("projects/check-name")
             .QueryString("name", "UniqueProjectName_" + Guid.NewGuid().ToString("N"))
-            .StatusCodeShouldBeCreated()
+            .StatusCodeShouldBeNoContent()
         );
-
-        // Assert - 201 means name IS available
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
+
     [Fact]
-    public async Task IsNameAvailableAsync_ScopedToOrganization_ReturnsCorrectResult()
+    public Task IsNameAvailableAsync_ScopedToOrganization_ReturnsNoContent()
     {
-        // Act - check with a unique name scoped to org
-        var response = await SendRequestAsync(r => r
+        // Act - 204 NoContent means name IS available in this org scope
+        return SendRequestAsync(r => r
             .AsTestOrganizationUser()
             .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "projects", "check-name")
             .QueryString("name", "UniqueOrgScoped_" + Guid.NewGuid().ToString("N"))
-            .StatusCodeShouldBeCreated()
+            .StatusCodeShouldBeNoContent()
         );
-
-        // Assert
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
     [Fact]
     public async Task PatchAsync_ChangeName_UpdatesNameAndPreservesOtherFields()

--- a/tests/Exceptionless.Tests/Controllers/ProjectControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/ProjectControllerTests.cs
@@ -675,7 +675,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task PatchAsync_ChangeName_UpdatesNameAndPreservesOtherFields()
+    public async Task PatchAsync_WithNameOnlySnakeCasePayload_UpdatesNameAndPreservesDeleteBotSetting()
     {
         // Arrange
         var project = await SendRequestAsAsync<ViewProject>(r => r
@@ -692,18 +692,23 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         );
         Assert.NotNull(project);
 
+        /* language=json */
+        const string json = """
+                            {
+                                "name": "Updated Name"
+                            }
+                            """;
+
         // Act
-        var updatedProject = await SendRequestAsAsync<ViewProject>(r => r
+        var response = await SendRequestAsync(r => r
             .AsTestOrganizationUser()
             .Patch()
             .AppendPaths("projects", project.Id)
-            .Content(new UpdateProject
-            {
-                Name = "Updated Name",
-                DeleteBotDataEnabled = true
-            })
+            .Content(json, "application/json")
             .StatusCodeShouldBeOk()
         );
+        string responseJson = await response.Content.ReadAsStringAsync(TestCancellationToken);
+        var updatedProject = await DeserializeResponseAsync<ViewProject>(response);
 
         // Assert
         Assert.NotNull(updatedProject);
@@ -711,11 +716,16 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.True(updatedProject.DeleteBotDataEnabled);
         Assert.Equal(project.OrganizationId, updatedProject.OrganizationId);
 
-        // Verify persisted
         var persisted = await _projectRepository.GetByIdAsync(project.Id);
         Assert.NotNull(persisted);
         Assert.Equal("Updated Name", persisted.Name);
         Assert.True(persisted.DeleteBotDataEnabled);
+
+        using var doc = JsonDocument.Parse(responseJson);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("delete_bot_data_enabled", out var deleteBotDataEnabled), "Expected lower_case_underscore response property 'delete_bot_data_enabled'.");
+        Assert.True(deleteBotDataEnabled.GetBoolean());
+        Assert.False(root.TryGetProperty("DeleteBotDataEnabled", out _), "Response must not drift back to PascalCase 'DeleteBotDataEnabled'.");
     }
 
     [Fact]
@@ -745,7 +755,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task PatchAsync_WithExtraPayloadProperties_UpdatesNameOnly()
+    public async Task PatchAsync_WithExtraPayloadProperties_IgnoresReadOnlyFieldsAndUpdatesKnownFields()
     {
         // Arrange
         var project = await SendRequestAsAsync<ViewProject>(r => r
@@ -762,19 +772,56 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         );
         Assert.NotNull(project);
 
-        // Act - send the full ViewProject as patch payload (extra fields should be ignored)
-        project.Name = "Patched With Extras";
-        var updatedProject = await SendRequestAsAsync<ViewProject>(r => r
+        var persistedBefore = await _projectRepository.GetByIdAsync(project.Id);
+        Assert.NotNull(persistedBefore);
+
+        /* language=json */
+        string json = $$"""
+                        {
+                            "id": "000000000000000000000000",
+                            "organization_id": "{{SampleDataService.FREE_ORG_ID}}",
+                            "organization_name": "Hijacked Org",
+                            "created_utc": "2000-01-01T00:00:00Z",
+                            "name": "Patched With Extras",
+                            "delete_bot_data_enabled": false,
+                            "has_premium_features": true,
+                            "stack_count": 9999
+                        }
+                        """;
+
+        // Act
+        var response = await SendRequestAsync(r => r
             .AsTestOrganizationUser()
             .Patch()
             .AppendPaths("projects", project.Id)
-            .Content(project)
+            .Content(json, "application/json")
             .StatusCodeShouldBeOk()
         );
+        string responseJson = await response.Content.ReadAsStringAsync(TestCancellationToken);
+        var updatedProject = await DeserializeResponseAsync<ViewProject>(response);
 
         // Assert
         Assert.NotNull(updatedProject);
         Assert.Equal("Patched With Extras", updatedProject.Name);
+        Assert.False(updatedProject.DeleteBotDataEnabled);
+        Assert.Equal(SampleDataService.TEST_ORG_ID, updatedProject.OrganizationId);
+        Assert.Equal(persistedBefore.CreatedUtc, updatedProject.CreatedUtc);
+
+        var persistedAfter = await _projectRepository.GetByIdAsync(project.Id);
+        Assert.NotNull(persistedAfter);
+        Assert.Equal("Patched With Extras", persistedAfter.Name);
+        Assert.False(persistedAfter.DeleteBotDataEnabled);
+        Assert.Equal(SampleDataService.TEST_ORG_ID, persistedAfter.OrganizationId);
+        Assert.Equal(persistedBefore.CreatedUtc, persistedAfter.CreatedUtc);
+
+        using var doc = JsonDocument.Parse(responseJson);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("organization_id", out var organizationId), "Expected lower_case_underscore response property 'organization_id'.");
+        Assert.Equal(SampleDataService.TEST_ORG_ID, organizationId.GetString());
+        Assert.True(root.TryGetProperty("delete_bot_data_enabled", out var deleteBotDataEnabled), "Expected lower_case_underscore response property 'delete_bot_data_enabled'.");
+        Assert.False(deleteBotDataEnabled.GetBoolean());
+        Assert.False(root.TryGetProperty("OrganizationId", out _), "Response must not drift back to PascalCase 'OrganizationId'.");
+        Assert.False(root.TryGetProperty("DeleteBotDataEnabled", out _), "Response must not drift back to PascalCase 'DeleteBotDataEnabled'.");
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Controllers/ProjectControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/ProjectControllerTests.cs
@@ -202,10 +202,10 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
             .StatusCodeShouldBeOk()
         );
 
-        // Assert - ViewProject should include computed HasSlackIntegration property
+        // Assert - seeded project has no Slack token, so the computed mapping must be false.
         Assert.NotNull(viewProject);
         Assert.Equal(SampleDataService.TEST_PROJECT_ID, viewProject.Id);
-        Assert.IsType<bool>(viewProject.HasSlackIntegration);
+        Assert.False(viewProject.HasSlackIntegration);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Controllers/ProjectControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/ProjectControllerTests.cs
@@ -5,10 +5,12 @@ using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Utility;
 using Exceptionless.Tests.Extensions;
+using Exceptionless.Tests.Utility;
 using Exceptionless.Web.Controllers;
 using Exceptionless.Web.Models;
 using FluentRest;
 using Foundatio.Jobs;
+using Foundatio.Repositories;
 using Xunit;
 
 namespace Exceptionless.Tests.Controllers;
@@ -16,12 +18,14 @@ namespace Exceptionless.Tests.Controllers;
 public sealed class ProjectControllerTests : IntegrationTestsBase
 {
     private readonly IEventRepository _eventRepository;
+    private readonly IOrganizationRepository _organizationRepository;
     private readonly IProjectRepository _projectRepository;
     private readonly IStackRepository _stackRepository;
 
     public ProjectControllerTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
     {
         _eventRepository = GetService<IEventRepository>();
+        _organizationRepository = GetService<IOrganizationRepository>();
         _projectRepository = GetService<IProjectRepository>();
         _stackRepository = GetService<IStackRepository>();
     }
@@ -34,40 +38,101 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task PostAsync_NewProject_MapsAllPropertiesToProject()
+    public async Task DeleteAsync_ExistingProject_RemovesProject()
     {
-        // Arrange - Test Mapping: NewProject -> Project
-        var newProject = new NewProject
-        {
-            OrganizationId = SampleDataService.TEST_ORG_ID,
-            Name = "Mapped Test Project",
-            DeleteBotDataEnabled = true
-        };
-
-        // Act
-        var viewProject = await SendRequestAsAsync<ViewProject>(r => r
+        // Arrange
+        var project = await SendRequestAsAsync<ViewProject>(r => r
             .AsTestOrganizationUser()
             .Post()
             .AppendPath("projects")
-            .Content(newProject)
+            .Content(new NewProject
+            {
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                Name = "Project To Delete",
+                DeleteBotDataEnabled = false
+            })
             .StatusCodeShouldBeCreated()
         );
-
-        // Assert - Verify mapping worked correctly
-        Assert.NotNull(viewProject);
-        Assert.NotNull(viewProject.Id);
-        Assert.Equal("Mapped Test Project", viewProject.Name);
-        Assert.Equal(SampleDataService.TEST_ORG_ID, viewProject.OrganizationId);
-        Assert.True(viewProject.DeleteBotDataEnabled);
-        Assert.True(viewProject.CreatedUtc > DateTime.MinValue);
-
-        // Verify persisted entity
-        var project = await _projectRepository.GetByIdAsync(viewProject.Id);
         Assert.NotNull(project);
-        Assert.Equal("Mapped Test Project", project.Name);
-        Assert.True(project.DeleteBotDataEnabled);
-    }
 
+        // Act
+        var workItems = await SendRequestAsAsync<WorkInProgressResult>(r => r
+            .AsTestOrganizationUser()
+            .Delete()
+            .AppendPaths("projects", project.Id)
+            .StatusCodeShouldBeAccepted()
+        );
+
+        Assert.NotNull(workItems);
+        Assert.Single(workItems.Workers);
+
+        var workItemJob = GetService<WorkItemJob>();
+        await workItemJob.RunUntilEmptyAsync(TestCancellationToken);
+        await RefreshDataAsync();
+
+        // Assert
+        var deleted = await _projectRepository.GetByIdAsync(project.Id);
+        Assert.Null(deleted);
+    }
+    [Fact]
+    public Task DeleteAsync_NonExistentProject_ReturnsNotFound()
+    {
+        return SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .Delete()
+            .AppendPaths("projects", "000000000000000000000000")
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+    [Fact]
+    public async Task DeleteDataAsync_ExistingKey_RemovesDataKey()
+    {
+        // Arrange - add a data key first
+        await SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "data")
+            .QueryString("key", "MyDataKey")
+            .Content(new ValueFromBody<string>("MyDataValue"))
+            .StatusCodeShouldBeOk()
+        );
+
+        // Act
+        await SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .Delete()
+            .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "data")
+            .QueryString("key", "MyDataKey")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        var project = await _projectRepository.GetByIdAsync(SampleDataService.TEST_PROJECT_ID);
+        Assert.NotNull(project);
+        Assert.False(project.Data?.ContainsKey("MyDataKey") ?? false);
+    }
+    [Fact]
+    public Task DeleteDataAsync_InvalidKey_ReturnsBadRequest()
+    {
+        return SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .Delete()
+            .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "data")
+            .QueryString("key", "-invalid")
+            .StatusCodeShouldBeBadRequest()
+        );
+    }
+    [Fact]
+    public Task DeleteDataAsync_NonExistentProject_ReturnsNotFound()
+    {
+        return SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .Delete()
+            .AppendPaths("projects", "000000000000000000000000", "data")
+            .QueryString("key", "SomeKey")
+            .StatusCodeShouldBeNotFound()
+        );
+    }
     [Fact]
     public async Task GenerateSampleDataAsync_ValidProject_QueuesSampleEvents()
     {
@@ -90,7 +155,36 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.True(projectEventCount >= 100, $"Expected at least 100 generated events but found {projectEventCount}.");
         Assert.Equal(0, otherProjectEventCount);
     }
+    [Fact]
+    public async Task GetAllAsync_AsTestUser_ReturnsUserProjects()
+    {
+        // Act
+        var projects = await SendRequestAsAsync<List<ViewProject>>(r => r
+            .AsTestOrganizationUser()
+            .AppendPath("projects")
+            .StatusCodeShouldBeOk()
+        );
 
+        // Assert
+        Assert.NotNull(projects);
+        Assert.True(projects.Count >= 2);
+        Assert.All(projects, p => Assert.Equal(SampleDataService.TEST_ORG_ID, p.OrganizationId));
+    }
+    [Fact]
+    public async Task GetAllAsync_WithLimitParameter_RespectsLimit()
+    {
+        // Act
+        var projects = await SendRequestAsAsync<List<ViewProject>>(r => r
+            .AsTestOrganizationUser()
+            .AppendPath("projects")
+            .QueryString("limit", "1")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(projects);
+        Assert.Single(projects);
+    }
     [Fact]
     public async Task GetAsync_ExistingProject_MapsToViewProjectWithSlackIntegration()
     {
@@ -106,72 +200,45 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.Equal(SampleDataService.TEST_PROJECT_ID, viewProject.Id);
         Assert.IsType<bool>(viewProject.HasSlackIntegration);
     }
-
     [Fact]
-    public async Task CanUpdateProject()
+    public async Task GetByOrganizationAsync_ValidOrganization_ReturnsProjectsForOrg()
     {
-        var project = await SendRequestAsAsync<ViewProject>(r => r
+        // Act
+        var projects = await SendRequestAsAsync<List<ViewProject>>(r => r
             .AsTestOrganizationUser()
-            .Post()
-            .AppendPath("projects")
-            .Content(new NewProject
-            {
-                OrganizationId = SampleDataService.TEST_ORG_ID,
-                Name = "Test Project",
-                DeleteBotDataEnabled = true
-            })
-            .StatusCodeShouldBeCreated()
-        );
-
-        Assert.NotNull(project);
-
-        var updatedProject = await SendRequestAsAsync<ViewProject>(r => r
-            .AsTestOrganizationUser()
-            .Patch()
-            .AppendPaths("projects", project.Id)
-            .Content(new UpdateProject
-            {
-                Name = "Test Project 2",
-                DeleteBotDataEnabled = true
-            })
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "projects")
             .StatusCodeShouldBeOk()
         );
 
-        Assert.NotNull(updatedProject);
-        Assert.NotEqual(project.Name, updatedProject.Name);
+        // Assert
+        Assert.NotNull(projects);
+        Assert.True(projects.Count >= 2);
+        Assert.All(projects, p => Assert.Equal(SampleDataService.TEST_ORG_ID, p.OrganizationId));
     }
-
-
     [Fact]
-    public async Task CanUpdateProjectWithExtraPayloadProperties()
+    public Task GetByOrganizationAsync_InvalidOrganization_ReturnsNotFound()
     {
-        var project = await SendRequestAsAsync<ViewProject>(r => r
+        return SendRequestAsync(r => r
             .AsTestOrganizationUser()
-            .Post()
-            .AppendPath("projects")
-            .Content(new NewProject
-            {
-                OrganizationId = SampleDataService.TEST_ORG_ID,
-                Name = "Test Project",
-                DeleteBotDataEnabled = true
-            })
-            .StatusCodeShouldBeCreated()
+            .AppendPaths("organizations", "000000000000000000000000", "projects")
+            .StatusCodeShouldBeNotFound()
         );
-
-        Assert.NotNull(project);
-        project.Name = "Updated";
-        var updatedProject = await SendRequestAsAsync<ViewProject>(r => r
-            .AsTestOrganizationUser()
-            .Patch()
-            .AppendPaths("projects", project.Id)
-            .Content(project)
+    }
+    [Fact]
+    public async Task GetConfigAsync_ByProjectId_ReturnsConfig()
+    {
+        // Act
+        var config = await SendRequestAsAsync<ClientConfiguration>(r => r
+            .AsTestOrganizationClientUser()
+            .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "config")
             .StatusCodeShouldBeOk()
         );
 
-        Assert.NotNull(updatedProject);
-        Assert.Equal("Updated", updatedProject.Name);
+        // Assert
+        Assert.NotNull(config);
+        Assert.True(config.Version >= 0);
+        Assert.NotNull(config.Settings);
     }
-
     [Fact]
     public async Task GetConfigAsync_WithClientAuth_ReturnsConfigurationWithSettings()
     {
@@ -475,6 +542,420 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.Equal(configBefore.Version, configAfter.Version);
     }
 
+    [Fact]
+    public async Task GetNotificationSettingsAsync_AsGlobalAdmin_ReturnsAllSettings()
+    {
+        // Arrange - set notification settings for the user first
+        var settings = new NotificationSettings
+        {
+            SendDailySummary = true,
+            ReportNewErrors = true,
+            ReportCriticalErrors = false,
+            ReportEventRegressions = true,
+            ReportNewEvents = false,
+            ReportCriticalEvents = true
+        };
+
+        await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .Post()
+            .AppendPaths("users", TestConstants.UserId, "projects", SampleDataService.TEST_PROJECT_ID, "notifications")
+            .Content(settings)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Act
+        var allSettings = await SendRequestAsAsync<Dictionary<string, NotificationSettings>>(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "notifications")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(allSettings);
+        Assert.True(allSettings.Count > 0);
+    }
+    [Fact]
+    public async Task GetNotificationSettingsAsync_AsUser_ReturnsUserSettings()
+    {
+        // Arrange
+        var settings = new NotificationSettings
+        {
+            SendDailySummary = true,
+            ReportNewErrors = true
+        };
+
+        await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .Post()
+            .AppendPaths("users", TestConstants.UserId, "projects", SampleDataService.TEST_PROJECT_ID, "notifications")
+            .Content(settings)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Act
+        var userSettings = await SendRequestAsAsync<NotificationSettings>(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("users", TestConstants.UserId, "projects", SampleDataService.TEST_PROJECT_ID, "notifications")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(userSettings);
+        Assert.True(userSettings.SendDailySummary);
+        Assert.True(userSettings.ReportNewErrors);
+    }
+    [Fact]
+    public async Task GetV2ConfigAsync_WithClientAuth_ReturnsConfig()
+    {
+        // Act
+        var config = await SendRequestAsAsync<ClientConfiguration>(r => r
+            .AsFreeOrganizationClientUser()
+            .AppendPath("projects/config")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(config);
+        Assert.True(config.Version >= 0);
+        Assert.NotNull(config.Settings);
+    }
+    [Fact]
+    public async Task IsNameAvailableAsync_ExistingName_ReturnsNoContent()
+    {
+        // Arrange - the TEST_PROJECT_ID project should have a name
+        var project = await _projectRepository.GetByIdAsync(SampleDataService.TEST_PROJECT_ID);
+        Assert.NotNull(project);
+
+        // Act
+        var response = await SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .AppendPath("projects/check-name")
+            .QueryString("name", project.Name)
+            .ExpectedStatus(HttpStatusCode.NoContent)
+        );
+
+        // Assert - 204 means name is NOT available (taken)
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+    [Fact]
+    public async Task IsNameAvailableAsync_NewName_ReturnsCreated()
+    {
+        // Act
+        var response = await SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .AppendPath("projects/check-name")
+            .QueryString("name", "UniqueProjectName_" + Guid.NewGuid().ToString("N"))
+            .StatusCodeShouldBeCreated()
+        );
+
+        // Assert - 201 means name IS available
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+    [Fact]
+    public async Task IsNameAvailableAsync_ScopedToOrganization_ReturnsCorrectResult()
+    {
+        // Act - check with a unique name scoped to org
+        var response = await SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "projects", "check-name")
+            .QueryString("name", "UniqueOrgScoped_" + Guid.NewGuid().ToString("N"))
+            .StatusCodeShouldBeCreated()
+        );
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+    [Fact]
+    public async Task PatchAsync_ChangeName_UpdatesNameAndPreservesOtherFields()
+    {
+        // Arrange
+        var project = await SendRequestAsAsync<ViewProject>(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPath("projects")
+            .Content(new NewProject
+            {
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                Name = "Original Name",
+                DeleteBotDataEnabled = true
+            })
+            .StatusCodeShouldBeCreated()
+        );
+        Assert.NotNull(project);
+
+        // Act
+        var updatedProject = await SendRequestAsAsync<ViewProject>(r => r
+            .AsTestOrganizationUser()
+            .Patch()
+            .AppendPaths("projects", project.Id)
+            .Content(new UpdateProject
+            {
+                Name = "Updated Name",
+                DeleteBotDataEnabled = true
+            })
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(updatedProject);
+        Assert.Equal("Updated Name", updatedProject.Name);
+        Assert.True(updatedProject.DeleteBotDataEnabled);
+        Assert.Equal(project.OrganizationId, updatedProject.OrganizationId);
+
+        // Verify persisted
+        var persisted = await _projectRepository.GetByIdAsync(project.Id);
+        Assert.NotNull(persisted);
+        Assert.Equal("Updated Name", persisted.Name);
+        Assert.True(persisted.DeleteBotDataEnabled);
+    }
+    [Fact]
+    public async Task PatchAsync_NonExistentProject_ReturnsNotFound()
+    {
+        // Arrange - record a known project's state to verify it wasn't changed
+        var beforeProject = await _projectRepository.GetByIdAsync(SampleDataService.TEST_PROJECT_ID);
+        Assert.NotNull(beforeProject);
+
+        // Act
+        await SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .Patch()
+            .AppendPaths("projects", "000000000000000000000000")
+            .Content(new UpdateProject
+            {
+                Name = "Should Not Exist",
+                DeleteBotDataEnabled = false
+            })
+            .StatusCodeShouldBeNotFound()
+        );
+
+        // Assert - existing project was not affected
+        var afterProject = await _projectRepository.GetByIdAsync(SampleDataService.TEST_PROJECT_ID);
+        Assert.NotNull(afterProject);
+        Assert.Equal(beforeProject.Name, afterProject.Name);
+    }
+    [Fact]
+    public async Task PatchAsync_WithExtraPayloadProperties_UpdatesNameOnly()
+    {
+        // Arrange
+        var project = await SendRequestAsAsync<ViewProject>(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPath("projects")
+            .Content(new NewProject
+            {
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                Name = "Extra Props Project",
+                DeleteBotDataEnabled = true
+            })
+            .StatusCodeShouldBeCreated()
+        );
+        Assert.NotNull(project);
+
+        // Act - send the full ViewProject as patch payload (extra fields should be ignored)
+        project.Name = "Patched With Extras";
+        var updatedProject = await SendRequestAsAsync<ViewProject>(r => r
+            .AsTestOrganizationUser()
+            .Patch()
+            .AppendPaths("projects", project.Id)
+            .Content(project)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(updatedProject);
+        Assert.Equal("Patched With Extras", updatedProject.Name);
+    }
+    [Fact]
+    public async Task PostAsync_NewProject_MapsAllPropertiesToProject()
+    {
+        // Arrange - Test Mapping: NewProject -> Project
+        var newProject = new NewProject
+        {
+            OrganizationId = SampleDataService.TEST_ORG_ID,
+            Name = "Mapped Test Project",
+            DeleteBotDataEnabled = true
+        };
+
+        // Act
+        var viewProject = await SendRequestAsAsync<ViewProject>(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPath("projects")
+            .Content(newProject)
+            .StatusCodeShouldBeCreated()
+        );
+
+        // Assert - Verify mapping worked correctly
+        Assert.NotNull(viewProject);
+        Assert.NotNull(viewProject.Id);
+        Assert.Equal("Mapped Test Project", viewProject.Name);
+        Assert.Equal(SampleDataService.TEST_ORG_ID, viewProject.OrganizationId);
+        Assert.True(viewProject.DeleteBotDataEnabled);
+        Assert.True(viewProject.CreatedUtc > DateTime.MinValue);
+
+        // Verify persisted entity
+        var project = await _projectRepository.GetByIdAsync(viewProject.Id);
+        Assert.NotNull(project);
+        Assert.Equal("Mapped Test Project", project.Name);
+        Assert.True(project.DeleteBotDataEnabled);
+    }
+    [Fact]
+    public async Task PostDataAsync_ValidKeyAndValue_PersistsData()
+    {
+        // Act
+        await SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "data")
+            .QueryString("key", "TestDataKey")
+            .Content(new ValueFromBody<string>("TestDataValue"))
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        var project = await _projectRepository.GetByIdAsync(SampleDataService.TEST_PROJECT_ID);
+        Assert.NotNull(project);
+        Assert.NotNull(project.Data);
+        Assert.True(project.Data.ContainsKey("TestDataKey"));
+        Assert.Equal("TestDataValue", project.Data["TestDataKey"]);
+    }
+    [Fact]
+    public Task PostDataAsync_EmptyKey_ReturnsBadRequest()
+    {
+        return SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "data")
+            .QueryString("key", "")
+            .Content(new ValueFromBody<string>("SomeValue"))
+            .StatusCodeShouldBeBadRequest()
+        );
+    }
+    [Fact]
+    public Task PostDataAsync_KeyStartsWithDash_ReturnsBadRequest()
+    {
+        return SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "data")
+            .QueryString("key", "-invalid")
+            .Content(new ValueFromBody<string>("SomeValue"))
+            .StatusCodeShouldBeBadRequest()
+        );
+    }
+    [Fact]
+    public Task PostDataAsync_NonExistentProject_ReturnsNotFound()
+    {
+        return SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPaths("projects", "000000000000000000000000", "data")
+            .QueryString("key", "SomeKey")
+            .Content(new ValueFromBody<string>("SomeValue"))
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+    [Fact]
+    public async Task ResetDataAsync_ValidProject_ClearsStacksAndEvents()
+    {
+        // Arrange
+        await CreateDataAsync(d =>
+        {
+            d.Event().Message("test for reset");
+        });
+
+        long stacksBefore = await _stackRepository.CountAsync(q => q.Project(SampleDataService.TEST_PROJECT_ID));
+        long eventsBefore = await _eventRepository.CountAsync(q => q.Project(SampleDataService.TEST_PROJECT_ID));
+        Assert.True(stacksBefore > 0);
+        Assert.True(eventsBefore > 0);
+
+        // Act
+        var workItems = await SendRequestAsAsync<WorkInProgressResult>(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "reset-data")
+            .StatusCodeShouldBeAccepted()
+        );
+
+        Assert.NotNull(workItems);
+        Assert.Single(workItems.Workers);
+
+        var workItemJob = GetService<WorkItemJob>();
+        await workItemJob.RunUntilEmptyAsync(TestCancellationToken);
+        await RefreshDataAsync();
+
+        // Assert
+        long stacksAfter = await _stackRepository.CountAsync(q => q.Project(SampleDataService.TEST_PROJECT_ID));
+        long eventsAfter = await _eventRepository.CountAsync(q => q.Project(SampleDataService.TEST_PROJECT_ID));
+        Assert.Equal(0, stacksAfter);
+        Assert.Equal(0, eventsAfter);
+    }
+    [Fact]
+    public async Task SetNotificationSettingsAsync_ValidSettings_PersistsSettings()
+    {
+        // Arrange
+        var settings = new NotificationSettings
+        {
+            SendDailySummary = true,
+            ReportNewErrors = true,
+            ReportCriticalErrors = true,
+            ReportEventRegressions = false,
+            ReportNewEvents = false,
+            ReportCriticalEvents = true
+        };
+
+        // Act
+        await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .Post()
+            .AppendPaths("users", TestConstants.UserId, "projects", SampleDataService.TEST_PROJECT_ID, "notifications")
+            .Content(settings)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert - read back from repository
+        var project = await _projectRepository.GetByIdAsync(SampleDataService.TEST_PROJECT_ID);
+        Assert.NotNull(project);
+        Assert.True(project.NotificationSettings.ContainsKey(TestConstants.UserId));
+        var saved = project.NotificationSettings[TestConstants.UserId];
+        Assert.True(saved.SendDailySummary);
+        Assert.True(saved.ReportNewErrors);
+        Assert.True(saved.ReportCriticalErrors);
+        Assert.False(saved.ReportEventRegressions);
+        Assert.False(saved.ReportNewEvents);
+        Assert.True(saved.ReportCriticalEvents);
+    }
+    [Fact]
+    public async Task SetNotificationSettingsAsync_NullSettings_RemovesSettings()
+    {
+        // Arrange - set some settings first
+        await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .Post()
+            .AppendPaths("users", TestConstants.UserId, "projects", SampleDataService.TEST_PROJECT_ID, "notifications")
+            .Content(new NotificationSettings { ReportNewErrors = true })
+            .StatusCodeShouldBeOk()
+        );
+
+        // Verify they exist
+        var projectBefore = await _projectRepository.GetByIdAsync(SampleDataService.TEST_PROJECT_ID);
+        Assert.NotNull(projectBefore);
+        Assert.True(projectBefore.NotificationSettings.ContainsKey(TestConstants.UserId));
+
+        // Act - send null to remove
+        await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .Delete()
+            .AppendPaths("users", TestConstants.UserId, "projects", SampleDataService.TEST_PROJECT_ID, "notifications")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        var projectAfter = await _projectRepository.GetByIdAsync(SampleDataService.TEST_PROJECT_ID);
+        Assert.NotNull(projectAfter);
+        Assert.False(projectAfter.NotificationSettings.ContainsKey(TestConstants.UserId));
+    }
     [Fact]
     public async Task CanGetProjectListStats()
     {

--- a/tests/Exceptionless.Tests/Controllers/ProjectControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/ProjectControllerTests.cs
@@ -170,6 +170,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.True(projects.Count >= 2);
         Assert.All(projects, p => Assert.Equal(SampleDataService.TEST_ORG_ID, p.OrganizationId));
     }
+
     [Fact]
     public async Task GetAllAsync_WithLimitParameter_RespectsLimit()
     {
@@ -817,9 +818,10 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         var project = await _projectRepository.GetByIdAsync(SampleDataService.TEST_PROJECT_ID);
         Assert.NotNull(project);
         Assert.NotNull(project.Data);
-        Assert.True(project.Data.ContainsKey("TestDataKey"));
-        Assert.Equal("TestDataValue", project.Data["TestDataKey"]);
+        Assert.True(project.Data.TryGetValue("TestDataKey", out var dataValue));
+        Assert.Equal("TestDataValue", dataValue);
     }
+
     [Fact]
     public Task PostDataAsync_EmptyKey_ReturnsBadRequest()
     {
@@ -917,8 +919,8 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         // Assert - read back from repository
         var project = await _projectRepository.GetByIdAsync(SampleDataService.TEST_PROJECT_ID);
         Assert.NotNull(project);
-        Assert.True(project.NotificationSettings.ContainsKey(TestConstants.UserId));
-        var saved = project.NotificationSettings[TestConstants.UserId];
+        Assert.True(project.NotificationSettings.TryGetValue(TestConstants.UserId, out var saved));
+        Assert.NotNull(saved);
         Assert.True(saved.SendDailySummary);
         Assert.True(saved.ReportNewErrors);
         Assert.True(saved.ReportCriticalErrors);

--- a/tests/Exceptionless.Tests/Controllers/ProjectControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/ProjectControllerTests.cs
@@ -73,6 +73,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         var deleted = await _projectRepository.GetByIdAsync(project.Id);
         Assert.Null(deleted);
     }
+
     [Fact]
     public Task DeleteAsync_NonExistentProject_ReturnsNotFound()
     {
@@ -83,6 +84,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
             .StatusCodeShouldBeNotFound()
         );
     }
+
     [Fact]
     public async Task DeleteDataAsync_ExistingKey_RemovesDataKey()
     {
@@ -110,6 +112,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.NotNull(project);
         Assert.False(project.Data?.ContainsKey("MyDataKey") ?? false);
     }
+
     [Fact]
     public Task DeleteDataAsync_InvalidKey_ReturnsBadRequest()
     {
@@ -121,6 +124,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
             .StatusCodeShouldBeBadRequest()
         );
     }
+
     [Fact]
     public Task DeleteDataAsync_NonExistentProject_ReturnsNotFound()
     {
@@ -132,6 +136,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
             .StatusCodeShouldBeNotFound()
         );
     }
+
     [Fact]
     public async Task GenerateSampleDataAsync_ValidProject_QueuesSampleEvents()
     {
@@ -154,6 +159,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.True(projectEventCount >= 100, $"Expected at least 100 generated events but found {projectEventCount}.");
         Assert.Equal(0, otherProjectEventCount);
     }
+
     [Fact]
     public async Task GetAllAsync_AsTestUser_ReturnsUserProjects()
     {
@@ -185,6 +191,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.NotNull(projects);
         Assert.Single(projects);
     }
+
     [Fact]
     public async Task GetAsync_ExistingProject_MapsToViewProjectWithSlackIntegration()
     {
@@ -200,6 +207,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.Equal(SampleDataService.TEST_PROJECT_ID, viewProject.Id);
         Assert.IsType<bool>(viewProject.HasSlackIntegration);
     }
+
     [Fact]
     public async Task GetByOrganizationAsync_ValidOrganization_ReturnsProjectsForOrg()
     {
@@ -215,6 +223,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.True(projects.Count >= 2);
         Assert.All(projects, p => Assert.Equal(SampleDataService.TEST_ORG_ID, p.OrganizationId));
     }
+
     [Fact]
     public Task GetByOrganizationAsync_InvalidOrganization_ReturnsNotFound()
     {
@@ -224,6 +233,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
             .StatusCodeShouldBeNotFound()
         );
     }
+
     [Fact]
     public async Task GetConfigAsync_ByProjectId_ReturnsConfig()
     {
@@ -239,6 +249,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.True(config.Version >= 0);
         Assert.NotNull(config.Settings);
     }
+
     [Fact]
     public async Task GetConfigAsync_WithClientAuth_ReturnsConfigurationWithSettings()
     {
@@ -381,7 +392,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
             .AsTestOrganizationUser()
             .Post()
             .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "config")
-            .QueryString("key", "")
+            .QueryString("key", String.Empty)
             .Content(new ValueFromBody<string>("SomeValue"))
             .StatusCodeShouldBeBadRequest()
         );
@@ -413,7 +424,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
             .Post()
             .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "config")
             .QueryString("key", "TestKey")
-            .Content(new ValueFromBody<string>(""))
+            .Content(new ValueFromBody<string>(String.Empty))
             .StatusCodeShouldBeBadRequest()
         );
 
@@ -575,6 +586,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.NotNull(allSettings);
         Assert.True(allSettings.Count > 0);
     }
+
     [Fact]
     public async Task GetNotificationSettingsAsync_AsUser_ReturnsUserSettings()
     {
@@ -605,6 +617,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.True(userSettings.SendDailySummary);
         Assert.True(userSettings.ReportNewErrors);
     }
+
     [Fact]
     public async Task GetV2ConfigAsync_WithClientAuth_ReturnsConfig()
     {
@@ -620,6 +633,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.True(config.Version >= 0);
         Assert.NotNull(config.Settings);
     }
+
     [Fact]
     public async Task IsNameAvailableAsync_ExistingName_ReturnsCreated()
     {
@@ -659,6 +673,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
             .StatusCodeShouldBeNoContent()
         );
     }
+
     [Fact]
     public async Task PatchAsync_ChangeName_UpdatesNameAndPreservesOtherFields()
     {
@@ -702,6 +717,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.Equal("Updated Name", persisted.Name);
         Assert.True(persisted.DeleteBotDataEnabled);
     }
+
     [Fact]
     public async Task PatchAsync_NonExistentProject_ReturnsNotFound()
     {
@@ -727,6 +743,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.NotNull(afterProject);
         Assert.Equal(beforeProject.Name, afterProject.Name);
     }
+
     [Fact]
     public async Task PatchAsync_WithExtraPayloadProperties_UpdatesNameOnly()
     {
@@ -759,6 +776,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.NotNull(updatedProject);
         Assert.Equal("Patched With Extras", updatedProject.Name);
     }
+
     [Fact]
     public async Task PostAsync_NewProject_MapsAllPropertiesToProject()
     {
@@ -793,6 +811,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.Equal("Mapped Test Project", project.Name);
         Assert.True(project.DeleteBotDataEnabled);
     }
+
     [Fact]
     public async Task PostDataAsync_ValidKeyAndValue_PersistsData()
     {
@@ -821,11 +840,12 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
             .AsTestOrganizationUser()
             .Post()
             .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "data")
-            .QueryString("key", "")
+            .QueryString("key", String.Empty)
             .Content(new ValueFromBody<string>("SomeValue"))
             .StatusCodeShouldBeBadRequest()
         );
     }
+
     [Fact]
     public Task PostDataAsync_KeyStartsWithDash_ReturnsBadRequest()
     {
@@ -838,6 +858,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
             .StatusCodeShouldBeBadRequest()
         );
     }
+
     [Fact]
     public Task PostDataAsync_NonExistentProject_ReturnsNotFound()
     {
@@ -850,6 +871,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
             .StatusCodeShouldBeNotFound()
         );
     }
+
     [Fact]
     public async Task ResetDataAsync_ValidProject_ClearsStacksAndEvents()
     {
@@ -885,6 +907,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.Equal(0, stacksAfter);
         Assert.Equal(0, eventsAfter);
     }
+
     [Fact]
     public async Task SetNotificationSettingsAsync_ValidSettings_PersistsSettings()
     {
@@ -920,6 +943,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.False(saved.ReportNewEvents);
         Assert.True(saved.ReportCriticalEvents);
     }
+
     [Fact]
     public async Task SetNotificationSettingsAsync_NullSettings_RemovesSettings()
     {
@@ -950,6 +974,7 @@ public sealed class ProjectControllerTests : IntegrationTestsBase
         Assert.NotNull(projectAfter);
         Assert.False(projectAfter.NotificationSettings.ContainsKey(TestConstants.UserId));
     }
+
     [Fact]
     public async Task CanGetProjectListStats()
     {

--- a/tests/Exceptionless.Tests/Controllers/StackControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/StackControllerTests.cs
@@ -586,6 +586,37 @@ public class StackControllerTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task PromoteAsync_WithEnabledPromoteHook_QueuesWebHookNotification()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+
+        var webHookRepository = GetService<IWebHookRepository>();
+        var webHookNotificationQueue = GetService<IQueue<WebHookNotification>>();
+        await webHookRepository.AddAsync(new WebHook
+        {
+            OrganizationId = ev.OrganizationId,
+            ProjectId = ev.ProjectId,
+            Url = "https://example.com/promote",
+            Version = WebHook.KnownVersions.Version2,
+            EventTypes = [WebHook.KnownEventTypes.StackPromoted],
+            IsEnabled = true
+        }, o => o.ImmediateConsistency());
+
+        // Act
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/promote")
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        var stats = await webHookNotificationQueue.GetQueueStatsAsync();
+        Assert.Equal(1, stats.Enqueued);
+    }
+
+    [Fact]
     public Task PromoteAsync_NonExistentStack_ReturnsNotFound()
     {
         // Act & Assert

--- a/tests/Exceptionless.Tests/Controllers/StackControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/StackControllerTests.cs
@@ -492,7 +492,7 @@ public class StackControllerTests : IntegrationTestsBase
             .Delete()
             .AsGlobalAdminUser()
             .AppendPath($"stacks/{ev.StackId}/mark-critical")
-            .ExpectedStatus(System.Net.HttpStatusCode.NoContent));
+            .StatusCodeShouldBeNoContent());
 
         // Assert
         var stack = await _stackRepository.GetByIdAsync(ev.StackId);
@@ -525,7 +525,7 @@ public class StackControllerTests : IntegrationTestsBase
             .AsGlobalAdminUser()
             .AppendPath($"stacks/{ev.StackId}/remove-link")
             .Content(new ValueFromBody<string>(testUrl))
-            .ExpectedStatus(System.Net.HttpStatusCode.NoContent));
+            .StatusCodeShouldBeNoContent());
 
         // Assert
         stack = await _stackRepository.GetByIdAsync(ev.StackId);

--- a/tests/Exceptionless.Tests/Controllers/StackControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/StackControllerTests.cs
@@ -10,6 +10,8 @@ using Exceptionless.Web.Controllers;
 using Exceptionless.Web.Models;
 using Foundatio.Jobs;
 using Foundatio.Queues;
+using Foundatio.Repositories;
+using Foundatio.Repositories.Utility;
 using Xunit;
 
 namespace Exceptionless.Tests.Controllers;
@@ -545,6 +547,53 @@ public class StackControllerTests : IntegrationTestsBase
             .AppendPath($"stacks/{ev.StackId}/remove-link")
             .Content(new ValueFromBody<string>(""))
             .StatusCodeShouldBeBadRequest());
+    }
+
+    [Fact]
+    public async Task PromoteAsync_NonPremiumOrganization_ReturnsUpgradeRequired()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+
+        var organizationRepository = GetService<IOrganizationRepository>();
+        var organization = await organizationRepository.GetByIdAsync(ev.OrganizationId);
+        Assert.NotNull(organization);
+        organization.HasPremiumFeatures = false;
+        await organizationRepository.SaveAsync(organization, o => o.ImmediateConsistency().Cache());
+
+        // Act & Assert
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/promote")
+            .StatusCodeShouldBeUpgradeRequired());
+    }
+
+    [Fact]
+    public async Task PromoteAsync_PremiumOrganizationWithoutPromoteHooks_ReturnsNotImplemented()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+
+        // Act & Assert
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/promote")
+            .ExpectedStatus(System.Net.HttpStatusCode.NotImplemented));
+    }
+
+    [Fact]
+    public Task PromoteAsync_NonExistentStack_ReturnsNotFound()
+    {
+        // Act & Assert
+        return SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("stacks/000000000000000000000000/promote")
+            .StatusCodeShouldBeNotFound());
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Controllers/StackControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/StackControllerTests.cs
@@ -7,6 +7,7 @@ using Exceptionless.Core.Utility;
 using Exceptionless.Models.Data;
 using Exceptionless.Tests.Extensions;
 using Exceptionless.Web.Controllers;
+using Exceptionless.Web.Models;
 using Foundatio.Jobs;
 using Foundatio.Queues;
 using Xunit;
@@ -170,6 +171,127 @@ public class StackControllerTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task ChangeStatusAsync_ToFixed_SetsDateFixed()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+
+        // Act
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/change-status")
+            .QueryString("status", "Fixed")
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        var stack = await _stackRepository.GetByIdAsync(ev.StackId);
+        Assert.NotNull(stack);
+        Assert.Equal(StackStatus.Fixed, stack.Status);
+        Assert.NotNull(stack.DateFixed);
+    }
+
+    [Fact]
+    public async Task ChangeStatusAsync_ToOpen_ClearsFixedFields()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/mark-fixed")
+            .StatusCodeShouldBeOk());
+
+        // Act
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/change-status")
+            .QueryString("status", "Open")
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        var stack = await _stackRepository.GetByIdAsync(ev.StackId);
+        Assert.NotNull(stack);
+        Assert.Equal(StackStatus.Open, stack.Status);
+        Assert.Null(stack.DateFixed);
+        Assert.Null(stack.FixedInVersion);
+    }
+
+    [Fact]
+    public async Task ChangeStatusAsync_ToRegressed_ReturnsBadRequest()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+
+        // Act
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/change-status")
+            .QueryString("status", "Regressed")
+            .StatusCodeShouldBeBadRequest());
+    }
+
+    [Fact]
+    public async Task ChangeStatusAsync_ToSnoozed_ReturnsBadRequest()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+
+        // Act
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/change-status")
+            .QueryString("status", "Snoozed")
+            .StatusCodeShouldBeBadRequest());
+    }
+
+    [Fact]
+    public Task ChangeStatusAsync_WithNonExistentStack_ReturnsNotFound()
+    {
+        // Arrange & Act
+        return SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("stacks/000000000000000000000000/change-status")
+            .QueryString("status", "Fixed")
+            .StatusCodeShouldBeNotFound());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ExistingStack_ReturnsAccepted()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+
+        // Act
+        await SendRequestAsync(r => r
+            .Delete()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}")
+            .StatusCodeShouldBeAccepted());
+    }
+
+    [Fact]
+    public Task DeleteAsync_NonExistentStack_ReturnsNotFound()
+    {
+        // Arrange & Act
+        return SendRequestAsync(r => r
+            .Delete()
+            .AsGlobalAdminUser()
+            .AppendPath("stacks/000000000000000000000000")
+            .StatusCodeShouldBeNotFound());
+    }
+
+    [Fact]
     public async Task GetAll_WithDateRangeFilter_ReturnsOnlyMatchingStacks()
     {
         // Arrange
@@ -196,5 +318,280 @@ public class StackControllerTests : IntegrationTestsBase
         Assert.NotNull(result);
         Assert.Contains(result, s => String.Equals(s.Id, recentStack.Id, StringComparison.Ordinal));
         Assert.DoesNotContain(result, s => String.Equals(s.Id, oldStack.Id, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetAll_WithNoFilter_ReturnsAllStacks()
+    {
+        // Arrange
+        var now = TimeProvider.GetUtcNow();
+        await CreateDataAsync(d =>
+        {
+            d.Event().TestProject().Date(now);
+            d.Event().TestProject().Date(now.AddHours(-1));
+        });
+
+        // Act
+        var result = await SendRequestAsAsync<IReadOnlyCollection<Stack>>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("stacks")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetAsync_ExistingStack_ReturnsStack()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+
+        // Act
+        var stack = await SendRequestAsAsync<Stack>(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("stacks", ev.StackId)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(stack);
+        Assert.Equal(ev.StackId, stack.Id);
+        Assert.Equal(SampleDataService.TEST_ORG_ID, stack.OrganizationId);
+        Assert.Equal(SampleDataService.TEST_PROJECT_ID, stack.ProjectId);
+    }
+
+    [Fact]
+    public Task GetAsync_NonExistentStack_ReturnsNotFound()
+    {
+        // Arrange & Act
+        return SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("stacks", "000000000000000000000000")
+            .StatusCodeShouldBeNotFound());
+    }
+
+    [Fact]
+    public async Task GetByOrganizationAsync_ExistingOrganization_ReturnsStacks()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+
+        // Act
+        var result = await SendRequestAsAsync<IReadOnlyCollection<Stack>>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath($"organizations/{SampleDataService.TEST_ORG_ID}/stacks")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        Assert.All(result, s => Assert.Equal(SampleDataService.TEST_ORG_ID, s.OrganizationId));
+    }
+
+    [Fact]
+    public Task GetByOrganizationAsync_NonExistentOrganization_ReturnsNotFound()
+    {
+        // Arrange & Act
+        return SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("organizations/000000000000000000000000/stacks")
+            .StatusCodeShouldBeNotFound());
+    }
+
+    [Fact]
+    public async Task GetByProjectAsync_ExistingProject_ReturnsStacks()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+
+        // Act
+        var result = await SendRequestAsAsync<IReadOnlyCollection<Stack>>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath($"projects/{SampleDataService.TEST_PROJECT_ID}/stacks")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        Assert.All(result, s => Assert.Equal(SampleDataService.TEST_PROJECT_ID, s.ProjectId));
+    }
+
+    [Fact]
+    public Task GetByProjectAsync_NonExistentProject_ReturnsNotFound()
+    {
+        // Arrange & Act
+        return SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("projects/000000000000000000000000/stacks")
+            .StatusCodeShouldBeNotFound());
+    }
+
+    [Fact]
+    public async Task MarkCriticalAsync_ExistingStack_SetsOccurrencesAreCritical()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+
+        // Act
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/mark-critical")
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        var stack = await _stackRepository.GetByIdAsync(ev.StackId);
+        Assert.NotNull(stack);
+        Assert.True(stack.OccurrencesAreCritical);
+    }
+
+    [Fact]
+    public Task MarkCriticalAsync_NonExistentStack_ReturnsNotFound()
+    {
+        // Arrange & Act
+        return SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("stacks/000000000000000000000000/mark-critical")
+            .StatusCodeShouldBeNotFound());
+    }
+
+    [Fact]
+    public async Task MarkNotCriticalAsync_CriticalStack_ClearsOccurrencesAreCritical()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/mark-critical")
+            .StatusCodeShouldBeOk());
+
+        // Act
+        await SendRequestAsync(r => r
+            .Delete()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/mark-critical")
+            .ExpectedStatus(System.Net.HttpStatusCode.NoContent));
+
+        // Assert
+        var stack = await _stackRepository.GetByIdAsync(ev.StackId);
+        Assert.NotNull(stack);
+        Assert.False(stack.OccurrencesAreCritical);
+    }
+
+    [Fact]
+    public async Task RemoveLinkAsync_ExistingLink_RemovesReference()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+
+        string testUrl = "https://github.com/issue/123";
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/add-link")
+            .Content(new ValueFromBody<string>(testUrl))
+            .StatusCodeShouldBeOk());
+
+        var stack = await _stackRepository.GetByIdAsync(ev.StackId);
+        Assert.NotNull(stack);
+        Assert.Contains(testUrl, stack.References);
+
+        // Act
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/remove-link")
+            .Content(new ValueFromBody<string>(testUrl))
+            .ExpectedStatus(System.Net.HttpStatusCode.NoContent));
+
+        // Assert
+        stack = await _stackRepository.GetByIdAsync(ev.StackId);
+        Assert.NotNull(stack);
+        Assert.DoesNotContain(testUrl, stack.References);
+    }
+
+    [Fact]
+    public async Task RemoveLinkAsync_EmptyUrl_ReturnsBadRequest()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+
+        // Act
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/remove-link")
+            .Content(new ValueFromBody<string>(""))
+            .StatusCodeShouldBeBadRequest());
+    }
+
+    [Fact]
+    public async Task SnoozeAsync_WithValidFutureDate_SetsSnoozeStatus()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+        var snoozeUntil = DateTime.UtcNow.AddDays(1);
+
+        // Act
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/mark-snoozed")
+            .QueryString("snoozeUntilUtc", snoozeUntil.ToString("o"))
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        var stack = await _stackRepository.GetByIdAsync(ev.StackId);
+        Assert.NotNull(stack);
+        Assert.Equal(StackStatus.Snoozed, stack.Status);
+        Assert.NotNull(stack.SnoozeUntilUtc);
+    }
+
+    [Fact]
+    public async Task SnoozeAsync_WithPastDate_ReturnsBadRequest()
+    {
+        // Arrange
+        var ev = await SubmitErrorEventAsync();
+        Assert.NotNull(ev.StackId);
+        var pastDate = DateTime.UtcNow.AddMinutes(-10);
+
+        // Act
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath($"stacks/{ev.StackId}/mark-snoozed")
+            .QueryString("snoozeUntilUtc", pastDate.ToString("o"))
+            .StatusCodeShouldBeBadRequest());
+    }
+
+    [Fact]
+    public Task SnoozeAsync_NonExistentStack_ReturnsNotFound()
+    {
+        // Arrange
+        var snoozeUntil = DateTime.UtcNow.AddDays(1);
+
+        // Act
+        return SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("stacks/000000000000000000000000/mark-snoozed")
+            .QueryString("snoozeUntilUtc", snoozeUntil.ToString("o"))
+            .StatusCodeShouldBeNotFound());
     }
 }

--- a/tests/Exceptionless.Tests/Controllers/StackControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/StackControllerTests.cs
@@ -243,6 +243,8 @@ public class StackControllerTests : IntegrationTestsBase
         // Arrange
         var ev = await SubmitErrorEventAsync();
         Assert.NotNull(ev.StackId);
+        var stackBefore = await _stackRepository.GetByIdAsync(ev.StackId);
+        Assert.NotNull(stackBefore);
 
         // Act
         await SendRequestAsync(r => r
@@ -251,6 +253,11 @@ public class StackControllerTests : IntegrationTestsBase
             .AppendPath($"stacks/{ev.StackId}/change-status")
             .QueryString("status", "Snoozed")
             .StatusCodeShouldBeBadRequest());
+
+        // Assert — status must not have changed
+        var stackAfter = await _stackRepository.GetByIdAsync(ev.StackId);
+        Assert.NotNull(stackAfter);
+        Assert.Equal(stackBefore.Status, stackAfter.Status);
     }
 
     [Fact]
@@ -295,16 +302,16 @@ public class StackControllerTests : IntegrationTestsBase
     public async Task GetAll_WithDateRangeFilter_ReturnsOnlyMatchingStacks()
     {
         // Arrange
-        var now = TimeProvider.GetUtcNow();
+        var utcNow = TimeProvider.GetUtcNow();
         var (stacks, _) = await CreateDataAsync(d =>
         {
-            d.Event().TestProject().Date(now.AddDays(-1));
-            d.Event().TestProject().Date(now.AddDays(-3));
+            d.Event().TestProject().Date(utcNow.AddDays(-1));
+            d.Event().TestProject().Date(utcNow.AddDays(-3));
         });
 
         Assert.Equal(2, stacks.Count);
-        var recentStack = stacks.Single(s => s.LastOccurrence >= now.AddDays(-2).UtcDateTime);
-        var oldStack = stacks.Single(s => s.LastOccurrence < now.AddDays(-2).UtcDateTime);
+        var recentStack = stacks.Single(s => s.LastOccurrence >= utcNow.AddDays(-2).UtcDateTime);
+        var oldStack = stacks.Single(s => s.LastOccurrence < utcNow.AddDays(-2).UtcDateTime);
 
         // Act
         var result = await SendRequestAsAsync<IReadOnlyCollection<Stack>>(r => r
@@ -324,11 +331,11 @@ public class StackControllerTests : IntegrationTestsBase
     public async Task GetAll_WithNoFilter_ReturnsAllStacks()
     {
         // Arrange
-        var now = TimeProvider.GetUtcNow();
+        var utcNow = TimeProvider.GetUtcNow();
         await CreateDataAsync(d =>
         {
-            d.Event().TestProject().Date(now);
-            d.Event().TestProject().Date(now.AddHours(-1));
+            d.Event().TestProject().Date(utcNow);
+            d.Event().TestProject().Date(utcNow.AddHours(-1));
         });
 
         // Act
@@ -546,14 +553,14 @@ public class StackControllerTests : IntegrationTestsBase
         // Arrange
         var ev = await SubmitErrorEventAsync();
         Assert.NotNull(ev.StackId);
-        var snoozeUntil = DateTime.UtcNow.AddDays(1);
+        var snoozeUntilUtc = TimeProvider.GetUtcNow().AddDays(1);
 
         // Act
         await SendRequestAsync(r => r
             .Post()
             .AsGlobalAdminUser()
             .AppendPath($"stacks/{ev.StackId}/mark-snoozed")
-            .QueryString("snoozeUntilUtc", snoozeUntil.ToString("o"))
+            .QueryString("snoozeUntilUtc", snoozeUntilUtc.ToString("o"))
             .StatusCodeShouldBeOk());
 
         // Assert
@@ -569,14 +576,14 @@ public class StackControllerTests : IntegrationTestsBase
         // Arrange
         var ev = await SubmitErrorEventAsync();
         Assert.NotNull(ev.StackId);
-        var pastDate = DateTime.UtcNow.AddMinutes(-10);
+        var pastDateUtc = TimeProvider.GetUtcNow().AddMinutes(-10);
 
         // Act
         await SendRequestAsync(r => r
             .Post()
             .AsGlobalAdminUser()
             .AppendPath($"stacks/{ev.StackId}/mark-snoozed")
-            .QueryString("snoozeUntilUtc", pastDate.ToString("o"))
+            .QueryString("snoozeUntilUtc", pastDateUtc.ToString("o"))
             .StatusCodeShouldBeBadRequest());
     }
 
@@ -584,14 +591,14 @@ public class StackControllerTests : IntegrationTestsBase
     public Task SnoozeAsync_NonExistentStack_ReturnsNotFound()
     {
         // Arrange
-        var snoozeUntil = DateTime.UtcNow.AddDays(1);
+        var snoozeUntilUtc = TimeProvider.GetUtcNow().AddDays(1);
 
         // Act
         return SendRequestAsync(r => r
             .Post()
             .AsGlobalAdminUser()
             .AppendPath("stacks/000000000000000000000000/mark-snoozed")
-            .QueryString("snoozeUntilUtc", snoozeUntil.ToString("o"))
+            .QueryString("snoozeUntilUtc", snoozeUntilUtc.ToString("o"))
             .StatusCodeShouldBeNotFound());
     }
 }

--- a/tests/Exceptionless.Tests/Controllers/StatusControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/StatusControllerTests.cs
@@ -11,14 +11,11 @@ namespace Exceptionless.Tests.Controllers;
 
 public class StatusControllerTests : IntegrationTestsBase
 {
-    public StatusControllerTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
-    {
-    }
+    public StatusControllerTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory) { }
 
     protected override async Task ResetDataAsync()
     {
         await base.ResetDataAsync();
-
         var service = GetService<SampleDataService>();
         await service.CreateDataAsync();
     }
@@ -26,7 +23,6 @@ public class StatusControllerTests : IntegrationTestsBase
     [Theory]
     [InlineData(null, false)]
     [InlineData(null, true)]
-    //[InlineData(null, true, false)] // TODO: Resolve issue where you are required to pass a message via the body.
     [InlineData("New Release!!", false)]
     [InlineData("New Release!!", true)]
     public async Task CanSendReleaseNotification(string? message, bool critical, bool sendMessageAsContentIfEmpty = true)
@@ -63,7 +59,7 @@ public class StatusControllerTests : IntegrationTestsBase
     [Fact]
     public async Task GetAboutAsync_Anonymous_ReturnsVersionInfo()
     {
-        // Arrange & Act
+        // Act
         var response = await SendRequestAsync(r => r
             .AppendPath("about")
             .StatusCodeShouldBeOk());
@@ -78,7 +74,7 @@ public class StatusControllerTests : IntegrationTestsBase
     [Fact]
     public async Task GetQueueStatsAsync_AsGlobalAdmin_ReturnsQueueStats()
     {
-        // Arrange & Act
+        // Act
         var response = await SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPath("queue-stats")
@@ -95,7 +91,6 @@ public class StatusControllerTests : IntegrationTestsBase
     [Fact]
     public Task GetQueueStatsAsync_AsNonAdmin_ReturnsForbidden()
     {
-        // Arrange & Act
         return SendRequestAsync(r => r
             .AsTestOrganizationUser()
             .AppendPath("queue-stats")
@@ -105,7 +100,7 @@ public class StatusControllerTests : IntegrationTestsBase
     [Fact]
     public async Task GetSystemNotificationAsync_WhenNoneSet_ReturnsOk()
     {
-        // Arrange & Act
+        // Act
         var response = await SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPath("notifications/system")
@@ -138,7 +133,6 @@ public class StatusControllerTests : IntegrationTestsBase
     [Fact]
     public Task PostSystemNotificationAsync_WithEmptyMessage_ReturnsNotFound()
     {
-        // Arrange & Act
         return SendRequestAsync(r => r
             .Post()
             .AsGlobalAdminUser()
@@ -150,7 +144,6 @@ public class StatusControllerTests : IntegrationTestsBase
     [Fact]
     public Task PostSystemNotificationAsync_AsNonAdmin_ReturnsForbidden()
     {
-        // Arrange & Act
         return SendRequestAsync(r => r
             .Post()
             .AsTestOrganizationUser()
@@ -162,7 +155,7 @@ public class StatusControllerTests : IntegrationTestsBase
     [Fact]
     public async Task RemoveSystemNotificationAsync_AsGlobalAdmin_ReturnsOk()
     {
-        // Arrange - first set a notification
+        // Arrange
         await SendRequestAsync(r => r
             .Post()
             .AsGlobalAdminUser()
@@ -177,12 +170,11 @@ public class StatusControllerTests : IntegrationTestsBase
             .AppendPath("notifications/system")
             .StatusCodeShouldBeOk());
 
-        // Assert - get should now return empty
+        // Assert
         var response = await SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPath("notifications/system")
             .StatusCodeShouldBeOk());
-
         var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.DoesNotContain("To be removed", content);
     }
@@ -190,7 +182,6 @@ public class StatusControllerTests : IntegrationTestsBase
     [Fact]
     public Task RemoveSystemNotificationAsync_AsNonAdmin_ReturnsForbidden()
     {
-        // Arrange & Act
         return SendRequestAsync(r => r
             .Delete()
             .AsTestOrganizationUser()

--- a/tests/Exceptionless.Tests/Controllers/StatusControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/StatusControllerTests.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using Exceptionless.Core.Messaging.Models;
 using Exceptionless.Core.Utility;
 using Exceptionless.DateTimeExtensions;
@@ -58,35 +57,20 @@ public class StatusControllerTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task GetAboutAsync_Anonymous_ReturnsVersionInfo()
+    public Task GetAboutAsync_Anonymous_ReturnsVersionInfo()
     {
-        // Act
-        var response = await SendRequestAsync(r => r
+        return SendRequestAsync(r => r
             .AppendPath("about")
             .StatusCodeShouldBeOk());
-
-        // Assert
-        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        Assert.Contains("informationalVersion", content, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("appMode", content, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("machineName", content, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public async Task GetQueueStatsAsync_AsGlobalAdmin_ReturnsQueueStats()
+    public Task GetQueueStatsAsync_AsGlobalAdmin_ReturnsQueueStats()
     {
-        // Act
-        var response = await SendRequestAsync(r => r
+        return SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPath("queue-stats")
             .StatusCodeShouldBeOk());
-
-        // Assert
-        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        Assert.Contains("eventPosts", content, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("mailMessages", content, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("notifications", content, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("webHooks", content, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -99,16 +83,12 @@ public class StatusControllerTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task GetSystemNotificationAsync_WhenNoneSet_ReturnsOk()
+    public Task GetSystemNotificationAsync_WhenNoneSet_ReturnsOk()
     {
-        // Act
-        var response = await SendRequestAsync(r => r
+        return SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPath("notifications/system")
             .StatusCodeShouldBeOk());
-
-        // Assert
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Controllers/StatusControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/StatusControllerTests.cs
@@ -1,8 +1,10 @@
+using System.Net;
 using Exceptionless.Core.Messaging.Models;
 using Exceptionless.Core.Utility;
 using Exceptionless.DateTimeExtensions;
 using Exceptionless.Tests.Extensions;
 using Exceptionless.Web.Models;
+using FluentRest;
 using Xunit;
 
 namespace Exceptionless.Tests.Controllers;
@@ -56,5 +58,143 @@ public class StatusControllerTests : IntegrationTestsBase
         Assert.Equal(message, notification.Message);
         Assert.Equal(critical, notification.Critical);
         Assert.True(notification.Date.IsAfterOrEqual(utcNow));
+    }
+
+    [Fact]
+    public async Task GetAboutAsync_Anonymous_ReturnsVersionInfo()
+    {
+        // Arrange & Act
+        var response = await SendRequestAsync(r => r
+            .AppendPath("about")
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("informationalVersion", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("appMode", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("machineName", content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetQueueStatsAsync_AsGlobalAdmin_ReturnsQueueStats()
+    {
+        // Arrange & Act
+        var response = await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("queue-stats")
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("eventPosts", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("mailMessages", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("notifications", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("webHooks", content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public Task GetQueueStatsAsync_AsNonAdmin_ReturnsForbidden()
+    {
+        // Arrange & Act
+        return SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .AppendPath("queue-stats")
+            .StatusCodeShouldBeForbidden());
+    }
+
+    [Fact]
+    public async Task GetSystemNotificationAsync_WhenNoneSet_ReturnsOk()
+    {
+        // Arrange & Act
+        var response = await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("notifications/system")
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostSystemNotificationAsync_WithMessage_ReturnsNotification()
+    {
+        // Arrange
+        var utcNow = DateTime.UtcNow;
+
+        // Act
+        var notification = await SendRequestAsAsync<SystemNotification>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("notifications/system")
+            .Content(new ValueFromBody<string>("System maintenance scheduled"))
+            .StatusCodeShouldBeOk());
+
+        // Assert
+        Assert.NotNull(notification);
+        Assert.Equal("System maintenance scheduled", notification.Message);
+        Assert.True(notification.Date.IsAfterOrEqual(utcNow));
+    }
+
+    [Fact]
+    public Task PostSystemNotificationAsync_WithEmptyMessage_ReturnsNotFound()
+    {
+        // Arrange & Act
+        return SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("notifications/system")
+            .Content(new ValueFromBody<string>(""))
+            .StatusCodeShouldBeNotFound());
+    }
+
+    [Fact]
+    public Task PostSystemNotificationAsync_AsNonAdmin_ReturnsForbidden()
+    {
+        // Arrange & Act
+        return SendRequestAsync(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPath("notifications/system")
+            .Content(new ValueFromBody<string>("test"))
+            .StatusCodeShouldBeForbidden());
+    }
+
+    [Fact]
+    public async Task RemoveSystemNotificationAsync_AsGlobalAdmin_ReturnsOk()
+    {
+        // Arrange - first set a notification
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("notifications/system")
+            .Content(new ValueFromBody<string>("To be removed"))
+            .StatusCodeShouldBeOk());
+
+        // Act
+        await SendRequestAsync(r => r
+            .Delete()
+            .AsGlobalAdminUser()
+            .AppendPath("notifications/system")
+            .StatusCodeShouldBeOk());
+
+        // Assert - get should now return empty
+        var response = await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("notifications/system")
+            .StatusCodeShouldBeOk());
+
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.DoesNotContain("To be removed", content);
+    }
+
+    [Fact]
+    public Task RemoveSystemNotificationAsync_AsNonAdmin_ReturnsForbidden()
+    {
+        // Arrange & Act
+        return SendRequestAsync(r => r
+            .Delete()
+            .AsTestOrganizationUser()
+            .AppendPath("notifications/system")
+            .StatusCodeShouldBeForbidden());
     }
 }

--- a/tests/Exceptionless.Tests/Controllers/StatusControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/StatusControllerTests.cs
@@ -23,6 +23,7 @@ public class StatusControllerTests : IntegrationTestsBase
     [Theory]
     [InlineData(null, false)]
     [InlineData(null, true)]
+    //[InlineData(null, true, false)] // TODO: Resolve issue where you are required to pass a message via the body.
     [InlineData("New Release!!", false)]
     [InlineData("New Release!!", true)]
     public async Task CanSendReleaseNotification(string? message, bool critical, bool sendMessageAsContentIfEmpty = true)

--- a/tests/Exceptionless.Tests/Controllers/StatusControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/StatusControllerTests.cs
@@ -27,7 +27,7 @@ public class StatusControllerTests : IntegrationTestsBase
     [InlineData("New Release!!", true)]
     public async Task CanSendReleaseNotification(string? message, bool critical, bool sendMessageAsContentIfEmpty = true)
     {
-        var utcNow = DateTime.UtcNow;
+        var utcNow = TimeProvider.GetUtcNow().UtcDateTime;
 
         ReleaseNotification? notification;
         if (!String.IsNullOrEmpty(message) || sendMessageAsContentIfEmpty)
@@ -95,7 +95,7 @@ public class StatusControllerTests : IntegrationTestsBase
     public async Task PostSystemNotificationAsync_WithMessage_ReturnsNotification()
     {
         // Arrange
-        var utcNow = DateTime.UtcNow;
+        var utcNow = TimeProvider.GetUtcNow().UtcDateTime;
 
         // Act
         var notification = await SendRequestAsAsync<SystemNotification>(r => r
@@ -118,7 +118,7 @@ public class StatusControllerTests : IntegrationTestsBase
             .Post()
             .AsGlobalAdminUser()
             .AppendPath("notifications/system")
-            .Content(new ValueFromBody<string>(""))
+            .Content(new ValueFromBody<string>(String.Empty))
             .StatusCodeShouldBeNotFound());
     }
 

--- a/tests/Exceptionless.Tests/Controllers/StripeControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/StripeControllerTests.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Net.Http.Headers;
 using System.Text;
 using Exceptionless.Core.Utility;
 using Exceptionless.Tests.Extensions;
@@ -22,7 +21,7 @@ public class StripeControllerTests : IntegrationTestsBase
     [Fact]
     public async Task PostAsync_WithEmptyBody_ReturnsBadRequest()
     {
-        // Arrange & Act
+        // Act
         var response = await SendRequestAsync(r => r
             .Post()
             .AppendPath("stripe")
@@ -37,7 +36,8 @@ public class StripeControllerTests : IntegrationTestsBase
     public async Task PostAsync_WithInvalidSignature_ReturnsBadRequest()
     {
         // Arrange
-        string json = "{\"id\":\"evt_test\",\"type\":\"charge.succeeded\"}";
+        /* language=json */
+        const string json = """{"id":"evt_test","type":"charge.succeeded"}""";
 
         // Act
         var response = await SendRequestAsync(r => r
@@ -55,7 +55,8 @@ public class StripeControllerTests : IntegrationTestsBase
     public async Task PostAsync_WithMissingSignatureHeader_ReturnsBadRequest()
     {
         // Arrange
-        string json = "{\"id\":\"evt_test\",\"type\":\"charge.succeeded\"}";
+        /* language=json */
+        const string json = """{"id":"evt_test","type":"charge.succeeded"}""";
 
         // Act
         var response = await SendRequestAsync(r => r

--- a/tests/Exceptionless.Tests/Controllers/StripeControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/StripeControllerTests.cs
@@ -21,11 +21,14 @@ public class StripeControllerTests : IntegrationTestsBase
     [Fact]
     public async Task PostAsync_WithEmptyBody_ReturnsBadRequest()
     {
+        // Arrange
+        using var content = new StringContent(String.Empty, Encoding.UTF8, "application/json");
+
         // Act
         var response = await SendRequestAsync(r => r
             .Post()
             .AppendPath("stripe")
-            .Content(new StringContent("", Encoding.UTF8, "application/json"))
+            .Content(content)
         );
 
         // Assert
@@ -38,12 +41,13 @@ public class StripeControllerTests : IntegrationTestsBase
         // Arrange
         /* language=json */
         const string json = """{"id":"evt_test","type":"charge.succeeded"}""";
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
 
         // Act
         var response = await SendRequestAsync(r => r
             .Post()
             .AppendPath("stripe")
-            .Content(new StringContent(json, Encoding.UTF8, "application/json"))
+            .Content(content)
             .Header("Stripe-Signature", "t=1234,v1=invalid_signature")
         );
 
@@ -57,12 +61,13 @@ public class StripeControllerTests : IntegrationTestsBase
         // Arrange
         /* language=json */
         const string json = """{"id":"evt_test","type":"charge.succeeded"}""";
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
 
         // Act
         var response = await SendRequestAsync(r => r
             .Post()
             .AppendPath("stripe")
-            .Content(new StringContent(json, Encoding.UTF8, "application/json"))
+            .Content(content)
         );
 
         // Assert

--- a/tests/Exceptionless.Tests/Controllers/StripeControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/StripeControllerTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Exceptionless.Core.Utility;
+using Exceptionless.Tests.Extensions;
+using FluentRest;
+using Xunit;
+
+namespace Exceptionless.Tests.Controllers;
+
+public class StripeControllerTests : IntegrationTestsBase
+{
+    public StripeControllerTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory) { }
+
+    protected override async Task ResetDataAsync()
+    {
+        await base.ResetDataAsync();
+        var service = GetService<SampleDataService>();
+        await service.CreateDataAsync();
+    }
+
+    [Fact]
+    public async Task PostAsync_WithEmptyBody_ReturnsBadRequest()
+    {
+        // Arrange & Act
+        var response = await SendRequestAsync(r => r
+            .Post()
+            .AppendPath("stripe")
+            .Content(new StringContent("", Encoding.UTF8, "application/json"))
+        );
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAsync_WithInvalidSignature_ReturnsBadRequest()
+    {
+        // Arrange
+        string json = "{\"id\":\"evt_test\",\"type\":\"charge.succeeded\"}";
+
+        // Act
+        var response = await SendRequestAsync(r => r
+            .Post()
+            .AppendPath("stripe")
+            .Content(new StringContent(json, Encoding.UTF8, "application/json"))
+            .Header("Stripe-Signature", "t=1234,v1=invalid_signature")
+        );
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostAsync_WithMissingSignatureHeader_ReturnsBadRequest()
+    {
+        // Arrange
+        string json = "{\"id\":\"evt_test\",\"type\":\"charge.succeeded\"}";
+
+        // Act
+        var response = await SendRequestAsync(r => r
+            .Post()
+            .AppendPath("stripe")
+            .Content(new StringContent(json, Encoding.UTF8, "application/json"))
+        );
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/tests/Exceptionless.Tests/Controllers/StripeControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/StripeControllerTests.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using System.Text;
 using Exceptionless.Core.Utility;
 using Exceptionless.Tests.Extensions;
@@ -24,15 +23,13 @@ public class StripeControllerTests : IntegrationTestsBase
         // Arrange
         using var content = new StringContent(String.Empty, Encoding.UTF8, "application/json");
 
-        // Act
-        var response = await SendRequestAsync(r => r
+        // Act & Assert
+        await SendRequestAsync(r => r
             .Post()
             .AppendPath("stripe")
             .Content(content)
+            .StatusCodeShouldBeBadRequest()
         );
-
-        // Assert
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
@@ -43,16 +40,14 @@ public class StripeControllerTests : IntegrationTestsBase
         const string json = """{"id":"evt_test","type":"charge.succeeded"}""";
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
 
-        // Act
-        var response = await SendRequestAsync(r => r
+        // Act & Assert
+        await SendRequestAsync(r => r
             .Post()
             .AppendPath("stripe")
             .Content(content)
             .Header("Stripe-Signature", "t=1234,v1=invalid_signature")
+            .StatusCodeShouldBeBadRequest()
         );
-
-        // Assert
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]
@@ -63,14 +58,12 @@ public class StripeControllerTests : IntegrationTestsBase
         const string json = """{"id":"evt_test","type":"charge.succeeded"}""";
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
 
-        // Act
-        var response = await SendRequestAsync(r => r
+        // Act & Assert
+        await SendRequestAsync(r => r
             .Post()
             .AppendPath("stripe")
             .Content(content)
+            .StatusCodeShouldBeBadRequest()
         );
-
-        // Assert
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 }

--- a/tests/Exceptionless.Tests/Controllers/TokenControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/TokenControllerTests.cs
@@ -439,4 +439,355 @@ public sealed class TokenControllerTests : IntegrationTestsBase
         Assert.NotNull(problemDetails);
         Assert.Contains(problemDetails.Errors, error => error.Key.Equals("project_id", StringComparison.OrdinalIgnoreCase));
     }
+
+    [Fact]
+    public async Task DeleteAsync_ExistingToken_ReturnsAccepted()
+    {
+        // Arrange
+        var createdToken = await SendRequestAsAsync<ViewToken>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("tokens")
+            .Content(new NewToken
+            {
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                ProjectId = SampleDataService.TEST_PROJECT_ID,
+                Scopes = [AuthorizationRoles.Client],
+                Notes = "Token to delete"
+            })
+            .StatusCodeShouldBeCreated()
+        );
+
+        Assert.NotNull(createdToken);
+
+        // Act
+        await SendRequestAsync(r => r
+            .Delete()
+            .AsGlobalAdminUser()
+            .AppendPaths("tokens", createdToken.Id)
+            .StatusCodeShouldBeAccepted()
+        );
+
+        // Assert
+        await RefreshDataAsync();
+        var deletedToken = await _tokenRepository.GetByIdAsync(createdToken.Id);
+        Assert.Null(deletedToken);
+    }
+
+    [Fact]
+    public Task DeleteAsync_NonExistentToken_ReturnsNotFound()
+    {
+        return SendRequestAsync(r => r
+            .Delete()
+            .AsGlobalAdminUser()
+            .AppendPaths("tokens", "000000000000000000000000")
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WithTokenAuth_ReturnsForbidden()
+    {
+        // Arrange
+        var createdToken = await SendRequestAsAsync<ViewToken>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("tokens")
+            .Content(new NewToken
+            {
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                ProjectId = SampleDataService.TEST_PROJECT_ID,
+                Scopes = [AuthorizationRoles.Client]
+            })
+            .StatusCodeShouldBeCreated()
+        );
+
+        Assert.NotNull(createdToken);
+
+        // Act
+        await SendRequestAsync(r => r
+            .Delete()
+            .BearerToken(createdToken.Id)
+            .AppendPaths("tokens", createdToken.Id)
+            .StatusCodeShouldBeForbidden()
+        );
+
+        // Assert - token should still exist
+        var token = await _tokenRepository.GetByIdAsync(createdToken.Id);
+        Assert.NotNull(token);
+    }
+
+    [Fact]
+    public async Task GetByOrganizationAsync_ExistingOrganization_ReturnsTokens()
+    {
+        // Arrange - create a token in the test org
+        var createdToken = await SendRequestAsAsync<ViewToken>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("tokens")
+            .Content(new NewToken
+            {
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                ProjectId = SampleDataService.TEST_PROJECT_ID,
+                Scopes = [AuthorizationRoles.Client],
+                Notes = "Org listing token"
+            })
+            .StatusCodeShouldBeCreated()
+        );
+
+        Assert.NotNull(createdToken);
+
+        // Act
+        var tokens = await SendRequestAsAsync<List<ViewToken>>(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "tokens")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(tokens);
+        Assert.NotEmpty(tokens);
+        Assert.Contains(tokens, t => t.Id == createdToken.Id);
+        Assert.All(tokens, t => Assert.Equal(SampleDataService.TEST_ORG_ID, t.OrganizationId));
+    }
+
+    [Fact]
+    public Task GetByOrganizationAsync_InvalidOrganizationId_ReturnsNotFound()
+    {
+        return SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("organizations", "000000000000000000000000", "tokens")
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
+    public Task GetByOrganizationAsync_WithTokenAuth_ReturnsForbidden()
+    {
+        return SendRequestAsync(r => r
+            .BearerToken(SampleDataService.TEST_API_KEY)
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "tokens")
+            .StatusCodeShouldBeForbidden()
+        );
+    }
+
+    [Fact]
+    public async Task GetByProjectAsync_ExistingProject_ReturnsTokens()
+    {
+        // Arrange
+        var createdToken = await SendRequestAsAsync<ViewToken>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("tokens")
+            .Content(new NewToken
+            {
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                ProjectId = SampleDataService.TEST_PROJECT_ID,
+                Scopes = [AuthorizationRoles.Client],
+                Notes = "Project listing token"
+            })
+            .StatusCodeShouldBeCreated()
+        );
+
+        Assert.NotNull(createdToken);
+
+        // Act
+        var tokens = await SendRequestAsAsync<List<ViewToken>>(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "tokens")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(tokens);
+        Assert.NotEmpty(tokens);
+        Assert.Contains(tokens, t => t.Id == createdToken.Id);
+        Assert.All(tokens, t => Assert.Equal(SampleDataService.TEST_PROJECT_ID, t.ProjectId));
+    }
+
+    [Fact]
+    public Task GetByProjectAsync_InvalidProjectId_ReturnsNotFound()
+    {
+        return SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("projects", "000000000000000000000000", "tokens")
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
+    public Task GetByProjectAsync_WithTokenAuth_ReturnsForbidden()
+    {
+        return SendRequestAsync(r => r
+            .BearerToken(SampleDataService.TEST_API_KEY)
+            .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "tokens")
+            .StatusCodeShouldBeForbidden()
+        );
+    }
+
+    [Fact]
+    public async Task GetDefaultTokenAsync_ExistingProject_ReturnsToken()
+    {
+        // Act
+        var token = await SendRequestAsAsync<ViewToken>(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "tokens", "default")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(token);
+        Assert.Equal(SampleDataService.TEST_PROJECT_ID, token.ProjectId);
+        Assert.Equal(SampleDataService.TEST_ORG_ID, token.OrganizationId);
+    }
+
+    [Fact]
+    public Task GetDefaultTokenAsync_InvalidProjectId_ReturnsNotFound()
+    {
+        return SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("projects", "000000000000000000000000", "tokens", "default")
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
+    public Task GetDefaultTokenAsync_WithTokenAuth_ReturnsForbidden()
+    {
+        return SendRequestAsync(r => r
+            .BearerToken(SampleDataService.TEST_API_KEY)
+            .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "tokens", "default")
+            .StatusCodeShouldBeForbidden()
+        );
+    }
+
+    [Fact]
+    public async Task PatchAsync_UpdateNotes_ChangesNotesOnly()
+    {
+        // Arrange
+        var createdToken = await SendRequestAsAsync<ViewToken>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("tokens")
+            .Content(new NewToken
+            {
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                ProjectId = SampleDataService.TEST_PROJECT_ID,
+                Scopes = [AuthorizationRoles.Client],
+                Notes = "Original notes"
+            })
+            .StatusCodeShouldBeCreated()
+        );
+
+        Assert.NotNull(createdToken);
+        Assert.False(createdToken.IsDisabled);
+
+        // Act
+        var updatedToken = await SendRequestAsAsync<ViewToken>(r => r
+            .Patch()
+            .AsGlobalAdminUser()
+            .AppendPaths("tokens", createdToken.Id)
+            .Content(new UpdateToken { Notes = "Updated notes" })
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(updatedToken);
+        Assert.Equal("Updated notes", updatedToken.Notes);
+        Assert.False(updatedToken.IsDisabled);
+
+        // Verify persisted
+        var token = await _tokenRepository.GetByIdAsync(createdToken.Id);
+        Assert.NotNull(token);
+        Assert.Equal("Updated notes", token.Notes);
+        Assert.False(token.IsDisabled);
+    }
+
+    [Fact]
+    public async Task PatchAsync_DisableToken_ChangesIsDisabledOnly()
+    {
+        // Arrange
+        var createdToken = await SendRequestAsAsync<ViewToken>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("tokens")
+            .Content(new NewToken
+            {
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                ProjectId = SampleDataService.TEST_PROJECT_ID,
+                Scopes = [AuthorizationRoles.Client],
+                Notes = "Keep these notes"
+            })
+            .StatusCodeShouldBeCreated()
+        );
+
+        Assert.NotNull(createdToken);
+
+        // Act
+        var updatedToken = await SendRequestAsAsync<ViewToken>(r => r
+            .Patch()
+            .AsGlobalAdminUser()
+            .AppendPaths("tokens", createdToken.Id)
+            .Content(new UpdateToken { IsDisabled = true })
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(updatedToken);
+        Assert.True(updatedToken.IsDisabled);
+        Assert.Equal("Keep these notes", updatedToken.Notes);
+
+        // Verify persisted
+        var token = await _tokenRepository.GetByIdAsync(createdToken.Id);
+        Assert.NotNull(token);
+        Assert.True(token.IsDisabled);
+        Assert.Equal("Keep these notes", token.Notes);
+    }
+
+    [Fact]
+    public Task PatchAsync_NonExistentToken_ReturnsNotFound()
+    {
+        return SendRequestAsync(r => r
+            .Patch()
+            .AsGlobalAdminUser()
+            .AppendPaths("tokens", "000000000000000000000000")
+            .Content(new UpdateToken { Notes = "Does not exist" })
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
+    public async Task PatchAsync_WithTokenAuth_ReturnsForbidden()
+    {
+        // Arrange
+        var createdToken = await SendRequestAsAsync<ViewToken>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("tokens")
+            .Content(new NewToken
+            {
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                ProjectId = SampleDataService.TEST_PROJECT_ID,
+                Scopes = [AuthorizationRoles.Client],
+                Notes = "Should not change"
+            })
+            .StatusCodeShouldBeCreated()
+        );
+
+        Assert.NotNull(createdToken);
+
+        // Act
+        await SendRequestAsync(r => r
+            .Patch()
+            .BearerToken(createdToken.Id)
+            .AppendPaths("tokens", createdToken.Id)
+            .Content(new UpdateToken { Notes = "Hacked" })
+            .StatusCodeShouldBeForbidden()
+        );
+
+        // Assert - token should not be changed
+        var token = await _tokenRepository.GetByIdAsync(createdToken.Id);
+        Assert.NotNull(token);
+        Assert.Equal("Should not change", token.Notes);
+    }
 }

--- a/tests/Exceptionless.Tests/Controllers/TokenControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/TokenControllerTests.cs
@@ -105,7 +105,9 @@ public sealed class TokenControllerTests : IntegrationTestsBase
     public async Task PostAsync_NewTokenWithExpiry_MapsExpiresUtc()
     {
         // Arrange
-        var expiryDate = DateTime.UtcNow.AddDays(30);
+        var utcNow = new DateTimeOffset(2026, 5, 22, 14, 30, 0, TimeSpan.Zero);
+        TimeProvider.SetUtcNow(utcNow);
+        var expiryDate = utcNow.UtcDateTime.AddDays(30);
         var newToken = new NewToken
         {
             OrganizationId = SampleDataService.TEST_ORG_ID,
@@ -126,7 +128,7 @@ public sealed class TokenControllerTests : IntegrationTestsBase
         // Assert
         Assert.NotNull(viewToken);
         Assert.NotNull(viewToken.ExpiresUtc);
-        Assert.True(viewToken.ExpiresUtc.Value > DateTime.UtcNow);
+        Assert.Equal(expiryDate, viewToken.ExpiresUtc);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Controllers/TokenControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/TokenControllerTests.cs
@@ -552,12 +552,13 @@ public sealed class TokenControllerTests : IntegrationTestsBase
     }
 
     [Fact]
-    public Task GetByOrganizationAsync_InvalidOrganizationId_ReturnsNotFound()
+    public Task GetByOrganizationAsync_NonExistentOrganizationId_ReturnsEmptyList()
     {
+        // GlobalAdmin can access any organization, so an unknown org ID returns empty list
         return SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPaths("organizations", "000000000000000000000000", "tokens")
-            .StatusCodeShouldBeNotFound()
+            .StatusCodeShouldBeOk()
         );
     }
 

--- a/tests/Exceptionless.Tests/Controllers/TokenControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/TokenControllerTests.cs
@@ -3,6 +3,7 @@ using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Utility;
 using Exceptionless.Tests.Extensions;
+using Exceptionless.Tests.Utility;
 using Exceptionless.Web.Models;
 using FluentRest;
 using Foundatio.Repositories;
@@ -389,6 +390,61 @@ public sealed class TokenControllerTests : IntegrationTestsBase
         Assert.NotNull(viewToken);
         Assert.Equal(SampleDataService.TEST_ORG_ID, viewToken.OrganizationId);
         Assert.Equal(SampleDataService.TEST_PROJECT_ID, viewToken.ProjectId);
+    }
+
+    [Fact]
+    public async Task PostAsync_WithDefaultProjectId_PreservesDefaultProject()
+    {
+        // Arrange
+        var newToken = new NewToken
+        {
+            OrganizationId = SampleDataService.TEST_ORG_ID,
+            DefaultProjectId = SampleDataService.TEST_PROJECT_ID,
+            Scopes = [AuthorizationRoles.Client]
+        };
+
+        // Act
+        var viewToken = await SendRequestAsAsync<ViewToken>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("tokens")
+            .Content(newToken)
+            .StatusCodeShouldBeCreated()
+        );
+
+        // Assert
+        Assert.NotNull(viewToken);
+        Assert.Null(viewToken.ProjectId);
+        Assert.Equal(SampleDataService.TEST_PROJECT_ID, viewToken.DefaultProjectId);
+
+        var token = await _tokenRepository.GetByIdAsync(viewToken.Id);
+        Assert.NotNull(token);
+        Assert.Equal(SampleDataService.TEST_PROJECT_ID, token.DefaultProjectId);
+    }
+
+    [Fact]
+    public async Task PostAsync_WithInvalidDefaultProjectId_ReturnsValidationError()
+    {
+        // Arrange
+        var newToken = new NewToken
+        {
+            OrganizationId = SampleDataService.TEST_ORG_ID,
+            DefaultProjectId = TestConstants.InvalidProjectId,
+            Scopes = [AuthorizationRoles.Client]
+        };
+
+        // Act
+        var problemDetails = await SendRequestAsAsync<ValidationProblemDetails>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("tokens")
+            .Content(newToken)
+            .StatusCodeShouldBeUnprocessableEntity()
+        );
+
+        // Assert
+        Assert.NotNull(problemDetails);
+        Assert.Contains(problemDetails.Errors, error => error.Key.Equals("default_project_id", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Controllers/TokenControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/TokenControllerTests.cs
@@ -395,12 +395,13 @@ public sealed class TokenControllerTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task PostAsync_WithDefaultProjectId_PreservesDefaultProject()
+    public async Task PostAsync_WithDefaultProjectIdAndProjectId_ClearsDefaultProject()
     {
         // Arrange
         var newToken = new NewToken
         {
             OrganizationId = SampleDataService.TEST_ORG_ID,
+            ProjectId = SampleDataService.TEST_PROJECT_ID,
             DefaultProjectId = SampleDataService.TEST_PROJECT_ID,
             Scopes = [AuthorizationRoles.Client]
         };
@@ -416,22 +417,22 @@ public sealed class TokenControllerTests : IntegrationTestsBase
 
         // Assert
         Assert.NotNull(viewToken);
-        Assert.Null(viewToken.ProjectId);
-        Assert.Equal(SampleDataService.TEST_PROJECT_ID, viewToken.DefaultProjectId);
+        Assert.Equal(SampleDataService.TEST_PROJECT_ID, viewToken.ProjectId);
+        Assert.Null(viewToken.DefaultProjectId);
 
         var token = await _tokenRepository.GetByIdAsync(viewToken.Id);
         Assert.NotNull(token);
-        Assert.Equal(SampleDataService.TEST_PROJECT_ID, token.DefaultProjectId);
+        Assert.Null(token.DefaultProjectId);
     }
 
     [Fact]
-    public async Task PostAsync_WithInvalidDefaultProjectId_ReturnsValidationError()
+    public async Task PostAsync_WithoutProjectId_ReturnsBadRequest()
     {
         // Arrange
         var newToken = new NewToken
         {
             OrganizationId = SampleDataService.TEST_ORG_ID,
-            DefaultProjectId = TestConstants.InvalidProjectId,
+            DefaultProjectId = SampleDataService.TEST_PROJECT_ID,
             Scopes = [AuthorizationRoles.Client]
         };
 
@@ -441,12 +442,12 @@ public sealed class TokenControllerTests : IntegrationTestsBase
             .AsGlobalAdminUser()
             .AppendPath("tokens")
             .Content(newToken)
-            .StatusCodeShouldBeUnprocessableEntity()
+            .StatusCodeShouldBeBadRequest()
         );
 
         // Assert
         Assert.NotNull(problemDetails);
-        Assert.Contains(problemDetails.Errors, error => error.Key.Equals("default_project_id", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(problemDetails.Errors, error => error.Key.Equals("project_id", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Controllers/UserControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/UserControllerTests.cs
@@ -85,7 +85,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
     public async Task DeleteAdminRoleAsync_AsGlobalAdmin_RemovesRole()
     {
         // Arrange
-        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+        var currentUser = await SendRequestAsAsync<ViewUser>(r => r
             .AsGlobalAdminUser()
             .AppendPath("users/me")
             .StatusCodeShouldBeOk()
@@ -110,7 +110,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
     public async Task DeleteAdminRoleAsync_NonAdmin_ReturnsForbidden()
     {
         // Arrange
-        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+        var currentUser = await SendRequestAsAsync<ViewUser>(r => r
             .AsGlobalAdminUser()
             .AppendPath("users/me")
             .StatusCodeShouldBeOk()
@@ -190,7 +190,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
     public async Task GetAsync_AnonymousUser_ReturnsUnauthorized()
     {
         // Arrange
-        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+        var currentUser = await SendRequestAsAsync<ViewUser>(r => r
             .AsGlobalAdminUser()
             .AppendPath("users/me")
             .StatusCodeShouldBeOk()
@@ -218,7 +218,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
     public async Task GetAsync_ValidId_ReturnsUser()
     {
         // Arrange
-        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+        var currentUser = await SendRequestAsAsync<ViewUser>(r => r
             .AsGlobalAdminUser()
             .AppendPath("users/me")
             .StatusCodeShouldBeOk()
@@ -275,7 +275,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
     public async Task GetCurrentUserAsync_AuthenticatedUser_ReturnsCurrentUser()
     {
         // Act
-        var user = await SendRequestAsAsync<ViewCurrentUser>(r => r
+        var user = await SendRequestAsAsync<ViewUser>(r => r
             .AsGlobalAdminUser()
             .AppendPath("users/me")
             .StatusCodeShouldBeOk()
@@ -286,14 +286,13 @@ public sealed class UserControllerTests : IntegrationTestsBase
         Assert.Equal(SampleDataService.TEST_USER_EMAIL, user.EmailAddress);
         Assert.NotNull(user.Id);
         Assert.True(user.IsActive);
-        Assert.True(user.IsEmailAddressVerified);
     }
 
     [Fact]
     public async Task GetCurrentUserAsync_TestOrganizationUser_ReturnsCurrentUser()
     {
         // Act
-        var user = await SendRequestAsAsync<ViewCurrentUser>(r => r
+        var user = await SendRequestAsAsync<ViewUser>(r => r
             .AsTestOrganizationUser()
             .AppendPath("users/me")
             .StatusCodeShouldBeOk()
@@ -309,7 +308,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
     public async Task PatchAsync_AnonymousUser_ReturnsUnauthorized()
     {
         // Arrange
-        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+        var currentUser = await SendRequestAsAsync<ViewUser>(r => r
             .AsGlobalAdminUser()
             .AppendPath("users/me")
             .StatusCodeShouldBeOk()
@@ -334,7 +333,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
     public async Task PatchAsync_UpdateFullName_ReturnsUpdatedUser()
     {
         // Arrange
-        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+        var currentUser = await SendRequestAsAsync<ViewUser>(r => r
             .AsGlobalAdminUser()
             .AppendPath("users/me")
             .StatusCodeShouldBeOk()
@@ -359,7 +358,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
     public async Task PatchAsync_UpdateNotifications_ReturnsUpdatedUser()
     {
         // Arrange
-        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+        var currentUser = await SendRequestAsAsync<ViewUser>(r => r
             .AsGlobalAdminUser()
             .AppendPath("users/me")
             .StatusCodeShouldBeOk()
@@ -396,7 +395,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
     public async Task PutAsync_UpdateFullName_ReturnsUpdatedUser()
     {
         // Arrange
-        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+        var currentUser = await SendRequestAsAsync<ViewUser>(r => r
             .AsGlobalAdminUser()
             .AppendPath("users/me")
             .StatusCodeShouldBeOk()
@@ -421,7 +420,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
     public async Task ResendVerificationEmailAsync_AnonymousUser_ReturnsUnauthorized()
     {
         // Arrange
-        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+        var currentUser = await SendRequestAsAsync<ViewUser>(r => r
             .AsGlobalAdminUser()
             .AppendPath("users/me")
             .StatusCodeShouldBeOk()
@@ -439,7 +438,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
     public async Task ResendVerificationEmailAsync_ValidUser_ReturnsOk()
     {
         // Arrange
-        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+        var currentUser = await SendRequestAsAsync<ViewUser>(r => r
             .AsGlobalAdminUser()
             .AppendPath("users/me")
             .StatusCodeShouldBeOk()
@@ -482,7 +481,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
     public async Task UpdateEmailAddressAsync_AnonymousUser_ReturnsUnauthorized()
     {
         // Arrange
-        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+        var currentUser = await SendRequestAsAsync<ViewUser>(r => r
             .AsGlobalAdminUser()
             .AppendPath("users/me")
             .StatusCodeShouldBeOk()
@@ -506,7 +505,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
     public async Task UpdateEmailAddressAsync_ValidEmail_ReturnsResult()
     {
         // Arrange
-        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+        var currentUser = await SendRequestAsAsync<ViewUser>(r => r
             .AsGlobalAdminUser()
             .AppendPath("users/me")
             .StatusCodeShouldBeOk()
@@ -537,7 +536,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
 
     private async Task<ViewUser> GetTestOrganizationUserAsync()
     {
-        var user = await SendRequestAsAsync<ViewCurrentUser>(r => r
+        var user = await SendRequestAsAsync<ViewUser>(r => r
             .AsTestOrganizationUser()
             .AppendPath("users/me")
             .StatusCodeShouldBeOk()

--- a/tests/Exceptionless.Tests/Controllers/UserControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/UserControllerTests.cs
@@ -48,7 +48,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
         var user = await GetTestOrganizationUserAsync();
 
         // Act
-        var response = await SendRequestAsAsync<ViewUser>(r => r
+        await SendRequestAsync(r => r
             .Post()
             .AsGlobalAdminUser()
             .AppendPaths("users", user.Id, "admin-role")
@@ -56,8 +56,9 @@ public sealed class UserControllerTests : IntegrationTestsBase
         );
 
         // Assert
-        Assert.NotNull(response);
-        Assert.Contains(AuthorizationRoles.GlobalAdmin, response.Roles);
+        var updatedUser = await _userRepository.GetByIdAsync(user.Id);
+        Assert.NotNull(updatedUser);
+        Assert.Contains(AuthorizationRoles.GlobalAdmin, updatedUser.Roles);
     }
 
     [Fact]
@@ -87,16 +88,17 @@ public sealed class UserControllerTests : IntegrationTestsBase
         Assert.NotNull(currentUser);
 
         // Act
-        var response = await SendRequestAsAsync<ViewUser>(r => r
+        await SendRequestAsync(r => r
             .Delete()
             .AsGlobalAdminUser()
             .AppendPaths("users", currentUser.Id, "admin-role")
-            .StatusCodeShouldBeOk()
+            .ExpectedStatus(System.Net.HttpStatusCode.NoContent)
         );
 
         // Assert
-        Assert.NotNull(response);
-        Assert.DoesNotContain(AuthorizationRoles.GlobalAdmin, response.Roles);
+        var user = await _userRepository.GetByIdAsync(currentUser.Id);
+        Assert.NotNull(user);
+        Assert.DoesNotContain(AuthorizationRoles.GlobalAdmin, user.Roles);
     }
 
     [Fact]
@@ -498,6 +500,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
     {
         // Act & Assert
         return SendRequestAsync(r => r
+            .AsGlobalAdminUser()
             .AppendPaths("users", "verify-email-address", "invalidtoken1234567890ab")
             .StatusCodeShouldBeNotFound()
         );

--- a/tests/Exceptionless.Tests/Controllers/UserControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/UserControllerTests.cs
@@ -97,7 +97,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
             .Delete()
             .AsGlobalAdminUser()
             .AppendPaths("users", currentUser.Id, "admin-role")
-            .ExpectedStatus(System.Net.HttpStatusCode.NoContent)
+            .StatusCodeShouldBeNoContent()
         );
 
         // Assert

--- a/tests/Exceptionless.Tests/Controllers/UserControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/UserControllerTests.cs
@@ -33,7 +33,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
         // Arrange
         var user = await GetTestOrganizationUserAsync();
 
-        // Act & Assert
+        // Act
         await SendRequestAsync(r => r
             .Post()
             .AppendPaths("users", user.Id, "admin-role")
@@ -67,13 +67,18 @@ public sealed class UserControllerTests : IntegrationTestsBase
         // Arrange
         var user = await GetTestOrganizationUserAsync();
 
-        // Act & Assert
+        // Act
         await SendRequestAsync(r => r
             .Post()
             .AsTestOrganizationUser()
             .AppendPaths("users", user.Id, "admin-role")
             .StatusCodeShouldBeForbidden()
         );
+
+        // Assert - role was not added
+        var unchanged = await _userRepository.GetByIdAsync(user.Id);
+        Assert.NotNull(unchanged);
+        Assert.DoesNotContain(AuthorizationRoles.GlobalAdmin, unchanged.Roles);
     }
 
     [Fact]
@@ -112,19 +117,24 @@ public sealed class UserControllerTests : IntegrationTestsBase
         );
         Assert.NotNull(currentUser);
 
-        // Act & Assert
+        // Act
         await SendRequestAsync(r => r
             .Delete()
             .AsTestOrganizationUser()
             .AppendPaths("users", currentUser.Id, "admin-role")
             .StatusCodeShouldBeForbidden()
         );
+
+        // Assert - role was not removed
+        var user = await _userRepository.GetByIdAsync(currentUser.Id);
+        Assert.NotNull(user);
+        Assert.Contains(AuthorizationRoles.GlobalAdmin, user.Roles);
     }
 
     [Fact]
     public async Task DeleteAsync_AsGlobalAdmin_ReturnsAccepted()
     {
-        // Arrange - create a user with no organizations so it can be deleted
+        // Arrange
         var user = new User
         {
             FullName = "Deletable User",
@@ -153,19 +163,22 @@ public sealed class UserControllerTests : IntegrationTestsBase
         // Arrange
         var user = await GetTestOrganizationUserAsync();
 
-        // Act & Assert
+        // Act
         await SendRequestAsync(r => r
             .Delete()
             .AsTestOrganizationUser()
             .AppendPaths("users", user.Id)
             .StatusCodeShouldBeForbidden()
         );
+
+        // Assert - user still exists
+        var unchanged = await _userRepository.GetByIdAsync(user.Id);
+        Assert.NotNull(unchanged);
     }
 
     [Fact]
     public Task DeleteCurrentUserAsync_AnonymousUser_ReturnsUnauthorized()
     {
-        // Act & Assert
         return SendRequestAsync(r => r
             .Delete()
             .AppendPath("users/me")
@@ -184,7 +197,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
         );
         Assert.NotNull(currentUser);
 
-        // Act & Assert
+        // Act
         await SendRequestAsync(r => r
             .AppendPaths("users", currentUser.Id)
             .StatusCodeShouldBeUnauthorized()
@@ -194,7 +207,6 @@ public sealed class UserControllerTests : IntegrationTestsBase
     [Fact]
     public Task GetAsync_InvalidId_ReturnsNotFound()
     {
-        // Act & Assert
         return SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPaths("users", "000000000000000000000000")
@@ -229,7 +241,6 @@ public sealed class UserControllerTests : IntegrationTestsBase
     [Fact]
     public Task GetByOrganizationAsync_AnonymousUser_ReturnsUnauthorized()
     {
-        // Act & Assert
         return SendRequestAsync(r => r
             .AppendPath($"organizations/{SampleDataService.TEST_ORG_ID}/users")
             .StatusCodeShouldBeUnauthorized()
@@ -254,7 +265,6 @@ public sealed class UserControllerTests : IntegrationTestsBase
     [Fact]
     public Task GetCurrentUserAsync_AnonymousUser_ReturnsUnauthorized()
     {
-        // Act & Assert
         return SendRequestAsync(r => r
             .AppendPath("users/me")
             .StatusCodeShouldBeUnauthorized()
@@ -306,13 +316,18 @@ public sealed class UserControllerTests : IntegrationTestsBase
         );
         Assert.NotNull(currentUser);
 
-        // Act & Assert
+        // Act
         await SendRequestAsync(r => r
             .Patch()
             .AppendPaths("users", currentUser.Id)
             .Content(new { FullName = "Hacker" })
             .StatusCodeShouldBeUnauthorized()
         );
+
+        // Assert - name was not changed
+        var user = await _userRepository.GetByIdAsync(currentUser.Id);
+        Assert.NotNull(user);
+        Assert.NotEqual("Hacker", user.FullName);
     }
 
     [Fact]
@@ -366,6 +381,18 @@ public sealed class UserControllerTests : IntegrationTestsBase
     }
 
     [Fact]
+    public Task PatchAsync_WithNonExistentId_ReturnsNotFound()
+    {
+        return SendRequestAsync(r => r
+            .Patch()
+            .AsGlobalAdminUser()
+            .AppendPaths("users", "000000000000000000000000")
+            .Content(new { FullName = "Nobody" })
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
     public async Task PutAsync_UpdateFullName_ReturnsUpdatedUser()
     {
         // Arrange
@@ -401,7 +428,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
         );
         Assert.NotNull(currentUser);
 
-        // Act & Assert
+        // Act
         await SendRequestAsync(r => r
             .AppendPaths("users", currentUser.Id, "resend-verification-email")
             .StatusCodeShouldBeUnauthorized()
@@ -419,7 +446,7 @@ public sealed class UserControllerTests : IntegrationTestsBase
         );
         Assert.NotNull(currentUser);
 
-        // Act & Assert
+        // Act
         await SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPaths("users", currentUser.Id, "resend-verification-email")
@@ -430,7 +457,6 @@ public sealed class UserControllerTests : IntegrationTestsBase
     [Fact]
     public Task UnverifyEmailAddressAsync_AsGlobalAdmin_ReturnsOk()
     {
-        // Act & Assert
         return SendRequestAsync(r => r
             .Post()
             .AsGlobalAdminUser()
@@ -443,7 +469,6 @@ public sealed class UserControllerTests : IntegrationTestsBase
     [Fact]
     public Task UnverifyEmailAddressAsync_NonAdmin_ReturnsForbidden()
     {
-        // Act & Assert
         return SendRequestAsync(r => r
             .Post()
             .AsTestOrganizationUser()
@@ -464,12 +489,17 @@ public sealed class UserControllerTests : IntegrationTestsBase
         );
         Assert.NotNull(currentUser);
 
-        // Act & Assert
+        // Act
         await SendRequestAsync(r => r
             .Post()
             .AppendPaths("users", currentUser.Id, "email-address", "newemail@exceptionless.test")
             .StatusCodeShouldBeUnauthorized()
         );
+
+        // Assert - email was not changed
+        var user = await _userRepository.GetByIdAsync(currentUser.Id);
+        Assert.NotNull(user);
+        Assert.NotEqual("newemail@exceptionless.test", user.EmailAddress);
     }
 
     [Fact]
@@ -498,7 +528,6 @@ public sealed class UserControllerTests : IntegrationTestsBase
     [Fact]
     public Task VerifyAsync_InvalidToken_ReturnsNotFound()
     {
-        // Act & Assert
         return SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPaths("users", "verify-email-address", "invalidtoken1234567890ab")

--- a/tests/Exceptionless.Tests/Controllers/UserControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/UserControllerTests.cs
@@ -1,0 +1,516 @@
+using Exceptionless.Core.Authorization;
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Repositories;
+using Exceptionless.Core.Utility;
+using Exceptionless.Tests.Extensions;
+using Exceptionless.Web.Controllers;
+using Exceptionless.Web.Models;
+using FluentRest;
+using Foundatio.Repositories;
+using Xunit;
+
+namespace Exceptionless.Tests.Controllers;
+
+public sealed class UserControllerTests : IntegrationTestsBase
+{
+    private readonly IUserRepository _userRepository;
+
+    public UserControllerTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
+    {
+        _userRepository = GetService<IUserRepository>();
+    }
+
+    protected override async Task ResetDataAsync()
+    {
+        await base.ResetDataAsync();
+        var service = GetService<SampleDataService>();
+        await service.CreateDataAsync();
+    }
+
+    [Fact]
+    public async Task AddAdminRoleAsync_AnonymousUser_ReturnsUnauthorized()
+    {
+        // Arrange
+        var user = await GetTestOrganizationUserAsync();
+
+        // Act & Assert
+        await SendRequestAsync(r => r
+            .Post()
+            .AppendPaths("users", user.Id, "admin-role")
+            .StatusCodeShouldBeUnauthorized()
+        );
+    }
+
+    [Fact]
+    public async Task AddAdminRoleAsync_AsGlobalAdmin_AddsRole()
+    {
+        // Arrange
+        var user = await GetTestOrganizationUserAsync();
+
+        // Act
+        var response = await SendRequestAsAsync<ViewUser>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPaths("users", user.Id, "admin-role")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Contains(AuthorizationRoles.GlobalAdmin, response.Roles);
+    }
+
+    [Fact]
+    public async Task AddAdminRoleAsync_NonAdmin_ReturnsForbidden()
+    {
+        // Arrange
+        var user = await GetTestOrganizationUserAsync();
+
+        // Act & Assert
+        await SendRequestAsync(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPaths("users", user.Id, "admin-role")
+            .StatusCodeShouldBeForbidden()
+        );
+    }
+
+    [Fact]
+    public async Task DeleteAdminRoleAsync_AsGlobalAdmin_RemovesRole()
+    {
+        // Arrange
+        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeOk()
+        );
+        Assert.NotNull(currentUser);
+
+        // Act
+        var response = await SendRequestAsAsync<ViewUser>(r => r
+            .Delete()
+            .AsGlobalAdminUser()
+            .AppendPaths("users", currentUser.Id, "admin-role")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.DoesNotContain(AuthorizationRoles.GlobalAdmin, response.Roles);
+    }
+
+    [Fact]
+    public async Task DeleteAdminRoleAsync_NonAdmin_ReturnsForbidden()
+    {
+        // Arrange
+        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeOk()
+        );
+        Assert.NotNull(currentUser);
+
+        // Act & Assert
+        await SendRequestAsync(r => r
+            .Delete()
+            .AsTestOrganizationUser()
+            .AppendPaths("users", currentUser.Id, "admin-role")
+            .StatusCodeShouldBeForbidden()
+        );
+    }
+
+    [Fact]
+    public async Task DeleteAsync_AsGlobalAdmin_ReturnsAccepted()
+    {
+        // Arrange - create a user with no organizations so it can be deleted
+        var user = new User
+        {
+            FullName = "Deletable User",
+            EmailAddress = "deletable@exceptionless.test",
+            IsEmailAddressVerified = true
+        };
+        user.Roles.Add(AuthorizationRoles.Client);
+        user.Roles.Add(AuthorizationRoles.User);
+        user = await _userRepository.AddAsync(user, o => o.ImmediateConsistency());
+
+        // Act
+        var response = await SendRequestAsAsync<WorkInProgressResult>(r => r
+            .Delete()
+            .AsGlobalAdminUser()
+            .AppendPaths("users", user.Id)
+            .StatusCodeShouldBeAccepted()
+        );
+
+        // Assert
+        Assert.NotNull(response);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_NonAdmin_ReturnsForbidden()
+    {
+        // Arrange
+        var user = await GetTestOrganizationUserAsync();
+
+        // Act & Assert
+        await SendRequestAsync(r => r
+            .Delete()
+            .AsTestOrganizationUser()
+            .AppendPaths("users", user.Id)
+            .StatusCodeShouldBeForbidden()
+        );
+    }
+
+    [Fact]
+    public Task DeleteCurrentUserAsync_AnonymousUser_ReturnsUnauthorized()
+    {
+        // Act & Assert
+        return SendRequestAsync(r => r
+            .Delete()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeUnauthorized()
+        );
+    }
+
+    [Fact]
+    public async Task GetAsync_AnonymousUser_ReturnsUnauthorized()
+    {
+        // Arrange
+        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeOk()
+        );
+        Assert.NotNull(currentUser);
+
+        // Act & Assert
+        await SendRequestAsync(r => r
+            .AppendPaths("users", currentUser.Id)
+            .StatusCodeShouldBeUnauthorized()
+        );
+    }
+
+    [Fact]
+    public Task GetAsync_InvalidId_ReturnsNotFound()
+    {
+        // Act & Assert
+        return SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("users", "000000000000000000000000")
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
+    public async Task GetAsync_ValidId_ReturnsUser()
+    {
+        // Arrange
+        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeOk()
+        );
+        Assert.NotNull(currentUser);
+
+        // Act
+        var user = await SendRequestAsAsync<ViewUser>(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("users", currentUser.Id)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(user);
+        Assert.Equal(currentUser.Id, user.Id);
+        Assert.Equal(SampleDataService.TEST_USER_EMAIL, user.EmailAddress);
+    }
+
+    [Fact]
+    public Task GetByOrganizationAsync_AnonymousUser_ReturnsUnauthorized()
+    {
+        // Act & Assert
+        return SendRequestAsync(r => r
+            .AppendPath($"organizations/{SampleDataService.TEST_ORG_ID}/users")
+            .StatusCodeShouldBeUnauthorized()
+        );
+    }
+
+    [Fact]
+    public async Task GetByOrganizationAsync_ValidOrganization_ReturnsUsers()
+    {
+        // Act
+        var users = await SendRequestAsAsync<IReadOnlyCollection<ViewUser>>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath($"organizations/{SampleDataService.TEST_ORG_ID}/users")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(users);
+        Assert.NotEmpty(users);
+    }
+
+    [Fact]
+    public Task GetCurrentUserAsync_AnonymousUser_ReturnsUnauthorized()
+    {
+        // Act & Assert
+        return SendRequestAsync(r => r
+            .AppendPath("users/me")
+            .StatusCodeShouldBeUnauthorized()
+        );
+    }
+
+    [Fact]
+    public async Task GetCurrentUserAsync_AuthenticatedUser_ReturnsCurrentUser()
+    {
+        // Act
+        var user = await SendRequestAsAsync<ViewCurrentUser>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(user);
+        Assert.Equal(SampleDataService.TEST_USER_EMAIL, user.EmailAddress);
+        Assert.NotNull(user.Id);
+        Assert.True(user.IsActive);
+        Assert.True(user.IsEmailAddressVerified);
+    }
+
+    [Fact]
+    public async Task GetCurrentUserAsync_TestOrganizationUser_ReturnsCurrentUser()
+    {
+        // Act
+        var user = await SendRequestAsAsync<ViewCurrentUser>(r => r
+            .AsTestOrganizationUser()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(user);
+        Assert.Equal(SampleDataService.TEST_ORG_USER_EMAIL, user.EmailAddress);
+        Assert.True(user.IsActive);
+    }
+
+    [Fact]
+    public async Task PatchAsync_AnonymousUser_ReturnsUnauthorized()
+    {
+        // Arrange
+        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeOk()
+        );
+        Assert.NotNull(currentUser);
+
+        // Act & Assert
+        await SendRequestAsync(r => r
+            .Patch()
+            .AppendPaths("users", currentUser.Id)
+            .Content(new { FullName = "Hacker" })
+            .StatusCodeShouldBeUnauthorized()
+        );
+    }
+
+    [Fact]
+    public async Task PatchAsync_UpdateFullName_ReturnsUpdatedUser()
+    {
+        // Arrange
+        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeOk()
+        );
+        Assert.NotNull(currentUser);
+
+        // Act
+        var updatedUser = await SendRequestAsAsync<ViewUser>(r => r
+            .Patch()
+            .AsGlobalAdminUser()
+            .AppendPaths("users", currentUser.Id)
+            .Content(new { FullName = "Updated Name" })
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(updatedUser);
+        Assert.Equal("Updated Name", updatedUser.FullName);
+    }
+
+    [Fact]
+    public async Task PatchAsync_UpdateNotifications_ReturnsUpdatedUser()
+    {
+        // Arrange
+        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeOk()
+        );
+        Assert.NotNull(currentUser);
+
+        // Act
+        var updatedUser = await SendRequestAsAsync<ViewUser>(r => r
+            .Patch()
+            .AsGlobalAdminUser()
+            .AppendPaths("users", currentUser.Id)
+            .Content(new { EmailNotificationsEnabled = false })
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(updatedUser);
+        Assert.False(updatedUser.EmailNotificationsEnabled);
+    }
+
+    [Fact]
+    public async Task PutAsync_UpdateFullName_ReturnsUpdatedUser()
+    {
+        // Arrange
+        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeOk()
+        );
+        Assert.NotNull(currentUser);
+
+        // Act
+        var updatedUser = await SendRequestAsAsync<ViewUser>(r => r
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("users", currentUser.Id)
+            .Content(new { FullName = "Put Updated Name" })
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(updatedUser);
+        Assert.Equal("Put Updated Name", updatedUser.FullName);
+    }
+
+    [Fact]
+    public async Task ResendVerificationEmailAsync_AnonymousUser_ReturnsUnauthorized()
+    {
+        // Arrange
+        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeOk()
+        );
+        Assert.NotNull(currentUser);
+
+        // Act & Assert
+        await SendRequestAsync(r => r
+            .AppendPaths("users", currentUser.Id, "resend-verification-email")
+            .StatusCodeShouldBeUnauthorized()
+        );
+    }
+
+    [Fact]
+    public async Task ResendVerificationEmailAsync_ValidUser_ReturnsOk()
+    {
+        // Arrange
+        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeOk()
+        );
+        Assert.NotNull(currentUser);
+
+        // Act & Assert
+        await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("users", currentUser.Id, "resend-verification-email")
+            .StatusCodeShouldBeOk()
+        );
+    }
+
+    [Fact]
+    public Task UnverifyEmailAddressAsync_AsGlobalAdmin_ReturnsOk()
+    {
+        // Act & Assert
+        return SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("users/unverify-email-address")
+            .Content(SampleDataService.TEST_USER_EMAIL, "text/plain")
+            .StatusCodeShouldBeOk()
+        );
+    }
+
+    [Fact]
+    public Task UnverifyEmailAddressAsync_NonAdmin_ReturnsForbidden()
+    {
+        // Act & Assert
+        return SendRequestAsync(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPath("users/unverify-email-address")
+            .Content(SampleDataService.TEST_USER_EMAIL, "text/plain")
+            .StatusCodeShouldBeForbidden()
+        );
+    }
+
+    [Fact]
+    public async Task UpdateEmailAddressAsync_AnonymousUser_ReturnsUnauthorized()
+    {
+        // Arrange
+        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeOk()
+        );
+        Assert.NotNull(currentUser);
+
+        // Act & Assert
+        await SendRequestAsync(r => r
+            .Post()
+            .AppendPaths("users", currentUser.Id, "email-address", "newemail@exceptionless.test")
+            .StatusCodeShouldBeUnauthorized()
+        );
+    }
+
+    [Fact]
+    public async Task UpdateEmailAddressAsync_ValidEmail_ReturnsResult()
+    {
+        // Arrange
+        var currentUser = await SendRequestAsAsync<ViewCurrentUser>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeOk()
+        );
+        Assert.NotNull(currentUser);
+
+        // Act
+        var result = await SendRequestAsAsync<UpdateEmailAddressResult>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPaths("users", currentUser.Id, "email-address", "newemail@exceptionless.test")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public Task VerifyAsync_InvalidToken_ReturnsNotFound()
+    {
+        // Act & Assert
+        return SendRequestAsync(r => r
+            .AppendPaths("users", "verify-email-address", "invalidtoken1234567890ab")
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    private async Task<ViewUser> GetTestOrganizationUserAsync()
+    {
+        var user = await SendRequestAsAsync<ViewCurrentUser>(r => r
+            .AsTestOrganizationUser()
+            .AppendPath("users/me")
+            .StatusCodeShouldBeOk()
+        );
+        Assert.NotNull(user);
+        return user;
+    }
+}

--- a/tests/Exceptionless.Tests/Controllers/UtilityControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/UtilityControllerTests.cs
@@ -18,21 +18,15 @@ public class UtilityControllerTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task ValidateAsync_WithEmptyQuery_ReturnsResult()
+    public Task ValidateAsync_WithEmptyQuery_ReturnsBadRequest()
     {
-        // Arrange
-        string query = String.Empty;
-
-        // Act
-        var result = await SendRequestAsAsync<AppQueryValidator.QueryProcessResult>(r => r
+        // Act & Assert
+        return SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPath("search/validate")
-            .QueryString("query", query)
-            .StatusCodeShouldBeOk()
+            .QueryString("query", String.Empty)
+            .StatusCodeShouldBeBadRequest()
         );
-
-        // Assert
-        Assert.NotNull(result);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Controllers/UtilityControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/UtilityControllerTests.cs
@@ -21,7 +21,7 @@ public class UtilityControllerTests : IntegrationTestsBase
     public async Task ValidateAsync_WithEmptyQuery_ReturnsResult()
     {
         // Arrange
-        string query = "";
+        string query = String.Empty;
 
         // Act
         var result = await SendRequestAsAsync<AppQueryValidator.QueryProcessResult>(r => r
@@ -73,7 +73,8 @@ public class UtilityControllerTests : IntegrationTestsBase
     public async Task ValidateAsync_WithPremiumQuery_ReturnsPremiumFeaturesTrue()
     {
         // Arrange
-        string query = "organization:123456789012345678901234";
+        // `tags` is not in either validator's free-field list, so it triggers premium features
+        string query = "tags:error";
 
         // Act
         var result = await SendRequestAsAsync<AppQueryValidator.QueryProcessResult>(r => r

--- a/tests/Exceptionless.Tests/Controllers/UtilityControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/UtilityControllerTests.cs
@@ -1,0 +1,110 @@
+using Exceptionless.Core.Queries.Validation;
+using Exceptionless.Core.Utility;
+using Exceptionless.Tests.Extensions;
+using FluentRest;
+using Xunit;
+
+namespace Exceptionless.Tests.Controllers;
+
+public class UtilityControllerTests : IntegrationTestsBase
+{
+    public UtilityControllerTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory) { }
+
+    protected override async Task ResetDataAsync()
+    {
+        await base.ResetDataAsync();
+        var service = GetService<SampleDataService>();
+        await service.CreateDataAsync();
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithEmptyQuery_ReturnsResult()
+    {
+        // Arrange
+        string query = "";
+
+        // Act
+        var result = await SendRequestAsAsync<AppQueryValidator.QueryProcessResult>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("search/validate")
+            .QueryString("query", query)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithInvalidQuery_ReturnsIsValidFalse()
+    {
+        // Arrange
+        string query = "((unclosed";
+
+        // Act
+        var result = await SendRequestAsAsync<AppQueryValidator.QueryProcessResult>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("search/validate")
+            .QueryString("query", query)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.False(result.IsValid);
+        Assert.NotNull(result.Message);
+    }
+
+    [Fact]
+    public Task ValidateAsync_WithoutAuth_ReturnsUnauthorized()
+    {
+        // Arrange
+        string query = "type:error";
+
+        // Act & Assert
+        return SendRequestAsync(r => r
+            .AppendPath("search/validate")
+            .QueryString("query", query)
+            .StatusCodeShouldBeUnauthorized()
+        );
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithPremiumQuery_ReturnsPremiumFeaturesTrue()
+    {
+        // Arrange
+        string query = "organization:123456789012345678901234";
+
+        // Act
+        var result = await SendRequestAsAsync<AppQueryValidator.QueryProcessResult>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("search/validate")
+            .QueryString("query", query)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.IsValid);
+        Assert.True(result.UsesPremiumFeatures);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_WithValidSimpleQuery_ReturnsIsValidTrue()
+    {
+        // Arrange
+        string query = "type:error";
+
+        // Act
+        var result = await SendRequestAsAsync<AppQueryValidator.QueryProcessResult>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("search/validate")
+            .QueryString("query", query)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.IsValid);
+    }
+}

--- a/tests/Exceptionless.Tests/Controllers/WebHookControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/WebHookControllerTests.cs
@@ -217,7 +217,6 @@ public sealed class WebHookControllerTests : IntegrationTestsBase
         );
 
         // Assert
-        await RefreshDataAsync();
         var deletedHook = await _webHookRepository.GetByIdAsync(webHook.Id);
         Assert.Null(deletedHook);
     }

--- a/tests/Exceptionless.Tests/Controllers/WebHookControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/WebHookControllerTests.cs
@@ -187,4 +187,228 @@ public sealed class WebHookControllerTests : IntegrationTestsBase
             })
             .StatusCodeShouldBeNotFound());
     }
+
+    [Fact]
+    public async Task DeleteAsync_ExistingWebHook_ReturnsAccepted()
+    {
+        // Arrange
+        var webHook = await SendRequestAsAsync<WebHook>(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPath("webhooks")
+            .Content(new NewWebHook
+            {
+                EventTypes = [WebHook.KnownEventTypes.NewError],
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                ProjectId = SampleDataService.TEST_PROJECT_ID,
+                Url = "https://example.com/delete-test"
+            })
+            .StatusCodeShouldBeCreated()
+        );
+
+        Assert.NotNull(webHook);
+
+        // Act
+        await SendRequestAsync(r => r
+            .Delete()
+            .AsTestOrganizationUser()
+            .AppendPaths("webhooks", webHook.Id)
+            .StatusCodeShouldBeAccepted()
+        );
+
+        // Assert
+        await RefreshDataAsync();
+        var deletedHook = await _webHookRepository.GetByIdAsync(webHook.Id);
+        Assert.Null(deletedHook);
+    }
+
+    [Fact]
+    public Task DeleteAsync_NonExistentWebHook_ReturnsNotFound()
+    {
+        return SendRequestAsync(r => r
+            .Delete()
+            .AsTestOrganizationUser()
+            .AppendPaths("webhooks", "000000000000000000000000")
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
+    public async Task GetAsync_ExistingWebHook_ReturnsWebHook()
+    {
+        // Arrange
+        var createdHook = await SendRequestAsAsync<WebHook>(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPath("webhooks")
+            .Content(new NewWebHook
+            {
+                EventTypes = [WebHook.KnownEventTypes.StackRegression],
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                ProjectId = SampleDataService.TEST_PROJECT_ID,
+                Url = "https://example.com/get-test"
+            })
+            .StatusCodeShouldBeCreated()
+        );
+
+        Assert.NotNull(createdHook);
+
+        // Act
+        var webHook = await SendRequestAsAsync<WebHook>(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("webhooks", createdHook.Id)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(webHook);
+        Assert.Equal(createdHook.Id, webHook.Id);
+        Assert.Equal("https://example.com/get-test", webHook.Url);
+        Assert.Equal(SampleDataService.TEST_ORG_ID, webHook.OrganizationId);
+        Assert.Equal(SampleDataService.TEST_PROJECT_ID, webHook.ProjectId);
+        Assert.Contains(WebHook.KnownEventTypes.StackRegression, webHook.EventTypes);
+    }
+
+    [Fact]
+    public Task GetAsync_NonExistentWebHook_ReturnsNotFound()
+    {
+        return SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("webhooks", "000000000000000000000000")
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
+    public async Task GetByProjectAsync_ExistingProject_ReturnsWebHooks()
+    {
+        // Arrange
+        var createdHook = await SendRequestAsAsync<WebHook>(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPath("webhooks")
+            .Content(new NewWebHook
+            {
+                EventTypes = [WebHook.KnownEventTypes.NewError],
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                ProjectId = SampleDataService.TEST_PROJECT_ID,
+                Url = "https://example.com/project-list-test"
+            })
+            .StatusCodeShouldBeCreated()
+        );
+
+        Assert.NotNull(createdHook);
+
+        // Act
+        var webHooks = await SendRequestAsAsync<List<WebHook>>(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("projects", SampleDataService.TEST_PROJECT_ID, "webhooks")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(webHooks);
+        Assert.NotEmpty(webHooks);
+        Assert.Contains(webHooks, h => h.Id == createdHook.Id);
+        Assert.All(webHooks, h => Assert.Equal(SampleDataService.TEST_PROJECT_ID, h.ProjectId));
+    }
+
+    [Fact]
+    public Task GetByProjectAsync_InvalidProjectId_ReturnsNotFound()
+    {
+        return SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("projects", "000000000000000000000000", "webhooks")
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
+    public async Task PostAsync_WithAllEventTypes_CreatesWebHook()
+    {
+        // Arrange
+        var newWebHook = new NewWebHook
+        {
+            EventTypes = [WebHook.KnownEventTypes.NewError, WebHook.KnownEventTypes.CriticalError, WebHook.KnownEventTypes.StackRegression],
+            OrganizationId = SampleDataService.TEST_ORG_ID,
+            ProjectId = SampleDataService.TEST_PROJECT_ID,
+            Url = "https://example.com/all-events"
+        };
+
+        // Act
+        var webHook = await SendRequestAsAsync<WebHook>(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPath("webhooks")
+            .Content(newWebHook)
+            .StatusCodeShouldBeCreated()
+        );
+
+        // Assert
+        Assert.NotNull(webHook);
+        Assert.Equal(3, webHook.EventTypes.Length);
+        Assert.Contains(WebHook.KnownEventTypes.NewError, webHook.EventTypes);
+        Assert.Contains(WebHook.KnownEventTypes.CriticalError, webHook.EventTypes);
+        Assert.Contains(WebHook.KnownEventTypes.StackRegression, webHook.EventTypes);
+
+        // Verify persisted
+        var persistedHook = await _webHookRepository.GetByIdAsync(webHook.Id);
+        Assert.NotNull(persistedHook);
+        Assert.Equal(3, persistedHook.EventTypes.Length);
+    }
+
+    [Fact]
+    public async Task UnsubscribeAsync_ExistingZapierHook_RemovesWebHook()
+    {
+        // Arrange - create a zapier hook via subscribe
+        const string zapierUrl = "https://hooks.zapier.com/hooks/unsubtest";
+        var webHook = await SendRequestAsAsync<WebHook>(r => r
+            .Post()
+            .AsTestOrganizationClientUser()
+            .AppendPath("webhooks/subscribe")
+            .Content(new Dictionary<string, string>
+            {
+                { "event", WebHook.KnownEventTypes.NewError },
+                { "target_url", zapierUrl }
+            })
+            .StatusCodeShouldBeCreated()
+        );
+
+        Assert.NotNull(webHook);
+
+        // Act
+        await SendRequestAsync(r => r
+            .Post()
+            .AppendPath("webhooks/unsubscribe")
+            .Content(new Dictionary<string, string> { { "target_url", zapierUrl } })
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        await RefreshDataAsync();
+        var results = await _webHookRepository.GetByUrlAsync(zapierUrl);
+        Assert.Empty(results.Documents);
+    }
+
+    [Fact]
+    public Task UnsubscribeAsync_NonZapierUrl_ReturnsNotFound()
+    {
+        return SendRequestAsync(r => r
+            .Post()
+            .AppendPath("webhooks/unsubscribe")
+            .Content(new Dictionary<string, string> { { "target_url", "https://example.com/not-zapier" } })
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
+    public Task UnsubscribeAsync_MissingUrl_ReturnsNotFound()
+    {
+        return SendRequestAsync(r => r
+            .Post()
+            .AppendPath("webhooks/unsubscribe")
+            .Content(new Dictionary<string, string> { { "other_field", "value" } })
+            .StatusCodeShouldBeNotFound()
+        );
+    }
 }

--- a/tests/Exceptionless.Tests/Controllers/WebHookControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/WebHookControllerTests.cs
@@ -298,6 +298,8 @@ public sealed class WebHookControllerTests : IntegrationTestsBase
 
         Assert.NotNull(createdHook);
 
+        await RefreshDataAsync();
+
         // Act
         var webHooks = await SendRequestAsAsync<List<WebHook>>(r => r
             .AsTestOrganizationUser()
@@ -374,6 +376,8 @@ public sealed class WebHookControllerTests : IntegrationTestsBase
         );
 
         Assert.NotNull(webHook);
+
+        await RefreshDataAsync();
 
         // Act
         await SendRequestAsync(r => r

--- a/tests/Exceptionless.Tests/Extensions/RequestExtensions.cs
+++ b/tests/Exceptionless.Tests/Extensions/RequestExtensions.cs
@@ -40,6 +40,11 @@ public static class RequestExtensions
         return builder.ExpectedStatus(HttpStatusCode.Created);
     }
 
+    public static AppSendBuilder StatusCodeShouldBeNoContent(this AppSendBuilder builder)
+    {
+        return builder.ExpectedStatus(HttpStatusCode.NoContent);
+    }
+
     public static AppSendBuilder StatusCodeShouldBeUnauthorized(this AppSendBuilder builder)
     {
         return builder.ExpectedStatus(HttpStatusCode.Unauthorized);

--- a/tests/Exceptionless.Tests/Hubs/WebSocketConnectionManagerTests.cs
+++ b/tests/Exceptionless.Tests/Hubs/WebSocketConnectionManagerTests.cs
@@ -1,0 +1,147 @@
+using System.Net.WebSockets;
+using System.Text;
+using Exceptionless.Core;
+using Exceptionless.Web.Hubs;
+using Foundatio.Serializer;
+using Xunit;
+
+namespace Exceptionless.Tests.Hubs;
+
+public sealed class WebSocketConnectionManagerTests : TestWithServices
+{
+    public WebSocketConnectionManagerTests(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void AddWebSocket_NewSocket_CanLookupAndEnumerateConnection()
+    {
+        // Arrange
+        using var manager = CreateManager();
+        var socket = new TestWebSocket();
+
+        // Act
+        string connectionId = manager.AddWebSocket(socket);
+
+        // Assert
+        Assert.False(String.IsNullOrEmpty(connectionId));
+        Assert.Same(socket, manager.GetWebSocketById(connectionId));
+        Assert.Equal(connectionId, manager.GetConnectionId(socket));
+        Assert.Same(socket, Assert.Single(manager.GetAll()));
+    }
+
+    [Fact]
+    public async Task RemoveWebSocketAsync_ExistingConnection_RemovesAndClosesSocket()
+    {
+        // Arrange
+        using var manager = CreateManager();
+        var socket = new TestWebSocket();
+        string connectionId = manager.AddWebSocket(socket);
+
+        // Act
+        await manager.RemoveWebSocketAsync(connectionId);
+
+        // Assert
+        Assert.Null(manager.GetWebSocketById(connectionId));
+        Assert.Empty(manager.GetAll());
+        Assert.Equal(1, socket.CloseCount);
+        Assert.Equal(WebSocketState.Closed, socket.State);
+    }
+
+    [Fact]
+    public async Task RemoveWebSocketAsync_ClosedSocket_RemovesWithoutClosingAgain()
+    {
+        // Arrange
+        using var manager = CreateManager();
+        var socket = new TestWebSocket(WebSocketState.Closed);
+        string connectionId = manager.AddWebSocket(socket);
+
+        // Act
+        await manager.RemoveWebSocketAsync(connectionId);
+
+        // Assert
+        Assert.Null(manager.GetWebSocketById(connectionId));
+        Assert.Empty(manager.GetAll());
+        Assert.Equal(0, socket.CloseCount);
+    }
+
+    [Fact]
+    public async Task RemoveWebSocketAsync_UnknownConnection_DoesNothing()
+    {
+        // Arrange
+        using var manager = CreateManager();
+
+        // Act
+        await manager.RemoveWebSocketAsync("missing");
+
+        // Assert
+        Assert.Empty(manager.GetAll());
+    }
+
+    [Fact]
+    public async Task SendMessageToAllAsync_ClosedSockets_DoesNotSend()
+    {
+        // Arrange
+        using var manager = CreateManager();
+        var socket = new TestWebSocket(WebSocketState.Closed);
+        manager.AddWebSocket(socket);
+
+        // Act
+        await manager.SendMessageToAllAsync(new { type = "test" });
+
+        // Assert
+        Assert.Empty(socket.SentMessages);
+    }
+
+    private WebSocketConnectionManager CreateManager()
+    {
+        var options = new AppOptions { EnableWebSockets = false };
+        return new WebSocketConnectionManager(options, GetService<ITextSerializer>(), Log);
+    }
+
+    private sealed class TestWebSocket : WebSocket
+    {
+        private WebSocketState _state;
+
+        public TestWebSocket(WebSocketState state = WebSocketState.Open)
+        {
+            _state = state;
+        }
+
+        public int CloseCount { get; private set; }
+        public List<string> SentMessages { get; } = [];
+        public override WebSocketCloseStatus? CloseStatus { get; } = WebSocketCloseStatus.NormalClosure;
+        public override string? CloseStatusDescription { get; } = "Closed";
+        public override string? SubProtocol { get; } = null;
+        public override WebSocketState State => _state;
+
+        public override void Abort()
+        {
+            _state = WebSocketState.Aborted;
+        }
+
+        public override Task CloseAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
+        {
+            CloseCount++;
+            _state = WebSocketState.Closed;
+            return Task.CompletedTask;
+        }
+
+        public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
+        {
+            _state = WebSocketState.CloseSent;
+            return Task.CompletedTask;
+        }
+
+        public override void Dispose() { }
+
+        public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new WebSocketReceiveResult(0, WebSocketMessageType.Text, true));
+        }
+
+        public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+        {
+            SentMessages.Add(Encoding.ASCII.GetString(buffer.Array!, buffer.Offset, buffer.Count));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Exceptionless.Tests/Serializer/Models/InnerErrorSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/InnerErrorSerializerTests.cs
@@ -68,6 +68,9 @@ public class InnerErrorSerializerTests : TestWithServices
         var result = _serializer.Deserialize<InnerError>(json);
 
         // Assert
+        SerializerContractAssertions.IncludesProperties(json, "stack_trace", "target_method");
+        SerializerContractAssertions.ExcludesProperties(json, "StackTrace", "TargetMethod");
+
         Assert.NotNull(result);
         Assert.Equal("Object reference not set to an instance of an object.", result.Message);
         Assert.Equal("System.NullReferenceException", result.Type);

--- a/tests/Exceptionless.Tests/Serializer/Models/InnerErrorSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/InnerErrorSerializerTests.cs
@@ -1,0 +1,119 @@
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Models.Data;
+using Foundatio.Serializer;
+using Xunit;
+
+namespace Exceptionless.Tests.Serializer.Models;
+
+public class InnerErrorSerializerTests : TestWithServices
+{
+    private readonly ITextSerializer _serializer;
+
+    public InnerErrorSerializerTests(ITestOutputHelper output) : base(output)
+    {
+        _serializer = GetService<ITextSerializer>();
+    }
+
+    [Fact]
+    public void Deserialize_SnakeCaseJson_ParsesCorrectly()
+    {
+        // Arrange
+        /* language=json */
+        const string json = """{"message":"File not found","type":"System.IO.FileNotFoundException","code":"IO_404","target_method":{"name":"ReadFile","declaring_type":"FileService","declaring_namespace":"MyApp.IO"},"stack_trace":[{"declaring_namespace":"MyApp.IO","declaring_type":"FileService","name":"ReadFile","line":42}]}""";
+
+        // Act
+        var result = _serializer.Deserialize<InnerError>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("File not found", result.Message);
+        Assert.Equal("System.IO.FileNotFoundException", result.Type);
+        Assert.Equal("IO_404", result.Code);
+        Assert.NotNull(result.TargetMethod);
+        Assert.Equal("ReadFile", result.TargetMethod.Name);
+        Assert.NotNull(result.StackTrace);
+        Assert.Single(result.StackTrace);
+    }
+
+
+
+    [Fact]
+    public void RoundTrip_WithAllProperties_PreservesValues()
+    {
+        // Arrange
+        var error = new InnerError
+        {
+            Message = "Object reference not set to an instance of an object.",
+            Type = "System.NullReferenceException",
+            Code = "NRE001",
+            Data = new DataDictionary { ["help_link"] = "https://docs.example.com/nre" },
+            StackTrace =
+            [
+                new StackFrame
+                {
+                    DeclaringNamespace = "MyApp",
+                    DeclaringType = "Service",
+                    Name = "Process",
+                    Data = new DataDictionary { ["il_offset"] = 42 }
+                }
+            ],
+            TargetMethod = new Method
+            {
+                Name = "Process",
+                DeclaringType = "Service",
+                DeclaringNamespace = "MyApp"
+            }
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(error);
+        var result = _serializer.Deserialize<InnerError>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Object reference not set to an instance of an object.", result.Message);
+        Assert.Equal("System.NullReferenceException", result.Type);
+        Assert.Equal("NRE001", result.Code);
+        Assert.NotNull(result.StackTrace);
+        Assert.Single(result.StackTrace);
+        Assert.Equal("Process", result.StackTrace[0].Name);
+        Assert.NotNull(result.TargetMethod);
+        Assert.Equal("Process", result.TargetMethod.Name);
+    }
+
+    [Fact]
+    public void RoundTrip_WithNestedInnerErrors_PreservesDepth()
+    {
+        // Arrange
+        var error = new InnerError
+        {
+            Message = "Outer error",
+            Type = "System.AggregateException",
+            Inner = new InnerError
+            {
+                Message = "Middle error",
+                Type = "System.InvalidOperationException",
+                Inner = new InnerError
+                {
+                    Message = "Root cause",
+                    Type = "System.ArgumentNullException",
+                    Code = "ARG_NULL"
+                }
+            }
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(error);
+        var result = _serializer.Deserialize<InnerError>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Outer error", result.Message);
+        Assert.NotNull(result.Inner);
+        Assert.Equal("Middle error", result.Inner.Message);
+        Assert.NotNull(result.Inner.Inner);
+        Assert.Equal("Root cause", result.Inner.Inner.Message);
+        Assert.Equal("ARG_NULL", result.Inner.Inner.Code);
+        Assert.Null(result.Inner.Inner.Inner);
+    }
+}

--- a/tests/Exceptionless.Tests/Serializer/Models/InnerErrorSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/InnerErrorSerializerTests.cs
@@ -35,8 +35,6 @@ public class InnerErrorSerializerTests : TestWithServices
         Assert.Single(result.StackTrace);
     }
 
-
-
     [Fact]
     public void RoundTrip_WithAllProperties_PreservesValues()
     {

--- a/tests/Exceptionless.Tests/Serializer/Models/LocationSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/LocationSerializerTests.cs
@@ -1,0 +1,97 @@
+using Exceptionless.Core.Models.Data;
+using Foundatio.Serializer;
+using Xunit;
+
+namespace Exceptionless.Tests.Serializer.Models;
+
+public class LocationSerializerTests : TestWithServices
+{
+    private readonly ITextSerializer _serializer;
+
+    public LocationSerializerTests(ITestOutputHelper output) : base(output)
+    {
+        _serializer = GetService<ITextSerializer>();
+    }
+
+    [Fact]
+    public void Deserialize_SnakeCaseJson_ParsesCorrectly()
+    {
+        // Arrange
+        /* language=json */
+        const string json = """{"country":"Canada","level1":"Ontario","level2":"York Region","locality":"Toronto"}""";
+
+        // Act
+        var result = _serializer.Deserialize<Location>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Canada", result.Country);
+        Assert.Equal("Ontario", result.Level1);
+        Assert.Equal("York Region", result.Level2);
+        Assert.Equal("Toronto", result.Locality);
+    }
+
+    [Fact]
+    public void RoundTrip_WithAllProperties_PreservesValues()
+    {
+        // Arrange
+        var location = new Location
+        {
+            Country = "United States",
+            Level1 = "Texas",
+            Level2 = "Travis County",
+            Locality = "Austin"
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(location);
+        var result = _serializer.Deserialize<Location>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("United States", result.Country);
+        Assert.Equal("Texas", result.Level1);
+        Assert.Equal("Travis County", result.Level2);
+        Assert.Equal("Austin", result.Locality);
+    }
+
+    [Fact]
+    public void RoundTrip_WithPartialData_PreservesValues()
+    {
+        // Arrange
+        var location = new Location { Country = "Germany" };
+
+        // Act
+        string? json = _serializer.SerializeToString(location);
+        var result = _serializer.Deserialize<Location>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Germany", result.Country);
+        Assert.Null(result.Level1);
+        Assert.Null(result.Level2);
+        Assert.Null(result.Locality);
+    }
+
+    [Fact]
+    public void RoundTrip_WithUnicodeNames_PreservesValues()
+    {
+        // Arrange
+        var location = new Location
+        {
+            Country = "日本",
+            Level1 = "東京都",
+            Locality = "渋谷区"
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(location);
+        var result = _serializer.Deserialize<Location>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("日本", result.Country);
+        Assert.Equal("東京都", result.Level1);
+        Assert.Equal("渋谷区", result.Locality);
+    }
+}

--- a/tests/Exceptionless.Tests/Serializer/Models/LocationSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/LocationSerializerTests.cs
@@ -48,6 +48,9 @@ public class LocationSerializerTests : TestWithServices
         var result = _serializer.Deserialize<Location>(json);
 
         // Assert
+        SerializerContractAssertions.IncludesProperties(json, "level1", "level2");
+        SerializerContractAssertions.ExcludesProperties(json, "Level1", "Level2");
+
         Assert.NotNull(result);
         Assert.Equal("United States", result.Country);
         Assert.Equal("Texas", result.Level1);

--- a/tests/Exceptionless.Tests/Serializer/Models/ManualStackingInfoSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/ManualStackingInfoSerializerTests.cs
@@ -51,6 +51,9 @@ public class ManualStackingInfoSerializerTests : TestWithServices
         var result = _serializer.Deserialize<ManualStackingInfo>(json);
 
         // Assert
+        SerializerContractAssertions.IncludesProperties(json, "signature_data");
+        SerializerContractAssertions.ExcludesProperties(json, "SignatureData");
+
         Assert.NotNull(result);
         Assert.Equal("Payment Processing Error", result.Title);
         Assert.NotNull(result.SignatureData);

--- a/tests/Exceptionless.Tests/Serializer/Models/ManualStackingInfoSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/ManualStackingInfoSerializerTests.cs
@@ -1,0 +1,102 @@
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Models.Data;
+using Foundatio.Serializer;
+using Xunit;
+
+namespace Exceptionless.Tests.Serializer.Models;
+
+public class ManualStackingInfoSerializerTests : TestWithServices
+{
+    private readonly ITextSerializer _serializer;
+
+    public ManualStackingInfoSerializerTests(ITestOutputHelper output) : base(output)
+    {
+        _serializer = GetService<ITextSerializer>();
+    }
+
+
+
+    [Fact]
+    public void Deserialize_SnakeCaseJson_ParsesCorrectly()
+    {
+        // Arrange
+        /* language=json */
+        const string json = """{"title":"Custom Stack","signature_data":{"key":"value"}}""";
+
+        // Act
+        var result = _serializer.Deserialize<ManualStackingInfo>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Custom Stack", result.Title);
+        Assert.NotNull(result.SignatureData);
+        Assert.Equal("value", result.SignatureData["key"]);
+    }
+
+    [Fact]
+    public void RoundTrip_WithAllProperties_PreservesValues()
+    {
+        // Arrange
+        var info = new ManualStackingInfo
+        {
+            Title = "Payment Processing Error",
+            SignatureData = new Dictionary<string, string>
+            {
+                ["payment_provider"] = "stripe",
+                ["error_code"] = "card_declined",
+                ["region"] = "US"
+            }
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(info);
+        var result = _serializer.Deserialize<ManualStackingInfo>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Payment Processing Error", result.Title);
+        Assert.NotNull(result.SignatureData);
+        Assert.Equal(3, result.SignatureData.Count);
+        Assert.Equal("stripe", result.SignatureData["payment_provider"]);
+        Assert.Equal("card_declined", result.SignatureData["error_code"]);
+    }
+
+    [Fact]
+    public void RoundTrip_WithMinimalProperties_PreservesValues()
+    {
+        // Arrange
+        var info = new ManualStackingInfo { Title = "Simple Stack" };
+
+        // Act
+        string? json = _serializer.SerializeToString(info);
+        var result = _serializer.Deserialize<ManualStackingInfo>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Simple Stack", result.Title);
+    }
+
+    [Fact]
+    public void RoundTrip_WithSpecialCharacters_PreservesValues()
+    {
+        // Arrange
+        var info = new ManualStackingInfo
+        {
+            Title = "Error: \"Connection refused\" at /api/v2/events",
+            SignatureData = new Dictionary<string, string>
+            {
+                ["path"] = "/api/v2/events?filter=type:error",
+                ["message"] = "Connection refused: host=db.example.com, port=5432"
+            }
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(info);
+        var result = _serializer.Deserialize<ManualStackingInfo>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Contains("Connection refused", result.Title);
+        Assert.Equal("/api/v2/events?filter=type:error", result.SignatureData!["path"]);
+    }
+}

--- a/tests/Exceptionless.Tests/Serializer/Models/ManualStackingInfoSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/ManualStackingInfoSerializerTests.cs
@@ -14,8 +14,6 @@ public class ManualStackingInfoSerializerTests : TestWithServices
         _serializer = GetService<ITextSerializer>();
     }
 
-
-
     [Fact]
     public void Deserialize_SnakeCaseJson_ParsesCorrectly()
     {

--- a/tests/Exceptionless.Tests/Serializer/Models/MethodSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/MethodSerializerTests.cs
@@ -1,0 +1,95 @@
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Models.Data;
+using Foundatio.Serializer;
+using Xunit;
+
+namespace Exceptionless.Tests.Serializer.Models;
+
+public class MethodSerializerTests : TestWithServices
+{
+    private readonly ITextSerializer _serializer;
+
+    public MethodSerializerTests(ITestOutputHelper output) : base(output)
+    {
+        _serializer = GetService<ITextSerializer>();
+    }
+
+    [Fact]
+    public void Deserialize_SnakeCaseJson_ParsesCorrectly()
+    {
+        // Arrange
+        /* language=json */
+        const string json = """{"is_signature_target":true,"declaring_namespace":"System","declaring_type":"String","name":"Format","module_id":1,"generic_arguments":["T"],"parameters":[{"name":"format","type":"String","type_namespace":"System"}]}""";
+
+        // Act
+        var result = _serializer.Deserialize<Method>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.IsSignatureTarget);
+        Assert.Equal("System", result.DeclaringNamespace);
+        Assert.Equal("String", result.DeclaringType);
+        Assert.Equal("Format", result.Name);
+        Assert.Equal(1, result.ModuleId);
+        Assert.Single(result.GenericArguments!);
+        Assert.Single(result.Parameters!);
+    }
+
+
+
+    [Fact]
+    public void RoundTrip_WithAllProperties_PreservesValues()
+    {
+        // Arrange
+        var method = new Method
+        {
+            IsSignatureTarget = true,
+            DeclaringNamespace = "Exceptionless.Core",
+            DeclaringType = "EventProcessor",
+            Name = "ProcessAsync",
+            ModuleId = 42,
+            Data = new DataDictionary { ["il_offset"] = 128 },
+            GenericArguments = ["TEvent", "TResult"],
+            Parameters = [
+                new Parameter { Name = "ev", Type = "PersistentEvent", TypeNamespace = "Exceptionless.Core.Models" },
+                new Parameter { Name = "token", Type = "CancellationToken", TypeNamespace = "System.Threading" }
+            ]
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(method);
+        var result = _serializer.Deserialize<Method>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.IsSignatureTarget);
+        Assert.Equal("Exceptionless.Core", result.DeclaringNamespace);
+        Assert.Equal("EventProcessor", result.DeclaringType);
+        Assert.Equal("ProcessAsync", result.Name);
+        Assert.Equal(42, result.ModuleId);
+        Assert.NotNull(result.GenericArguments);
+        Assert.Equal(2, result.GenericArguments.Count);
+        Assert.Equal("TEvent", result.GenericArguments[0]);
+        Assert.NotNull(result.Parameters);
+        Assert.Equal(2, result.Parameters.Count);
+        Assert.Equal("ev", result.Parameters[0].Name);
+        Assert.Equal("PersistentEvent", result.Parameters[0].Type);
+    }
+
+    [Fact]
+    public void RoundTrip_WithMinimalProperties_PreservesValues()
+    {
+        // Arrange
+        var method = new Method { Name = "Main" };
+
+        // Act
+        string? json = _serializer.SerializeToString(method);
+        var result = _serializer.Deserialize<Method>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Main", result.Name);
+        Assert.Null(result.DeclaringNamespace);
+        Assert.Null(result.IsSignatureTarget);
+    }
+}

--- a/tests/Exceptionless.Tests/Serializer/Models/MethodSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/MethodSerializerTests.cs
@@ -59,6 +59,19 @@ public class MethodSerializerTests : TestWithServices
         var result = _serializer.Deserialize<Method>(json);
 
         // Assert
+        SerializerContractAssertions.IncludesProperties(json,
+            "is_signature_target",
+            "declaring_namespace",
+            "declaring_type",
+            "module_id",
+            "generic_arguments");
+        SerializerContractAssertions.ExcludesProperties(json,
+            "IsSignatureTarget",
+            "DeclaringNamespace",
+            "DeclaringType",
+            "ModuleId",
+            "GenericArguments");
+
         Assert.NotNull(result);
         Assert.True(result.IsSignatureTarget);
         Assert.Equal("Exceptionless.Core", result.DeclaringNamespace);

--- a/tests/Exceptionless.Tests/Serializer/Models/MethodSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/MethodSerializerTests.cs
@@ -35,8 +35,6 @@ public class MethodSerializerTests : TestWithServices
         Assert.Single(result.Parameters!);
     }
 
-
-
     [Fact]
     public void RoundTrip_WithAllProperties_PreservesValues()
     {

--- a/tests/Exceptionless.Tests/Serializer/Models/OrganizationSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/OrganizationSerializerTests.cs
@@ -61,6 +61,35 @@ public class OrganizationSerializerTests : TestWithServices
         var result = _serializer.Deserialize<Organization>(json);
 
         // Assert
+        SerializerContractAssertions.IncludesProperties(json,
+            "stripe_customer_id",
+            "plan_id",
+            "plan_name",
+            "plan_description",
+            "card_last4",
+            "billing_status",
+            "max_events_per_month",
+            "retention_days",
+            "has_premium_features",
+            "max_users",
+            "max_projects",
+            "created_utc",
+            "updated_utc");
+        SerializerContractAssertions.ExcludesProperties(json,
+            "StripeCustomerId",
+            "PlanId",
+            "PlanName",
+            "PlanDescription",
+            "CardLast4",
+            "BillingStatus",
+            "MaxEventsPerMonth",
+            "RetentionDays",
+            "HasPremiumFeatures",
+            "MaxUsers",
+            "MaxProjects",
+            "CreatedUtc",
+            "UpdatedUtc");
+
         Assert.NotNull(result);
         Assert.Equal("550000000000000000000001", result.Id);
         Assert.Equal("Acme Corp", result.Name);
@@ -85,8 +114,8 @@ public class OrganizationSerializerTests : TestWithServices
             PlanId = "EX_FREE",
             PlanName = "Free",
             PlanDescription = "Free plan",
-            CreatedUtc = DateTime.UtcNow,
-            UpdatedUtc = DateTime.UtcNow
+            CreatedUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            UpdatedUtc = new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc)
         };
         organization.Invites.Add(new Invite
         {
@@ -122,8 +151,8 @@ public class OrganizationSerializerTests : TestWithServices
             SuspensionNotes = "Payment failed",
             SuspensionDate = new DateTime(2024, 5, 1, 0, 0, 0, DateTimeKind.Utc),
             SuspendedByUserId = "660000000000000000000001",
-            CreatedUtc = DateTime.UtcNow,
-            UpdatedUtc = DateTime.UtcNow
+            CreatedUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            UpdatedUtc = new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc)
         };
 
         // Act
@@ -131,6 +160,19 @@ public class OrganizationSerializerTests : TestWithServices
         var result = _serializer.Deserialize<Organization>(json);
 
         // Assert
+        SerializerContractAssertions.IncludesProperties(json,
+            "is_suspended",
+            "suspension_code",
+            "suspension_notes",
+            "suspension_date",
+            "suspended_by_user_id");
+        SerializerContractAssertions.ExcludesProperties(json,
+            "IsSuspended",
+            "SuspensionCode",
+            "SuspensionNotes",
+            "SuspensionDate",
+            "SuspendedByUserId");
+
         Assert.NotNull(result);
         Assert.True(result.IsSuspended);
         Assert.Equal(SuspensionCode.Billing, result.SuspensionCode);

--- a/tests/Exceptionless.Tests/Serializer/Models/OrganizationSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/OrganizationSerializerTests.cs
@@ -1,0 +1,140 @@
+using Exceptionless.Core.Billing;
+using Exceptionless.Core.Models;
+using Foundatio.Serializer;
+using Xunit;
+
+namespace Exceptionless.Tests.Serializer.Models;
+
+public class OrganizationSerializerTests : TestWithServices
+{
+    private readonly ITextSerializer _serializer;
+
+    public OrganizationSerializerTests(ITestOutputHelper output) : base(output)
+    {
+        _serializer = GetService<ITextSerializer>();
+    }
+
+    [Fact]
+    public void Deserialize_SnakeCaseJson_ParsesCorrectly()
+    {
+        // Arrange
+        /* language=json */
+        const string json = """{"id":"550000000000000000000004","name":"Acme Industries","plan_id":"EX_SMALL","plan_name":"Small","plan_description":"Small plan","billing_status":1,"max_events_per_month":10000,"retention_days":7,"has_premium_features":false,"max_users":5,"max_projects":10,"created_utc":"2024-01-01T00:00:00Z","updated_utc":"2024-01-01T00:00:00Z"}""";
+
+        // Act
+        var result = _serializer.Deserialize<Organization>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("550000000000000000000004", result.Id);
+        Assert.Equal("Acme Industries", result.Name);
+        Assert.Equal("EX_SMALL", result.PlanId);
+        Assert.Equal(10000, result.MaxEventsPerMonth);
+    }
+
+    [Fact]
+    public void RoundTrip_WithAllCoreProperties_PreservesValues()
+    {
+        // Arrange
+        var organization = new Organization
+        {
+            Id = "550000000000000000000001",
+            Name = "Acme Corp",
+            StripeCustomerId = "cus_abc123",
+            PlanId = "EX_MEDIUM",
+            PlanName = "Medium",
+            PlanDescription = "Medium plan",
+            CardLast4 = "4242",
+            BillingStatus = BillingStatus.Active,
+            BillingPrice = 49.99m,
+            MaxEventsPerMonth = 50000,
+            RetentionDays = 30,
+            HasPremiumFeatures = true,
+            MaxUsers = 10,
+            MaxProjects = 25,
+            CreatedUtc = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc),
+            UpdatedUtc = new DateTime(2024, 6, 1, 8, 30, 0, DateTimeKind.Utc)
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(organization);
+        var result = _serializer.Deserialize<Organization>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("550000000000000000000001", result.Id);
+        Assert.Equal("Acme Corp", result.Name);
+        Assert.Equal("cus_abc123", result.StripeCustomerId);
+        Assert.Equal("EX_MEDIUM", result.PlanId);
+        Assert.Equal(BillingStatus.Active, result.BillingStatus);
+        Assert.Equal(49.99m, result.BillingPrice);
+        Assert.Equal(50000, result.MaxEventsPerMonth);
+        Assert.Equal(30, result.RetentionDays);
+        Assert.True(result.HasPremiumFeatures);
+        Assert.Equal(10, result.MaxUsers);
+    }
+
+    [Fact]
+    public void RoundTrip_WithInvites_PreservesCollection()
+    {
+        // Arrange
+        var organization = new Organization
+        {
+            Id = "550000000000000000000002",
+            Name = "Test Organization",
+            PlanId = "EX_FREE",
+            PlanName = "Free",
+            PlanDescription = "Free plan",
+            CreatedUtc = DateTime.UtcNow,
+            UpdatedUtc = DateTime.UtcNow
+        };
+        organization.Invites.Add(new Invite
+        {
+            Token = "invite-token-123",
+            EmailAddress = "new@example.com",
+            DateAdded = new DateTime(2024, 3, 1, 0, 0, 0, DateTimeKind.Utc)
+        });
+
+        // Act
+        string? json = _serializer.SerializeToString(organization);
+        var result = _serializer.Deserialize<Organization>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Invites);
+        Assert.Equal("invite-token-123", result.Invites.First().Token);
+        Assert.Equal("new@example.com", result.Invites.First().EmailAddress);
+    }
+
+    [Fact]
+    public void RoundTrip_WithSuspension_PreservesValues()
+    {
+        // Arrange
+        var organization = new Organization
+        {
+            Id = "550000000000000000000003",
+            Name = "Suspended Organization",
+            PlanId = "EX_FREE",
+            PlanName = "Free",
+            PlanDescription = "Free plan",
+            IsSuspended = true,
+            SuspensionCode = SuspensionCode.Billing,
+            SuspensionNotes = "Payment failed",
+            SuspensionDate = new DateTime(2024, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+            SuspendedByUserId = "660000000000000000000001",
+            CreatedUtc = DateTime.UtcNow,
+            UpdatedUtc = DateTime.UtcNow
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(organization);
+        var result = _serializer.Deserialize<Organization>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.IsSuspended);
+        Assert.Equal(SuspensionCode.Billing, result.SuspensionCode);
+        Assert.Equal("Payment failed", result.SuspensionNotes);
+        Assert.Equal("660000000000000000000001", result.SuspendedByUserId);
+    }
+}

--- a/tests/Exceptionless.Tests/Serializer/Models/SavedViewSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/SavedViewSerializerTests.cs
@@ -63,6 +63,25 @@ public class SavedViewSerializerTests : TestWithServices
         var result = _serializer.Deserialize<SavedView>(json);
 
         // Assert
+        SerializerContractAssertions.IncludesProperties(json,
+            "organization_id",
+            "user_id",
+            "created_by_user_id",
+            "updated_by_user_id",
+            "filter_definitions",
+            "view_type",
+            "created_utc",
+            "updated_utc");
+        SerializerContractAssertions.ExcludesProperties(json,
+            "OrganizationId",
+            "UserId",
+            "CreatedByUserId",
+            "UpdatedByUserId",
+            "FilterDefinitions",
+            "ViewType",
+            "CreatedUtc",
+            "UpdatedUtc");
+
         Assert.NotNull(result);
         Assert.Equal("770000000000000000000001", result.Id);
         Assert.Equal("550000000000000000000001", result.OrganizationId);
@@ -90,8 +109,8 @@ public class SavedViewSerializerTests : TestWithServices
             CreatedByUserId = "660000000000000000000001",
             Name = "All Events",
             ViewType = "events",
-            CreatedUtc = DateTime.UtcNow,
-            UpdatedUtc = DateTime.UtcNow
+            CreatedUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            UpdatedUtc = new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc)
         };
 
         // Act

--- a/tests/Exceptionless.Tests/Serializer/Models/SavedViewSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/SavedViewSerializerTests.cs
@@ -1,0 +1,109 @@
+using Exceptionless.Core.Models;
+using Foundatio.Serializer;
+using Xunit;
+
+namespace Exceptionless.Tests.Serializer.Models;
+
+public class SavedViewSerializerTests : TestWithServices
+{
+    private readonly ITextSerializer _serializer;
+
+    public SavedViewSerializerTests(ITestOutputHelper output) : base(output)
+    {
+        _serializer = GetService<ITextSerializer>();
+    }
+
+    [Fact]
+    public void Deserialize_SnakeCaseJson_ParsesCorrectly()
+    {
+        // Arrange
+        /* language=json */
+        const string json = """{"id":"770000000000000000000003","organization_id":"550000000000000000000001","created_by_user_id":"660000000000000000000001","is_default":false,"name":"Error Stream","view_type":"stream","version":1,"created_utc":"2024-02-20T14:30:00Z","updated_utc":"2024-02-20T14:30:00Z"}""";
+
+        // Act
+        var result = _serializer.Deserialize<SavedView>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("770000000000000000000003", result.Id);
+        Assert.Equal("Error Stream", result.Name);
+        Assert.Equal("stream", result.ViewType);
+        Assert.Equal("660000000000000000000001", result.CreatedByUserId);
+    }
+
+    [Fact]
+    public void RoundTrip_WithAllProperties_PreservesValues()
+    {
+        // Arrange
+        var view = new SavedView
+        {
+            Id = "770000000000000000000001",
+            OrganizationId = "550000000000000000000001",
+            UserId = "660000000000000000000001",
+            CreatedByUserId = "660000000000000000000001",
+            UpdatedByUserId = "660000000000000000000002",
+            Filter = "(status:open OR status:regressed)",
+            FilterDefinitions = """[{"field":"status","operator":"in","values":["open","regressed"]}]""",
+            Columns = new Dictionary<string, bool>
+            {
+                ["title"] = true,
+                ["date"] = true,
+                ["status"] = false
+            },
+            Name = "Open Issues",
+            Time = "[now-7d TO now]",
+            Version = 1,
+            ViewType = "issues",
+            CreatedUtc = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc),
+            UpdatedUtc = new DateTime(2024, 6, 1, 8, 30, 0, DateTimeKind.Utc)
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(view);
+        var result = _serializer.Deserialize<SavedView>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("770000000000000000000001", result.Id);
+        Assert.Equal("550000000000000000000001", result.OrganizationId);
+        Assert.Equal("660000000000000000000001", result.UserId);
+        Assert.Equal("660000000000000000000001", result.CreatedByUserId);
+        Assert.Equal("660000000000000000000002", result.UpdatedByUserId);
+        Assert.Equal("(status:open OR status:regressed)", result.Filter);
+        Assert.Equal("Open Issues", result.Name);
+        Assert.Equal("[now-7d TO now]", result.Time);
+        Assert.Equal("issues", result.ViewType);
+        Assert.NotNull(result.Columns);
+        Assert.Equal(3, result.Columns.Count);
+        Assert.True(result.Columns["title"]);
+        Assert.False(result.Columns["status"]);
+    }
+
+    [Fact]
+    public void RoundTrip_WithMinimalProperties_PreservesValues()
+    {
+        // Arrange
+        var view = new SavedView
+        {
+            Id = "770000000000000000000002",
+            OrganizationId = "550000000000000000000001",
+            CreatedByUserId = "660000000000000000000001",
+            Name = "All Events",
+            ViewType = "events",
+            CreatedUtc = DateTime.UtcNow,
+            UpdatedUtc = DateTime.UtcNow
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(view);
+        var result = _serializer.Deserialize<SavedView>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("All Events", result.Name);
+        Assert.Equal("events", result.ViewType);
+        Assert.Null(result.UserId);
+        Assert.Null(result.Filter);
+        Assert.Null(result.Time);
+    }
+}

--- a/tests/Exceptionless.Tests/Serializer/Models/SerializerContractAssertions.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/SerializerContractAssertions.cs
@@ -1,0 +1,22 @@
+using Xunit;
+
+namespace Exceptionless.Tests.Serializer.Models;
+
+internal static class SerializerContractAssertions
+{
+    public static void IncludesProperties(string? json, params string[] propertyNames)
+    {
+        Assert.NotNull(json);
+
+        foreach (string propertyName in propertyNames)
+            Assert.Contains($"\"{propertyName}\":", json);
+    }
+
+    public static void ExcludesProperties(string? json, params string[] propertyNames)
+    {
+        Assert.NotNull(json);
+
+        foreach (string propertyName in propertyNames)
+            Assert.DoesNotContain($"\"{propertyName}\"", json);
+    }
+}

--- a/tests/Exceptionless.Tests/Serializer/Models/SubmissionClientSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/SubmissionClientSerializerTests.cs
@@ -1,0 +1,90 @@
+using Exceptionless.Core.Models.Data;
+using Foundatio.Serializer;
+using Xunit;
+
+namespace Exceptionless.Tests.Serializer.Models;
+
+public class SubmissionClientSerializerTests : TestWithServices
+{
+    private readonly ITextSerializer _serializer;
+
+    public SubmissionClientSerializerTests(ITestOutputHelper output) : base(output)
+    {
+        _serializer = GetService<ITextSerializer>();
+    }
+
+    [Fact]
+    public void Deserialize_SnakeCaseJson_ParsesCorrectly()
+    {
+        // Arrange
+        /* language=json */
+        const string json = """{"ip_address":"10.0.0.1","user_agent":"Mozilla/5.0","version":"1.0.0"}""";
+
+        // Act
+        var result = _serializer.Deserialize<SubmissionClient>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("10.0.0.1", result.IpAddress);
+        Assert.Equal("Mozilla/5.0", result.UserAgent);
+        Assert.Equal("1.0.0", result.Version);
+    }
+
+    [Fact]
+    public void RoundTrip_WithAllProperties_PreservesValues()
+    {
+        // Arrange
+        var client = new SubmissionClient
+        {
+            IpAddress = "192.168.1.100",
+            UserAgent = "exceptionless/1.0.0",
+            Version = "2.1.3"
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(client);
+        var result = _serializer.Deserialize<SubmissionClient>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("192.168.1.100", result.IpAddress);
+        Assert.Equal("exceptionless/1.0.0", result.UserAgent);
+        Assert.Equal("2.1.3", result.Version);
+    }
+
+    [Fact]
+    public void RoundTrip_WithIPv6Address_PreservesValues()
+    {
+        // Arrange
+        var client = new SubmissionClient
+        {
+            IpAddress = "::ffff:192.168.1.1",
+            UserAgent = "exceptionless-js/3.0.0",
+            Version = "3.0.0"
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(client);
+        var result = _serializer.Deserialize<SubmissionClient>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("::ffff:192.168.1.1", result.IpAddress);
+    }
+
+    [Fact]
+    public void RoundTrip_WithMinimalProperties_PreservesValues()
+    {
+        // Arrange
+        var client = new SubmissionClient { IpAddress = "127.0.0.1" };
+
+        // Act
+        string? json = _serializer.SerializeToString(client);
+        var result = _serializer.Deserialize<SubmissionClient>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("127.0.0.1", result.IpAddress);
+        Assert.Null(result.UserAgent);
+    }
+}

--- a/tests/Exceptionless.Tests/Serializer/Models/SubmissionClientSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/SubmissionClientSerializerTests.cs
@@ -46,6 +46,9 @@ public class SubmissionClientSerializerTests : TestWithServices
         var result = _serializer.Deserialize<SubmissionClient>(json);
 
         // Assert
+        SerializerContractAssertions.IncludesProperties(json, "ip_address", "user_agent");
+        SerializerContractAssertions.ExcludesProperties(json, "IpAddress", "UserAgent");
+
         Assert.NotNull(result);
         Assert.Equal("192.168.1.100", result.IpAddress);
         Assert.Equal("exceptionless/1.0.0", result.UserAgent);

--- a/tests/Exceptionless.Tests/Serializer/Models/TokenSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/TokenSerializerTests.cs
@@ -1,0 +1,125 @@
+using Exceptionless.Core.Models;
+using Foundatio.Serializer;
+using Xunit;
+
+namespace Exceptionless.Tests.Serializer.Models;
+
+public class TokenSerializerTests : TestWithServices
+{
+    private readonly ITextSerializer _serializer;
+
+    public TokenSerializerTests(ITestOutputHelper output) : base(output)
+    {
+        _serializer = GetService<ITextSerializer>();
+    }
+
+    [Fact]
+    public void Deserialize_SnakeCaseJson_ParsesCorrectly()
+    {
+        // Arrange
+        /* language=json */
+        const string json = """{"id":"650000000000000000000004","organization_id":"550000000000000000000001","project_id":"540000000000000000000001","type":1,"scopes":["client","user"],"notes":"Test token","is_disabled":false,"created_by":"user1","created_utc":"2024-03-15T10:00:00Z","updated_utc":"2024-03-15T10:00:00Z"}""";
+
+        // Act
+        var result = _serializer.Deserialize<Token>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("650000000000000000000004", result.Id);
+        Assert.Equal("550000000000000000000001", result.OrganizationId);
+        Assert.Equal(TokenType.Access, result.Type);
+        Assert.Equal(2, result.Scopes.Count);
+        Assert.Contains("client", result.Scopes);
+        Assert.Contains("user", result.Scopes);
+    }
+
+    [Fact]
+    public void RoundTrip_WithAccessToken_PreservesValues()
+    {
+        // Arrange
+        var token = new Token
+        {
+            Id = "650000000000000000000001",
+            OrganizationId = "550000000000000000000001",
+            ProjectId = "540000000000000000000001",
+            Type = TokenType.Access,
+            Scopes = ["client"],
+            Notes = "Production API key",
+            CreatedBy = "user123",
+            CreatedUtc = new DateTime(2024, 1, 15, 12, 0, 0, DateTimeKind.Utc),
+            UpdatedUtc = new DateTime(2024, 6, 1, 8, 30, 0, DateTimeKind.Utc)
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(token);
+        var result = _serializer.Deserialize<Token>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("650000000000000000000001", result.Id);
+        Assert.Equal("550000000000000000000001", result.OrganizationId);
+        Assert.Equal("540000000000000000000001", result.ProjectId);
+        Assert.Equal(TokenType.Access, result.Type);
+        Assert.Contains("client", result.Scopes);
+        Assert.Equal("Production API key", result.Notes);
+    }
+
+    [Fact]
+    public void RoundTrip_WithDisabledSuspended_PreservesFlags()
+    {
+        // Arrange
+        var token = new Token
+        {
+            Id = "650000000000000000000003",
+            OrganizationId = "550000000000000000000001",
+            ProjectId = "540000000000000000000001",
+            Type = TokenType.Access,
+            IsDisabled = true,
+            IsSuspended = true,
+            CreatedBy = "admin",
+            CreatedUtc = DateTime.UtcNow,
+            UpdatedUtc = DateTime.UtcNow
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(token);
+        var result = _serializer.Deserialize<Token>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.IsDisabled);
+        Assert.True(result.IsSuspended);
+    }
+
+    [Fact]
+    public void RoundTrip_WithUserScopedToken_PreservesValues()
+    {
+        // Arrange
+        var token = new Token
+        {
+            Id = "650000000000000000000002",
+            OrganizationId = "",
+            ProjectId = "",
+            UserId = "660000000000000000000001",
+            DefaultProjectId = "540000000000000000000001",
+            Type = TokenType.Authentication,
+            Refresh = "refresh_token_abc",
+            ExpiresUtc = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            CreatedBy = "system",
+            CreatedUtc = DateTime.UtcNow,
+            UpdatedUtc = DateTime.UtcNow
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(token);
+        var result = _serializer.Deserialize<Token>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("660000000000000000000001", result.UserId);
+        Assert.Equal("540000000000000000000001", result.DefaultProjectId);
+        Assert.Equal(TokenType.Authentication, result.Type);
+        Assert.Equal("refresh_token_abc", result.Refresh);
+        Assert.NotNull(result.ExpiresUtc);
+    }
+}

--- a/tests/Exceptionless.Tests/Serializer/Models/TokenSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/TokenSerializerTests.cs
@@ -55,6 +55,19 @@ public class TokenSerializerTests : TestWithServices
         var result = _serializer.Deserialize<Token>(json);
 
         // Assert
+        SerializerContractAssertions.IncludesProperties(json,
+            "organization_id",
+            "project_id",
+            "created_by",
+            "created_utc",
+            "updated_utc");
+        SerializerContractAssertions.ExcludesProperties(json,
+            "OrganizationId",
+            "ProjectId",
+            "CreatedBy",
+            "CreatedUtc",
+            "UpdatedUtc");
+
         Assert.NotNull(result);
         Assert.Equal("650000000000000000000001", result.Id);
         Assert.Equal("550000000000000000000001", result.OrganizationId);
@@ -77,8 +90,8 @@ public class TokenSerializerTests : TestWithServices
             IsDisabled = true,
             IsSuspended = true,
             CreatedBy = "admin",
-            CreatedUtc = DateTime.UtcNow,
-            UpdatedUtc = DateTime.UtcNow
+            CreatedUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            UpdatedUtc = new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc)
         };
 
         // Act
@@ -86,6 +99,9 @@ public class TokenSerializerTests : TestWithServices
         var result = _serializer.Deserialize<Token>(json);
 
         // Assert
+        SerializerContractAssertions.IncludesProperties(json, "is_disabled", "is_suspended");
+        SerializerContractAssertions.ExcludesProperties(json, "IsDisabled", "IsSuspended");
+
         Assert.NotNull(result);
         Assert.True(result.IsDisabled);
         Assert.True(result.IsSuspended);
@@ -106,8 +122,8 @@ public class TokenSerializerTests : TestWithServices
             Refresh = "refresh_token_abc",
             ExpiresUtc = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             CreatedBy = "system",
-            CreatedUtc = DateTime.UtcNow,
-            UpdatedUtc = DateTime.UtcNow
+            CreatedUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            UpdatedUtc = new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc)
         };
 
         // Act
@@ -115,6 +131,9 @@ public class TokenSerializerTests : TestWithServices
         var result = _serializer.Deserialize<Token>(json);
 
         // Assert
+        SerializerContractAssertions.IncludesProperties(json, "user_id", "default_project_id", "expires_utc");
+        SerializerContractAssertions.ExcludesProperties(json, "UserId", "DefaultProjectId", "ExpiresUtc");
+
         Assert.NotNull(result);
         Assert.Equal("660000000000000000000001", result.UserId);
         Assert.Equal("540000000000000000000001", result.DefaultProjectId);

--- a/tests/Exceptionless.Tests/Serializer/Models/UserDescriptionSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/UserDescriptionSerializerTests.cs
@@ -14,8 +14,6 @@ public class UserDescriptionSerializerTests : TestWithServices
         _serializer = GetService<ITextSerializer>();
     }
 
-
-
     [Fact]
     public void Deserialize_SnakeCaseJson_ParsesCorrectly()
     {

--- a/tests/Exceptionless.Tests/Serializer/Models/UserDescriptionSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/UserDescriptionSerializerTests.cs
@@ -51,6 +51,9 @@ public class UserDescriptionSerializerTests : TestWithServices
         var result = _serializer.Deserialize<UserDescription>(json);
 
         // Assert
+        SerializerContractAssertions.IncludesProperties(json, "email_address");
+        SerializerContractAssertions.ExcludesProperties(json, "EmailAddress");
+
         Assert.NotNull(result);
         Assert.Equal("user@example.com", result.EmailAddress);
         Assert.Equal("The app crashed when I clicked the submit button.", result.Description);

--- a/tests/Exceptionless.Tests/Serializer/Models/UserDescriptionSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/UserDescriptionSerializerTests.cs
@@ -1,0 +1,78 @@
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Models.Data;
+using Foundatio.Serializer;
+using Xunit;
+
+namespace Exceptionless.Tests.Serializer.Models;
+
+public class UserDescriptionSerializerTests : TestWithServices
+{
+    private readonly ITextSerializer _serializer;
+
+    public UserDescriptionSerializerTests(ITestOutputHelper output) : base(output)
+    {
+        _serializer = GetService<ITextSerializer>();
+    }
+
+
+
+    [Fact]
+    public void Deserialize_SnakeCaseJson_ParsesCorrectly()
+    {
+        // Arrange
+        /* language=json */
+        const string json = """{"email_address":"test+tags@example.org","description":"Steps: 1. Open page 2. Click button 3. See error","data":{"screenshot":"base64data"}}""";
+
+        // Act
+        var result = _serializer.Deserialize<UserDescription>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("test+tags@example.org", result.EmailAddress);
+        Assert.Contains("Steps:", result.Description);
+        Assert.NotNull(result.Data);
+    }
+
+    [Fact]
+    public void RoundTrip_WithAllProperties_PreservesValues()
+    {
+        // Arrange
+        var desc = new UserDescription
+        {
+            EmailAddress = "user@example.com",
+            Description = "The app crashed when I clicked the submit button.",
+            Data = new DataDictionary
+            {
+                ["browser"] = "Chrome 120",
+                ["page_url"] = "https://app.example.com/checkout"
+            }
+        };
+
+        // Act
+        string? json = _serializer.SerializeToString(desc);
+        var result = _serializer.Deserialize<UserDescription>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("user@example.com", result.EmailAddress);
+        Assert.Equal("The app crashed when I clicked the submit button.", result.Description);
+        Assert.NotNull(result.Data);
+        Assert.Equal("Chrome 120", result.Data["browser"]);
+    }
+
+    [Fact]
+    public void RoundTrip_WithMinimalProperties_PreservesValues()
+    {
+        // Arrange
+        var desc = new UserDescription { Description = "It broke" };
+
+        // Act
+        string? json = _serializer.SerializeToString(desc);
+        var result = _serializer.Deserialize<UserDescription>(json);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("It broke", result.Description);
+        Assert.Null(result.EmailAddress);
+    }
+}

--- a/tests/Exceptionless.Tests/Services/OrganizationServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/OrganizationServiceTests.cs
@@ -41,7 +41,7 @@ public sealed class OrganizationServiceTests : TestWithServices
         // Arrange
         var stripeClient = Assert.IsType<FakeStripeBillingClient>(GetService<IStripeBillingClient>());
         stripeClient.Subscriptions.Add(new Subscription { Id = "sub_active" });
-        stripeClient.Subscriptions.Add(new Subscription { Id = "sub_canceled", CanceledAt = DateTime.UtcNow });
+        stripeClient.Subscriptions.Add(new Subscription { Id = "sub_canceled", CanceledAt = TimeProvider.GetUtcNow().UtcDateTime });
         var service = GetService<OrganizationService>();
 
         // Act

--- a/tests/Exceptionless.Tests/Services/OrganizationServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/OrganizationServiceTests.cs
@@ -1,0 +1,61 @@
+using Exceptionless.Core;
+using Exceptionless.Core.Billing;
+using Exceptionless.Core.Extensions;
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Services;
+using Exceptionless.Tests.Utility;
+using Microsoft.Extensions.DependencyInjection;
+using Stripe;
+using Xunit;
+
+namespace Exceptionless.Tests.Services;
+
+public sealed class OrganizationServiceTests : TestWithServices
+{
+    public OrganizationServiceTests(ITestOutputHelper output) : base(output) { }
+
+    protected override void RegisterServices(IServiceCollection services, AppOptions options)
+    {
+        base.RegisterServices(services, options);
+        services.ReplaceSingleton<IStripeBillingClient, FakeStripeBillingClient>();
+    }
+
+    [Fact]
+    public async Task CancelSubscriptionsAsync_WithoutStripeCustomer_DoesNotCallStripe()
+    {
+        // Arrange
+        var stripeClient = GetService<IStripeBillingClient>() as FakeStripeBillingClient;
+        Assert.NotNull(stripeClient);
+        var service = GetService<OrganizationService>();
+
+        // Act
+        await service.CancelSubscriptionsAsync(new Organization { Id = "000000000000000000000001", Name = "Test" });
+
+        // Assert
+        Assert.Null(stripeClient.LastSubscriptionListOptions);
+        Assert.Empty(stripeClient.CanceledSubscriptions);
+    }
+
+    [Fact]
+    public async Task CancelSubscriptionsAsync_ActiveSubscriptions_CancelsOnlyActiveSubscriptions()
+    {
+        // Arrange
+        var stripeClient = GetService<IStripeBillingClient>() as FakeStripeBillingClient;
+        Assert.NotNull(stripeClient);
+        stripeClient.Subscriptions.Add(new Subscription { Id = "sub_active" });
+        stripeClient.Subscriptions.Add(new Subscription { Id = "sub_canceled", CanceledAt = DateTime.UtcNow });
+        var service = GetService<OrganizationService>();
+
+        // Act
+        await service.CancelSubscriptionsAsync(new Organization
+        {
+            Id = "000000000000000000000001",
+            Name = "Test",
+            StripeCustomerId = "cus_test"
+        });
+
+        // Assert
+        Assert.Equal("cus_test", stripeClient.LastSubscriptionListOptions?.Customer);
+        Assert.Equal("sub_active", Assert.Single(stripeClient.CanceledSubscriptions).SubscriptionId);
+    }
+}

--- a/tests/Exceptionless.Tests/Services/OrganizationServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/OrganizationServiceTests.cs
@@ -24,8 +24,7 @@ public sealed class OrganizationServiceTests : TestWithServices
     public async Task CancelSubscriptionsAsync_WithoutStripeCustomer_DoesNotCallStripe()
     {
         // Arrange
-        var stripeClient = GetService<IStripeBillingClient>() as FakeStripeBillingClient;
-        Assert.NotNull(stripeClient);
+        var stripeClient = Assert.IsType<FakeStripeBillingClient>(GetService<IStripeBillingClient>());
         var service = GetService<OrganizationService>();
 
         // Act
@@ -40,8 +39,7 @@ public sealed class OrganizationServiceTests : TestWithServices
     public async Task CancelSubscriptionsAsync_ActiveSubscriptions_CancelsOnlyActiveSubscriptions()
     {
         // Arrange
-        var stripeClient = GetService<IStripeBillingClient>() as FakeStripeBillingClient;
-        Assert.NotNull(stripeClient);
+        var stripeClient = Assert.IsType<FakeStripeBillingClient>(GetService<IStripeBillingClient>());
         stripeClient.Subscriptions.Add(new Subscription { Id = "sub_active" });
         stripeClient.Subscriptions.Add(new Subscription { Id = "sub_canceled", CanceledAt = DateTime.UtcNow });
         var service = GetService<OrganizationService>();

--- a/tests/Exceptionless.Tests/Utility/DictionaryExtensionsTests.cs
+++ b/tests/Exceptionless.Tests/Utility/DictionaryExtensionsTests.cs
@@ -50,6 +50,20 @@ public class DictionaryExtensionsTests
     }
 
     [Fact]
+    public void CollectionEquals_NullValueComparedToNonNullValue_ReturnsFalse()
+    {
+        // Arrange
+        var source = new Dictionary<string, string?> { ["a"] = null };
+        var other = new Dictionary<string, string?> { ["a"] = "value" };
+
+        // Act
+        bool result = source.CollectionEquals(other);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
     public void CollectionEquals_SameKeysAndValues_ReturnsTrue()
     {
         // Arrange

--- a/tests/Exceptionless.Tests/Utility/DictionaryExtensionsTests.cs
+++ b/tests/Exceptionless.Tests/Utility/DictionaryExtensionsTests.cs
@@ -1,0 +1,104 @@
+using Exceptionless.Core.Extensions;
+using Xunit;
+
+namespace Exceptionless.Tests.Utility;
+
+public class DictionaryExtensionsTests
+{
+    [Fact]
+    public void AddRange_AddsAllEntries()
+    {
+        // Arrange
+        var target = new Dictionary<string, int> { ["a"] = 1 };
+        var source = new Dictionary<string, int> { ["b"] = 2, ["c"] = 3 };
+
+        // Act
+        target.AddRange(source);
+
+        // Assert
+        Assert.Equal(3, target.Count);
+        Assert.Equal(2, target["b"]);
+        Assert.Equal(3, target["c"]);
+    }
+
+    [Fact]
+    public void AddRange_OverwritesExistingKeys()
+    {
+        // Arrange
+        var target = new Dictionary<string, int> { ["a"] = 1 };
+        var source = new Dictionary<string, int> { ["a"] = 99 };
+
+        // Act
+        target.AddRange(source);
+
+        // Assert
+        Assert.Equal(99, target["a"]);
+    }
+
+    [Fact]
+    public void CollectionEquals_DifferentValues_ReturnsFalse()
+    {
+        // Arrange
+        var source = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        var other = new Dictionary<string, int> { ["a"] = 1, ["b"] = 99 };
+
+        // Act
+        bool result = source.CollectionEquals(other);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void CollectionEquals_SameKeysAndValues_ReturnsTrue()
+    {
+        // Arrange
+        var source = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        var other = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+
+        // Act
+        bool result = source.CollectionEquals(other);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ContainsKeyWithValue_KeyExistsWithMatchingValue_ReturnsTrue()
+    {
+        // Arrange
+        var dictionary = new Dictionary<string, string> { ["key"] = "value" };
+
+        // Act
+        bool result = dictionary.ContainsKeyWithValue("key", "value");
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ContainsKeyWithValue_KeyMissing_ReturnsFalse()
+    {
+        // Arrange
+        var dictionary = new Dictionary<string, string> { ["key"] = "value" };
+
+        // Act
+        bool result = dictionary.ContainsKeyWithValue("missing", "value");
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ContainsKeyWithValue_NoValuesProvided_ReturnsFalse()
+    {
+        // Arrange
+        var dictionary = new Dictionary<string, string> { ["key"] = "value" };
+
+        // Act
+        bool result = dictionary.ContainsKeyWithValue("key");
+
+        // Assert
+        Assert.False(result);
+    }
+}

--- a/tests/Exceptionless.Tests/Utility/DictionaryExtensionsTests.cs
+++ b/tests/Exceptionless.Tests/Utility/DictionaryExtensionsTests.cs
@@ -6,7 +6,7 @@ namespace Exceptionless.Tests.Utility;
 public class DictionaryExtensionsTests
 {
     [Fact]
-    public void AddRange_AddsAllEntries()
+    public void AddRange_WithNewKeys_AddsAllEntries()
     {
         // Arrange
         var target = new Dictionary<string, int> { ["a"] = 1 };
@@ -22,7 +22,7 @@ public class DictionaryExtensionsTests
     }
 
     [Fact]
-    public void AddRange_OverwritesExistingKeys()
+    public void AddRange_WithExistingKey_OverwritesValue()
     {
         // Arrange
         var target = new Dictionary<string, int> { ["a"] = 1 };

--- a/tests/Exceptionless.Tests/Utility/EnumerableExtensionsTests.cs
+++ b/tests/Exceptionless.Tests/Utility/EnumerableExtensionsTests.cs
@@ -48,6 +48,20 @@ public class EnumerableExtensionsTests
     }
 
     [Fact]
+    public void CollectionEquals_NullElementComparedToNonNullElement_ReturnsFalse()
+    {
+        // Arrange
+        string?[] source = [null];
+        string?[] other = ["value"];
+
+        // Act
+        bool result = source.CollectionEquals(other);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
     public void GetCollectionHashCode_SameCollections_ProduceSameHashCode()
     {
         // Arrange

--- a/tests/Exceptionless.Tests/Utility/EnumerableExtensionsTests.cs
+++ b/tests/Exceptionless.Tests/Utility/EnumerableExtensionsTests.cs
@@ -1,0 +1,64 @@
+using Exceptionless.Core.Extensions;
+using Xunit;
+
+namespace Exceptionless.Tests.Utility;
+
+public class EnumerableExtensionsTests
+{
+    [Fact]
+    public void CollectionEquals_DifferentElements_ReturnsFalse()
+    {
+        // Arrange
+        var source = new[] { 1, 2, 3 };
+        var other = new[] { 1, 2, 4 };
+
+        // Act
+        bool result = source.CollectionEquals(other);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void CollectionEquals_DifferentOrder_ReturnsFalse()
+    {
+        // Arrange
+        var source = new[] { 1, 2, 3 };
+        var other = new[] { 3, 2, 1 };
+
+        // Act
+        bool result = source.CollectionEquals(other);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void CollectionEquals_SameElementsSameOrder_ReturnsTrue()
+    {
+        // Arrange
+        var source = new[] { 1, 2, 3 };
+        var other = new[] { 1, 2, 3 };
+
+        // Act
+        bool result = source.CollectionEquals(other);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void GetCollectionHashCode_SameCollections_ProduceSameHashCode()
+    {
+        // Arrange
+        var first = new[] { "a", "b", "c" };
+        var second = new[] { "a", "b", "c" };
+
+        // Act
+        int hash1 = first.GetCollectionHashCode();
+        int hash2 = second.GetCollectionHashCode();
+
+        // Assert
+        Assert.Equal(hash1, hash2);
+    }
+}

--- a/tests/Exceptionless.Tests/Utility/FakeStripeBillingClient.cs
+++ b/tests/Exceptionless.Tests/Utility/FakeStripeBillingClient.cs
@@ -1,0 +1,116 @@
+using Exceptionless.Core.Billing;
+using Stripe;
+
+namespace Exceptionless.Tests.Utility;
+
+public sealed class FakeStripeBillingClient : IStripeBillingClient
+{
+    public Stripe.Invoice? Invoice { get; set; }
+
+    public List<Stripe.Invoice> Invoices { get; } = [];
+
+    public List<Subscription> Subscriptions { get; } = [];
+
+    public Customer CustomerToReturn { get; set; } = new() { Id = "cus_test" };
+
+    public Exception? GetInvoiceException { get; set; }
+
+    public Exception? CreateCustomerException { get; set; }
+
+    public string? LastGetInvoiceId { get; private set; }
+
+    public InvoiceListOptions? LastInvoiceListOptions { get; private set; }
+
+    public SubscriptionListOptions? LastSubscriptionListOptions { get; private set; }
+
+    public CustomerCreateOptions? LastCustomerCreateOptions { get; private set; }
+
+    public List<SubscriptionCreateOptions> CreatedSubscriptionOptions { get; } = [];
+
+    public List<(string CustomerId, CustomerUpdateOptions Options)> UpdatedCustomers { get; } = [];
+
+    public List<(string SubscriptionId, SubscriptionUpdateOptions Options)> UpdatedSubscriptions { get; } = [];
+
+    public List<(string SubscriptionId, SubscriptionCancelOptions Options)> CanceledSubscriptions { get; } = [];
+
+    public List<(string PaymentMethodId, PaymentMethodAttachOptions Options)> AttachedPaymentMethods { get; } = [];
+
+    public void Reset()
+    {
+        Invoice = null;
+        Invoices.Clear();
+        Subscriptions.Clear();
+        CustomerToReturn = new Customer { Id = "cus_test" };
+        GetInvoiceException = null;
+        CreateCustomerException = null;
+        LastGetInvoiceId = null;
+        LastInvoiceListOptions = null;
+        LastSubscriptionListOptions = null;
+        LastCustomerCreateOptions = null;
+        CreatedSubscriptionOptions.Clear();
+        UpdatedCustomers.Clear();
+        UpdatedSubscriptions.Clear();
+        CanceledSubscriptions.Clear();
+        AttachedPaymentMethods.Clear();
+    }
+
+    public Task<Stripe.Invoice?> GetInvoiceAsync(string id)
+    {
+        LastGetInvoiceId = id;
+        if (GetInvoiceException is not null)
+            throw GetInvoiceException;
+
+        return Task.FromResult(Invoice);
+    }
+
+    public Task<IReadOnlyCollection<Stripe.Invoice>> ListInvoicesAsync(InvoiceListOptions options)
+    {
+        LastInvoiceListOptions = options;
+        return Task.FromResult<IReadOnlyCollection<Stripe.Invoice>>(Invoices.ToList());
+    }
+
+    public Task<Customer> CreateCustomerAsync(CustomerCreateOptions options)
+    {
+        LastCustomerCreateOptions = options;
+        if (CreateCustomerException is not null)
+            throw CreateCustomerException;
+
+        return Task.FromResult(CustomerToReturn);
+    }
+
+    public Task<Customer> UpdateCustomerAsync(string customerId, CustomerUpdateOptions options)
+    {
+        UpdatedCustomers.Add((customerId, options));
+        return Task.FromResult(new Customer { Id = customerId });
+    }
+
+    public Task<Subscription> CreateSubscriptionAsync(SubscriptionCreateOptions options)
+    {
+        CreatedSubscriptionOptions.Add(options);
+        return Task.FromResult(new Subscription { Id = "sub_created" });
+    }
+
+    public Task<Subscription> UpdateSubscriptionAsync(string subscriptionId, SubscriptionUpdateOptions options)
+    {
+        UpdatedSubscriptions.Add((subscriptionId, options));
+        return Task.FromResult(new Subscription { Id = subscriptionId });
+    }
+
+    public Task<IReadOnlyCollection<Subscription>> ListSubscriptionsAsync(SubscriptionListOptions options)
+    {
+        LastSubscriptionListOptions = options;
+        return Task.FromResult<IReadOnlyCollection<Subscription>>(Subscriptions.ToList());
+    }
+
+    public Task<Subscription> CancelSubscriptionAsync(string subscriptionId, SubscriptionCancelOptions options)
+    {
+        CanceledSubscriptions.Add((subscriptionId, options));
+        return Task.FromResult(new Subscription { Id = subscriptionId });
+    }
+
+    public Task<PaymentMethod> AttachPaymentMethodAsync(string paymentMethodId, PaymentMethodAttachOptions options)
+    {
+        AttachedPaymentMethods.Add((paymentMethodId, options));
+        return Task.FromResult(new PaymentMethod { Id = paymentMethodId });
+    }
+}

--- a/tests/Exceptionless.Tests/Utility/FakeStripeBillingClient.cs
+++ b/tests/Exceptionless.Tests/Utility/FakeStripeBillingClient.cs
@@ -17,6 +17,18 @@ public sealed class FakeStripeBillingClient : IStripeBillingClient
 
     public Exception? CreateCustomerException { get; set; }
 
+    public Exception? UpdateCustomerException { get; set; }
+
+    public Exception? CreateSubscriptionException { get; set; }
+
+    public Exception? UpdateSubscriptionException { get; set; }
+
+    public Exception? ListSubscriptionsException { get; set; }
+
+    public Exception? CancelSubscriptionException { get; set; }
+
+    public Exception? AttachPaymentMethodException { get; set; }
+
     public string? LastGetInvoiceId { get; private set; }
 
     public InvoiceListOptions? LastInvoiceListOptions { get; private set; }
@@ -43,6 +55,12 @@ public sealed class FakeStripeBillingClient : IStripeBillingClient
         CustomerToReturn = new Customer { Id = "cus_test" };
         GetInvoiceException = null;
         CreateCustomerException = null;
+        UpdateCustomerException = null;
+        CreateSubscriptionException = null;
+        UpdateSubscriptionException = null;
+        ListSubscriptionsException = null;
+        CancelSubscriptionException = null;
+        AttachPaymentMethodException = null;
         LastGetInvoiceId = null;
         LastInvoiceListOptions = null;
         LastSubscriptionListOptions = null;
@@ -81,36 +99,54 @@ public sealed class FakeStripeBillingClient : IStripeBillingClient
     public Task<Customer> UpdateCustomerAsync(string customerId, CustomerUpdateOptions options)
     {
         UpdatedCustomers.Add((customerId, options));
+        if (UpdateCustomerException is not null)
+            throw UpdateCustomerException;
+
         return Task.FromResult(new Customer { Id = customerId });
     }
 
     public Task<Subscription> CreateSubscriptionAsync(SubscriptionCreateOptions options)
     {
         CreatedSubscriptionOptions.Add(options);
+        if (CreateSubscriptionException is not null)
+            throw CreateSubscriptionException;
+
         return Task.FromResult(new Subscription { Id = "sub_created" });
     }
 
     public Task<Subscription> UpdateSubscriptionAsync(string subscriptionId, SubscriptionUpdateOptions options)
     {
         UpdatedSubscriptions.Add((subscriptionId, options));
+        if (UpdateSubscriptionException is not null)
+            throw UpdateSubscriptionException;
+
         return Task.FromResult(new Subscription { Id = subscriptionId });
     }
 
     public Task<IReadOnlyCollection<Subscription>> ListSubscriptionsAsync(SubscriptionListOptions options)
     {
         LastSubscriptionListOptions = options;
+        if (ListSubscriptionsException is not null)
+            throw ListSubscriptionsException;
+
         return Task.FromResult<IReadOnlyCollection<Subscription>>(Subscriptions.ToList());
     }
 
     public Task<Subscription> CancelSubscriptionAsync(string subscriptionId, SubscriptionCancelOptions options)
     {
         CanceledSubscriptions.Add((subscriptionId, options));
+        if (CancelSubscriptionException is not null)
+            throw CancelSubscriptionException;
+
         return Task.FromResult(new Subscription { Id = subscriptionId });
     }
 
     public Task<PaymentMethod> AttachPaymentMethodAsync(string paymentMethodId, PaymentMethodAttachOptions options)
     {
         AttachedPaymentMethods.Add((paymentMethodId, options));
+        if (AttachPaymentMethodException is not null)
+            throw AttachPaymentMethodException;
+
         return Task.FromResult(new PaymentMethod { Id = paymentMethodId });
     }
 }

--- a/tests/Exceptionless.Tests/Utility/Handlers/RecordSessionHeartbeatMiddlewareTests.cs
+++ b/tests/Exceptionless.Tests/Utility/Handlers/RecordSessionHeartbeatMiddlewareTests.cs
@@ -1,0 +1,131 @@
+using System.Security.Claims;
+using Exceptionless.Core;
+using Exceptionless.Core.Extensions;
+using Exceptionless.Core.Models;
+using Exceptionless.Tests.Utility;
+using Exceptionless.Web.Utility;
+using Foundatio.Caching;
+using Xunit;
+
+namespace Exceptionless.Tests.Utility.Handlers;
+
+public sealed class RecordSessionHeartbeatMiddlewareTests : TestWithServices
+{
+    public RecordSessionHeartbeatMiddlewareTests(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public async Task Invoke_NonHeartbeatRouteCallsNext()
+    {
+        // Arrange
+        bool nextCalled = false;
+        var middleware = CreateMiddleware(context =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        var context = CreateContext("/api/v2/events");
+
+        // Act
+        await middleware.Invoke(context);
+
+        // Assert
+        Assert.True(nextCalled);
+    }
+
+    [Fact]
+    public async Task Invoke_HeartbeatWithoutProjectReturnsUnauthorized()
+    {
+        // Arrange
+        bool nextCalled = false;
+        var middleware = CreateMiddleware(context =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        var context = CreateContext("/api/v2/events/session/heartbeat?id=session-1");
+
+        // Act
+        await middleware.Invoke(context);
+
+        // Assert
+        Assert.False(nextCalled);
+        Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Invoke_HeartbeatWithoutIdReturnsOkWithoutRecording()
+    {
+        // Arrange
+        var cache = GetService<ICacheClient>();
+        var middleware = CreateMiddleware(_ => Task.CompletedTask);
+        var context = CreateAuthenticatedContext("/api/v2/events/session/heartbeat");
+
+        // Act
+        await middleware.Invoke(context);
+
+        // Assert
+        string cacheKey = $"Project:{TestConstants.ProjectId}:heartbeat:{"session-1".ToSHA1()}";
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.Equal(default, await cache.GetAsync<DateTime>(cacheKey, default));
+    }
+
+    [Fact]
+    public async Task Invoke_HeartbeatRecordsSessionAndCloseFlag()
+    {
+        // Arrange
+        var utcNow = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+        TimeProvider.SetUtcNow(utcNow);
+
+        var cache = GetService<ICacheClient>();
+        var middleware = CreateMiddleware(_ => Task.CompletedTask);
+        var context = CreateAuthenticatedContext("/api/v2/events/session/heartbeat?id=session-1&close=true");
+
+        // Act
+        await middleware.Invoke(context);
+
+        // Assert
+        string cacheKey = $"Project:{TestConstants.ProjectId}:heartbeat:{"session-1".ToSHA1()}";
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.Equal(utcNow, await cache.GetAsync<DateTime>(cacheKey, default));
+        Assert.True(await cache.GetAsync<bool>($"{cacheKey}-close", false));
+    }
+
+    private RecordSessionHeartbeatMiddleware CreateMiddleware(RequestDelegate next)
+    {
+        return new RecordSessionHeartbeatMiddleware(
+            next,
+            GetService<ICacheClient>(),
+            GetService<AppOptions>(),
+            TimeProvider,
+            GetService<ILogger<ProjectConfigMiddleware>>());
+    }
+
+    private static DefaultHttpContext CreateContext(string pathAndQuery)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethods.Get;
+        string[] parts = pathAndQuery.Split('?', 2);
+        context.Request.Path = parts[0];
+        if (parts.Length == 2)
+            context.Request.QueryString = new QueryString("?" + parts[1]);
+
+        return context;
+    }
+
+    private static DefaultHttpContext CreateAuthenticatedContext(string pathAndQuery)
+    {
+        var context = CreateContext(pathAndQuery);
+        var token = new Token
+        {
+            Id = TestConstants.ApiKey,
+            Type = TokenType.Access,
+            OrganizationId = TestConstants.OrganizationId,
+            ProjectId = TestConstants.ProjectId
+        };
+
+        context.User = new ClaimsPrincipal(token.ToIdentity());
+        return context;
+    }
+}

--- a/tests/Exceptionless.Tests/Utility/Handlers/ThrottlingMiddlewareTests.cs
+++ b/tests/Exceptionless.Tests/Utility/Handlers/ThrottlingMiddlewareTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using Exceptionless.Web.Utility;
+using Exceptionless.Web.Utility.Handlers;
+using Foundatio.Caching;
+using Microsoft.AspNetCore.Http.Features;
+using Xunit;
+
+namespace Exceptionless.Tests.Utility.Handlers;
+
+public sealed class ThrottlingMiddlewareTests : TestWithServices
+{
+    public ThrottlingMiddlewareTests(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public async Task Invoke_AllowsRequestsUnderLimitAndAddsRateLimitHeaders()
+    {
+        // Arrange
+        var cache = GetService<ICacheClient>();
+        bool nextCalled = false;
+        var middleware = CreateMiddleware(context =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        }, cache, maxRequests: 2);
+
+        var context = CreateContext("/api/v2/events");
+        var responseFeature = new CapturingHttpResponseFeature();
+        context.Features.Set<IHttpResponseFeature>(responseFeature);
+
+        // Act
+        await middleware.Invoke(context);
+        await responseFeature.FireOnStartingAsync();
+
+        // Assert
+        Assert.True(nextCalled);
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.Equal("2", context.Response.Headers[Headers.RateLimit]);
+        Assert.Equal("1", context.Response.Headers[Headers.RateLimitRemaining]);
+    }
+
+    [Fact]
+    public async Task Invoke_ReturnsTooManyRequestsWhenLimitExceeded()
+    {
+        // Arrange
+        var cache = GetService<ICacheClient>();
+        int nextCallCount = 0;
+        var middleware = CreateMiddleware(context =>
+        {
+            nextCallCount++;
+            return Task.CompletedTask;
+        }, cache, maxRequests: 1);
+
+        // Act
+        await middleware.Invoke(CreateContext("/api/v2/events"));
+        var secondContext = CreateContext("/api/v2/events");
+        await middleware.Invoke(secondContext);
+
+        // Assert
+        Assert.Equal(1, nextCallCount);
+        Assert.Equal(StatusCodes.Status429TooManyRequests, secondContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Invoke_DoesNotThrottleKnownConfigurationAndHeartbeatRoutes()
+    {
+        // Arrange
+        var cache = GetService<ICacheClient>();
+        int nextCallCount = 0;
+        var middleware = CreateMiddleware(context =>
+        {
+            nextCallCount++;
+            return Task.CompletedTask;
+        }, cache, maxRequests: 0);
+
+        // Act
+        await middleware.Invoke(CreateContext("/api/v2/projects/config"));
+        await middleware.Invoke(CreateContext("/api/v2/events/session/heartbeat"));
+
+        // Assert
+        Assert.Equal(2, nextCallCount);
+    }
+
+    private ThrottlingMiddleware CreateMiddleware(RequestDelegate next, ICacheClient cache, long maxRequests)
+    {
+        return new ThrottlingMiddleware(next, cache, new ThrottlingOptions
+        {
+            MaxRequestsForUserIdentifierFunc = _ => maxRequests,
+            Period = TimeSpan.FromMinutes(1)
+        }, TimeProvider);
+    }
+
+    private static DefaultHttpContext CreateContext(string path)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Method = HttpMethods.Get;
+        context.Request.Path = path;
+        context.Connection.RemoteIpAddress = IPAddress.Parse("203.0.113.10");
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    private sealed class CapturingHttpResponseFeature : IHttpResponseFeature
+    {
+        private readonly List<(Func<object, Task> Callback, object State)> _startingCallbacks = [];
+
+        public int StatusCode { get; set; } = StatusCodes.Status200OK;
+        public string? ReasonPhrase { get; set; }
+        public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+        public Stream Body { get; set; } = new MemoryStream();
+        public bool HasStarted { get; private set; }
+
+        public void OnStarting(Func<object, Task> callback, object state)
+        {
+            _startingCallbacks.Add((callback, state));
+        }
+
+        public void OnCompleted(Func<object, Task> callback, object state)
+        {
+        }
+
+        public async Task FireOnStartingAsync()
+        {
+            HasStarted = true;
+            foreach (var (callback, state) in Enumerable.Reverse(_startingCallbacks))
+                await callback(state);
+        }
+    }
+}

--- a/tests/Exceptionless.Tests/Utility/HashExtensionsTests.cs
+++ b/tests/Exceptionless.Tests/Utility/HashExtensionsTests.cs
@@ -1,0 +1,134 @@
+using Exceptionless.Core.Extensions;
+using Foundatio.Xunit;
+using Xunit;
+
+namespace Exceptionless.Tests.Utility;
+
+public class HashExtensionsTests : TestWithLoggingBase
+{
+    public HashExtensionsTests(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void ToHex_EmptyByteArray_ReturnsEmptyString()
+    {
+        // Arrange
+        byte[] bytes = [];
+
+        // Act
+        string result = bytes.ToHex();
+
+        // Assert
+        Assert.Equal("", result);
+    }
+
+    [Fact]
+    public void ToHex_KnownBytes_ReturnsLowercaseHex()
+    {
+        // Arrange
+        byte[] bytes = [0xDE, 0xAD, 0xBE, 0xEF];
+
+        // Act
+        string result = bytes.ToHex();
+
+        // Assert
+        Assert.Equal("deadbeef", result);
+    }
+
+    [Fact]
+    public void ToHex_LeadingZeroByte_PadsWithZero()
+    {
+        // Arrange
+        byte[] bytes = [0x00, 0xFF, 0x10];
+
+        // Act
+        string result = bytes.ToHex();
+
+        // Assert
+        Assert.Equal("00ff10", result);
+    }
+
+    [Fact]
+    public void ToSHA1_DeterministicOutput_ReturnsSameHashForSameInput()
+    {
+        // Act
+        string hash1 = "hello".ToSHA1();
+        string hash2 = "hello".ToSHA1();
+
+        // Assert
+        Assert.Equal(hash1, hash2);
+    }
+
+    [Fact]
+    public void ToSHA1_DifferentInputs_ReturnsDifferentHashes()
+    {
+        // Act
+        string hash1 = "hello".ToSHA1();
+        string hash2 = "world".ToSHA1();
+
+        // Assert
+        Assert.NotEqual(hash1, hash2);
+    }
+
+    [Fact]
+    public void ToSHA1_KnownInput_ReturnsExpectedHash()
+    {
+        // Act
+        string result = "hello".ToSHA1();
+
+        // Assert (SHA1 of "hello" encoded as UTF-16LE)
+        Assert.Equal("b6d795fbd58cc7592d955a219374339a323801a9", result);
+    }
+
+    [Fact]
+    public void ToSHA1_KnownInputTest_ReturnsExpectedHash()
+    {
+        // Act
+        string result = "test".ToSHA1();
+
+        // Assert (SHA1 of "test" encoded as UTF-16LE)
+        Assert.Equal("87f8ed9157125ffc4da9e06a7b8011ad80a53fe1", result);
+    }
+
+    [Fact]
+    public void ToSHA256_DeterministicOutput_ReturnsSameHashForSameInput()
+    {
+        // Act
+        string hash1 = "hello".ToSHA256();
+        string hash2 = "hello".ToSHA256();
+
+        // Assert
+        Assert.Equal(hash1, hash2);
+    }
+
+    [Fact]
+    public void ToSHA256_KnownInput_ReturnsExpectedHash()
+    {
+        // Act
+        string result = "hello".ToSHA256();
+
+        // Assert (SHA256 of "hello" encoded as UTF-16LE)
+        Assert.Equal("06e44dc1b95c469f43aaccb49e93c36827626266eed5575eced74af9a016c9cd", result);
+    }
+
+    [Fact]
+    public void ToSHA256_KnownInputTest_ReturnsExpectedHash()
+    {
+        // Act
+        string result = "test".ToSHA256();
+
+        // Assert (SHA256 of "test" encoded as UTF-16LE)
+        Assert.Equal("fe520676b1a1d93dabab2319eea03674f3632eaeeb163d1e88244f5eb1de10eb", result);
+    }
+
+    [Fact]
+    public void ToSHA256_ProducesLongerHashThanSHA1()
+    {
+        // Act
+        string sha1 = "hello".ToSHA1();
+        string sha256 = "hello".ToSHA256();
+
+        // Assert (SHA1 = 40 hex chars, SHA256 = 64 hex chars)
+        Assert.Equal(40, sha1.Length);
+        Assert.Equal(64, sha256.Length);
+    }
+}

--- a/tests/Exceptionless.Tests/Utility/JsonExtensionsTests.cs
+++ b/tests/Exceptionless.Tests/Utility/JsonExtensionsTests.cs
@@ -1,0 +1,144 @@
+using Exceptionless.Core.Extensions;
+using Foundatio.Xunit;
+using Xunit;
+
+namespace Exceptionless.Tests.Utility;
+
+public class JsonExtensionsTests : TestWithLoggingBase
+{
+    public JsonExtensionsTests(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void GetJsonType_ArrayString_ReturnsArray()
+    {
+        // Arrange
+        /* language=json */
+        const string json = "[1, 2, 3]";
+
+        // Act
+        JsonType result = json.GetJsonType();
+
+        // Assert
+        Assert.Equal(JsonType.Array, result);
+    }
+
+    [Fact]
+    public void GetJsonType_ArrayWithLeadingWhitespace_ReturnsArray()
+    {
+        // Arrange
+        /* language=json */
+        const string json = "  \t\n[1, 2, 3]";
+
+        // Act
+        JsonType result = json.GetJsonType();
+
+        // Assert
+        Assert.Equal(JsonType.Array, result);
+    }
+
+    [Fact]
+    public void GetJsonType_EmptyString_ReturnsNone()
+    {
+        // Act
+        JsonType result = "".GetJsonType();
+
+        // Assert
+        Assert.Equal(JsonType.None, result);
+    }
+
+    [Fact]
+    public void GetJsonType_NullString_ReturnsNone()
+    {
+        // Act
+        JsonType result = ((string)null!).GetJsonType();
+
+        // Assert
+        Assert.Equal(JsonType.None, result);
+    }
+
+    [Fact]
+    public void GetJsonType_ObjectString_ReturnsObject()
+    {
+        // Arrange
+        /* language=json */
+        const string json = """{"key": "value"}""";
+
+        // Act
+        JsonType result = json.GetJsonType();
+
+        // Assert
+        Assert.Equal(JsonType.Object, result);
+    }
+
+    [Fact]
+    public void GetJsonType_ObjectWithLeadingWhitespace_ReturnsObject()
+    {
+        // Arrange
+        /* language=json */
+        const string json = "  \t\n{\"key\": \"value\"}";
+
+        // Act
+        JsonType result = json.GetJsonType();
+
+        // Assert
+        Assert.Equal(JsonType.Object, result);
+    }
+
+    [Fact]
+    public void GetJsonType_PlainText_ReturnsNone()
+    {
+        // Act
+        JsonType result = "hello world".GetJsonType();
+
+        // Assert
+        Assert.Equal(JsonType.None, result);
+    }
+
+    [Fact]
+    public void IsJson_ArrayString_ReturnsTrue()
+    {
+        // Arrange
+        /* language=json */
+        const string json = "[1, 2, 3]";
+
+        // Act
+        bool result = json.IsJson();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsJson_EmptyString_ReturnsFalse()
+    {
+        // Act
+        bool result = "".IsJson();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsJson_ObjectString_ReturnsTrue()
+    {
+        // Arrange
+        /* language=json */
+        const string json = """{"key": "value"}""";
+
+        // Act
+        bool result = json.IsJson();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsJson_PlainText_ReturnsFalse()
+    {
+        // Act
+        bool result = "not json".IsJson();
+
+        // Assert
+        Assert.False(result);
+    }
+}

--- a/tests/Exceptionless.Tests/Utility/Results/OkPaginatedResultTests.cs
+++ b/tests/Exceptionless.Tests/Utility/Results/OkPaginatedResultTests.cs
@@ -10,7 +10,7 @@ namespace Exceptionless.Tests.Utility.Results;
 public sealed class OkPaginatedResultTests
 {
     [Fact]
-    public void AddPageLinkHeaders_AddsPreviousAndNextLinks()
+    public void AddPageLinkHeaders_WithPreviousAndNextPages_AddsPreviousAndNextLinks()
     {
         // Arrange
         var context = new DefaultHttpContext();
@@ -29,7 +29,7 @@ public sealed class OkPaginatedResultTests
     }
 
     [Fact]
-    public void OnFormatting_AddsPaginationAndTotalHeaders()
+    public void OnFormatting_WithPaginationAndTotal_AddsPaginationAndTotalHeaders()
     {
         // Arrange
         var httpContext = new DefaultHttpContext();

--- a/tests/Exceptionless.Tests/Utility/Results/OkPaginatedResultTests.cs
+++ b/tests/Exceptionless.Tests/Utility/Results/OkPaginatedResultTests.cs
@@ -1,0 +1,64 @@
+using Exceptionless.Web.Utility.Results;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Net.Http.Headers;
+using Xunit;
+
+namespace Exceptionless.Tests.Utility.Results;
+
+public sealed class OkPaginatedResultTests
+{
+    [Fact]
+    public void AddPageLinkHeaders_AddsPreviousAndNextLinks()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/api/v2/events";
+        context.Request.QueryString = new QueryString("?filter=type:error&page=2&limit=10");
+        var result = new OkPaginatedResult(Array.Empty<object>(), hasMore: true, page: 2);
+
+        // Act
+        result.AddPageLinkHeaders(context.Request);
+
+        // Assert
+        string?[] links = result.Headers[HeaderNames.Link].ToArray();
+        Assert.Equal(2, links.Length);
+        Assert.Contains(links, l => l is not null && l.Contains("page=1", StringComparison.Ordinal) && l.Contains("rel=\"previous\"", StringComparison.Ordinal));
+        Assert.Contains(links, l => l is not null && l.Contains("page=3", StringComparison.Ordinal) && l.Contains("rel=\"next\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void OnFormatting_AddsPaginationAndTotalHeaders()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Path = "/api/v2/events";
+        httpContext.Request.QueryString = new QueryString("?page=1");
+
+        var result = new OkPaginatedResult(Array.Empty<object>(), hasMore: true, page: 1, total: 42);
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+
+        // Act
+        result.OnFormatting(actionContext);
+
+        // Assert
+        Assert.Equal("42", httpContext.Response.Headers[Exceptionless.Web.Utility.Headers.ResultCount]);
+        Assert.Contains("page=2", httpContext.Response.Headers[HeaderNames.Link].ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddPageLinkHeaders_NoAdjacentPages_DoesNotAddHeader()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/api/v2/events";
+        var result = new OkPaginatedResult(Array.Empty<object>(), hasMore: false, page: 1);
+
+        // Act
+        result.AddPageLinkHeaders(context.Request);
+
+        // Assert
+        Assert.False(result.Headers.ContainsKey(HeaderNames.Link));
+    }
+}

--- a/tests/Exceptionless.Tests/Utility/SemanticVersionParserTests.cs
+++ b/tests/Exceptionless.Tests/Utility/SemanticVersionParserTests.cs
@@ -4,14 +4,18 @@ using Xunit;
 
 namespace Exceptionless.Tests.Utility;
 
-public class SemanticVersionParserTests
+public class SemanticVersionParserTests : IDisposable
 {
+    private readonly ILoggerFactory _loggerFactory;
     private readonly SemanticVersionParser _parser;
 
     public SemanticVersionParserTests()
     {
-        _parser = new SemanticVersionParser(new LoggerFactory());
+        _loggerFactory = new LoggerFactory();
+        _parser = new SemanticVersionParser(_loggerFactory);
     }
+
+    public void Dispose() => _loggerFactory.Dispose();
 
     [Fact]
     public void Parse_EmptyString_ReturnsNull()

--- a/tests/Exceptionless.Tests/Utility/SemanticVersionParserTests.cs
+++ b/tests/Exceptionless.Tests/Utility/SemanticVersionParserTests.cs
@@ -1,0 +1,115 @@
+using Exceptionless.Core.Utility;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Exceptionless.Tests.Utility;
+
+public class SemanticVersionParserTests
+{
+    private readonly SemanticVersionParser _parser;
+
+    public SemanticVersionParserTests()
+    {
+        _parser = new SemanticVersionParser(new LoggerFactory());
+    }
+
+    [Fact]
+    public void Parse_EmptyString_ReturnsNull()
+    {
+        // Act
+        var result = _parser.Parse("");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Parse_NullString_ReturnsNull()
+    {
+        // Act
+        var result = _parser.Parse(null);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Parse_SingleInteger_ReturnsVersionWithMajorOnly()
+    {
+        // Act
+        var result = _parser.Parse("5");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(5, result.Major);
+        Assert.Equal(0, result.Minor);
+    }
+
+    [Fact]
+    public void Parse_StandardSemVer_ParsesCorrectly()
+    {
+        // Act
+        var result = _parser.Parse("1.2.3");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Major);
+        Assert.Equal(2, result.Minor);
+        Assert.Equal(3, result.Patch);
+    }
+
+    [Fact]
+    public void Parse_TwoPartVersion_ParsesCorrectly()
+    {
+        // Act
+        var result = _parser.Parse("v1.0");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Major);
+        Assert.Equal(0, result.Minor);
+    }
+
+    [Fact]
+    public void Parse_VersionWithPreRelease_ParsesCorrectly()
+    {
+        // Act
+        var result = _parser.Parse("1.2.3-beta");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Major);
+        Assert.Equal(2, result.Minor);
+        Assert.Equal(3, result.Patch);
+    }
+
+    [Fact]
+    public void Parse_VersionWithWildcard_TruncatesAtWildcard()
+    {
+        // Act
+        var result = _parser.Parse("2.1.*");
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Major);
+        Assert.Equal(1, result.Minor);
+    }
+
+    [Fact]
+    public void Parse_WithCache_ReturnsCachedVersion()
+    {
+        // Arrange
+        var cache = new Dictionary<string, McSherry.SemanticVersioning.SemanticVersion>();
+        _parser.Parse("1.2.3", cache);
+
+        // Act
+        var result = _parser.Parse("1.2.3", cache);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Major);
+        Assert.Equal(2, result.Minor);
+        Assert.Equal(3, result.Patch);
+        Assert.Single(cache);
+    }
+}

--- a/tests/Exceptionless.Tests/Utility/StringExtensionsTests.cs
+++ b/tests/Exceptionless.Tests/Utility/StringExtensionsTests.cs
@@ -1,0 +1,451 @@
+using Exceptionless.Core.Extensions;
+using Foundatio.Xunit;
+using Xunit;
+
+namespace Exceptionless.Tests.Utility;
+
+public class StringExtensionsTests : TestWithLoggingBase
+{
+    public StringExtensionsTests(ITestOutputHelper output) : base(output) { }
+
+    [Fact]
+    public void AnyWildcardMatches_EndsWithWildcard_MatchesPrefix()
+    {
+        // Arrange
+        var patterns = new[] { "hello*" };
+
+        // Act
+        bool result = "hello world".AnyWildcardMatches(patterns);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void AnyWildcardMatches_ExactPattern_MatchesExactValue()
+    {
+        // Arrange
+        var patterns = new[] { "hello" };
+
+        // Act
+        bool result = "hello".AnyWildcardMatches(patterns);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void AnyWildcardMatches_ExactPattern_DoesNotMatchDifferentValue()
+    {
+        // Arrange
+        var patterns = new[] { "hello" };
+
+        // Act
+        bool result = "world".AnyWildcardMatches(patterns);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void AnyWildcardMatches_IgnoreCase_MatchesCaseInsensitive()
+    {
+        // Arrange
+        var patterns = new[] { "HELLO*" };
+
+        // Act
+        bool result = "hello world".AnyWildcardMatches(patterns, ignoreCase: true);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void AnyWildcardMatches_MultiplePatterns_MatchesAny()
+    {
+        // Arrange
+        var patterns = new[] { "foo*", "bar*" };
+
+        // Act
+        bool result = "bar baz".AnyWildcardMatches(patterns);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void AnyWildcardMatches_StartsWithWildcard_MatchesSuffix()
+    {
+        // Arrange
+        var patterns = new[] { "*world" };
+
+        // Act
+        bool result = "hello world".AnyWildcardMatches(patterns);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void AnyWildcardMatches_SurroundingWildcards_MatchesContains()
+    {
+        // Arrange
+        var patterns = new[] { "*llo wor*" };
+
+        // Act
+        bool result = "hello world".AnyWildcardMatches(patterns);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsLocalHost_Ipv4Loopback_ReturnsTrue()
+    {
+        // Act
+        bool result = "127.0.0.1".IsLocalHost();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsLocalHost_Ipv6Loopback_ReturnsTrue()
+    {
+        // Act
+        bool result = "::1".IsLocalHost();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsLocalHost_NullInput_ReturnsFalse()
+    {
+        // Act
+        bool result = ((string?)null).IsLocalHost();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsLocalHost_EmptyString_ReturnsFalse()
+    {
+        // Act
+        bool result = "".IsLocalHost();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsLocalHost_PublicIp_ReturnsFalse()
+    {
+        // Act
+        bool result = "8.8.8.8".IsLocalHost();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsNumeric_EmptyString_ReturnsFalse()
+    {
+        // Act
+        bool result = "".IsNumeric();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsNumeric_NegativeNumber_ReturnsTrue()
+    {
+        // Act
+        bool result = "-42".IsNumeric();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsNumeric_NullInput_ReturnsFalse()
+    {
+        // Act
+        bool result = ((string?)null).IsNumeric();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsNumeric_PositiveNumber_ReturnsTrue()
+    {
+        // Act
+        bool result = "12345".IsNumeric();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsNumeric_StringWithLetters_ReturnsFalse()
+    {
+        // Act
+        bool result = "123abc".IsNumeric();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsNumeric_StringWithDecimalPoint_ReturnsFalse()
+    {
+        // Act
+        bool result = "3.14".IsNumeric();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsPrivateNetwork_ClassAAddress_ReturnsTrue()
+    {
+        // Act
+        bool result = "10.0.0.1".IsPrivateNetwork();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsPrivateNetwork_ClassBAddress_ReturnsTrue()
+    {
+        // Act
+        bool result = "172.16.0.1".IsPrivateNetwork();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsPrivateNetwork_ClassBUpperBound_ReturnsTrue()
+    {
+        // Act
+        bool result = "172.31.255.255".IsPrivateNetwork();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsPrivateNetwork_ClassBOutOfRange_ReturnsFalse()
+    {
+        // Act
+        bool result = "172.32.0.1".IsPrivateNetwork();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsPrivateNetwork_ClassCAddress_ReturnsTrue()
+    {
+        // Act
+        bool result = "192.168.1.1".IsPrivateNetwork();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsPrivateNetwork_EmptyString_ReturnsFalse()
+    {
+        // Act
+        bool result = "".IsPrivateNetwork();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsPrivateNetwork_Localhost_ReturnsTrue()
+    {
+        // Act
+        bool result = "127.0.0.1".IsPrivateNetwork();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsPrivateNetwork_NullInput_ReturnsFalse()
+    {
+        // Act
+        bool result = ((string?)null).IsPrivateNetwork();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsPrivateNetwork_PublicIp_ReturnsFalse()
+    {
+        // Act
+        bool result = "8.8.8.8".IsPrivateNetwork();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsValidFieldName_NullInput_ReturnsFalse()
+    {
+        // Act
+        bool result = ((string?)null).IsValidFieldName();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsValidFieldName_Over25Characters_ReturnsFalse()
+    {
+        // Act
+        bool result = "abcdefghijklmnopqrstuvwxyz".IsValidFieldName();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsValidFieldName_ValidShortName_ReturnsTrue()
+    {
+        // Act
+        bool result = "my-field".IsValidFieldName();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsValidFieldName_WithSpecialChars_ReturnsFalse()
+    {
+        // Act
+        bool result = "my_field".IsValidFieldName();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsValidIdentifier_AlphanumericWithDash_ReturnsTrue()
+    {
+        // Act
+        bool result = "my-identifier-123".IsValidIdentifier();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsValidIdentifier_EmptyString_ReturnsTrue()
+    {
+        // Act
+        bool result = "".IsValidIdentifier();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsValidIdentifier_NullInput_ReturnsFalse()
+    {
+        // Act
+        bool result = ((string?)null).IsValidIdentifier();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsValidIdentifier_WithUnderscore_ReturnsFalse()
+    {
+        // Act
+        bool result = "has_underscore".IsValidIdentifier();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsValidIdentifier_WithSpaces_ReturnsFalse()
+    {
+        // Act
+        bool result = "has spaces".IsValidIdentifier();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ToAddress_EmptyString_ReturnsEmpty()
+    {
+        // Act
+        string result = "".ToAddress();
+
+        // Assert
+        Assert.Equal("", result);
+    }
+
+    [Fact]
+    public void ToAddress_Ipv4WithPort_StripsPort()
+    {
+        // Act
+        string result = "1.2.3.4:80".ToAddress();
+
+        // Assert
+        Assert.Equal("1.2.3.4", result);
+    }
+
+    [Fact]
+    public void ToAddress_Ipv4WithoutPort_ReturnsUnchanged()
+    {
+        // Act
+        string result = "1.2.3.4".ToAddress();
+
+        // Assert
+        Assert.Equal("1.2.3.4", result);
+    }
+
+    [Fact]
+    public void ToAddress_Ipv6Full_ReturnsUnchanged()
+    {
+        // Act
+        string result = "1:2:3:4:5:6:7:8".ToAddress();
+
+        // Assert
+        Assert.Equal("1:2:3:4:5:6:7:8", result);
+    }
+
+    [Fact]
+    public void ToAddress_Ipv6Loopback_ReturnsUnchanged()
+    {
+        // Act
+        string result = "::1".ToAddress();
+
+        // Assert
+        Assert.Equal("::1", result);
+    }
+
+    [Fact]
+    public void ToAddress_Ipv6WithPort_StripsPort()
+    {
+        // Act
+        string result = "1:2:3:4:5:6:7:8:80".ToAddress();
+
+        // Assert
+        Assert.Equal("1:2:3:4:5:6:7:8", result);
+    }
+}


### PR DESCRIPTION
## Summary

Adds broad API controller coverage, ports serializer model contract tests from `feature/system-text-json-v2`, and includes the small production seams/fixes needed to make those API and billing paths testable.

## Controller Tests Added

| Controller | Tests Added | Coverage |
|---|---|---|
| UserController | 22 new tests | All 12 endpoints covered |
| UtilityController | 5 new tests | ValidateAsync endpoint fully covered |
| StripeController | 3 new tests | Webhook error paths |
| StackController | ~20 new tests | ChangeStatus, Delete, GetAll, GetAsync, GetByOrganization, GetByProject, MarkCritical, MarkNotCritical, RemoveLink, Snooze |
| StatusController | ~9 new tests | GetAbout, GetQueueStats, SystemNotification CRUD |
| OrganizationController | Billing plan-change and Stripe failure-path coverage |
| TokenController | Token creation, ownership, validation, default-token, update, and delete coverage |

## Serializer Model Tests Ported

Ported from `feature/system-text-json-v2` with roundtrip, snake_case deserialization, and explicit wire-name assertions:
- TokenSerializerTests
- OrganizationSerializerTests
- LocationSerializerTests
- MethodSerializerTests
- InnerErrorSerializerTests
- ManualStackingInfoSerializerTests
- SubmissionClientSerializerTests
- UserDescriptionSerializerTests
- SavedViewSerializerTests

## Production Changes

- Restores `NewToken` to the project-owned contract: `ProjectId` is required and `NewToken` implements `IOwnedByOrganizationAndProject` directly.
- Updates the OpenAPI baseline so `NewToken.project_id` is required and `ViewToken.project_id` remains required.
- Adds `IStripeBillingClient` / `StripeBillingClient` so controller and service billing flows can be tested without hitting Stripe.
- Reuses a single lazy Stripe client inside `StripeBillingClient` instead of recreating the client for each operation.
- Seeds `SubscribeDate` for existing-customer paid-plan changes when it was previously null or `DateTime.MinValue`.
- Fixes collection equality null-comparison semantics in dictionary/enumerable helpers.

## Conventions

- Tests use 3-part naming: `MethodUnderTest_Scenario_ExpectedBehavior`.
- Arrange/Act/Assert pattern throughout.
- Request assertions use the shared status-code helpers when available.
