### PR TITLE
Add predefined saved views

### DIFF
--- a/src/Exceptionless.AppHost/Exceptionless.AppHost.csproj
+++ b/src/Exceptionless.AppHost/Exceptionless.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.3.4">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.5">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,10 +8,10 @@
     <NoWarn>$(NoWarn);ASPIRECERTIFICATES001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.3.4" />
-    <PackageReference Include="Aspire.Hosting.Browsers" Version="13.3.4-preview.1.26268.8" />
-    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.3.4" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.3.4" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.3.5" />
+    <PackageReference Include="Aspire.Hosting.Browsers" Version="13.3.5-preview.1.26270.6" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.3.5" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.3.5" />
     <PackageReference Include="AspNetCore.HealthChecks.Elasticsearch" Version="9.0.0" />
   </ItemGroup>
 

--- a/src/Exceptionless.Core/Bootstrapper.cs
+++ b/src/Exceptionless.Core/Bootstrapper.cs
@@ -20,6 +20,7 @@ using Exceptionless.Core.Queries.Validation;
 using Exceptionless.Core.Queues.Models;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Repositories.Configuration;
+using Exceptionless.Core.Seed;
 using Exceptionless.Core.Serialization;
 using Exceptionless.Core.Services;
 using Exceptionless.Core.Utility;
@@ -93,6 +94,10 @@ public class Bootstrapper
         services.AddSingleton<Nest.IElasticClient>(s => s.GetRequiredService<ExceptionlessElasticConfiguration>().Client);
         services.AddSingleton<IElasticConfiguration>(s => s.GetRequiredService<ExceptionlessElasticConfiguration>());
         services.AddStartupAction<ExceptionlessElasticConfiguration>();
+
+        services.AddSingleton<DataSeedService>();
+        services.AddSingleton<IDataSeed, PredefinedSavedViewsDataSeed>();
+        services.AddStartupAction<DataSeedService>();
 
         services.AddStartupAction("Create Sample Data", CreateSampleDataAsync);
 

--- a/src/Exceptionless.Core/Exceptionless.Core.csproj
+++ b/src/Exceptionless.Core/Exceptionless.Core.csproj
@@ -20,6 +20,9 @@
     <EmbeddedResource Include="Mail\Templates\user-password-reset.html" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="Seed\predefined-saved-views.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Exceptionless.DateTimeExtensions" Version="6.0.1" />
     <PackageReference Include="Exceptionless.RandomData" Version="2.0.1" />
     <PackageReference Include="Foundatio.Extensions.Hosting" Version="13.0.1" />

--- a/src/Exceptionless.Core/Models/SavedView.cs
+++ b/src/Exceptionless.Core/Models/SavedView.cs
@@ -55,6 +55,10 @@ public record SavedView : IOwnedByOrganizationWithIdentity, IHaveDates
     /// <summary>Whether the dashboard chart is shown for this view. Null means use the default.</summary>
     public bool? ShowChart { get; set; }
 
+    /// <summary>Stable identifier used to synchronize predefined saved views across organizations.</summary>
+    [MaxLength(150)]
+    public string? PredefinedKey { get; set; }
+
     /// <summary>Display name shown in the sidebar and picker.</summary>
     [Required]
     [MaxLength(100)]

--- a/src/Exceptionless.Core/Seed/DataSeedService.cs
+++ b/src/Exceptionless.Core/Seed/DataSeedService.cs
@@ -1,0 +1,32 @@
+using Foundatio.Extensions.Hosting.Startup;
+using Microsoft.Extensions.Logging;
+
+namespace Exceptionless.Core.Seed;
+
+public class DataSeedService : IStartupAction
+{
+    private readonly IEnumerable<IDataSeed> _seeds;
+    private readonly ILogger _logger;
+
+    public DataSeedService(IEnumerable<IDataSeed> seeds, ILoggerFactory loggerFactory)
+    {
+        _seeds = seeds;
+        _logger = loggerFactory.CreateLogger<DataSeedService>();
+    }
+
+    public Task RunAsync(CancellationToken shutdownToken = default)
+    {
+        return SeedAsync(shutdownToken);
+    }
+
+    public async Task SeedAsync(CancellationToken cancellationToken = default)
+    {
+        foreach (var seed in _seeds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            _logger.LogInformation("Running data seed {DataSeedName}", seed.Name);
+            await seed.SeedAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Exceptionless.Core/Seed/IDataSeed.cs
+++ b/src/Exceptionless.Core/Seed/IDataSeed.cs
@@ -1,0 +1,8 @@
+namespace Exceptionless.Core.Seed;
+
+public interface IDataSeed
+{
+    string Name { get; }
+
+    Task SeedAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Exceptionless.Core/Seed/PredefinedSavedViewsDataSeed.cs
+++ b/src/Exceptionless.Core/Seed/PredefinedSavedViewsDataSeed.cs
@@ -59,7 +59,8 @@ public class PredefinedSavedViewsDataSeed : IDataSeed
 
     private static string GetSeedFilePath()
     {
-        return Path.Combine(AppContext.BaseDirectory, "Seed", SeedFileName);
+        var seedFileName = Path.GetFileName(SeedFileName);
+        return Path.Combine(AppContext.BaseDirectory, "Seed", seedFileName);
     }
 
     private static SavedView CreateSavedView(PredefinedSavedViewDefinition definition)

--- a/src/Exceptionless.Core/Seed/PredefinedSavedViewsDataSeed.cs
+++ b/src/Exceptionless.Core/Seed/PredefinedSavedViewsDataSeed.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Repositories;
+using Foundatio.Lock;
+using Foundatio.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace Exceptionless.Core.Seed;
+
+public class PredefinedSavedViewsDataSeed : IDataSeed
+{
+    public const string SystemOrganizationId = "000000000000000000000001";
+    public const string SystemUserId = "000000000000000000000001";
+    public const string SeedFileName = "predefined-saved-views.json";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        AllowTrailingCommas = true,
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip
+    };
+
+    private readonly ISavedViewRepository _savedViewRepository;
+    private readonly ILockProvider _lockProvider;
+    private readonly ILogger _logger;
+
+    public PredefinedSavedViewsDataSeed(ISavedViewRepository savedViewRepository, ILockProvider lockProvider, ILoggerFactory loggerFactory)
+    {
+        _savedViewRepository = savedViewRepository;
+        _lockProvider = lockProvider;
+        _logger = loggerFactory.CreateLogger<PredefinedSavedViewsDataSeed>();
+    }
+
+    public string Name => "Predefined Saved Views";
+
+    public Task SeedAsync(CancellationToken cancellationToken = default)
+    {
+        return _lockProvider.TryUsingAsync("data-seed:predefined-saved-views", async () =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (await _savedViewRepository.CountByOrganizationIdAsync(SystemOrganizationId) > 0)
+                return;
+
+            var definitions = await ReadDefaultSavedViewsAsync(cancellationToken);
+            var savedViews = definitions.Select(CreateSavedView).ToList();
+            await _savedViewRepository.AddAsync(savedViews, o => o.Cache().ImmediateConsistency());
+            _logger.LogInformation("Seeded {Count} predefined saved views", savedViews.Count);
+        }, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(15));
+    }
+
+    public static async Task<IReadOnlyCollection<PredefinedSavedViewDefinition>> ReadDefaultSavedViewsAsync(CancellationToken cancellationToken = default)
+    {
+        await using var stream = File.OpenRead(GetSeedFilePath());
+        var definitions = await JsonSerializer.DeserializeAsync<List<PredefinedSavedViewDefinition>>(stream, JsonOptions, cancellationToken);
+        return definitions ?? [];
+    }
+
+    private static string GetSeedFilePath()
+    {
+        return Path.Combine(AppContext.BaseDirectory, "Seed", SeedFileName);
+    }
+
+    private static SavedView CreateSavedView(PredefinedSavedViewDefinition definition)
+    {
+        return new SavedView
+        {
+            OrganizationId = SystemOrganizationId,
+            CreatedByUserId = SystemUserId,
+            PredefinedKey = definition.Key,
+            Name = definition.Name,
+            Slug = definition.Slug,
+            ViewType = definition.ViewType,
+            Filter = definition.Filter,
+            Time = definition.Time,
+            Sort = definition.Sort,
+            FilterDefinitions = GetRawJson(definition.FilterDefinitions),
+            Columns = definition.Columns?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value),
+            ColumnOrder = definition.ColumnOrder is null ? null : [.. definition.ColumnOrder],
+            ShowStats = definition.ShowStats,
+            ShowChart = definition.ShowChart,
+            Version = 1
+        };
+    }
+
+    public static string? GetRawJson(JsonElement? value)
+    {
+        if (value is not { } element || element.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+            return null;
+
+        return element.GetRawText();
+    }
+}
+
+public sealed record PredefinedSavedViewDefinition
+{
+    [JsonPropertyName("key")]
+    public required string Key { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("slug")]
+    public required string Slug { get; init; }
+
+    [JsonPropertyName("viewType")]
+    public required string ViewType { get; init; }
+
+    [JsonPropertyName("filter")]
+    public string? Filter { get; init; }
+
+    [JsonPropertyName("time")]
+    public string? Time { get; init; }
+
+    [JsonPropertyName("sort")]
+    public string? Sort { get; init; }
+
+    [JsonPropertyName("filterDefinitions")]
+    public JsonElement? FilterDefinitions { get; init; }
+
+    [JsonPropertyName("columns")]
+    public IReadOnlyDictionary<string, bool>? Columns { get; init; }
+
+    [JsonPropertyName("columnOrder")]
+    public IReadOnlyCollection<string>? ColumnOrder { get; init; }
+
+    [JsonPropertyName("showStats")]
+    public bool? ShowStats { get; init; }
+
+    [JsonPropertyName("showChart")]
+    public bool? ShowChart { get; init; }
+}

--- a/src/Exceptionless.Core/Seed/predefined-saved-views.json
+++ b/src/Exceptionless.Core/Seed/predefined-saved-views.json
@@ -1,0 +1,141 @@
+[
+    {
+        "key": "events:errors",
+        "name": "Errors",
+        "slug": "errors",
+        "viewType": "events",
+        "filter": "type:error",
+        "time": "[now-7d TO now]",
+        "sort": "-date",
+        "filterDefinitions": [
+            {
+                "type": "date",
+                "term": "date",
+                "value": "[now-7d TO now]"
+            },
+            {
+                "type": "type",
+                "value": ["error"],
+                "hidden": true
+            }
+        ],
+        "columns": {
+            "level": false,
+            "message": false,
+            "name": false,
+            "source": false,
+            "type": false
+        },
+        "showStats": true,
+        "showChart": true
+    },
+    {
+        "key": "events:logs",
+        "name": "Logs",
+        "slug": "logs",
+        "viewType": "events",
+        "filter": "type:log",
+        "time": "[now-7d TO now]",
+        "sort": "-date",
+        "filterDefinitions": [
+            {
+                "type": "date",
+                "term": "date",
+                "value": "[now-7d TO now]"
+            },
+            {
+                "type": "type",
+                "value": ["log"],
+                "hidden": true
+            }
+        ],
+        "columns": {
+            "level": false,
+            "message": false,
+            "name": false,
+            "source": false,
+            "type": false
+        },
+        "showStats": true,
+        "showChart": true
+    },
+    {
+        "key": "issues:most-frequent-404s",
+        "name": "Most Frequent 404s",
+        "slug": "most-frequent-404s",
+        "viewType": "issues",
+        "filter": "(status:open OR status:regressed) type:404",
+        "time": "[now-7d TO now]",
+        "sort": "-events",
+        "filterDefinitions": [
+            {
+                "type": "date",
+                "term": "date",
+                "value": "[now-7d TO now]"
+            },
+            {
+                "type": "status",
+                "value": ["open", "regressed"],
+                "hidden": true
+            },
+            {
+                "type": "type",
+                "value": ["404"],
+                "hidden": true
+            }
+        ],
+        "showStats": true,
+        "showChart": true
+    },
+    {
+        "key": "issues:most-frequent-errors",
+        "name": "Most Frequent Errors",
+        "slug": "most-frequent-errors",
+        "viewType": "issues",
+        "filter": "type:error (status:open OR status:regressed)",
+        "time": "[now-7d TO now]",
+        "sort": "-events",
+        "filterDefinitions": [
+            {
+                "type": "date",
+                "term": "date",
+                "value": "[now-7d TO now]"
+            },
+            {
+                "type": "type",
+                "value": ["error"],
+                "hidden": true
+            },
+            {
+                "type": "status",
+                "value": ["open", "regressed"],
+                "hidden": true
+            }
+        ],
+        "showStats": true,
+        "showChart": true
+    },
+    {
+        "key": "issues:most-used-features",
+        "name": "Most Used Features",
+        "slug": "most-used-features",
+        "viewType": "issues",
+        "filter": "type:usage",
+        "time": "[now-7d TO now]",
+        "sort": "-events",
+        "filterDefinitions": [
+            {
+                "type": "date",
+                "term": "date",
+                "value": "[now-7d TO now]"
+            },
+            {
+                "type": "type",
+                "value": ["usage"],
+                "hidden": true
+            }
+        ],
+        "showStats": true,
+        "showChart": true
+    }
+]

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
@@ -1,7 +1,7 @@
 import { type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
 import { createMutation, createQuery } from '@tanstack/svelte-query';
 
-import type { AdminStats, ElasticsearchInfo, ElasticsearchSnapshotsResponse, MigrationsResponse } from './models';
+import type { AdminStats, ElasticsearchInfo, ElasticsearchSnapshotsResponse, MigrationsResponse, PredefinedSavedViewDefinition } from './models';
 
 export type RunMaintenanceJobParams = {
     name: string;
@@ -74,6 +74,17 @@ export function getMigrationsQuery() {
         },
         queryKey: queryKeys.migrations,
         staleTime: 30 * 1000
+    }));
+}
+
+export function getPredefinedSavedViewsMutation() {
+    return createMutation<string, ProblemDetails, void>(() => ({
+        mutationFn: async () => {
+            const client = useFetchClient();
+            const response = await client.getJSON<PredefinedSavedViewDefinition[]>('saved-views/predefined');
+
+            return JSON.stringify(response.data ?? [], null, 2);
+        }
     }));
 }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/models.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/models.ts
@@ -72,11 +72,13 @@ export type MaintenanceAction = {
     description: string;
     hasDateRange?: boolean;
     hasOrganizationId?: boolean;
+    kind?: MaintenanceActionKind;
     label: string;
     name: string;
 };
 
 export type MaintenanceActionCategory = 'Billing' | 'Configuration' | 'Elasticsearch' | 'Maintenance' | 'Security' | 'Users';
+export type MaintenanceActionKind = 'maintenance-job' | 'predefined-saved-views';
 export type MigrationsResponse = {
     current_version: number;
     states: MigrationState[];
@@ -92,6 +94,21 @@ export type MigrationState = {
 };
 
 export type MigrationStatus = 'Completed' | 'Failed' | 'Pending' | 'Running';
+
+export type PredefinedSavedViewDefinition = {
+    columnOrder?: null | string[];
+    columns?: null | Record<string, boolean>;
+    filter?: null | string;
+    filterDefinitions?: unknown;
+    key: string;
+    name: string;
+    showChart?: boolean | null;
+    showStats?: boolean | null;
+    slug: string;
+    sort?: null | string;
+    time?: null | string;
+    viewType: string;
+};
 
 export type ShardMetric = {
     id: string;
@@ -131,6 +148,15 @@ export const maintenanceActions: MaintenanceAction[] = [
             'Re-stamps the latest system-default user-agent bot-filter patterns onto every project and bumps the configuration version, forcing all Exceptionless clients to refresh their local settings on the next request.',
         label: 'Update Project Default Bot Lists',
         name: 'update-project-default-bot-lists'
+    },
+    {
+        category: 'Configuration',
+        dangerous: false,
+        description:
+            'Loads the current global predefined saved views from the API and displays the seed JSON for review or copying into the bundled predefined saved views file.',
+        kind: 'predefined-saved-views',
+        label: 'View Predefined Saved Views',
+        name: 'predefined-saved-views'
     },
     {
         category: 'Configuration',

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/organization-notifications.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/organization-notifications.svelte
@@ -6,6 +6,9 @@
     import { SuspensionCode } from '$features/organizations/models';
     import { getOrganizationProjectsQuery } from '$features/projects/api.svelte';
     import { getMeQuery } from '$features/users/api.svelte';
+    import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
+    import { useEventListener } from 'runed';
+    import { debounce } from 'throttle-debounce';
 
     import FreePlanNotification from './notifications/free-plan-notification.svelte';
     import HourlyOverageNotification from './notifications/hourly-overage-notification.svelte';
@@ -65,7 +68,8 @@
 
     const organization = $derived(organizationQuery.data);
     const projects = $derived((projectsQuery.data?.data ?? []).filter((p) => p.organization_id === currentOrganizationId.current));
-    const projectsNeedingConfig = $derived(projects.filter((p) => p.is_configured === false));
+    let configuredProjectIds = $state(new Set<string>());
+    const projectsNeedingConfig = $derived(projects.filter((p) => p.is_configured === false && !configuredProjectIds.has(p.id!)));
 
     const suspensionCode: SuspensionCode | undefined = $derived(
         organization?.suspension_code === 'Billing'
@@ -89,6 +93,21 @@
         projectsQuery.isSuccess && !ignoreConfigureProjects && projects.length > 0 && projectsNeedingConfig.length === projects.length
     );
     const requiresPremiumUpgrade = $derived(requiresPremium && !organization?.has_premium_features && !needsProjectConfiguration);
+
+    const refetchConfigurationState = debounce(1500, async () => {
+        await Promise.all([organizationQuery.refetch(), projectsQuery.refetch()]);
+    });
+
+    useEventListener(document, 'PersistentEventChanged', (event) => {
+        const message = (event as CustomEvent<WebSocketMessageValue<'PersistentEventChanged'>>).detail;
+
+        if (message.change_type === ChangeType.Removed || message.organization_id !== currentOrganizationId.current || !message.project_id) {
+            return;
+        }
+
+        configuredProjectIds = new Set(configuredProjectIds).add(message.project_id);
+        void refetchConfigurationState();
+    });
 </script>
 
 {#if isImpersonating && organization}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/organization-notifications.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/organization-notifications.svelte
@@ -8,6 +8,7 @@
     import { getMeQuery } from '$features/users/api.svelte';
     import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
     import { useEventListener } from 'runed';
+    import { SvelteSet } from 'svelte/reactivity';
     import { debounce } from 'throttle-debounce';
 
     import FreePlanNotification from './notifications/free-plan-notification.svelte';
@@ -68,7 +69,7 @@
 
     const organization = $derived(organizationQuery.data);
     const projects = $derived((projectsQuery.data?.data ?? []).filter((p) => p.organization_id === currentOrganizationId.current));
-    let configuredProjectIds = $state(new Set<string>());
+    let configuredProjectIds = new SvelteSet<string>();
     const projectsNeedingConfig = $derived(projects.filter((p) => p.is_configured === false && !configuredProjectIds.has(p.id!)));
 
     const suspensionCode: SuspensionCode | undefined = $derived(
@@ -105,7 +106,7 @@
             return;
         }
 
-        configuredProjectIds = new Set(configuredProjectIds).add(message.project_id);
+        configuredProjectIds.add(message.project_id);
         void refetchConfigurationState();
     });
 </script>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.svelte.ts
@@ -58,6 +58,18 @@ export const queryKeys = {
 
 let deletedSavedViewIds = $state<string[]>([]);
 
+export function deletePredefinedSavedView(request: { route: { id: string | undefined } }) {
+    return createMutation<void, ProblemDetails, void>(() => ({
+        enabled: () => !!accessToken.current && !!request.route.id,
+        mutationFn: async () => {
+            const client = useFetchClient();
+            await client.delete(`saved-views/${request.route.id}/predefined`, {
+                expectedStatusCodes: [204]
+            });
+        }
+    }));
+}
+
 export function deleteSavedView(request: { route: { organizationId: string | undefined } }) {
     const queryClient = useQueryClient();
 
@@ -138,18 +150,13 @@ export function patchSavedView(request: { route: { id: string | undefined } }) {
     }));
 }
 
-export function postSavedView(request: { route: { organizationId: string | undefined } }) {
-    const queryClient = useQueryClient();
-
-    return createMutation<SavedView, ProblemDetails, NewSavedView>(() => ({
-        enabled: () => !!accessToken.current && !!request.route.organizationId,
-        mutationFn: async (data: NewSavedView) => {
+export function postPredefinedSavedView(request: { route: { id: string | undefined } }) {
+    return createMutation<SavedView, ProblemDetails, void>(() => ({
+        enabled: () => !!accessToken.current && !!request.route.id,
+        mutationFn: async () => {
             const client = useFetchClient();
-            const response = await client.postJSON<SavedView>(`organizations/${request.route.organizationId}/saved-views`, data);
+            const response = await client.postJSON<SavedView>(`saved-views/${request.route.id}/predefined`, {});
             return response.data!;
-        },
-        onSuccess: (savedView: SavedView) => {
-            syncSavedViewCaches(queryClient, savedView, request.route.organizationId);
         }
     }));
 }
@@ -172,32 +179,26 @@ export function postPredefinedSavedViews(request: { route: { organizationId: str
             }
 
             void queryClient.invalidateQueries({ queryKey: queryKeys.organization(request.route.organizationId) });
-            for (const view of new Set(savedViews.map((savedView) => savedView.view_type))) {
+            const viewTypes = savedViews.map((savedView) => savedView.view_type).filter((view, index, views) => views.indexOf(view) === index);
+            for (const view of viewTypes) {
                 void queryClient.invalidateQueries({ queryKey: queryKeys.view(request.route.organizationId, view) });
             }
         }
     }));
 }
 
-export function postPredefinedSavedView(request: { route: { id: string | undefined } }) {
-    return createMutation<SavedView, ProblemDetails, void>(() => ({
-        enabled: () => !!accessToken.current && !!request.route.id,
-        mutationFn: async () => {
-            const client = useFetchClient();
-            const response = await client.postJSON<SavedView>(`saved-views/${request.route.id}/predefined`, {});
-            return response.data!;
-        }
-    }));
-}
+export function postSavedView(request: { route: { organizationId: string | undefined } }) {
+    const queryClient = useQueryClient();
 
-export function deletePredefinedSavedView(request: { route: { id: string | undefined } }) {
-    return createMutation<void, ProblemDetails, void>(() => ({
-        enabled: () => !!accessToken.current && !!request.route.id,
-        mutationFn: async () => {
+    return createMutation<SavedView, ProblemDetails, NewSavedView>(() => ({
+        enabled: () => !!accessToken.current && !!request.route.organizationId,
+        mutationFn: async (data: NewSavedView) => {
             const client = useFetchClient();
-            await client.delete(`saved-views/${request.route.id}/predefined`, {
-                expectedStatusCodes: [204]
-            });
+            const response = await client.postJSON<SavedView>(`organizations/${request.route.organizationId}/saved-views`, data);
+            return response.data!;
+        },
+        onSuccess: (savedView: SavedView) => {
+            syncSavedViewCaches(queryClient, savedView, request.route.organizationId);
         }
     }));
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.svelte.ts
@@ -51,6 +51,7 @@ async function invalidateSavedViewCache(queryClient: QueryClient, organizationId
 export const queryKeys = {
     id: (id: string | undefined) => [...queryKeys.type, id] as const,
     organization: (organizationId: string | undefined) => [...queryKeys.type, 'organization', organizationId] as const,
+    predefined: (organizationId: string | undefined) => [...queryKeys.type, 'organization', organizationId, 'predefined'] as const,
     type: ['SavedView'] as const,
     view: (organizationId: string | undefined, view: string | undefined) => [...queryKeys.type, 'organization', organizationId, 'view', view] as const
 };
@@ -149,6 +150,54 @@ export function postSavedView(request: { route: { organizationId: string | undef
         },
         onSuccess: (savedView: SavedView) => {
             syncSavedViewCaches(queryClient, savedView, request.route.organizationId);
+        }
+    }));
+}
+
+export function postPredefinedSavedViews(request: { route: { organizationId: string | undefined } }) {
+    const queryClient = useQueryClient();
+
+    return createMutation<SavedView[], ProblemDetails, void>(() => ({
+        enabled: () => !!accessToken.current && !!request.route.organizationId,
+        mutationFn: async () => {
+            const client = useFetchClient();
+            const response = await client.postJSON<SavedView[]>(`organizations/${request.route.organizationId}/saved-views/predefined`, {});
+            return response.data!;
+        },
+        mutationKey: queryKeys.predefined(request.route.organizationId),
+        onSuccess: (savedViews: SavedView[]) => {
+            for (const savedView of savedViews) {
+                restoreDeletedSavedView(savedView);
+                syncSavedViewCaches(queryClient, savedView, request.route.organizationId);
+            }
+
+            void queryClient.invalidateQueries({ queryKey: queryKeys.organization(request.route.organizationId) });
+            for (const view of new Set(savedViews.map((savedView) => savedView.view_type))) {
+                void queryClient.invalidateQueries({ queryKey: queryKeys.view(request.route.organizationId, view) });
+            }
+        }
+    }));
+}
+
+export function postPredefinedSavedView(request: { route: { id: string | undefined } }) {
+    return createMutation<SavedView, ProblemDetails, void>(() => ({
+        enabled: () => !!accessToken.current && !!request.route.id,
+        mutationFn: async () => {
+            const client = useFetchClient();
+            const response = await client.postJSON<SavedView>(`saved-views/${request.route.id}/predefined`, {});
+            return response.data!;
+        }
+    }));
+}
+
+export function deletePredefinedSavedView(request: { route: { id: string | undefined } }) {
+    return createMutation<void, ProblemDetails, void>(() => ({
+        enabled: () => !!accessToken.current && !!request.route.id,
+        mutationFn: async () => {
+            const client = useFetchClient();
+            await client.delete(`saved-views/${request.route.id}/predefined`, {
+                expectedStatusCodes: [204]
+            });
         }
     }));
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
@@ -14,10 +14,12 @@
     import { toFilter } from '$features/events/components/filters/helpers.svelte';
     import { serializeFilters } from '$features/events/components/filters/helpers.svelte';
     import { organization } from '$features/organizations/context.svelte';
+    import { getMeQuery } from '$features/users/api.svelte';
     import GripVertical from '@lucide/svelte/icons/grip-vertical';
     import Pencil from '@lucide/svelte/icons/pencil';
     import Plus from '@lucide/svelte/icons/plus';
     import Save from '@lucide/svelte/icons/save';
+    import ShieldCheck from '@lucide/svelte/icons/shield-check';
     import SlidersHorizontal from '@lucide/svelte/icons/sliders-horizontal';
     import Trash2 from '@lucide/svelte/icons/trash-2';
     import Undo2 from '@lucide/svelte/icons/undo-2';
@@ -26,7 +28,15 @@
 
     import type { NewSavedView, SavedView, UpdateSavedView } from '../models';
 
-    import { deleteSavedView, markSavedViewDeleted, patchSavedView, postSavedView, restoreDeletedSavedView } from '../api.svelte';
+    import {
+        deletePredefinedSavedView,
+        deleteSavedView,
+        markSavedViewDeleted,
+        patchSavedView,
+        postPredefinedSavedView,
+        postSavedView,
+        restoreDeletedSavedView
+    } from '../api.svelte';
     import DeleteViewDialog from './delete-view-dialog.svelte';
     import RenameViewDialog from './rename-view-dialog.svelte';
     import SaveViewDialog from './save-view-dialog.svelte';
@@ -103,6 +113,27 @@
             }
         }
     });
+    const predefinedViewMutation = postPredefinedSavedView({
+        route: {
+            get id() {
+                return predefinedViewTarget?.id;
+            }
+        }
+    });
+    const deletePredefinedViewMutation = deletePredefinedSavedView({
+        route: {
+            get id() {
+                return predefinedViewTarget?.id;
+            }
+        }
+    });
+    const predefinedViewUpdateMutation = patchSavedView({
+        route: {
+            get id() {
+                return predefinedViewTarget?.id;
+            }
+        }
+    });
     const removeMutation = deleteSavedView({
         route: {
             get organizationId() {
@@ -110,8 +141,17 @@
             }
         }
     });
+    const meQuery = getMeQuery();
+    const isGlobalAdmin = $derived(!!meQuery.data?.roles?.includes('global'));
 
-    const saving = $derived(createMutation.isPending || updateMutation.isPending || removeMutation.isPending);
+    const saving = $derived(
+        createMutation.isPending ||
+            updateMutation.isPending ||
+                predefinedViewUpdateMutation.isPending ||
+                predefinedViewMutation.isPending ||
+                deletePredefinedViewMutation.isPending ||
+            removeMutation.isPending
+    );
 
     const currentFilterString = $derived(toFilter(filters.filter((f) => f.type !== 'date')));
 
@@ -139,6 +179,7 @@
     });
 
     const activeView = $derived(activeSavedView);
+    const predefinedViewTarget = $derived(activeView ?? duplicateView);
     const hideableColumns = $derived(table.getAllLeafColumns().filter((column) => column.getCanHide()));
     const reorderableColumns = $derived(table.getAllLeafColumns().filter((column) => column.id !== 'select'));
     const visibleHideableColumnCount = $derived(hideableColumns.filter((column) => column.getIsVisible()).length);
@@ -274,12 +315,8 @@
         }
     }
 
-    async function handleUpdate() {
-        if (!activeView || !organizationId) {
-            return;
-        }
-
-        const body: UpdateSavedView = {
+    function getUpdateBody(): UpdateSavedView {
+        return {
             column_order: getSavedColumnOrder() ?? null,
             columns: columnVisibility,
             filter: currentFilterString || null,
@@ -289,12 +326,46 @@
             sort: sort || null,
             time: time || null
         };
+    }
+
+    async function handleUpdate() {
+        if (!activeView || !organizationId) {
+            return;
+        }
 
         try {
-            await updateMutation.mutateAsync(body);
+            await updateMutation.mutateAsync(getUpdateBody());
             toast.success(`View "${activeView.name}" saved.`);
         } catch (error) {
             toast.error(getErrorMessage(error, 'Failed to save view. Please try again.'));
+        }
+    }
+
+    async function handleSavePredefinedView() {
+        if (!predefinedViewTarget || !organizationId) {
+            return;
+        }
+
+        try {
+            await predefinedViewUpdateMutation.mutateAsync(getUpdateBody());
+
+            const result = await predefinedViewMutation.mutateAsync();
+            toast.success(`"${result.name}" is now a predefined saved view.`);
+        } catch (error) {
+            toast.error(getErrorMessage(error, 'Failed to save predefined saved view. Please try again.'));
+        }
+    }
+
+    async function handleDeletePredefinedView() {
+        if (!predefinedViewTarget || !organizationId) {
+            return;
+        }
+
+        try {
+            await deletePredefinedViewMutation.mutateAsync();
+            toast.success(`"${predefinedViewTarget.name}" is no longer a predefined saved view.`);
+        } catch (error) {
+            toast.error(getErrorMessage(error, 'Failed to delete predefined saved view. Please try again.'));
         }
     }
 
@@ -366,6 +437,18 @@
                 <DropdownMenu.Item class="text-destructive" onclick={() => openDeleteDialog(activeView)}>
                     <Trash2 class="mr-2 size-4" aria-hidden="true" />
                     Delete "{activeView.name}"
+                </DropdownMenu.Item>
+            {/if}
+            {#if isGlobalAdmin && predefinedViewTarget}
+                <DropdownMenu.Separator />
+                <DropdownMenu.Label>Predefined Saved Views</DropdownMenu.Label>
+                <DropdownMenu.Item disabled={saving} onclick={handleSavePredefinedView}>
+                    <ShieldCheck class="mr-2 size-4" aria-hidden="true" />
+                    Save Predefined
+                </DropdownMenu.Item>
+                <DropdownMenu.Item class="text-destructive" disabled={saving} onclick={handleDeletePredefinedView}>
+                    <Trash2 class="mr-2 size-4" aria-hidden="true" />
+                    Delete Predefined
                 </DropdownMenu.Item>
             {/if}
         </DropdownMenu.Group>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
@@ -147,9 +147,9 @@
     const saving = $derived(
         createMutation.isPending ||
             updateMutation.isPending ||
-                predefinedViewUpdateMutation.isPending ||
-                predefinedViewMutation.isPending ||
-                deletePredefinedViewMutation.isPending ||
+            predefinedViewUpdateMutation.isPending ||
+            predefinedViewMutation.isPending ||
+            deletePredefinedViewMutation.isPending ||
             removeMutation.isPending
     );
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -2,7 +2,7 @@ import type { IFilter } from '$comp/faceted-filter';
 import type { ColumnOrderState, ColumnVisibilityState } from '@tanstack/svelte-table';
 
 import { goto } from '$app/navigation';
-import { deserializeFilters } from '$features/events/components/filters/helpers.svelte';
+import { buildFilterCacheKey, deserializeFilters } from '$features/events/components/filters/helpers.svelte';
 import { organization } from '$features/organizations/context.svelte';
 
 import type { SavedView } from './models';
@@ -162,7 +162,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         if (view.filter_definitions) {
             try {
                 const hydrated = deserializeFilters(view.filter_definitions);
-                options.updateFilterCache(options.filterCacheKey(view.filter ?? null), hydrated);
+                updateSavedViewFilterCache(options, view, hydrated);
             } catch {
                 console.error('Failed to deserialize saved view filter definitions');
             }
@@ -232,7 +232,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         if (view.filter_definitions) {
             try {
                 const hydrated = deserializeFilters(view.filter_definitions);
-                options.updateFilterCache(options.filterCacheKey(view.filter ?? null), hydrated);
+                updateSavedViewFilterCache(options, view, hydrated);
             } catch {
                 console.error('Failed to deserialize saved view filter definitions');
             }
@@ -337,4 +337,17 @@ function normalizeFilterDefinitions(value: null | string | undefined): string {
 
 function supportsSavedQueryParam(queryParams: SavedViewQueryParams): queryParams is SavedViewQueryParams & { saved: null | string | undefined } {
     return Object.prototype.hasOwnProperty.call(queryParams, 'saved');
+}
+
+function updateSavedViewFilterCache(options: UseSavedViewsOptions, view: SavedView, filters: IFilter[]): void {
+    const currentRouteKey = options.filterCacheKey(view.filter ?? null);
+    options.updateFilterCache(currentRouteKey, filters);
+
+    const canonicalHref = savedViewHref(view);
+    const queryIndex = canonicalHref.indexOf('?');
+    const canonicalPath = queryIndex >= 0 ? canonicalHref.slice(0, queryIndex) : canonicalHref;
+    const canonicalRouteKey = buildFilterCacheKey(organization.current, canonicalPath, view.filter ?? null);
+    if (canonicalRouteKey !== currentRouteKey) {
+        options.updateFilterCache(canonicalRouteKey, filters);
+    }
 }

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
@@ -443,7 +443,20 @@
     function onIntercomUnreadCountChange(unreadCount: number) {
         intercomUnreadCount = Math.max(0, unreadCount);
     }
+
+    const setupPath = resolve('/(app)/organization/add');
+    const isSetupPage = $derived(page.url.pathname === setupPath);
 </script>
+
+{#snippet setupShell()}
+    <div class="flex h-screen w-full items-center justify-center px-4">
+        <main class="w-full">
+            <div in:fade={{ delay: 150, duration: 150 }} out:fade={{ duration: 150 }}>
+                {@render children()}
+            </div>
+        </main>
+    </div>
+{/snippet}
 
 {#snippet appShell(openChat: () => void)}
     <Navbar openCommand={openCommandPalette}></Navbar>
@@ -508,7 +521,11 @@
         routeKey={page.url.pathname}
     >
         {#snippet children(openChat)}
-            {@render appShell(openChat)}
+            {#if isSetupPage}
+                {@render setupShell()}
+            {:else}
+                {@render appShell(openChat)}
+            {/if}
         {/snippet}
     </IntercomShell>
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/events/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/events/+page.svelte
@@ -21,8 +21,8 @@
         filterChanged,
         filterRemoved,
         getFiltersFromCache,
-        shouldRefreshPersistentEventChanged,
         serializeFilters,
+        shouldRefreshPersistentEventChanged,
         toFilter,
         updateFilterCache
     } from '$features/events/components/filters/helpers.svelte';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/events/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/events/+page.svelte
@@ -158,7 +158,6 @@
         const savedView = savedViewsState.activeSavedView;
         if (!page.url.searchParams.has('filter') && savedView?.filter_definitions && filter === (savedView.filter ?? null)) {
             const hydrated = deserializeFilters(savedView.filter_definitions);
-            updateFilterCache(filterCacheKey(filter), hydrated);
             return applyTimeFilter(hydrated, getQueryTime());
         }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/events/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/events/+page.svelte
@@ -17,6 +17,7 @@
     import {
         applyTimeFilter,
         buildFilterCacheKey,
+        deserializeFilters,
         filterCacheVersionNumber,
         filterChanged,
         filterRemoved,
@@ -152,12 +153,23 @@
         { lazy: true }
     );
 
-    let filters = $state(applyTimeFilter(getFiltersFromCache(filterCacheKey(getEffectiveFilter()), getEffectiveFilter()), getQueryTime()));
+    function getCurrentFilters(): FacetedFilter.IFilter[] {
+        const filter = getEffectiveFilter();
+        const savedView = savedViewsState.activeSavedView;
+        if (!page.url.searchParams.has('filter') && savedView?.filter_definitions && filter === (savedView.filter ?? null)) {
+            const hydrated = deserializeFilters(savedView.filter_definitions);
+            updateFilterCache(filterCacheKey(filter), hydrated);
+            return applyTimeFilter(hydrated, getQueryTime());
+        }
+
+        return applyTimeFilter(getFiltersFromCache(filterCacheKey(filter), filter), getQueryTime());
+    }
+
+    let filters = $state(getCurrentFilters());
     watch(
-        [() => page.url.search, () => savedViewsState.activeSavedView, () => filterCacheVersionNumber()],
+        [() => page.url.pathname, () => page.url.search, () => savedViewsState.activeSavedView, () => filterCacheVersionNumber()],
         () => {
-            const filter = getEffectiveFilter();
-            filters = applyTimeFilter(getFiltersFromCache(filterCacheKey(filter), filter), getQueryTime());
+            filters = getCurrentFilters();
         },
         { lazy: true }
     );

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/events/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/events/+page.svelte
@@ -21,6 +21,7 @@
         filterChanged,
         filterRemoved,
         getFiltersFromCache,
+        shouldRefreshPersistentEventChanged,
         serializeFilters,
         toFilter,
         updateFilterCache
@@ -44,7 +45,7 @@
     import { createTable } from '@tanstack/svelte-table';
     import { queryParamsState } from 'kit-query-params';
     import { useEventListener, watch } from 'runed';
-    import { throttle } from 'throttle-debounce';
+    import { debounce, throttle } from 'throttle-debounce';
 
     let selectedEventId: null | string = $state(null);
 
@@ -275,6 +276,7 @@
     }
 
     const throttledLoadData = throttle(10000, loadData);
+    const debouncedLoadData = debounce(1500, loadData);
 
     async function onPersistentEventChanged(message: WebSocketMessageValue<'PersistentEventChanged'>) {
         if (message.id && message.change_type === ChangeType.Removed) {
@@ -288,6 +290,16 @@
                 }
             }
         }
+
+        if (message.change_type === ChangeType.Removed) {
+            return;
+        }
+
+        if (!shouldRefreshPersistentEventChanged(filters, queryParams.filter, message.organization_id, message.project_id, message.stack_id, message.id)) {
+            return;
+        }
+
+        await debouncedLoadData();
     }
 
     useEventListener(document, 'PersistentEventChanged', async (event) => await onPersistentEventChanged((event as CustomEvent).detail));
@@ -354,6 +366,19 @@
             totalEvents,
             totalIssues
         };
+    });
+
+    let lastStatsRefreshKey = $state<string>();
+
+    $effect(() => {
+        const refreshKey = `${organization.current}:${page.url.search}:${stats.totalEvents}`;
+
+        if (!clientResponse?.ok || stats.totalEvents <= 0 || !isTableEmpty(table) || lastStatsRefreshKey === refreshKey) {
+            return;
+        }
+
+        lastStatsRefreshKey = refreshKey;
+        void loadData();
     });
 
     function onRangeSelect(start: Date, end: Date) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/issues/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/issues/+page.svelte
@@ -15,6 +15,7 @@
     import {
         applyTimeFilter,
         buildFilterCacheKey,
+        deserializeFilters,
         filterCacheVersionNumber,
         filterChanged,
         filterRemoved,
@@ -144,12 +145,23 @@
         { lazy: true }
     );
 
-    let filters = $state(applyTimeFilter(getFiltersFromCache(filterCacheKey(getEffectiveFilter()), getEffectiveFilter()), getQueryTime()));
+    function getCurrentFilters(): FacetedFilter.IFilter[] {
+        const filter = getEffectiveFilter();
+        const savedView = savedViewsState.activeSavedView;
+        if (!page.url.searchParams.has('filter') && savedView?.filter_definitions && filter === (savedView.filter ?? null)) {
+            const hydrated = deserializeFilters(savedView.filter_definitions);
+            updateFilterCache(filterCacheKey(filter), hydrated);
+            return applyTimeFilter(hydrated, getQueryTime());
+        }
+
+        return applyTimeFilter(getFiltersFromCache(filterCacheKey(filter), filter), getQueryTime());
+    }
+
+    let filters = $state(getCurrentFilters());
     watch(
-        [() => page.url.search, () => savedViewsState.activeSavedView, () => filterCacheVersionNumber()],
+        [() => page.url.pathname, () => page.url.search, () => savedViewsState.activeSavedView, () => filterCacheVersionNumber()],
         () => {
-            const filter = getEffectiveFilter();
-            filters = applyTimeFilter(getFiltersFromCache(filterCacheKey(filter), filter), getQueryTime());
+            filters = getCurrentFilters();
         },
         { lazy: true }
     );

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/issues/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/issues/+page.svelte
@@ -150,7 +150,6 @@
         const savedView = savedViewsState.activeSavedView;
         if (!page.url.searchParams.has('filter') && savedView?.filter_definitions && filter === (savedView.filter ?? null)) {
             const hydrated = deserializeFilters(savedView.filter_definitions);
-            updateFilterCache(filterCacheKey(filter), hydrated);
             return applyTimeFilter(hydrated, getQueryTime());
         }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/features/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/features/+page.svelte
@@ -2,11 +2,18 @@
     import { page } from '$app/state';
     import ErrorMessage from '$comp/error-message.svelte';
     import { Muted } from '$comp/typography';
+    import { Button } from '$comp/ui/button';
     import { Skeleton } from '$comp/ui/skeleton';
+    import { Spinner } from '$comp/ui/spinner';
     import { Switch } from '$comp/ui/switch';
     import { getOrganizationQuery, removeOrganizationFeature, setOrganizationFeature } from '$features/organizations/api.svelte';
+    import { postPredefinedSavedViews } from '$features/saved-views/api.svelte';
     import { getMeQuery } from '$features/users/api.svelte';
+    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import RefreshCw from '@lucide/svelte/icons/refresh-cw';
     import { toast } from 'svelte-sonner';
+
+    let toastId = $state<number | string>();
 
     const organizationId = $derived(page.params.organizationId || '');
 
@@ -45,6 +52,14 @@
         }
     });
 
+    const predefinedSavedViews = postPredefinedSavedViews({
+        route: {
+            get organizationId() {
+                return organizationId;
+            }
+        }
+    });
+
     async function handleToggleFeature(featureId: string, enabled: boolean) {
         if (!isGlobalAdmin) {
             return;
@@ -59,6 +74,17 @@
             toast.error('Failed to update feature. Please try again.');
         }
     }
+
+    async function updatePredefinedSavedViews() {
+        toast.dismiss(toastId);
+        try {
+            const savedViews = await predefinedSavedViews.mutateAsync();
+            toastId = toast.success(`Updated ${savedViews.length} predefined saved views.`);
+        } catch (error: unknown) {
+            const message = error instanceof ProblemDetails ? error.title : 'Please try again.';
+            toastId = toast.error(`An error occurred while updating predefined saved views: ${message}`);
+        }
+    }
 </script>
 
 {#if organizationQuery.isError}
@@ -67,9 +93,40 @@
     <ErrorMessage message="You do not have permission to manage features." />
 {:else}
     <div class="space-y-6">
-        <Muted>Enable or disable features for this organization</Muted>
+        <Muted>Manage organization features</Muted>
 
-        <div class="space-y-3">
+        <section class="space-y-3" aria-labelledby="saved-views-heading">
+            <div class="space-y-1">
+                <h2 id="saved-views-heading" class="text-sm font-medium">Saved views</h2>
+                <Muted class="text-xs">Update predefined saved views without removing custom saved views.</Muted>
+            </div>
+
+            <div class="rounded-lg border bg-card">
+                <div class="p-4">
+                    <Button
+                        class="w-full sm:w-auto"
+                        variant="secondary"
+                        onclick={updatePredefinedSavedViews}
+                        disabled={predefinedSavedViews.isPending || !organizationId}
+                    >
+                        {#if predefinedSavedViews.isPending}
+                            <Spinner />
+                            <span>Updating...</span>
+                        {:else}
+                            <RefreshCw class="mr-2 size-4" aria-hidden="true" />
+                            <span>Update Predefined Saved Views</span>
+                        {/if}
+                    </Button>
+                </div>
+            </div>
+        </section>
+
+        <section class="space-y-3" aria-labelledby="feature-flags-heading">
+            <div class="space-y-1">
+                <h2 id="feature-flags-heading" class="text-sm font-medium">Feature flags</h2>
+                <Muted class="text-xs">Manage feature flags</Muted>
+            </div>
+
             {#if organizationQuery.isLoading}
                 {#each Array.from({ length: KNOWN_FEATURES.length }, (_, index) => index) as i (`skeleton-${i}`)}
                     <div class="rounded-lg border p-4">
@@ -82,6 +139,10 @@
                         </div>
                     </div>
                 {/each}
+            {:else if KNOWN_FEATURES.length === 0}
+                <div class="rounded-lg border border-dashed p-6 text-center">
+                    <Muted class="text-xs">Feature flags will be available here when they are ready.</Muted>
+                </div>
             {:else}
                 {#each KNOWN_FEATURES as feature (feature.id)}
                     <div class="rounded-lg border p-4">
@@ -100,6 +161,6 @@
                     </div>
                 {/each}
             {/if}
-        </div>
+        </section>
     </div>
 {/if}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/features/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/features/+page.svelte
@@ -101,7 +101,7 @@
                 <Muted class="text-xs">Update predefined saved views without removing custom saved views.</Muted>
             </div>
 
-            <div class="rounded-lg border bg-card">
+            <div class="bg-card rounded-lg border">
                 <div class="p-4">
                     <Button
                         class="w-full sm:w-auto"

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/add/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/add/+page.svelte
@@ -20,7 +20,7 @@
     import { ProblemDetails } from '@exceptionless/fetchclient';
     import { createForm } from '@tanstack/svelte-form';
     import { toast } from 'svelte-sonner';
-    import { object, string, type infer as Infer } from 'zod';
+    import { type infer as Infer, object, string } from 'zod';
 
     const SetupSchema = object({
         organization_name: string().min(1, 'Organization name is required'),

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/add/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/add/+page.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
+    import type { NewProject } from '$features/projects/models';
+
     import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';
     import ErrorMessage from '$comp/error-message.svelte';
-    import { H3, Muted } from '$comp/typography';
+    import Logo from '$comp/logo.svelte';
+    import { Muted } from '$comp/typography';
     import { Button } from '$comp/ui/button';
+    import * as Card from '$comp/ui/card';
     import * as Field from '$comp/ui/field';
     import { Input } from '$comp/ui/input';
     import { Spinner } from '$comp/ui/spinner';
@@ -11,32 +15,48 @@
     import { postOrganization } from '$features/organizations/api.svelte';
     import { organization } from '$features/organizations/context.svelte';
     import { useHideOrganizationNotifications } from '$features/organizations/hooks/use-hide-organization-notifications.svelte';
-    import { type NewOrganizationFormData, NewOrganizationSchema } from '$features/organizations/schemas';
+    import { postProject } from '$features/projects/api.svelte';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
     import { ProblemDetails } from '@exceptionless/fetchclient';
     import { createForm } from '@tanstack/svelte-form';
     import { toast } from 'svelte-sonner';
+    import { object, string, type infer as Infer } from 'zod';
+
+    const SetupSchema = object({
+        organization_name: string().min(1, 'Organization name is required'),
+        project_name: string().min(1, 'Project name is required')
+    });
+
+    type SetupFormData = Infer<typeof SetupSchema>;
 
     let toastId = $state<number | string>();
     const createOrganization = postOrganization();
-    const CREATE_ERROR_MESSAGE = 'Error creating organization. Please try again.';
+    const createProject = postProject();
+    const CREATE_ERROR_MESSAGE = 'Error creating setup. Please try again.';
 
     useHideOrganizationNotifications();
 
     const form = createForm(() => ({
         defaultValues: {
-            name: ''
-        } as NewOrganizationFormData,
+            organization_name: '',
+            project_name: ''
+        } as SetupFormData,
         validators: {
-            onSubmit: NewOrganizationSchema,
+            onSubmit: SetupSchema,
             onSubmitAsync: async ({ value }) => {
                 toast.dismiss(toastId);
                 try {
-                    const { id } = await createOrganization.mutateAsync(value);
-                    // Update the persisted organization state so the sidebar selects the new org
-                    organization.current = id;
-                    toastId = toast.success('Organization added successfully');
-                    await goto(resolve('/(app)/organization/[organizationId]/manage', { organizationId: id }));
+                    const createdOrganization = await createOrganization.mutateAsync({ name: value.organization_name });
+                    organization.current = createdOrganization.id;
+
+                    const createdProject = await createProject.mutateAsync({
+                        delete_bot_data_enabled: true,
+                        name: value.project_name,
+                        organization_id: createdOrganization.id
+                    } as NewProject);
+
+                    toastId = toast.success('Project added successfully');
+                    await goto(resolve('/(app)/project/[projectId]/configure', { projectId: createdProject.id }) + '?redirect=true');
                     return null;
                 } catch (error: unknown) {
                     if (showBillingDialogOnUpgradeProblem(error, organization.current, () => form.handleSubmit())) {
@@ -56,50 +76,70 @@
     }));
 </script>
 
-<div class="flex flex-col gap-4">
-    <div class="flex flex-col gap-1">
-        <H3>Add Organization</H3>
-        <Muted>Add a new organization to start tracking errors and events</Muted>
-    </div>
-    <form
-        onsubmit={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            form.handleSubmit();
-        }}
-    >
-        <form.Subscribe selector={(state) => state.errors}>
-            {#snippet children(errors)}
-                <ErrorMessage message={getFormErrorMessages(errors)}></ErrorMessage>
-            {/snippet}
-        </form.Subscribe>
-        <form.Field name="name">
-            {#snippet children(field)}
-                <Field.Field data-invalid={ariaInvalid(field)}>
-                    <Field.Label for={field.name}>Organization Name</Field.Label>
-                    <Input
-                        id={field.name}
-                        name={field.name}
-                        placeholder="Enter organization name"
-                        value={field.state.value}
-                        onblur={field.handleBlur}
-                        oninput={(e) => field.handleChange(e.currentTarget.value)}
-                        aria-invalid={ariaInvalid(field)}
-                    />
-                    <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
-                </Field.Field>
-            {/snippet}
-        </form.Field>
-        <form.Subscribe selector={(state) => state.isSubmitting}>
-            {#snippet children(isSubmitting)}
-                <Button type="submit" class="mt-4" disabled={isSubmitting}>
-                    {#if isSubmitting}
-                        <Spinner /> Adding Organization...
-                    {:else}
-                        Add Organization
-                    {/if}
-                </Button>
-            {/snippet}
-        </form.Subscribe>
-    </form>
-</div>
+<Card.Root class="mx-auto w-sm">
+    <Card.Header>
+        <Logo />
+        <Card.Title class="text-center text-2xl">Set Up Exceptionless</Card.Title>
+        <Muted class="text-center">Create an organization and project. Next, we'll connect your app.</Muted>
+    </Card.Header>
+    <Card.Content>
+        <form
+            onsubmit={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                form.handleSubmit();
+            }}
+        >
+            <form.Subscribe selector={(state) => state.errors}>
+                {#snippet children(errors)}
+                    <ErrorMessage message={getFormErrorMessages(errors)}></ErrorMessage>
+                {/snippet}
+            </form.Subscribe>
+            <form.Field name="organization_name">
+                {#snippet children(field)}
+                    <Field.Field data-invalid={ariaInvalid(field)}>
+                        <Field.Label for={field.name}>Organization Name</Field.Label>
+                        <Input
+                            id={field.name}
+                            name={field.name}
+                            placeholder="Enter organization name"
+                            value={field.state.value}
+                            onblur={field.handleBlur}
+                            oninput={(e) => field.handleChange(e.currentTarget.value)}
+                            aria-invalid={ariaInvalid(field)}
+                        />
+                        <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
+                    </Field.Field>
+                {/snippet}
+            </form.Field>
+            <form.Field name="project_name">
+                {#snippet children(field)}
+                    <Field.Field data-invalid={ariaInvalid(field)}>
+                        <Field.Label for={field.name}>Project Name</Field.Label>
+                        <Input
+                            id={field.name}
+                            name={field.name}
+                            placeholder="Enter project name"
+                            value={field.state.value}
+                            onblur={field.handleBlur}
+                            oninput={(e) => field.handleChange(e.currentTarget.value)}
+                            aria-invalid={ariaInvalid(field)}
+                        />
+                        <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
+                    </Field.Field>
+                {/snippet}
+            </form.Field>
+            <form.Subscribe selector={(state) => state.isSubmitting}>
+                {#snippet children(isSubmitting)}
+                    <Button type="submit" class="mt-4 w-full" disabled={isSubmitting}>
+                        {#if isSubmitting}
+                            <Spinner /> Creating Setup...
+                        {:else}
+                            Continue
+                        {/if}
+                    </Button>
+                {/snippet}
+            </form.Subscribe>
+        </form>
+    </Card.Content>
+</Card.Root>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/+layout.svelte
@@ -33,6 +33,8 @@
         }
     });
     const currentPath = $derived(page.url.pathname);
+    const configurePath = $derived(resolve('/(app)/project/[projectId]/configure', { projectId }));
+    const isConfigurePage = $derived(currentPath === configurePath || currentPath.startsWith(configurePath + '/'));
 
     $effect(() => {
         if (projectQuery.isError) {
@@ -53,7 +55,7 @@
                 {#if projectQuery.isSuccess}
                     <span>{projectQuery.data.name}</span>
                 {/if}
-                <span class="shrink-0">Settings</span>
+                <span class="shrink-0">{isConfigurePage ? 'Configure Client' : 'Settings'}</span>
             </H3>
         </div>
         <div class="flex items-center gap-2">
@@ -68,21 +70,23 @@
         </div>
     </div>
     <div class="mt-6 space-y-6">
-        <nav class="bg-muted flex w-full flex-row flex-nowrap gap-1 overflow-x-auto rounded-lg p-1">
-            {#each routes() as route (route.href)}
-                {@const isActive = currentPath === route.href || currentPath.startsWith(route.href + '/')}
-                <A
-                    variant="ghost"
-                    href={route.href}
-                    data-sveltekit-noscroll
-                    class="shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors {isActive
-                        ? 'bg-background text-foreground shadow-xs'
-                        : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
-                >
-                    {route.title}
-                </A>
-            {/each}
-        </nav>
+        {#if !isConfigurePage}
+            <nav class="bg-muted flex w-full flex-row flex-nowrap gap-1 overflow-x-auto rounded-lg p-1">
+                {#each routes() as route (route.href)}
+                    {@const isActive = currentPath === route.href || currentPath.startsWith(route.href + '/')}
+                    <A
+                        variant="ghost"
+                        href={route.href}
+                        data-sveltekit-noscroll
+                        class="shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors {isActive
+                            ? 'bg-background text-foreground shadow-xs'
+                            : 'text-muted-foreground hover:bg-muted hover:text-foreground'}"
+                    >
+                        {route.title}
+                    </A>
+                {/each}
+            </nav>
+        {/if}
         {@render children()}
     </div>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/configure/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/configure/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';
     import { page } from '$app/state';
     import CopyToClipboardButton from '$comp/copy-to-clipboard-button.svelte';
@@ -9,15 +8,20 @@
     import * as Select from '$comp/ui/select';
     import { Spinner } from '$comp/ui/spinner';
     import { env } from '$env/dynamic/public';
+    import { ProjectFilter } from '$features/events/components/filters';
     import { getIntercom } from '$features/intercom';
     import { openSupportChat } from '$features/intercom/chat';
+    import { organization } from '$features/organizations/context.svelte';
     import { generateSampleData } from '$features/projects/api.svelte';
     import { getProjectDefaultTokenQuery, patchToken } from '$features/tokens/api.svelte';
     import EnableTokenDialog from '$features/tokens/components/dialogs/enable-token-dialog.svelte';
+    import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
     import Database from '@lucide/svelte/icons/database';
     import { queryParamsState } from 'kit-query-params';
     import { useEventListener } from 'runed';
     import { toast } from 'svelte-sonner';
+
+    import { redirectToEventsWithFilter } from '../../../redirect-to-events.svelte';
 
     // Project ID from route params
     const projectId = $derived(page.params.projectId || '');
@@ -241,9 +245,12 @@ public partial class App : Application {
 }`
     });
 
-    useEventListener(document, 'PersistentEventChanged', async () => {
-        if (queryParams.redirect) {
-            await goto(resolve('/(app)/issues'));
+    useEventListener(document, 'PersistentEventChanged', async (event) => {
+        const message = (event as CustomEvent<WebSocketMessageValue<'PersistentEventChanged'>>).detail;
+
+        if (queryParams.redirect && message.project_id === projectId && message.change_type !== ChangeType.Removed) {
+            toast.success('First event received. Opening Events...');
+            await redirectToEventsWithFilter(organization.current, new ProjectFilter([projectId]));
         }
     });
 
@@ -252,6 +259,10 @@ public partial class App : Application {
 
     function openChat() {
         openSupportChat(intercom);
+    }
+
+    async function goToProjectEvents() {
+        await redirectToEventsWithFilter(organization.current, new ProjectFilter([projectId]));
     }
 </script>
 
@@ -276,6 +287,15 @@ public partial class App : Application {
                 <P
                     >The configuration steps won't work while your project's API key is suspended. Please <A onclick={openChat}>contact support</A> for more information.</P
                 >
+            </NotificationDescription>
+        </Notification>
+    {/if}
+
+    {#if queryParams.redirect}
+        <Notification>
+            <NotificationTitle>Waiting for your first event</NotificationTitle>
+            <NotificationDescription>
+                <P>Send an event from your app. When it arrives, we'll open the project Events page automatically.</P>
             </NotificationDescription>
         </Notification>
     {/if}
@@ -623,7 +643,7 @@ public partial class App : Application {
                 <Database class="mr-2 size-4" aria-hidden="true" /> Generate Sample Data
             {/if}
         </Button>
-        <Button variant="secondary" href={`${resolve('/(app)/issues')}?filter=project:${projectId}`}>Go To Most Frequent</Button>
+        <Button variant="secondary" onclick={goToProjectEvents}>View Events</Button>
     </div>
 
     {#if isTokenDisabled}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/configure/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/configure/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import { resolve } from '$app/paths';
     import { page } from '$app/state';
     import CopyToClipboardButton from '$comp/copy-to-clipboard-button.svelte';
     import { Notification, NotificationDescription, NotificationTitle } from '$comp/notification';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/manage/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/manage/+page.svelte
@@ -6,12 +6,12 @@
     import { page } from '$app/state';
     import ErrorMessage from '$comp/error-message.svelte';
     import { Muted } from '$comp/typography';
-    import { Button, buttonVariants } from '$comp/ui/button';
-    import * as DropdownMenu from '$comp/ui/dropdown-menu';
+    import { Button } from '$comp/ui/button';
     import * as Field from '$comp/ui/field';
     import { Input } from '$comp/ui/input';
     import { Spinner } from '$comp/ui/spinner';
-    import { deleteProject, getProjectQuery, resetData, updateProject } from '$features/projects/api.svelte';
+    import * as Tooltip from '$comp/ui/tooltip';
+    import { deleteProject, generateSampleData, getProjectQuery, resetData, updateProject } from '$features/projects/api.svelte';
     import RemoveProjectDialog from '$features/projects/components/dialogs/remove-project-dialog.svelte';
     import ResetProjectDataDialog from '$features/projects/components/dialogs/reset-project-data-dialog.svelte';
     import { type UpdateProjectFormData, UpdateProjectSchema } from '$features/projects/schemas';
@@ -19,6 +19,8 @@
     import { ProblemDetails } from '@exceptionless/fetchclient';
     import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
     import Issues from '@lucide/svelte/icons/bug';
+    import Configure from '@lucide/svelte/icons/cloud-download';
+    import Database from '@lucide/svelte/icons/database';
     import X from '@lucide/svelte/icons/x';
     import { createForm } from '@tanstack/svelte-form';
     import { toast } from 'svelte-sonner';
@@ -75,6 +77,26 @@
 
         toast.dismiss(toastId);
         toastId = toast.success('Successfully queued the project for data reset.');
+    }
+
+    const generateSampleDataMutation = generateSampleData({
+        route: {
+            get id() {
+                return projectId;
+            }
+        }
+    });
+
+    async function generateProjectSampleData() {
+        toast.dismiss(toastId);
+
+        try {
+            await generateSampleDataMutation.mutateAsync();
+            toastId = toast.success('Sample data generation has been queued. Events will appear shortly.');
+        } catch (error) {
+            toastId = toast.error('Failed to generate sample data. Please try again.');
+            throw error;
+        }
     }
 
     const form = createForm(() => ({
@@ -150,38 +172,64 @@
             <Button variant="secondary" href={`${resolve('/(app)/issues')}?filter=project:${projectId}`}>
                 <Issues class="mr-2 size-4" /> Go To Issues
             </Button>
+            <Button variant="secondary" href={resolve('/(app)/project/[projectId]/configure', { projectId })}>
+                <Configure class="mr-2 size-4" /> Configure Project
+            </Button>
+            <Button variant="secondary" onclick={generateProjectSampleData} disabled={generateSampleDataMutation.isPending}>
+                {#if generateSampleDataMutation.isPending}
+                    <Spinner />
+                    <span>Generating...</span>
+                {:else}
+                    <Database class="mr-2 size-4" />
+                    <span>Generate Sample Data</span>
+                {/if}
+            </Button>
         </div>
 
-        <div>
-            <DropdownMenu.Root>
-                <DropdownMenu.Trigger class={buttonVariants({ variant: 'destructive' })}>
-                    <X class="size-4" />
-                </DropdownMenu.Trigger>
-                <DropdownMenu.Content align="end" class="w-56">
-                    <DropdownMenu.Group>
-                        <DropdownMenu.GroupHeading>Actions</DropdownMenu.GroupHeading>
-                        <DropdownMenu.Separator />
-                        <DropdownMenu.Item onclick={() => (showResetDialog = true)} disabled={resetProject.isPending}>
+        <div class="flex items-center gap-2">
+            <Tooltip.Root>
+                <Tooltip.Trigger>
+                    {#snippet child({ props })}
+                        <Button
+                            {...props}
+                            variant="destructive"
+                            size="icon"
+                            aria-label="Reset project data"
+                            onclick={() => (showResetDialog = true)}
+                            disabled={resetProject.isPending}
+                        >
                             {#if resetProject.isPending}
                                 <Spinner />
-                                <span>Resetting...</span>
                             {:else}
-                                <AlertTriangle class="mr-2 size-4" />
-                                <span>Reset Project Data</span>
+                                <AlertTriangle class="size-4" />
                             {/if}
-                        </DropdownMenu.Item>
-                        <DropdownMenu.Item onclick={() => (showRemoveDialog = true)} disabled={removeProject.isPending}>
+                        </Button>
+                    {/snippet}
+                </Tooltip.Trigger>
+                <Tooltip.Content>Reset project data</Tooltip.Content>
+            </Tooltip.Root>
+
+            <Tooltip.Root>
+                <Tooltip.Trigger>
+                    {#snippet child({ props })}
+                        <Button
+                            {...props}
+                            variant="destructive"
+                            size="icon"
+                            aria-label="Delete project"
+                            onclick={() => (showRemoveDialog = true)}
+                            disabled={removeProject.isPending}
+                        >
                             {#if removeProject.isPending}
                                 <Spinner />
-                                <span>Deleting Project...</span>
                             {:else}
-                                <X class="mr-2 size-4" />
-                                <span>Delete Project</span>
+                                <X class="size-4" />
                             {/if}
-                        </DropdownMenu.Item>
-                    </DropdownMenu.Group>
-                </DropdownMenu.Content>
-            </DropdownMenu.Root>
+                        </Button>
+                    {/snippet}
+                </Tooltip.Trigger>
+                <Tooltip.Content>Delete project</Tooltip.Content>
+            </Tooltip.Root>
         </div>
     </div>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/routes.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/routes.svelte.ts
@@ -3,7 +3,6 @@ import { page } from '$app/state';
 import Usage from '@lucide/svelte/icons/bar-chart';
 import ClientConfig from '@lucide/svelte/icons/braces';
 import Issues from '@lucide/svelte/icons/bug';
-import Configure from '@lucide/svelte/icons/cloud-download';
 import ApiKey from '@lucide/svelte/icons/key';
 import Integration from '@lucide/svelte/icons/plug-2';
 import Settings from '@lucide/svelte/icons/settings';
@@ -44,19 +43,13 @@ export function routes(): NavigationItem[] {
             group: 'Project Settings',
             href: resolve('/(app)/project/[projectId]/configuration-values', { projectId: page.params.projectId }),
             icon: ClientConfig,
-            title: 'Configuration Values'
+            title: 'Configuration'
         },
         {
             group: 'Project Settings',
             href: resolve('/(app)/project/[projectId]/integrations', { projectId: page.params.projectId }),
             icon: Integration,
             title: 'Integrations'
-        },
-        {
-            group: 'Project Settings',
-            href: resolve('/(app)/project/[projectId]/configure', { projectId: page.params.projectId }),
-            icon: Configure,
-            title: 'Configure Client'
         },
         {
             group: 'Project Settings',

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/add/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/add/+page.svelte
@@ -16,6 +16,7 @@
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
     import { ProblemDetails } from '@exceptionless/fetchclient';
     import { createForm } from '@tanstack/svelte-form';
+    import { untrack } from 'svelte';
     import { toast } from 'svelte-sonner';
 
     let toastId = $state<number | string>();
@@ -25,14 +26,14 @@
         defaultValues: {
             delete_bot_data_enabled: true,
             name: '',
-            organization_id: organization.current
+            organization_id: organization.current ?? ''
         } as NewProjectFormData,
         validators: {
             onSubmit: NewProjectSchema,
             onSubmitAsync: async ({ value }) => {
                 toast.dismiss(toastId);
                 try {
-                    const { id } = await createProject.mutateAsync(value as NewProject);
+                    const { id } = await createProject.mutateAsync({ ...value, organization_id: organization.current ?? value.organization_id } as NewProject);
                     toastId = toast.success('Project added successfully');
                     await goto(resolve('/(app)/project/[projectId]/configure', { projectId: id }) + '?redirect=true');
                     return null;
@@ -52,12 +53,17 @@
             }
         }
     }));
+
+    $effect(() => {
+        const organizationId = organization.current ?? '';
+        untrack(() => form.setFieldValue('organization_id', organizationId));
+    });
 </script>
 
 <div class="flex flex-col gap-4">
     <div class="flex flex-col gap-1">
         <H3>Add Project</H3>
-        <Muted>Add a new project to start tracking errors and events</Muted>
+        <Muted>Create a project, then configure a client to send your first event.</Muted>
     </div>
     <form
         onsubmit={(e) => {
@@ -94,7 +100,7 @@
                     {#if isSubmitting}
                         <Spinner /> Adding Project...
                     {:else}
-                        Add Project
+                        Continue to Client Setup
                     {/if}
                 </Button>
             {/snippet}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/actions/[[category]]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/actions/[[category]]/+page.svelte
@@ -4,13 +4,17 @@
     import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';
     import { page } from '$app/state';
-    import { Muted } from '$comp/typography';
+    import CopyToClipboardButton from '$comp/copy-to-clipboard-button.svelte';
+    import { CodeBlock, Muted } from '$comp/typography';
     import { Button } from '$comp/ui/button';
+    import * as Dialog from '$comp/ui/dialog';
     import { Input } from '$comp/ui/input';
-    import { runMaintenanceJobMutation } from '$features/admin/api.svelte';
+    import { Spinner } from '$comp/ui/spinner';
+    import { getPredefinedSavedViewsMutation, runMaintenanceJobMutation } from '$features/admin/api.svelte';
     import RunMaintenanceJobDialog from '$features/admin/components/dialogs/run-maintenance-job-dialog.svelte';
     import { maintenanceActions } from '$features/admin/models';
     import { ProblemDetails } from '@exceptionless/fetchclient';
+    import FileJson from '@lucide/svelte/icons/file-json';
     import Play from '@lucide/svelte/icons/play';
     import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
     import { toast } from 'svelte-sonner';
@@ -21,10 +25,15 @@
 
     let searchQuery = $state(page.url.searchParams.get('q') ?? '');
     let selectedAction = $state<MaintenanceAction | undefined>();
+    let jsonOutputAction = $state<MaintenanceAction | undefined>();
+    let jsonOutput = $state('');
+    let runningActionName = $state<string>();
     let openDialog = $state(false);
+    let openJsonDialog = $state(false);
     let toastId = $state<number | string>();
 
     const runJob = runMaintenanceJobMutation();
+    const predefinedSavedViews = getPredefinedSavedViewsMutation();
 
     $effect(() => {
         const query = searchQuery.trim();
@@ -65,9 +74,30 @@
 
     const destructiveCount = $derived(filteredActions.filter((a) => a.dangerous).length);
 
-    function handleRun(action: MaintenanceAction) {
+    async function handleRun(action: MaintenanceAction) {
+        if (action.kind === 'predefined-saved-views') {
+            await showPredefinedSavedViews(action);
+            return;
+        }
+
         selectedAction = action;
         openDialog = true;
+    }
+
+    async function showPredefinedSavedViews(action: MaintenanceAction) {
+        toast.dismiss(toastId);
+        runningActionName = action.name;
+
+        try {
+            jsonOutput = await predefinedSavedViews.mutateAsync();
+            jsonOutputAction = action;
+            openJsonDialog = true;
+        } catch (error: unknown) {
+            const message = error instanceof ProblemDetails ? error.title : 'Please try again.';
+            toastId = toast.error(`An error occurred while loading predefined saved views: ${message}`);
+        } finally {
+            runningActionName = undefined;
+        }
     }
 
     async function handleConfirm(params: Parameters<typeof runJob.mutateAsync>[0]) {
@@ -142,9 +172,27 @@
                     </div>
                     <p class="text-muted-foreground text-sm leading-relaxed">{action.description}</p>
                 </div>
-                <Button class="shrink-0" onclick={() => handleRun(action)} size="sm" variant={action.dangerous ? 'destructive' : 'outline'}>
-                    <Play class="size-3.5" />
-                    Run
+                <Button
+                    class="shrink-0"
+                    disabled={action.kind === 'predefined-saved-views' && predefinedSavedViews.isPending}
+                    onclick={() => {
+                        void handleRun(action);
+                    }}
+                    size="sm"
+                    variant={action.dangerous ? 'destructive' : 'outline'}
+                >
+                    {#if action.kind === 'predefined-saved-views'}
+                        {#if predefinedSavedViews.isPending && runningActionName === action.name}
+                            <Spinner />
+                            Loading...
+                        {:else}
+                            <FileJson class="size-3.5" aria-hidden="true" />
+                            View
+                        {/if}
+                    {:else}
+                        <Play class="size-3.5" aria-hidden="true" />
+                        Run
+                    {/if}
                 </Button>
             </div>
         {/each}
@@ -156,4 +204,29 @@
 
 {#if selectedAction && openDialog}
     <RunMaintenanceJobDialog bind:open={openDialog} action={selectedAction} onConfirm={handleConfirm} />
+{/if}
+
+{#if jsonOutputAction && openJsonDialog}
+    <Dialog.Root bind:open={openJsonDialog}>
+        <Dialog.Content class="max-h-[90vh] gap-3 sm:max-w-4xl">
+            <Dialog.Header>
+                <Dialog.Title>{jsonOutputAction.label}</Dialog.Title>
+                <Dialog.Description>Current response from /api/v2/saved-views/predefined.</Dialog.Description>
+            </Dialog.Header>
+            <div class="flex justify-end">
+                <CopyToClipboardButton value={jsonOutput} size="sm" variant="outline">Copy JSON</CopyToClipboardButton>
+            </div>
+            <CodeBlock class="max-h-[60vh] overflow-auto" code={jsonOutput} language="json" />
+            <Dialog.Footer>
+                <Button
+                    variant="outline"
+                    onclick={() => {
+                        openJsonDialog = false;
+                    }}
+                >
+                    Close
+                </Button>
+            </Dialog.Footer>
+        </Dialog.Content>
+    </Dialog.Root>
 {/if}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(auth)/signup/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(auth)/signup/+page.svelte
@@ -32,8 +32,8 @@
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$shared/validation';
     import { createForm } from '@tanstack/svelte-form';
 
-    const redirectUrl = resolve('/(app)/project/add');
     const inviteToken = page.url.searchParams.get('token');
+    const redirectUrl = inviteToken ? resolve('/(app)/project/add') : resolve('/(app)/organization/add');
 
     const form = createForm(() => ({
         defaultValues: {
@@ -63,142 +63,144 @@
         <Card.Title class="text-center text-2xl">Signup for a FREE account in seconds</Card.Title>
     </Card.Header>
     <Card.Content>
-        {#if enableOAuthLogin}
-            <P class="text-center">Sign up with</P>
-            <div class="auto-cols-2 grid grid-flow-col grid-rows-2 gap-4">
-                {#if microsoftClientId}
-                    <Button aria-label="Sign up with Microsoft" onclick={() => liveLogin(redirectUrl)}>
-                        <MicrosoftIcon class="size-4" /> Microsoft
-                    </Button>
-                {/if}
-                {#if googleClientId}
-                    <Button aria-label="Sign up with Google" onclick={() => googleLogin(redirectUrl)}>
-                        <GoogleIcon class="size-4" /> Google
-                    </Button>
-                {/if}
-                {#if facebookClientId}
-                    <Button aria-label="Sign up with Facebook" onclick={() => facebookLogin(redirectUrl)}>
-                        <FacebookIcon class="size-4" /> Facebook
-                    </Button>
-                {/if}
-                {#if gitHubClientId}
-                    <Button aria-label="Sign up with GitHub" onclick={() => githubLogin(redirectUrl)}>
-                        <GitHubIcon class="size-4" /> GitHub
-                    </Button>
-                {/if}
-            </div>
+        <div>
+            {#if enableOAuthLogin}
+                <P class="text-center">Sign up with</P>
+                <div class="auto-cols-2 grid grid-flow-col grid-rows-2 gap-4">
+                    {#if microsoftClientId}
+                        <Button aria-label="Sign up with Microsoft" onclick={() => liveLogin(redirectUrl)}>
+                            <MicrosoftIcon class="size-4" /> Microsoft
+                        </Button>
+                    {/if}
+                    {#if googleClientId}
+                        <Button aria-label="Sign up with Google" onclick={() => googleLogin(redirectUrl)}>
+                            <GoogleIcon class="size-4" /> Google
+                        </Button>
+                    {/if}
+                    {#if facebookClientId}
+                        <Button aria-label="Sign up with Facebook" onclick={() => facebookLogin(redirectUrl)}>
+                            <FacebookIcon class="size-4" /> Facebook
+                        </Button>
+                    {/if}
+                    {#if gitHubClientId}
+                        <Button aria-label="Sign up with GitHub" onclick={() => githubLogin(redirectUrl)}>
+                            <GitHubIcon class="size-4" /> GitHub
+                        </Button>
+                    {/if}
+                </div>
 
-            <div class="my-4 flex w-full items-center">
-                <hr class="w-full" />
-                <P class="px-3">OR</P>
-                <hr class="w-full" />
-            </div>
-        {/if}
+                <div class="my-4 flex w-full items-center">
+                    <hr class="w-full" />
+                    <P class="px-3">OR</P>
+                    <hr class="w-full" />
+                </div>
+            {/if}
 
-        <form
-            onsubmit={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                form.handleSubmit();
-            }}
-        >
-            <form.Subscribe selector={(state) => state.errors}>
-                {#snippet children(errors)}
-                    <ErrorMessage message={getFormErrorMessages(errors)}></ErrorMessage>
-                {/snippet}
-            </form.Subscribe>
-            <form.Field name="name">
-                {#snippet children(field)}
-                    <Field.Field data-invalid={ariaInvalid(field)}>
-                        <Field.Label for={field.name}>Name</Field.Label>
-                        <Input
-                            id={field.name}
-                            name={field.name}
-                            type="text"
-                            placeholder="Your first and last name"
-                            autocomplete="name"
-                            autocapitalize="words"
-                            required
-                            value={field.state.value}
-                            onblur={field.handleBlur}
-                            oninput={(e) => field.handleChange(e.currentTarget.value)}
-                            aria-invalid={ariaInvalid(field)}
-                        />
-                        <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
-                    </Field.Field>
-                {/snippet}
-            </form.Field>
-            <form.Field name="email" validators={{ onChangeAsync: ({ value }) => validateEmailAvailability(value), onChangeAsyncDebounceMs: 1000 }}>
-                {#snippet children(field)}
-                    <Field.Field data-invalid={ariaInvalid(field)}>
-                        <Field.Label for={field.name}>Email</Field.Label>
-                        <InputGroup.Root>
-                            <InputGroup.Input
+            <form
+                onsubmit={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    form.handleSubmit();
+                }}
+            >
+                <form.Subscribe selector={(state) => state.errors}>
+                    {#snippet children(errors)}
+                        <ErrorMessage message={getFormErrorMessages(errors)}></ErrorMessage>
+                    {/snippet}
+                </form.Subscribe>
+                <form.Field name="name">
+                    {#snippet children(field)}
+                        <Field.Field data-invalid={ariaInvalid(field)}>
+                            <Field.Label for={field.name}>Name</Field.Label>
+                            <Input
                                 id={field.name}
                                 name={field.name}
-                                type="email"
-                                placeholder="Email address (no spam)"
-                                autocomplete="email"
+                                type="text"
+                                placeholder="Your first and last name"
+                                autocomplete="name"
+                                autocapitalize="words"
                                 required
                                 value={field.state.value}
                                 onblur={field.handleBlur}
                                 oninput={(e) => field.handleChange(e.currentTarget.value)}
                                 aria-invalid={ariaInvalid(field)}
                             />
-                            {#if field.state.meta.isValidating}
-                                <InputGroup.Addon align="inline-end" aria-label="Validating email">
-                                    <Spinner class="size-4" />
-                                </InputGroup.Addon>
+                            <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
+                        </Field.Field>
+                    {/snippet}
+                </form.Field>
+                <form.Field name="email" validators={{ onChangeAsync: ({ value }) => validateEmailAvailability(value), onChangeAsyncDebounceMs: 1000 }}>
+                    {#snippet children(field)}
+                        <Field.Field data-invalid={ariaInvalid(field)}>
+                            <Field.Label for={field.name}>Email</Field.Label>
+                            <InputGroup.Root>
+                                <InputGroup.Input
+                                    id={field.name}
+                                    name={field.name}
+                                    type="email"
+                                    placeholder="Email address (no spam)"
+                                    autocomplete="email"
+                                    required
+                                    value={field.state.value}
+                                    onblur={field.handleBlur}
+                                    oninput={(e) => field.handleChange(e.currentTarget.value)}
+                                    aria-invalid={ariaInvalid(field)}
+                                />
+                                {#if field.state.meta.isValidating}
+                                    <InputGroup.Addon align="inline-end" aria-label="Validating email">
+                                        <Spinner class="size-4" />
+                                    </InputGroup.Addon>
+                                {/if}
+                            </InputGroup.Root>
+                            <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
+                        </Field.Field>
+                    {/snippet}
+                </form.Field>
+                <form.Field name="password">
+                    {#snippet children(field)}
+                        <Field.Field data-invalid={ariaInvalid(field)}>
+                            <Field.Label for={field.name}>Password</Field.Label>
+                            <Input
+                                id={field.name}
+                                name={field.name}
+                                type="password"
+                                placeholder="Password"
+                                autocomplete="new-password"
+                                maxlength={100}
+                                minlength={6}
+                                required
+                                value={field.state.value}
+                                onblur={field.handleBlur}
+                                oninput={(e) => field.handleChange(e.currentTarget.value)}
+                                aria-invalid={ariaInvalid(field)}
+                            />
+                            <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
+                        </Field.Field>
+                    {/snippet}
+                </form.Field>
+                <form.Subscribe selector={(state) => state.isSubmitting}>
+                    {#snippet children(isSubmitting)}
+                        <Button type="submit" class="mt-4 w-full" disabled={isSubmitting}>
+                            {#if isSubmitting}
+                                <Spinner /> Creating Account...
+                            {:else}
+                                Create My Account
                             {/if}
-                        </InputGroup.Root>
-                        <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
-                    </Field.Field>
-                {/snippet}
-            </form.Field>
-            <form.Field name="password">
-                {#snippet children(field)}
-                    <Field.Field data-invalid={ariaInvalid(field)}>
-                        <Field.Label for={field.name}>Password</Field.Label>
-                        <Input
-                            id={field.name}
-                            name={field.name}
-                            type="password"
-                            placeholder="Password"
-                            autocomplete="new-password"
-                            maxlength={100}
-                            minlength={6}
-                            required
-                            value={field.state.value}
-                            onblur={field.handleBlur}
-                            oninput={(e) => field.handleChange(e.currentTarget.value)}
-                            aria-invalid={ariaInvalid(field)}
-                        />
-                        <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
-                    </Field.Field>
-                {/snippet}
-            </form.Field>
-            <form.Subscribe selector={(state) => state.isSubmitting}>
-                {#snippet children(isSubmitting)}
-                    <Button type="submit" class="mt-4 w-full" disabled={isSubmitting}>
-                        {#if isSubmitting}
-                            <Spinner /> Creating Account...
-                        {:else}
-                            Create My Account
-                        {/if}
-                    </Button>
-                {/snippet}
-            </form.Subscribe>
-        </form>
+                        </Button>
+                    {/snippet}
+                </form.Subscribe>
+            </form>
 
-        <P class="mt-4 text-center text-sm">
-            Already have an account?
-            <A href={inviteToken ? `${resolve('/(auth)/login')}?token=${inviteToken}` : resolve('/(auth)/login')}>Log In</A>
-        </P>
+            <P class="mt-4 text-center text-sm">
+                Already have an account?
+                <A href={inviteToken ? `${resolve('/(auth)/login')}?token=${inviteToken}` : resolve('/(auth)/login')}>Log In</A>
+            </P>
 
-        <P class="text-center text-sm">
-            By signing up, you agree to our <A href="https://exceptionless.com/privacy" target="_blank">Privacy Policy</A>
-            and
-            <A href="https://exceptionless.com/terms" target="_blank">Terms of Service</A>.
-        </P>
+            <P class="text-center text-sm">
+                By signing up, you agree to our <A href="https://exceptionless.com/privacy" target="_blank">Privacy Policy</A>
+                and
+                <A href="https://exceptionless.com/terms" target="_blank">Terms of Service</A>.
+            </P>
+        </div>
     </Card.Content>
 </Card.Root>

--- a/src/Exceptionless.Web/Controllers/SavedViewController.cs
+++ b/src/Exceptionless.Web/Controllers/SavedViewController.cs
@@ -433,20 +433,26 @@ public class SavedViewController : RepositoryApiController<ISavedViewRepository,
     {
         List<SavedView> savedViews = [];
 
-        await _lockProvider.TryUsingAsync($"predefined-saved-views:{organizationId}", async () =>
+        bool lockAcquired = await _lockProvider.TryUsingAsync($"predefined-saved-views:{organizationId}", async () =>
         {
             var organization = await _organizationRepository.GetByIdAsync(organizationId);
             if (organization is null)
                 return;
 
             if (onlyIfNeverCreated && HasCreatedPredefinedSavedViews(organization))
+            {
+                savedViews = await GetExistingPredefinedSavedViewsForOrganizationAsync(organizationId);
                 return;
+            }
 
             savedViews = await UpsertPredefinedSavedViewsForOrganizationAsync(organizationId);
             organization.Data ??= new DataDictionary();
             organization.Data[PredefinedSavedViewsDataKey] = PredefinedSavedViewsVersion.ToString();
             await _organizationRepository.SaveAsync(organization, o => o.Cache().ImmediateConsistency());
         }, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(15));
+
+        if (!lockAcquired)
+            return await GetExistingPredefinedSavedViewsForOrganizationAsync(organizationId);
 
         return savedViews;
     }
@@ -466,8 +472,7 @@ public class SavedViewController : RepositoryApiController<ISavedViewRepository,
                 savedViewsByView.Add(definition.ViewType, existingViews);
             }
 
-            var existing = existingViews.FirstOrDefault(view => view.UserId is null && String.Equals(view.PredefinedKey, definition.Key, StringComparison.OrdinalIgnoreCase))
-                ?? existingViews.FirstOrDefault(view => view.UserId is null && String.IsNullOrWhiteSpace(view.PredefinedKey) && String.Equals(view.Name.Trim(), definition.Name, StringComparison.OrdinalIgnoreCase));
+            var existing = FindPredefinedSavedView(definition, existingViews);
             var slug = GetUniqueSlug(definition.Slug, existingViews, existing?.Id);
 
             if (existing is null)
@@ -491,9 +496,41 @@ public class SavedViewController : RepositoryApiController<ISavedViewRepository,
         return upserted;
     }
 
+    private async Task<List<SavedView>> GetExistingPredefinedSavedViewsForOrganizationAsync(string organizationId)
+    {
+        var savedViewsByView = new Dictionary<string, List<SavedView>>(StringComparer.OrdinalIgnoreCase);
+        var existingPredefinedViews = new List<SavedView>();
+
+        var definitions = await GetPredefinedSavedViewsAsync();
+        foreach (var definition in definitions)
+        {
+            if (!savedViewsByView.TryGetValue(definition.ViewType, out var existingViews))
+            {
+                var results = await _repository.GetByViewAsync(organizationId, definition.ViewType, o => o.PageLimit(1000));
+                existingViews = results.Documents.ToList();
+                savedViewsByView.Add(definition.ViewType, existingViews);
+            }
+
+            var existing = FindPredefinedSavedView(definition, existingViews);
+            if (existing is not null)
+                existingPredefinedViews.Add(existing);
+        }
+
+        return existingPredefinedViews;
+    }
+
+    private static SavedView? FindPredefinedSavedView(PredefinedSavedViewDefinition definition, IReadOnlyCollection<SavedView> existingViews)
+    {
+        return existingViews.FirstOrDefault(view => view.UserId is null && String.Equals(view.PredefinedKey, definition.Key, StringComparison.OrdinalIgnoreCase))
+            ?? existingViews.FirstOrDefault(view => view.UserId is null && String.IsNullOrWhiteSpace(view.PredefinedKey) && String.Equals(view.Name.Trim(), definition.Name, StringComparison.OrdinalIgnoreCase));
+    }
+
     private static bool HasCreatedPredefinedSavedViews(Organization organization)
     {
-        return organization.Data is not null && organization.Data.ContainsKey(PredefinedSavedViewsDataKey);
+        if (organization.Data is null || !organization.Data.TryGetValue(PredefinedSavedViewsDataKey, out object? versionValue))
+            return false;
+
+        return Int32.TryParse(versionValue?.ToString(), out int version) && version >= PredefinedSavedViewsVersion;
     }
 
     private SavedView CreatePredefinedSavedView(string organizationId, PredefinedSavedViewDefinition definition, string slug)
@@ -698,11 +735,14 @@ public class SavedViewController : RepositoryApiController<ISavedViewRepository,
 
     private static bool DictionaryEquals(IReadOnlyDictionary<string, bool>? left, IReadOnlyDictionary<string, bool>? right)
     {
-        if ((left?.Count ?? 0) != (right?.Count ?? 0))
+        if (left is null)
+            return right is null;
+
+        if (right is null)
             return false;
 
-        if (left is null || right is null)
-            return true;
+        if (left.Count != right.Count)
+            return false;
 
         return left.All(kvp => right.TryGetValue(kvp.Key, out var value) && value == kvp.Value);
     }

--- a/src/Exceptionless.Web/Controllers/SavedViewController.cs
+++ b/src/Exceptionless.Web/Controllers/SavedViewController.cs
@@ -1,17 +1,21 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Exceptionless.Core.Authorization;
 using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Queries.Validation;
 using Exceptionless.Core.Repositories;
+using Exceptionless.Core.Seed;
 using Exceptionless.Web.Controllers;
 using Exceptionless.Web.Mapping;
 using Exceptionless.Web.Models;
 using Exceptionless.Web.Utility;
+using Foundatio.Lock;
 using Foundatio.Repositories;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using DataDictionary = Exceptionless.Core.Models.DataDictionary;
 
 namespace Exceptionless.App.Controllers.API;
 
@@ -20,14 +24,24 @@ namespace Exceptionless.App.Controllers.API;
 public class SavedViewController : RepositoryApiController<ISavedViewRepository, SavedView, ViewSavedView, NewSavedView, UpdateSavedView>
 {
     private const int MaxViewsPerOrganization = 100;
+    private const string PredefinedSavedViewsDataKey = "@@PredefinedSavedViewsVersion";
+    private const int PredefinedSavedViewsVersion = 2;
+
+    private readonly IOrganizationRepository _organizationRepository;
+    private readonly ILockProvider _lockProvider;
 
     public SavedViewController(
         ISavedViewRepository repository,
+        IOrganizationRepository organizationRepository,
+        ILockProvider lockProvider,
         ApiMapper mapper,
         IAppQueryValidator validator,
         TimeProvider timeProvider,
         ILoggerFactory loggerFactory) : base(repository, mapper, validator, timeProvider, loggerFactory)
-    { }
+    {
+        _organizationRepository = organizationRepository;
+        _lockProvider = lockProvider;
+    }
 
     protected override SavedView MapToModel(NewSavedView newModel)
     {
@@ -61,6 +75,7 @@ public class SavedViewController : RepositoryApiController<ISavedViewRepository,
             return NotFound();
 
         // Reads remain available even when the feature is disabled to preserve access to existing saved views.
+        await EnsurePredefinedSavedViewsCreatedAsync(organizationId);
 
         page = GetPage(page);
         limit = GetLimit(limit);
@@ -89,6 +104,7 @@ public class SavedViewController : RepositoryApiController<ISavedViewRepository,
             return NotFound();
 
         // Reads remain available even when the feature is disabled to preserve access to existing saved views.
+        await EnsurePredefinedSavedViewsCreatedAsync(organizationId);
 
         page = GetPage(page);
         limit = GetLimit(limit);
@@ -130,6 +146,69 @@ public class SavedViewController : RepositoryApiController<ISavedViewRepository,
             savedView.UserId = CurrentUser.Id;
 
         return await PostImplAsync(savedView);
+    }
+
+    /// <summary>
+    /// Create or update predefined saved views
+    /// </summary>
+    /// <param name="organizationId">The identifier of the organization.</param>
+    /// <response code="200">The predefined saved views were created or updated.</response>
+    /// <response code="404">The organization could not be found.</response>
+    [HttpPost("~/" + API_PREFIX + "/organizations/{organizationId:objectid}/saved-views/predefined")]
+    public async Task<ActionResult<IReadOnlyCollection<ViewSavedView>>> PostPredefinedAsync(string organizationId)
+    {
+        if (!IsInOrganization(organizationId))
+            return NotFound();
+
+        var savedViews = await UpsertPredefinedSavedViewsAsync(organizationId);
+        return Ok(MapToViewModels(savedViews));
+    }
+
+    /// <summary>
+    /// Get global predefined saved views as seed JSON
+    /// </summary>
+    /// <response code="200">The current predefined saved views.</response>
+    [HttpGet("predefined")]
+    [Authorize(Policy = AuthorizationRoles.GlobalAdminPolicy)]
+    public async Task<ActionResult<IReadOnlyCollection<PredefinedSavedViewDefinition>>> GetPredefinedAsync()
+    {
+        return Ok(await GetPredefinedSavedViewsAsync());
+    }
+
+    /// <summary>
+    /// Save a saved view as a global predefined saved view
+    /// </summary>
+    /// <param name="id">The identifier of the saved view to promote.</param>
+    /// <response code="200">The predefined saved view was created or updated.</response>
+    /// <response code="404">The saved view could not be found.</response>
+    [HttpPost("{id:objectid}/predefined")]
+    [Authorize(Policy = AuthorizationRoles.GlobalAdminPolicy)]
+    public async Task<ActionResult<ViewSavedView>> PostPredefinedSavedViewAsync(string id)
+    {
+        var source = await _repository.GetByIdAsync(id);
+        if (source is null)
+            return NotFound();
+
+        var savedView = await UpsertSystemPredefinedSavedViewAsync(source);
+        return Ok(MapToViewModel(savedView));
+    }
+
+    /// <summary>
+    /// Delete a global predefined saved view
+    /// </summary>
+    /// <param name="id">The identifier of the saved view whose predefined saved view should be deleted.</param>
+    /// <response code="204">The predefined saved view was deleted.</response>
+    /// <response code="404">The saved view could not be found.</response>
+    [HttpDelete("{id:objectid}/predefined")]
+    [Authorize(Policy = AuthorizationRoles.GlobalAdminPolicy)]
+    public async Task<ActionResult> DeletePredefinedSavedViewAsync(string id)
+    {
+        var source = await _repository.GetByIdAsync(id);
+        if (source is null)
+            return NotFound();
+
+        await DeleteSystemPredefinedSavedViewAsync(source);
+        return NoContent();
     }
 
     /// <summary>
@@ -341,6 +420,314 @@ public class SavedViewController : RepositoryApiController<ISavedViewRepository,
         return await base.CanDeleteAsync(value);
     }
 
+    private async Task EnsurePredefinedSavedViewsCreatedAsync(string organizationId)
+    {
+        var organization = await _organizationRepository.GetByIdAsync(organizationId);
+        if (organization is null || HasCreatedPredefinedSavedViews(organization))
+            return;
+
+        await UpsertPredefinedSavedViewsAsync(organizationId, true);
+    }
+
+    private async Task<IReadOnlyCollection<SavedView>> UpsertPredefinedSavedViewsAsync(string organizationId, bool onlyIfNeverCreated = false)
+    {
+        List<SavedView> savedViews = [];
+
+        await _lockProvider.TryUsingAsync($"predefined-saved-views:{organizationId}", async () =>
+        {
+            var organization = await _organizationRepository.GetByIdAsync(organizationId);
+            if (organization is null)
+                return;
+
+            if (onlyIfNeverCreated && HasCreatedPredefinedSavedViews(organization))
+                return;
+
+            savedViews = await UpsertPredefinedSavedViewsForOrganizationAsync(organizationId);
+            organization.Data ??= new DataDictionary();
+            organization.Data[PredefinedSavedViewsDataKey] = PredefinedSavedViewsVersion.ToString();
+            await _organizationRepository.SaveAsync(organization, o => o.Cache().ImmediateConsistency());
+        }, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(15));
+
+        return savedViews;
+    }
+
+    private async Task<List<SavedView>> UpsertPredefinedSavedViewsForOrganizationAsync(string organizationId)
+    {
+        var savedViewsByView = new Dictionary<string, List<SavedView>>(StringComparer.OrdinalIgnoreCase);
+        var upserted = new List<SavedView>();
+
+        var definitions = await GetPredefinedSavedViewsAsync();
+        foreach (var definition in definitions)
+        {
+            if (!savedViewsByView.TryGetValue(definition.ViewType, out var existingViews))
+            {
+                var results = await _repository.GetByViewAsync(organizationId, definition.ViewType, o => o.PageLimit(1000));
+                existingViews = results.Documents.ToList();
+                savedViewsByView.Add(definition.ViewType, existingViews);
+            }
+
+            var existing = existingViews.FirstOrDefault(view => view.UserId is null && String.Equals(view.PredefinedKey, definition.Key, StringComparison.OrdinalIgnoreCase))
+                ?? existingViews.FirstOrDefault(view => view.UserId is null && String.IsNullOrWhiteSpace(view.PredefinedKey) && String.Equals(view.Name.Trim(), definition.Name, StringComparison.OrdinalIgnoreCase));
+            var slug = GetUniqueSlug(definition.Slug, existingViews, existing?.Id);
+
+            if (existing is null)
+            {
+                var savedView = CreatePredefinedSavedView(organizationId, definition, slug);
+                await _repository.AddAsync(savedView, o => o.Cache().ImmediateConsistency());
+                existingViews.Add(savedView);
+                upserted.Add(savedView);
+                continue;
+            }
+
+            if (ApplyPredefinedSavedView(existing, definition, slug))
+            {
+                existing.UpdatedByUserId = CurrentUser.Id;
+                await _repository.SaveAsync(existing, o => o.Cache().ImmediateConsistency());
+            }
+
+            upserted.Add(existing);
+        }
+
+        return upserted;
+    }
+
+    private static bool HasCreatedPredefinedSavedViews(Organization organization)
+    {
+        return organization.Data is not null && organization.Data.ContainsKey(PredefinedSavedViewsDataKey);
+    }
+
+    private SavedView CreatePredefinedSavedView(string organizationId, PredefinedSavedViewDefinition definition, string slug)
+    {
+        return new SavedView
+        {
+            OrganizationId = organizationId,
+            CreatedByUserId = CurrentUser.Id,
+            PredefinedKey = definition.Key,
+            Name = definition.Name,
+            Slug = slug,
+            ViewType = definition.ViewType,
+            Filter = definition.Filter,
+            Time = definition.Time,
+            Sort = definition.Sort,
+            FilterDefinitions = PredefinedSavedViewsDataSeed.GetRawJson(definition.FilterDefinitions),
+            Columns = Copy(definition.Columns),
+            ColumnOrder = definition.ColumnOrder is null ? null : [.. definition.ColumnOrder],
+            ShowStats = definition.ShowStats,
+            ShowChart = definition.ShowChart,
+            Version = 1
+        };
+    }
+
+    private static bool ApplyPredefinedSavedView(SavedView savedView, PredefinedSavedViewDefinition definition, string slug)
+    {
+        var changed = false;
+        changed |= SetIfChanged(savedView, definition.Key, static (view, value) => view.PredefinedKey = value, static view => view.PredefinedKey);
+        changed |= SetIfChanged(savedView, definition.Name, static (view, value) => view.Name = value, static view => view.Name);
+        changed |= SetIfChanged(savedView, slug, static (view, value) => view.Slug = value, static view => view.Slug);
+        changed |= SetIfChanged(savedView, definition.Filter, static (view, value) => view.Filter = value, static view => view.Filter);
+        changed |= SetIfChanged(savedView, definition.Time, static (view, value) => view.Time = value, static view => view.Time);
+        changed |= SetIfChanged(savedView, definition.Sort, static (view, value) => view.Sort = value, static view => view.Sort);
+        changed |= SetIfChanged(savedView, PredefinedSavedViewsDataSeed.GetRawJson(definition.FilterDefinitions), static (view, value) => view.FilterDefinitions = value, static view => view.FilterDefinitions);
+        changed |= SetDictionaryIfChanged(savedView, definition.Columns);
+        changed |= SetListIfChanged(savedView, definition.ColumnOrder);
+        changed |= SetIfChanged(savedView, definition.ShowStats, static (view, value) => view.ShowStats = value, static view => view.ShowStats);
+        changed |= SetIfChanged(savedView, definition.ShowChart, static (view, value) => view.ShowChart = value, static view => view.ShowChart);
+        changed |= SetIfChanged(savedView, 1, static (view, value) => view.Version = value, static view => view.Version);
+
+        return changed;
+    }
+
+    private async Task<SavedView> UpsertSystemPredefinedSavedViewAsync(SavedView source)
+    {
+        var existingPredefinedViews = await GetSystemPredefinedSavedViewsAsync(source.ViewType);
+        var key = GetPredefinedKey(source);
+        var existing = existingPredefinedViews.FirstOrDefault(view => String.Equals(view.PredefinedKey, key, StringComparison.OrdinalIgnoreCase))
+            ?? existingPredefinedViews.FirstOrDefault(view => String.IsNullOrWhiteSpace(view.PredefinedKey) && String.Equals(view.Slug, source.Slug, StringComparison.OrdinalIgnoreCase));
+        var slug = GetUniqueSlug(source.Slug, existingPredefinedViews, existing?.Id);
+
+        if (existing is null)
+        {
+            var savedView = CreateSystemPredefinedSavedView(source, key, slug);
+            await _repository.AddAsync(savedView, o => o.Cache().ImmediateConsistency());
+            return savedView;
+        }
+
+        ApplySavedViewConfiguration(existing, source, key, slug);
+        existing.UpdatedByUserId = CurrentUser.Id;
+        await _repository.SaveAsync(existing, o => o.Cache().ImmediateConsistency());
+        return existing;
+    }
+
+    private SavedView CreateSystemPredefinedSavedView(SavedView source, string key, string slug)
+    {
+        var savedView = new SavedView
+        {
+            OrganizationId = PredefinedSavedViewsDataSeed.SystemOrganizationId,
+            CreatedByUserId = CurrentUser.Id,
+            Version = 1
+        };
+
+        ApplySavedViewConfiguration(savedView, source, key, slug);
+        return savedView;
+    }
+
+    private static void ApplySavedViewConfiguration(SavedView destination, SavedView source, string key, string slug)
+    {
+        destination.UserId = null;
+        destination.PredefinedKey = key;
+        destination.Name = source.Name;
+        destination.Slug = slug;
+        destination.ViewType = source.ViewType;
+        destination.Filter = source.Filter;
+        destination.Time = source.Time;
+        destination.Sort = source.Sort;
+        destination.FilterDefinitions = source.FilterDefinitions;
+        destination.Columns = Copy(source.Columns);
+        destination.ColumnOrder = source.ColumnOrder is null ? null : [.. source.ColumnOrder];
+        destination.ShowStats = source.ShowStats;
+        destination.ShowChart = source.ShowChart;
+    }
+
+    private async Task<IReadOnlyCollection<PredefinedSavedViewDefinition>> GetPredefinedSavedViewsAsync()
+    {
+        var definitions = new List<PredefinedSavedViewDefinition>();
+
+        foreach (var viewType in NewSavedView.ValidViewTypes)
+        {
+            var savedViews = await GetSystemPredefinedSavedViewsAsync(viewType);
+            foreach (var savedView in savedViews)
+            {
+                var key = GetPredefinedKey(savedView);
+                definitions.Add(ToPredefinedSavedView(savedView, key));
+            }
+        }
+
+        return definitions;
+    }
+
+    private async Task DeleteSystemPredefinedSavedViewAsync(SavedView source)
+    {
+        var key = GetPredefinedKey(source);
+        var existingPredefinedViews = await GetSystemPredefinedSavedViewsAsync(source.ViewType);
+        var existing = existingPredefinedViews.FirstOrDefault(view => String.Equals(view.PredefinedKey, key, StringComparison.OrdinalIgnoreCase))
+            ?? existingPredefinedViews.FirstOrDefault(view => String.IsNullOrWhiteSpace(view.PredefinedKey) && String.Equals(view.Slug, source.Slug, StringComparison.OrdinalIgnoreCase));
+
+        if (existing is not null)
+            await _repository.RemoveAsync(existing.Id, o => o.ImmediateConsistency());
+    }
+
+    private async Task<List<SavedView>> GetSystemPredefinedSavedViewsAsync(string viewType)
+    {
+        var results = await _repository.GetByViewAsync(PredefinedSavedViewsDataSeed.SystemOrganizationId, viewType, o => o.PageLimit(1000));
+        return results.Documents.Where(view => view.UserId is null).ToList();
+    }
+
+    private static PredefinedSavedViewDefinition ToPredefinedSavedView(SavedView savedView, string key)
+    {
+        return new PredefinedSavedViewDefinition
+        {
+            Key = key,
+            Name = savedView.Name,
+            Slug = savedView.Slug,
+            ViewType = savedView.ViewType,
+            Filter = savedView.Filter,
+            Time = savedView.Time,
+            Sort = savedView.Sort,
+            FilterDefinitions = ParseFilterDefinitions(savedView.FilterDefinitions),
+            Columns = savedView.Columns,
+            ColumnOrder = savedView.ColumnOrder,
+            ShowStats = savedView.ShowStats,
+            ShowChart = savedView.ShowChart
+        };
+    }
+
+    private static JsonElement? ParseFilterDefinitions(string? filterDefinitions)
+    {
+        if (String.IsNullOrWhiteSpace(filterDefinitions))
+            return null;
+
+        try
+        {
+            return JsonSerializer.Deserialize<JsonElement>(filterDefinitions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string GetPredefinedKey(SavedView savedView)
+    {
+        if (!String.IsNullOrWhiteSpace(savedView.PredefinedKey))
+            return savedView.PredefinedKey;
+
+        return $"{savedView.ViewType}:{ToSlug(String.IsNullOrWhiteSpace(savedView.Slug) ? savedView.Name : savedView.Slug)}";
+    }
+
+    private static bool SetIfChanged<T>(SavedView savedView, T value, Action<SavedView, T> setValue, Func<SavedView, T> getValue)
+    {
+        if (EqualityComparer<T>.Default.Equals(getValue(savedView), value))
+            return false;
+
+        setValue(savedView, value);
+        return true;
+    }
+
+    private static bool SetDictionaryIfChanged(SavedView savedView, IReadOnlyDictionary<string, bool>? value)
+    {
+        if (DictionaryEquals(savedView.Columns, value))
+            return false;
+
+        savedView.Columns = Copy(value);
+        return true;
+    }
+
+    private static bool SetListIfChanged(SavedView savedView, IReadOnlyCollection<string>? value)
+    {
+        if ((savedView.ColumnOrder ?? []).SequenceEqual(value ?? []))
+            return false;
+
+        savedView.ColumnOrder = value is null ? null : [.. value];
+        return true;
+    }
+
+    private static Dictionary<string, bool>? Copy(IReadOnlyDictionary<string, bool>? value)
+    {
+        return value is null ? null : value.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+    }
+
+    private static bool DictionaryEquals(IReadOnlyDictionary<string, bool>? left, IReadOnlyDictionary<string, bool>? right)
+    {
+        if ((left?.Count ?? 0) != (right?.Count ?? 0))
+            return false;
+
+        if (left is null || right is null)
+            return true;
+
+        return left.All(kvp => right.TryGetValue(kvp.Key, out var value) && value == kvp.Value);
+    }
+
+    private static string GetUniqueSlug(string slug, IReadOnlyCollection<SavedView> existingViews, string? excludingId)
+    {
+        var baseSlug = ToSlug(slug);
+        if (String.IsNullOrWhiteSpace(baseSlug))
+            baseSlug = "saved-view";
+
+        baseSlug = baseSlug.Length > 100 ? baseSlug[..100].Trim('-') : baseSlug;
+        var candidate = baseSlug;
+        var suffix = 2;
+
+        while (existingViews.Any(view => view.Id != excludingId && String.Equals(ToFallbackSlug(String.IsNullOrWhiteSpace(view.Slug) ? view.Name : view.Slug, view.Id), candidate, StringComparison.OrdinalIgnoreCase)))
+        {
+            var suffixText = $"-{suffix}";
+            var maxBaseLength = 100 - suffixText.Length;
+            candidate = $"{baseSlug[..Math.Min(baseSlug.Length, maxBaseLength)].Trim('-')}{suffixText}";
+            suffix++;
+        }
+
+        return candidate;
+    }
+
     private async Task<bool> SlugExistsAsync(string organizationId, string viewType, string slug, string? excludingId)
     {
         var results = await _repository.GetByViewForUserAsync(organizationId, viewType, CurrentUser.Id, o => o.PageLimit(1000));
@@ -378,4 +765,5 @@ public class SavedViewController : RepositoryApiController<ISavedViewRepository,
 
         return String.IsNullOrWhiteSpace(id) ? "saved-view" : $"saved-view-{id}";
     }
+
 }

--- a/tests/Exceptionless.Tests/Controllers/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Controllers/Data/openapi.json
@@ -337,6 +337,134 @@
         }
       }
     },
+    "/api/v2/organizations/{organizationId}/saved-views/predefined": {
+      "post": {
+        "tags": [
+          "SavedView"
+        ],
+        "summary": "Create or update predefined saved views",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "description": "The identifier of the organization.",
+            "required": true,
+            "schema": {
+              "pattern": "^[a-zA-Z\\d]{24,36}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The predefined saved views were created or updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ViewSavedView"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The organization could not be found."
+          }
+        }
+      }
+    },
+    "/api/v2/saved-views/predefined": {
+      "get": {
+        "tags": [
+          "SavedView"
+        ],
+        "summary": "Get global predefined saved views as seed JSON",
+        "responses": {
+          "200": {
+            "description": "The current predefined saved views.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PredefinedSavedViewDefinition"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/saved-views/{id}/predefined": {
+      "post": {
+        "tags": [
+          "SavedView"
+        ],
+        "summary": "Save a saved view as a global predefined saved view",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The identifier of the saved view to promote.",
+            "required": true,
+            "schema": {
+              "pattern": "^[a-zA-Z\\d]{24,36}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The predefined saved view was created or updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ViewSavedView"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The saved view could not be found."
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "SavedView"
+        ],
+        "summary": "Delete a global predefined saved view",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The identifier of the saved view whose predefined saved view should be deleted.",
+            "required": true,
+            "schema": {
+              "pattern": "^[a-zA-Z\\d]{24,36}$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": { }
+            }
+          },
+          "204": {
+            "description": "The predefined saved view was deleted."
+          },
+          "404": {
+            "description": "The saved view could not be found."
+          }
+        }
+      }
+    },
     "/api/v2/saved-views/{ids}": {
       "delete": {
         "tags": [
@@ -7801,6 +7929,7 @@
           }
         }
       },
+      "JsonElement": { },
       "Login": {
         "required": [
           "email",
@@ -8245,6 +8374,87 @@
               "string"
             ],
             "description": "An optional identifier to be used for referencing this event instance at a later time."
+          }
+        }
+      },
+      "PredefinedSavedViewDefinition": {
+        "required": [
+          "key",
+          "name",
+          "slug",
+          "viewType"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "viewType": {
+            "type": "string"
+          },
+          "filter": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "time": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "sort": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "filterDefinitions": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/JsonElement"
+              }
+            ]
+          },
+          "columns": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "boolean"
+            }
+          },
+          "columnOrder": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "showStats": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "showChart": {
+            "type": [
+              "null",
+              "boolean"
+            ]
           }
         }
       },

--- a/tests/Exceptionless.Tests/Controllers/SavedViewControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/SavedViewControllerTests.cs
@@ -1,6 +1,8 @@
 using System.Net;
+using System.Text.Json;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
+using Exceptionless.Core.Seed;
 using Exceptionless.Core.Services;
 using Exceptionless.Core.Utility;
 using Exceptionless.Tests.Extensions;
@@ -14,12 +16,14 @@ namespace Exceptionless.Tests.Controllers;
 
 public sealed class SavedViewControllerTests : IntegrationTestsBase
 {
+    private readonly IOrganizationRepository _organizationRepository;
     private readonly ISavedViewRepository _savedViewRepository;
     private readonly IUserRepository _userRepository;
     private readonly OrganizationService _organizationService;
 
     public SavedViewControllerTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
     {
+        _organizationRepository = GetService<IOrganizationRepository>();
         _savedViewRepository = GetService<ISavedViewRepository>();
         _userRepository = GetService<IUserRepository>();
         _organizationService = GetService<OrganizationService>();
@@ -30,6 +34,73 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
         await base.ResetDataAsync();
         var service = GetService<SampleDataService>();
         await service.CreateDataAsync();
+        await GetService<DataSeedService>().SeedAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task DataSeedAsync_ExistingDataWithoutPredefinedViews_CreatesSystemPredefinedViews()
+    {
+        // Arrange
+        Assert.True(await _organizationRepository.CountAsync() > 0);
+
+        var existingSystemViews = await GetSystemPredefinedSavedViewsAsync();
+        Assert.Equal(5, existingSystemViews.Count);
+
+        foreach (var savedView in existingSystemViews)
+            await _savedViewRepository.RemoveAsync(savedView.Id, o => o.ImmediateConsistency());
+
+        await RefreshDataAsync();
+        Assert.Equal(0, await _savedViewRepository.CountByOrganizationIdAsync(PredefinedSavedViewsDataSeed.SystemOrganizationId));
+
+        // Act
+        await GetService<DataSeedService>().SeedAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var seededSystemViews = await GetSystemPredefinedSavedViewsAsync();
+        Assert.Equal(5, seededSystemViews.Count);
+        Assert.Contains(seededSystemViews, view => IsPredefinedSavedView(view, "events", "Logs"));
+        Assert.Contains(seededSystemViews, view => IsPredefinedSavedView(view, "events", "Errors"));
+        Assert.Contains(seededSystemViews, view => IsPredefinedSavedView(view, "issues", "Most Frequent Errors"));
+        Assert.Contains(seededSystemViews, view => IsPredefinedSavedView(view, "issues", "Most Frequent 404s"));
+        Assert.Contains(seededSystemViews, view => IsPredefinedSavedView(view, "issues", "Most Used Features"));
+    }
+
+    [Fact]
+    public async Task GetPredefinedAsync_GlobalAdmin_ReturnsSeedJsonShape()
+    {
+        // Act
+        var response = await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("saved-views", "predefined")
+            .StatusCodeShouldBeOk()
+        );
+        string json = await response.Content.ReadAsStringAsync(TestCancellationToken);
+        var definitions = await DeserializeResponseAsync<List<PredefinedSavedViewDefinition>>(response);
+
+        // Assert
+        Assert.Contains("\"filterDefinitions\"", json);
+        Assert.DoesNotContain("\"filter_definitions\"", json);
+        Assert.NotNull(definitions);
+        Assert.Equal(5, definitions.Count);
+
+        var logs = definitions.FirstOrDefault(view => String.Equals(view.Key, "events:logs", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(logs);
+        Assert.Equal("Logs", logs.Name);
+        Assert.Equal("logs", logs.Slug);
+        Assert.Equal("events", logs.ViewType);
+        Assert.Equal("type:log", logs.Filter);
+        Assert.NotNull(logs.FilterDefinitions);
+        Assert.Equal(JsonValueKind.Array, logs.FilterDefinitions.Value.ValueKind);
+    }
+
+    [Fact]
+    public Task GetPredefinedAsync_User_ReturnsForbidden()
+    {
+        return SendRequestAsync(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("saved-views", "predefined")
+            .StatusCodeShouldBeForbidden()
+        );
     }
 
     [Fact]
@@ -434,6 +505,352 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
         Assert.NotNull(filters);
         Assert.Contains(filters, f => String.Equals(f.Id, eventsFilter.Id));
         Assert.DoesNotContain(filters, f => String.Equals(f.Id, issuesFilter.Id));
+    }
+
+    [Fact]
+    public async Task GetByOrganizationAsync_FirstRequest_CreatesPredefinedSavedViewsOnce()
+    {
+        // Act
+        var filters = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(filters);
+        Assert.Contains(filters, view => IsPredefinedSavedView(view, "events", "Logs"));
+        Assert.Contains(filters, view => IsPredefinedSavedView(view, "events", "Errors"));
+        Assert.Contains(filters, view => IsPredefinedSavedView(view, "issues", "Most Frequent Errors"));
+        Assert.Contains(filters, view => IsPredefinedSavedView(view, "issues", "Most Frequent 404s"));
+        Assert.Contains(filters, view => IsPredefinedSavedView(view, "issues", "Most Used Features"));
+
+        foreach (var savedView in filters.Where(IsPredefinedSavedView))
+            await _savedViewRepository.RemoveAsync(savedView.Id, o => o.ImmediateConsistency());
+
+        await RefreshDataAsync();
+
+        var afterDelete = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views")
+            .StatusCodeShouldBeOk()
+        );
+
+        Assert.NotNull(afterDelete);
+        Assert.DoesNotContain(afterDelete, IsPredefinedSavedView);
+    }
+
+    [Fact]
+    public async Task PostPredefinedAsync_AfterDelete_RecreatesPredefinedSavedViews()
+    {
+        // Arrange
+        var filters = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views")
+            .StatusCodeShouldBeOk()
+        );
+
+        Assert.NotNull(filters);
+        foreach (var savedView in filters.Where(IsPredefinedSavedView))
+            await _savedViewRepository.RemoveAsync(savedView.Id, o => o.ImmediateConsistency());
+
+        await RefreshDataAsync();
+
+        // Act
+        var predefinedViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views", "predefined")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(predefinedViews);
+        Assert.Equal(5, predefinedViews.Count);
+        Assert.Contains(predefinedViews, view => IsPredefinedSavedView(view, "events", "Logs"));
+        Assert.Contains(predefinedViews, view => IsPredefinedSavedView(view, "events", "Errors"));
+        Assert.Contains(predefinedViews, view => IsPredefinedSavedView(view, "issues", "Most Frequent Errors"));
+        Assert.Contains(predefinedViews, view => IsPredefinedSavedView(view, "issues", "Most Frequent 404s"));
+        Assert.Contains(predefinedViews, view => IsPredefinedSavedView(view, "issues", "Most Used Features"));
+    }
+
+    [Fact]
+    public async Task PostPredefinedAsync_ExistingViews_UpdatesByNameAndViewTypeAndPreservesCustomViews()
+    {
+        // Arrange
+        var predefinedViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views", "predefined")
+            .StatusCodeShouldBeOk()
+        );
+
+        Assert.NotNull(predefinedViews);
+        var logs = predefinedViews.FirstOrDefault(view => IsPredefinedSavedView(view, "events", "Logs"));
+        Assert.NotNull(logs);
+
+        var savedLogs = await _savedViewRepository.GetByIdAsync(logs.Id);
+        Assert.NotNull(savedLogs);
+        savedLogs.Filter = "type:error";
+        savedLogs.Slug = "legacy-logs";
+        await _savedViewRepository.SaveAsync(savedLogs, o => o.ImmediateConsistency());
+
+        var testUser = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_USER_EMAIL);
+        Assert.NotNull(testUser);
+
+        var customView = await _savedViewRepository.AddAsync(new SavedView
+        {
+            OrganizationId = SampleDataService.TEST_ORG_ID,
+            Name = "Custom Investigation",
+            Filter = "type:error",
+            Slug = "custom-investigation",
+            ViewType = "events",
+            CreatedByUserId = testUser.Id
+        }, o => o.ImmediateConsistency());
+
+        await RefreshDataAsync();
+
+        // Act
+        var updatedPredefinedViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views", "predefined")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(updatedPredefinedViews);
+        var updatedLogs = updatedPredefinedViews.FirstOrDefault(view => IsPredefinedSavedView(view, "events", "Logs"));
+        Assert.NotNull(updatedLogs);
+        Assert.Equal(logs.Id, updatedLogs.Id);
+        Assert.Equal("type:log", updatedLogs.Filter);
+        Assert.Equal("logs", updatedLogs.Slug);
+
+        Assert.NotNull(await _savedViewRepository.GetByIdAsync(customView.Id));
+    }
+
+    [Fact]
+    public Task PostPredefinedAsync_CrossOrganization_ReturnsNotFound()
+    {
+        return SendRequestAsync(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.FREE_ORG_ID, "saved-views", "predefined")
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
+    public async Task PostPredefinedSavedViewAsync_GlobalAdmin_UsesPromotedConfigurationForPredefinedViews()
+    {
+        // Arrange
+        var predefinedViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views", "predefined")
+            .StatusCodeShouldBeOk()
+        );
+
+        Assert.NotNull(predefinedViews);
+        var logs = predefinedViews.FirstOrDefault(view => IsPredefinedSavedView(view, "events", "Logs"));
+        Assert.NotNull(logs);
+
+        var savedLogs = await _savedViewRepository.GetByIdAsync(logs.Id);
+        Assert.NotNull(savedLogs);
+        savedLogs.Name = "Application Logs";
+        savedLogs.Slug = "application-logs";
+        savedLogs.Filter = "type:log level:error";
+        savedLogs.ShowChart = false;
+        savedLogs.Columns = new Dictionary<string, bool>
+        {
+            ["summary"] = true,
+            ["date"] = true,
+            ["type"] = false
+        };
+        savedLogs.ColumnOrder = ["summary", "date", "type"];
+        await _savedViewRepository.SaveAsync(savedLogs, o => o.ImmediateConsistency());
+        await RefreshDataAsync();
+
+        // Act
+        var promoted = await SendRequestAsAsync<ViewSavedView>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPaths("saved-views", logs.Id, "predefined")
+            .StatusCodeShouldBeOk()
+        );
+
+        Assert.NotNull(promoted);
+        Assert.Equal("Application Logs", promoted.Name);
+        Assert.Equal("application-logs", promoted.Slug);
+
+        foreach (var savedView in predefinedViews)
+            await _savedViewRepository.RemoveAsync(savedView.Id, o => o.ImmediateConsistency());
+
+        await RefreshDataAsync();
+
+        var updatedPredefinedViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views", "predefined")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(updatedPredefinedViews);
+        Assert.Equal(5, updatedPredefinedViews.Count);
+        var applicationLogs = updatedPredefinedViews.FirstOrDefault(view => IsPredefinedSavedView(view, "events", "Application Logs"));
+        Assert.NotNull(applicationLogs);
+        Assert.Equal("application-logs", applicationLogs.Slug);
+        Assert.Equal("type:log level:error", applicationLogs.Filter);
+        Assert.False(applicationLogs.ShowChart);
+        Assert.NotNull(applicationLogs.Columns);
+        Assert.True(applicationLogs.Columns["summary"]);
+        Assert.False(applicationLogs.Columns["type"]);
+        Assert.Equal(new[] { "summary", "date", "type" }, applicationLogs.ColumnOrder);
+        Assert.DoesNotContain(updatedPredefinedViews, view => IsPredefinedSavedView(view, "events", "Logs"));
+        Assert.Contains(updatedPredefinedViews, view => IsPredefinedSavedView(view, "events", "Errors"));
+    }
+
+    [Fact]
+    public async Task PostPredefinedSavedViewAsync_AfterPatch_ExportsLatestConfiguration()
+    {
+        // Arrange
+        var predefinedViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views", "predefined")
+            .StatusCodeShouldBeOk()
+        );
+
+        Assert.NotNull(predefinedViews);
+        var logs = predefinedViews.FirstOrDefault(view => IsPredefinedSavedView(view, "events", "Logs"));
+        Assert.NotNull(logs);
+
+        await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("saved-views", logs.Id)
+            .StatusCodeShouldBeOk()
+        );
+
+        var changes = new UpdateSavedView
+        {
+            Filter = "type:log level:warn",
+            FilterDefinitions = """[{"type":"type","value":["log"],"hidden":true},{"type":"level","value":["Warn"]}]"""
+        };
+
+        await SendRequestAsync(r => r
+            .Patch()
+            .AsGlobalAdminUser()
+            .AppendPaths("saved-views", logs.Id)
+            .Content(changes)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Act
+        await SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPaths("saved-views", logs.Id, "predefined")
+            .StatusCodeShouldBeOk()
+        );
+
+        var definitions = await SendRequestAsAsync<List<PredefinedSavedViewDefinition>>(r => r
+            .AsGlobalAdminUser()
+            .AppendPaths("saved-views", "predefined")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(definitions);
+        var logsDefinition = definitions.FirstOrDefault(view => String.Equals(view.Key, "events:logs", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(logsDefinition);
+        Assert.Equal("type:log level:warn", logsDefinition.Filter);
+        Assert.NotNull(logsDefinition.FilterDefinitions);
+
+        var filterDefinitions = logsDefinition.FilterDefinitions.Value;
+        Assert.Equal(JsonValueKind.Array, filterDefinitions.ValueKind);
+        Assert.Equal(2, filterDefinitions.GetArrayLength());
+        Assert.True(filterDefinitions[0].GetProperty("hidden").GetBoolean());
+        Assert.Equal("level", filterDefinitions[1].GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task PostPredefinedSavedViewAsync_User_ReturnsForbidden()
+    {
+        // Arrange
+        var created = await CreateSavedViewAsync("User View", "type:error", "events");
+        Assert.NotNull(created);
+
+        // Act & Assert
+        await SendRequestAsync(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPaths("saved-views", created.Id, "predefined")
+            .StatusCodeShouldBeForbidden()
+        );
+    }
+
+    [Fact]
+    public async Task DeletePredefinedSavedViewAsync_GlobalAdmin_RemovesSeededPredefinedView()
+    {
+        // Arrange
+        var predefinedViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views", "predefined")
+            .StatusCodeShouldBeOk()
+        );
+
+        Assert.NotNull(predefinedViews);
+        var logs = predefinedViews.FirstOrDefault(view => IsPredefinedSavedView(view, "events", "Logs"));
+        Assert.NotNull(logs);
+
+        // Act
+        await SendRequestAsync(r => r
+            .Delete()
+            .AsGlobalAdminUser()
+            .AppendPaths("saved-views", logs.Id, "predefined")
+            .ExpectedStatus(HttpStatusCode.NoContent)
+        );
+
+        foreach (var savedView in predefinedViews)
+            await _savedViewRepository.RemoveAsync(savedView.Id, o => o.ImmediateConsistency());
+
+        await RefreshDataAsync();
+
+        var updatedPredefinedViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views", "predefined")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(updatedPredefinedViews);
+        Assert.Equal(4, updatedPredefinedViews.Count);
+        Assert.DoesNotContain(updatedPredefinedViews, view => IsPredefinedSavedView(view, "events", "Logs"));
+        Assert.Contains(updatedPredefinedViews, view => IsPredefinedSavedView(view, "events", "Errors"));
+
+        await GetService<DataSeedService>().SeedAsync(TestContext.Current.CancellationToken);
+        await RefreshDataAsync();
+
+        Assert.Equal(4, await _savedViewRepository.CountByOrganizationIdAsync(PredefinedSavedViewsDataSeed.SystemOrganizationId));
+    }
+
+    [Fact]
+    public async Task DeletePredefinedSavedViewAsync_User_ReturnsForbidden()
+    {
+        // Arrange
+        var created = await CreateSavedViewAsync("User View", "type:error", "events");
+        Assert.NotNull(created);
+
+        // Act & Assert
+        await SendRequestAsync(r => r
+            .Delete()
+            .AsTestOrganizationUser()
+            .AppendPaths("saved-views", created.Id, "predefined")
+            .StatusCodeShouldBeForbidden()
+        );
     }
 
     [Fact]
@@ -868,6 +1285,12 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
 
         await RefreshDataAsync();
         return result;
+    }
+
+    private async Task<List<SavedView>> GetSystemPredefinedSavedViewsAsync()
+    {
+        var results = await _savedViewRepository.GetByOrganizationForUserAsync(PredefinedSavedViewsDataSeed.SystemOrganizationId, PredefinedSavedViewsDataSeed.SystemUserId, o => o.PageLimit(1000));
+        return results.Documents.Where(view => view.UserId is null).ToList();
     }
 
     // CanUpdateAsync permission tests
@@ -1744,6 +2167,25 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
         Assert.True(removed > 0);
         Assert.Null(await _savedViewRepository.GetByIdAsync(privateView.Id));
         Assert.NotNull(await _savedViewRepository.GetByIdAsync(publicView.Id));
+    }
+
+    private static bool IsPredefinedSavedView(ViewSavedView savedView, string viewType, string name)
+    {
+        return String.Equals(savedView.ViewType, viewType, StringComparison.OrdinalIgnoreCase) && String.Equals(savedView.Name, name, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsPredefinedSavedView(SavedView savedView, string viewType, string name)
+    {
+        return String.Equals(savedView.ViewType, viewType, StringComparison.OrdinalIgnoreCase) && String.Equals(savedView.Name, name, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsPredefinedSavedView(ViewSavedView savedView)
+    {
+        return IsPredefinedSavedView(savedView, "events", "Logs")
+            || IsPredefinedSavedView(savedView, "events", "Errors")
+            || IsPredefinedSavedView(savedView, "issues", "Most Frequent Errors")
+            || IsPredefinedSavedView(savedView, "issues", "Most Frequent 404s")
+            || IsPredefinedSavedView(savedView, "issues", "Most Used Features");
     }
 
 }

--- a/tests/Exceptionless.Tests/Controllers/SavedViewControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/SavedViewControllerTests.cs
@@ -89,8 +89,8 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
         Assert.Equal("logs", logs.Slug);
         Assert.Equal("events", logs.ViewType);
         Assert.Equal("type:log", logs.Filter);
-        Assert.NotNull(logs.FilterDefinitions);
-        Assert.Equal(JsonValueKind.Array, logs.FilterDefinitions.Value.ValueKind);
+        var filterDefinitions = logs.FilterDefinitions ?? throw new Xunit.Sdk.XunitException("Expected FilterDefinitions to be non-null.");
+        Assert.Equal(JsonValueKind.Array, filterDefinitions.ValueKind);
     }
 
     [Fact]
@@ -765,9 +765,7 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
         var logsDefinition = definitions.FirstOrDefault(view => String.Equals(view.Key, "events:logs", StringComparison.OrdinalIgnoreCase));
         Assert.NotNull(logsDefinition);
         Assert.Equal("type:log level:warn", logsDefinition.Filter);
-        Assert.NotNull(logsDefinition.FilterDefinitions);
-
-        var filterDefinitions = logsDefinition.FilterDefinitions.Value;
+        var filterDefinitions = logsDefinition.FilterDefinitions ?? throw new Xunit.Sdk.XunitException("Expected FilterDefinitions to be non-null.");
         Assert.Equal(JsonValueKind.Array, filterDefinitions.ValueKind);
         Assert.Equal(2, filterDefinitions.GetArrayLength());
         Assert.True(filterDefinitions[0].GetProperty("hidden").GetBoolean());

--- a/tests/http/saved-views.http
+++ b/tests/http/saved-views.http
@@ -30,6 +30,14 @@ Authorization: Bearer {{token}}
 GET {{apiUrl}}/organizations/{{organizationId}}/saved-views/events
 Authorization: Bearer {{token}}
 
+### Create or update predefined saved views
+POST {{apiUrl}}/organizations/{{organizationId}}/saved-views/predefined
+Authorization: Bearer {{token}}
+
+### Get global predefined saved views as seed JSON
+GET {{apiUrl}}/saved-views/predefined
+Authorization: Bearer {{token}}
+
 ### Create organization-wide saved view
 # @name newSavedView
 POST {{apiUrl}}/organizations/{{organizationId}}/saved-views
@@ -87,6 +95,14 @@ Content-Type: application/json
     "sort": "date",
     "column_order": ["summary", "date", "user"]
 }
+
+### Save saved view as a predefined saved view
+POST {{apiUrl}}/saved-views/{{savedViewId}}/predefined
+Authorization: Bearer {{token}}
+
+### Delete predefined saved view
+DELETE {{apiUrl}}/saved-views/{{savedViewId}}/predefined
+Authorization: Bearer {{token}}
 
 ### Delete saved view
 DELETE {{apiUrl}}/saved-views/{{savedViewId}}


### PR DESCRIPTION
Adds predefined saved views that can be seeded globally, synced into organizations, and managed from the next UI.

Summary:
- Add data seeding for global predefined saved views, including hidden filter metadata in the seed JSON.
- Add saved view API endpoints for syncing organization predefined saved views and managing global predefined saved views.
- Add next UI actions to update/view predefined saved views and global admin picker actions to save/delete predefined definitions.
- Update OpenAPI baseline, HTTP samples, and controller coverage for the new API surface.

Validation:
- `npm run check`
- `dotnet test --artifacts-path artifacts/copilot-dotnet-test -- --filter-class Exceptionless.Tests.Controllers.SavedViewControllerTests`