### PR TITLE
Polish detail sheet and stack card UI

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
@@ -54,6 +54,16 @@ export interface DeleteEventsRequest {
     };
 }
 
+export interface EventNavigation {
+    nextId: null | string;
+    previousId: null | string;
+}
+
+export interface EventWithNavigation {
+    event: PersistentEvent;
+    navigation: EventNavigation;
+}
+
 export interface GetEventRequest {
     params?: {
         offset?: string;
@@ -201,23 +211,13 @@ export function getEventQuery(request: GetEventRequest) {
     }));
 }
 
-export interface EventNavigation {
-    nextId: string | null;
-    previousId: string | null;
-}
-
-export interface EventWithNavigation {
-    event: PersistentEvent;
-    navigation: EventNavigation;
-}
-
 export function getEventWithNavigationQuery(request: GetEventRequest) {
     const queryClient = useQueryClient();
     return createQuery<EventWithNavigation, ProblemDetails>(() => ({
         enabled: () => !!accessToken.current && !!request.route.id,
         placeholderData: () => {
             const cachedEvent = queryClient.getQueryData<PersistentEvent>(queryKeys.id(request.route.id));
-            return cachedEvent ? { event: cachedEvent, navigation: { previousId: null, nextId: null } } : undefined;
+            return cachedEvent ? { event: cachedEvent, navigation: { nextId: null, previousId: null } } : undefined;
         },
         queryFn: async ({ signal }: { signal: AbortSignal }) => {
             const client = useFetchClient();
@@ -238,8 +238,8 @@ export function getEventWithNavigationQuery(request: GetEventRequest) {
             return {
                 event,
                 navigation: {
-                    previousId: previousUrl ? previousUrl.split('/').pop() ?? null : null,
-                    nextId: nextUrl ? nextUrl.split('/').pop() ?? null : null
+                    nextId: nextUrl ? (nextUrl.split('/').pop() ?? null) : null,
+                    previousId: previousUrl ? (previousUrl.split('/').pop() ?? null) : null
                 }
             };
         },

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
@@ -201,6 +201,52 @@ export function getEventQuery(request: GetEventRequest) {
     }));
 }
 
+export interface EventNavigation {
+    nextId: string | null;
+    previousId: string | null;
+}
+
+export interface EventWithNavigation {
+    event: PersistentEvent;
+    navigation: EventNavigation;
+}
+
+export function getEventWithNavigationQuery(request: GetEventRequest) {
+    const queryClient = useQueryClient();
+    return createQuery<EventWithNavigation, ProblemDetails>(() => ({
+        enabled: () => !!accessToken.current && !!request.route.id,
+        placeholderData: () => {
+            const cachedEvent = queryClient.getQueryData<PersistentEvent>(queryKeys.id(request.route.id));
+            return cachedEvent ? { event: cachedEvent, navigation: { previousId: null, nextId: null } } : undefined;
+        },
+        queryFn: async ({ signal }: { signal: AbortSignal }) => {
+            const client = useFetchClient();
+            const response = await client.getJSON<PersistentEvent>(`events/${request.route.id}`, {
+                params: {
+                    ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
+                    ...request.params
+                },
+                signal
+            });
+
+            const event = response.data!;
+            queryClient.setQueryData(queryKeys.id(request.route.id), event);
+
+            const previousUrl = response.meta?.links?.previous?.url;
+            const nextUrl = response.meta?.links?.next?.url;
+
+            return {
+                event,
+                navigation: {
+                    previousId: previousUrl ? previousUrl.split('/').pop() ?? null : null,
+                    nextId: nextUrl ? nextUrl.split('/').pop() ?? null : null
+                }
+            };
+        },
+        queryKey: [...queryKeys.id(request.route.id), 'withNavigation']
+    }));
+}
+
 export function getOrganizationCountQuery(request: GetOrganizationCountRequest) {
     const queryClient = useQueryClient();
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/event-detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/event-detail-sheet.svelte
@@ -28,7 +28,7 @@
     }
 </script>
 
-<DetailSheet detailsHref={resolvedHref} {onClose} open={!!eventId} title="Event Details">
+<DetailSheet detailsHref={resolvedHref} {onClose} open={!!eventId} title="Event">
     {#if eventId}
         <EventsOverview {filterChanged} id={eventId} {handleError} onNavigate={(newId) => (eventId = newId)} />
     {/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/event-detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/event-detail-sheet.svelte
@@ -3,9 +3,7 @@
     import type { ProblemDetails } from '@exceptionless/fetchclient';
 
     import { resolve } from '$app/paths';
-    import { Button } from '$comp/ui/button';
-    import * as Sheet from '$comp/ui/sheet';
-    import ExternalLink from '@lucide/svelte/icons/external-link';
+    import DetailSheet from '$comp/detail-sheet.svelte';
 
     import EventsOverview from './events-overview.svelte';
 
@@ -21,10 +19,6 @@
 
     const resolvedHref = $derived(detailsHref ?? (eventId ? resolve('/(app)/events/[eventId=objectid]', { eventId }) : '#'));
 
-    function handleOpenChange() {
-        onClose();
-    }
-
     function handleError(problem: ProblemDetails) {
         if (onError) {
             onError(problem);
@@ -34,24 +28,8 @@
     }
 </script>
 
-<Sheet.Root onOpenChange={handleOpenChange} open={!!eventId}>
-    <Sheet.Content
-        class="top-15.25! bottom-0! h-auto! w-full transform-gpu overflow-y-auto rounded-l-lg border-l shadow-2xl duration-150 ease-out will-change-transform sm:max-w-full! md:w-5/6!"
-        overlayProps={{ class: 'top-15.25! bg-black/5 supports-backdrop-filter:backdrop-blur-none!' }}
-        preventScroll={false}
-    >
-        <Sheet.Header class="pt-4.5 pb-0">
-            <Sheet.Title class="flex items-center gap-2 text-2xl font-semibold tracking-tight" level={3}>
-                Event Details
-                <Button aria-label="Open event details in new window" href={resolvedHref} size="icon-sm" title="Open in new window" variant="ghost">
-                    <ExternalLink aria-hidden="true" />
-                </Button>
-            </Sheet.Title>
-        </Sheet.Header>
-        <div class="mt-0.5 px-4">
-            {#if eventId}
-                <EventsOverview {filterChanged} id={eventId} {handleError} />
-            {/if}
-        </div>
-    </Sheet.Content>
-</Sheet.Root>
+<DetailSheet detailsHref={resolvedHref} {onClose} open={!!eventId} title="Event Details">
+    {#if eventId}
+        <EventsOverview {filterChanged} id={eventId} {handleError} onNavigate={(newId) => (eventId = newId)} />
+    {/if}
+</DetailSheet>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
@@ -5,16 +5,19 @@
 
     import DateTime from '$comp/formatters/date-time.svelte';
     import TimeAgo from '$comp/formatters/time-ago.svelte';
+    import CopyToClipboardButton from '$comp/copy-to-clipboard-button.svelte';
     import { Button } from '$comp/ui/button';
+    import * as Dialog from '$comp/ui/dialog';
     import { Skeleton } from '$comp/ui/skeleton';
     import * as Table from '$comp/ui/table';
     import * as Tabs from '$comp/ui/tabs';
-    import { getEventQuery } from '$features/events/api.svelte';
+    import { getEventWithNavigationQuery } from '$features/events/api.svelte';
     import * as EventsFacetedFilter from '$features/events/components/filters';
     import { getExtendedDataItems, hasErrorOrSimpleError } from '$features/events/persistent-event';
     import { getOrganizationQuery } from '$features/organizations/api.svelte';
     import { getProjectQuery } from '$features/projects/api.svelte';
     import StackCard from '$features/stacks/components/stack-card.svelte';
+    import Braces from '@lucide/svelte/icons/braces';
     import ChevronLeft from '@lucide/svelte/icons/chevron-left';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
     import { onMount, tick } from 'svelte';
@@ -35,9 +38,10 @@
         filterChanged: (filter: IFilter) => void;
         handleError: (problem: ProblemDetails) => void;
         id: string;
+        onNavigate?: (eventId: string) => void;
     }
 
-    let { filterChanged, handleError, id }: Props = $props();
+    let { filterChanged, handleError, id, onNavigate }: Props = $props();
 
     function getTabs(event?: null | PersistentEvent, project?: ViewProject): TabType[] {
         if (!event) {
@@ -87,7 +91,7 @@
         return tabs;
     }
 
-    const eventQuery = getEventQuery({
+    const eventQuery = getEventWithNavigationQuery({
         route: {
             get id() {
                 return id;
@@ -95,10 +99,13 @@
         }
     });
 
+    const event = $derived(eventQuery.data?.event);
+    const navigation = $derived(eventQuery.data?.navigation);
+
     const projectQuery = getProjectQuery({
         route: {
             get id() {
-                return eventQuery.data?.project_id;
+                return event?.project_id;
             }
         }
     });
@@ -106,7 +113,7 @@
     const organizationQuery = getOrganizationQuery({
         route: {
             get id() {
-                return eventQuery.data?.organization_id;
+                return event?.organization_id;
             }
         }
     });
@@ -116,10 +123,11 @@
     type TabType = 'Environment' | 'Exception' | 'Extended Data' | 'Overview' | 'Request' | 'Trace Log' | string;
 
     let activeTab = $state<TabType>('Overview');
-    let tabs = $derived<TabType[]>(getTabs(eventQuery.data, projectQuery.data));
+    let tabs = $derived<TabType[]>(getTabs(event, projectQuery.data));
     let tabsListRef = $state<HTMLElement | null>(null);
     let canScrollTabsLeft = $state(false);
     let canScrollTabsRight = $state(false);
+    let showJsonDialog = $state(false);
 
     function updateTabsOverflow(): void {
         if (!tabsListRef) {
@@ -147,6 +155,18 @@
 
     function onDemoted(): void {
         activeTab = 'Extended Data';
+    }
+
+    function navigateToPrevious(): void {
+        if (navigation?.previousId && onNavigate) {
+            onNavigate(navigation.previousId);
+        }
+    }
+
+    function navigateToNext(): void {
+        if (navigation?.nextId && onNavigate) {
+            onNavigate(navigation.nextId);
+        }
     }
 
     $effect(() => {
@@ -185,107 +205,168 @@
     });
 </script>
 
-<StackCard {filterChanged} id={eventQuery.data?.stack_id}></StackCard>
+<section>
+    <h4 class="text-muted-foreground mb-3 text-sm font-semibold uppercase tracking-wide">Stack</h4>
+    <StackCard {filterChanged} id={event?.stack_id}></StackCard>
+</section>
 
-<Table.Root class="mt-4">
-    <Table.Body>
-        <Table.Row class="group">
-            {#if eventQuery.isSuccess}
-                <Table.Head class="w-40 font-semibold whitespace-nowrap">Occurred On</Table.Head>
-                <Table.Cell class="w-4 pr-0"></Table.Cell>
-                <Table.Cell class="flex items-center"
-                    ><DateTime value={eventQuery.data.date}></DateTime> (<TimeAgo value={eventQuery.data.date}></TimeAgo>)</Table.Cell
-                >
-            {:else}
-                <Table.Head class="w-40 font-semibold whitespace-nowrap"><Skeleton class="h-6 w-full rounded-full" /></Table.Head>
-                <Table.Cell class="w-4 pr-0"></Table.Cell>
-                <Table.Cell class="flex items-center"><Skeleton class="h-6 w-full rounded-full" /></Table.Cell>{/if}
-        </Table.Row>
-        <Table.Row class="group">
-            {#if projectQuery.isSuccess}
-                <Table.Head class="w-40 font-semibold whitespace-nowrap">Project</Table.Head>
-                <Table.Cell class="w-4 pr-0"
-                    ><EventsFacetedFilter.ProjectTrigger changed={filterChanged} class="mr-0" value={[projectQuery.data.id!]} /></Table.Cell
-                >
-                <Table.Cell>{projectQuery.data.name}</Table.Cell>
-            {:else}
-                <Table.Head class="w-40 font-semibold whitespace-nowrap"><Skeleton class="h-6 w-full rounded-full" /></Table.Head>
-                <Table.Cell class="w-4 pr-0"></Table.Cell>
-                <Table.Cell class="flex items-center"><Skeleton class="h-6 w-full rounded-full" /></Table.Cell>
-            {/if}
-        </Table.Row>
-    </Table.Body>
-</Table.Root>
-
-{#if eventQuery.isSuccess}
-    <Tabs.Root class="mt-4 mb-4" value={activeTab}>
-        <div class="relative">
-            {#if canScrollTabsLeft}
+<section class="mt-2">
+    <div class="mb-2 flex items-center justify-between">
+        <h4 class="text-muted-foreground text-sm font-semibold uppercase tracking-wide">Event</h4>
+        <div class="flex items-center gap-1">
+            {#if event}
                 <Button
-                    aria-label="Scroll tabs left"
-                    class="bg-background/95 absolute top-1/2 left-0 z-10 -translate-y-1/2 shadow-sm"
-                    onclick={() => scrollTabs('left')}
+                    aria-label="View Event JSON"
+                    onclick={() => (showJsonDialog = true)}
                     size="icon-sm"
+                    title="View Event JSON"
+                    variant="outline"
+                >
+                    <Braces class="size-4" />
+                </Button>
+            {/if}
+            {#if onNavigate && (navigation?.previousId || navigation?.nextId)}
+                <Button
+                    aria-label="Older event"
+                    disabled={!navigation?.previousId}
+                    onclick={navigateToPrevious}
+                    size="icon-sm"
+                    title="Older event"
                     variant="outline"
                 >
                     <ChevronLeft class="size-4" />
                 </Button>
-            {/if}
-            <Tabs.List
-                bind:ref={tabsListRef}
-                class="no-scrollbar w-full justify-normal overflow-x-auto overflow-y-hidden scroll-smooth"
-                onscroll={updateTabsOverflow}
-            >
-                {#each tabs as tab (tab)}
-                    <Tabs.Trigger class="flex-none px-3" value={tab}>{tab}</Tabs.Trigger>
-                {/each}
-            </Tabs.List>
-            {#if canScrollTabsRight}
                 <Button
-                    aria-label="Scroll tabs right"
-                    class="bg-background/95 absolute top-1/2 right-0 z-10 -translate-y-1/2 shadow-sm"
-                    onclick={() => scrollTabs('right')}
+                    aria-label="Newer event"
+                    disabled={!navigation?.nextId}
+                    onclick={navigateToNext}
                     size="icon-sm"
+                    title="Newer event"
                     variant="outline"
                 >
                     <ChevronRight class="size-4" />
                 </Button>
             {/if}
         </div>
+    </div>
 
-        {#each tabs as tab (tab)}
-            <Tabs.Content value={tab}>
-                {#if tab === 'Overview'}
-                    <Overview {filterChanged} event={eventQuery.data}></Overview>
-                {:else if tab === 'Exception'}
-                    <Error {filterChanged} event={eventQuery.data}></Error>
-                {:else if tab === 'Environment'}
-                    <Environment {filterChanged} event={eventQuery.data}></Environment>
-                {:else if tab === 'Request'}
-                    <Request {filterChanged} event={eventQuery.data}></Request>
-                {:else if tab === 'Trace Log'}
-                    <TraceLog logs={eventQuery.data.data?.['@trace']}></TraceLog>
-                {:else if tab === 'Session Events'}
-                    <SessionEvents event={eventQuery.data} {hasPremiumFeatures}></SessionEvents>
-                {:else if tab === 'Extended Data'}
-                    <ExtendedData event={eventQuery.data} project={projectQuery.data} promoted={onPromoted}></ExtendedData>
-                {:else}
-                    <PromotedExtendedData demoted={onDemoted} event={eventQuery.data} title={tab + ''}></PromotedExtendedData>
-                {/if}
-            </Tabs.Content>
-        {/each}
-    </Tabs.Root>
-{:else}
-    <Skeleton class="mt-4 h-7.5 w-full rounded-full" />
-    <Table.Root class="mt-4">
+    <Table.Root>
         <Table.Body>
-            {#each { length: 5 } as name, index (`${name}-${index}`)}
-                <Table.Row class="group">
+            <Table.Row class="group">
+                {#if event}
+                    <Table.Head class="w-40 font-semibold whitespace-nowrap">Occurred On</Table.Head>
+                    <Table.Cell class="w-4 pr-0"></Table.Cell>
+                    <Table.Cell class="flex items-center"
+                        ><DateTime value={event.date}></DateTime> (<TimeAgo value={event.date}></TimeAgo>)</Table.Cell
+                    >
+                {:else}
+                    <Table.Head class="w-40 font-semibold whitespace-nowrap"><Skeleton class="h-6 w-full rounded-full" /></Table.Head>
+                    <Table.Cell class="w-4 pr-0"></Table.Cell>
+                    <Table.Cell class="flex items-center"><Skeleton class="h-6 w-full rounded-full" /></Table.Cell>{/if}
+            </Table.Row>
+            <Table.Row class="group">
+                {#if projectQuery.isSuccess}
+                    <Table.Head class="w-40 font-semibold whitespace-nowrap">Project</Table.Head>
+                    <Table.Cell class="w-4 pr-0"
+                        ><EventsFacetedFilter.ProjectTrigger changed={filterChanged} class="mr-0" value={[projectQuery.data.id!]} /></Table.Cell
+                    >
+                    <Table.Cell>{projectQuery.data.name}</Table.Cell>
+                {:else}
                     <Table.Head class="w-40 font-semibold whitespace-nowrap"><Skeleton class="h-6 w-full rounded-full" /></Table.Head>
                     <Table.Cell class="w-4 pr-0"></Table.Cell>
                     <Table.Cell class="flex items-center"><Skeleton class="h-6 w-full rounded-full" /></Table.Cell>
-                </Table.Row>
-            {/each}
+                {/if}
+            </Table.Row>
         </Table.Body>
     </Table.Root>
-{/if}
+
+    {#if event}
+        <Tabs.Root class="mt-4 mb-4" value={activeTab}>
+            <div class="relative">
+                {#if canScrollTabsLeft}
+                    <Button
+                        aria-label="Scroll tabs left"
+                        class="bg-background/95 absolute top-1/2 left-0 z-10 -translate-y-1/2 shadow-sm"
+                        onclick={() => scrollTabs('left')}
+                        size="icon-sm"
+                        variant="outline"
+                    >
+                        <ChevronLeft class="size-4" />
+                    </Button>
+                {/if}
+                <Tabs.List
+                    bind:ref={tabsListRef}
+                    class="no-scrollbar w-full justify-normal overflow-x-auto overflow-y-hidden scroll-smooth"
+                    onscroll={updateTabsOverflow}
+                >
+                    {#each tabs as tab (tab)}
+                        <Tabs.Trigger class="flex-none px-3" value={tab}>{tab}</Tabs.Trigger>
+                    {/each}
+                </Tabs.List>
+                {#if canScrollTabsRight}
+                    <Button
+                        aria-label="Scroll tabs right"
+                        class="bg-background/95 absolute top-1/2 right-0 z-10 -translate-y-1/2 shadow-sm"
+                        onclick={() => scrollTabs('right')}
+                        size="icon-sm"
+                        variant="outline"
+                    >
+                        <ChevronRight class="size-4" />
+                    </Button>
+                {/if}
+            </div>
+
+            {#each tabs as tab (tab)}
+                <Tabs.Content value={tab}>
+                    {#if tab === 'Overview'}
+                        <Overview {filterChanged} {event}></Overview>
+                    {:else if tab === 'Exception'}
+                        <Error {filterChanged} {event}></Error>
+                    {:else if tab === 'Environment'}
+                        <Environment {filterChanged} {event}></Environment>
+                    {:else if tab === 'Request'}
+                        <Request {filterChanged} {event}></Request>
+                    {:else if tab === 'Trace Log'}
+                        <TraceLog logs={event.data?.['@trace']}></TraceLog>
+                    {:else if tab === 'Session Events'}
+                        <SessionEvents {event} {hasPremiumFeatures}></SessionEvents>
+                    {:else if tab === 'Extended Data'}
+                        <ExtendedData {event} project={projectQuery.data} promoted={onPromoted}></ExtendedData>
+                    {:else}
+                        <PromotedExtendedData demoted={onDemoted} {event} title={tab + ''}></PromotedExtendedData>
+                    {/if}
+                </Tabs.Content>
+            {/each}
+        </Tabs.Root>
+    {:else}
+        <Skeleton class="mt-4 h-7.5 w-full rounded-full" />
+        <Table.Root class="mt-4">
+            <Table.Body>
+                {#each { length: 5 } as name, index (`${name}-${index}`)}
+                    <Table.Row class="group">
+                        <Table.Head class="w-40 font-semibold whitespace-nowrap"><Skeleton class="h-6 w-full rounded-full" /></Table.Head>
+                        <Table.Cell class="w-4 pr-0"></Table.Cell>
+                        <Table.Cell class="flex items-center"><Skeleton class="h-6 w-full rounded-full" /></Table.Cell>
+                    </Table.Row>
+                {/each}
+            </Table.Body>
+        </Table.Root>
+    {/if}
+</section>
+
+<Dialog.Root bind:open={showJsonDialog}>
+    <Dialog.Content class="flex max-h-[min(42rem,calc(100vh-2rem))] flex-col sm:max-w-3xl">
+        <Dialog.Header>
+            <Dialog.Title>View Event JSON</Dialog.Title>
+            <Dialog.Description class="sr-only">Raw JSON representation of the event</Dialog.Description>
+        </Dialog.Header>
+        <div class="flex-1 overflow-y-auto rounded-md border p-4">
+            <pre class="text-xs whitespace-pre-wrap break-all">{JSON.stringify(event, null, 2)}</pre>
+        </div>
+        <Dialog.Footer>
+            <CopyToClipboardButton size="sm" title="Copy JSON to Clipboard" value={JSON.stringify(event, null, 2)} variant="outline">
+                Copy to Clipboard
+            </CopyToClipboardButton>
+        </Dialog.Footer>
+    </Dialog.Content>
+</Dialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
@@ -20,6 +20,7 @@
     import Braces from '@lucide/svelte/icons/braces';
     import ChevronLeft from '@lucide/svelte/icons/chevron-left';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
+    import Funnel from '@lucide/svelte/icons/funnel';
     import { onMount, tick } from 'svelte';
 
     import type { PersistentEvent } from '../models/index';
@@ -223,6 +224,17 @@
                     variant="outline"
                 >
                     <Braces class="size-4" />
+                </Button>
+            {/if}
+            {#if event?.stack_id}
+                <Button
+                    aria-label="Show all events"
+                    onclick={() => filterChanged(new EventsFacetedFilter.StringFilter('stack', event!.stack_id))}
+                    size="icon-sm"
+                    title="Show all events"
+                    variant="outline"
+                >
+                    <Funnel class="size-4" />
                 </Button>
             {/if}
             {#if onNavigate && (navigation?.previousId || navigation?.nextId)}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
@@ -3,9 +3,9 @@
     import type { ViewProject } from '$features/projects/models';
     import type { ProblemDetails } from '@exceptionless/fetchclient';
 
+    import CopyToClipboardButton from '$comp/copy-to-clipboard-button.svelte';
     import DateTime from '$comp/formatters/date-time.svelte';
     import TimeAgo from '$comp/formatters/time-ago.svelte';
-    import CopyToClipboardButton from '$comp/copy-to-clipboard-button.svelte';
     import { Button } from '$comp/ui/button';
     import * as Dialog from '$comp/ui/dialog';
     import { Skeleton } from '$comp/ui/skeleton';
@@ -207,22 +207,16 @@
 </script>
 
 <section>
-    <h4 class="text-muted-foreground mb-3 text-sm font-semibold uppercase tracking-wide">Stack</h4>
+    <h4 class="text-muted-foreground mb-3 text-sm font-semibold tracking-wide uppercase">Stack</h4>
     <StackCard {filterChanged} id={event?.stack_id}></StackCard>
 </section>
 
 <section class="mt-2">
     <div class="mb-2 flex items-center justify-between">
-        <h4 class="text-muted-foreground text-sm font-semibold uppercase tracking-wide">Event</h4>
+        <h4 class="text-muted-foreground text-sm font-semibold tracking-wide uppercase">Event</h4>
         <div class="flex items-center gap-1">
             {#if event}
-                <Button
-                    aria-label="View Event JSON"
-                    onclick={() => (showJsonDialog = true)}
-                    size="icon-sm"
-                    title="View Event JSON"
-                    variant="outline"
-                >
+                <Button aria-label="View Event JSON" onclick={() => (showJsonDialog = true)} size="icon-sm" title="View Event JSON" variant="outline">
                     <Braces class="size-4" />
                 </Button>
             {/if}
@@ -248,14 +242,7 @@
                 >
                     <ChevronLeft class="size-4" />
                 </Button>
-                <Button
-                    aria-label="Newer event"
-                    disabled={!navigation?.nextId}
-                    onclick={navigateToNext}
-                    size="icon-sm"
-                    title="Newer event"
-                    variant="outline"
-                >
+                <Button aria-label="Newer event" disabled={!navigation?.nextId} onclick={navigateToNext} size="icon-sm" title="Newer event" variant="outline">
                     <ChevronRight class="size-4" />
                 </Button>
             {/if}
@@ -268,9 +255,7 @@
                 {#if event}
                     <Table.Head class="w-40 font-semibold whitespace-nowrap">Occurred On</Table.Head>
                     <Table.Cell class="w-4 pr-0"></Table.Cell>
-                    <Table.Cell class="flex items-center"
-                        ><DateTime value={event.date}></DateTime> (<TimeAgo value={event.date}></TimeAgo>)</Table.Cell
-                    >
+                    <Table.Cell class="flex items-center"><DateTime value={event.date}></DateTime> (<TimeAgo value={event.date}></TimeAgo>)</Table.Cell>
                 {:else}
                     <Table.Head class="w-40 font-semibold whitespace-nowrap"><Skeleton class="h-6 w-full rounded-full" /></Table.Head>
                     <Table.Cell class="w-4 pr-0"></Table.Cell>
@@ -373,7 +358,7 @@
             <Dialog.Description class="sr-only">Raw JSON representation of the event</Dialog.Description>
         </Dialog.Header>
         <div class="flex-1 overflow-y-auto rounded-md border p-4">
-            <pre class="text-xs whitespace-pre-wrap break-all">{JSON.stringify(event, null, 2)}</pre>
+            <pre class="text-xs break-all whitespace-pre-wrap">{JSON.stringify(event, null, 2)}</pre>
         </div>
         <Dialog.Footer>
             <CopyToClipboardButton size="sm" title="Copy JSON to Clipboard" value={JSON.stringify(event, null, 2)} variant="outline">

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-stats-dashboard.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-stats-dashboard.svelte
@@ -20,7 +20,7 @@
     let { eventsPerHour = 0, isLoading = false, newStacks = 0, totalEvents = 0, totalStacks = 0 }: Props = $props();
 
     const metricCardClass =
-        "relative h-[66px]! justify-between gap-1! overflow-hidden bg-card py-2! ring-[color-mix(in_oklab,var(--chart-1)_42%,transparent)] before:absolute before:inset-x-0 before:top-0 before:h-1 before:bg-[linear-gradient(90deg,var(--chart-1),var(--chart-2))] before:content-['']";
+        "relative h-[66px]! justify-between gap-1! overflow-hidden bg-background py-2! ring-[color-mix(in_oklab,var(--chart-1)_42%,transparent)] before:absolute before:inset-x-0 before:top-0 before:h-1 before:bg-[linear-gradient(90deg,var(--chart-1),var(--chart-2))] before:content-['']";
     const metricHeaderClass = 'flex flex-row items-center justify-between gap-1.5 px-3 pb-0';
     const metricTitleClass = 'min-w-0 truncate text-xs font-semibold text-[color-mix(in_oklab,var(--chart-2)_82%,var(--foreground))]';
     const metricIconClass = 'size-3.5 shrink-0 text-[var(--chart-2)]';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-stats-dashboard.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-stats-dashboard.svelte
@@ -20,7 +20,7 @@
     let { eventsPerHour = 0, isLoading = false, newStacks = 0, totalEvents = 0, totalStacks = 0 }: Props = $props();
 
     const metricCardClass =
-        "relative h-[66px]! justify-between gap-1! overflow-hidden bg-background py-2! ring-[color-mix(in_oklab,var(--chart-1)_42%,transparent)] before:absolute before:inset-x-0 before:top-0 before:h-1 before:bg-[linear-gradient(90deg,var(--chart-1),var(--chart-2))] before:content-['']";
+        "relative h-[66px]! justify-between gap-1! overflow-hidden bg-card py-2! ring-[color-mix(in_oklab,var(--chart-1)_42%,transparent)] before:absolute before:inset-x-0 before:top-0 before:h-1 before:bg-[linear-gradient(90deg,var(--chart-1),var(--chart-2))] before:content-['']";
     const metricHeaderClass = 'flex flex-row items-center justify-between gap-1.5 px-3 pb-0';
     const metricTitleClass = 'min-w-0 truncate text-xs font-semibold text-[color-mix(in_oklab,var(--chart-2)_82%,var(--foreground))]';
     const metricIconClass = 'size-3.5 shrink-0 text-[var(--chart-2)]';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/boolean-faceted-filter-trigger.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/boolean-faceted-filter-trigger.svelte
@@ -16,7 +16,7 @@
     variant="ghost"
     size={children ? 'xs' : 'icon-xs'}
     onclick={() => changed(new BooleanFilter(term, value))}
-    title={`Search ${term}:${value}`}
+    title={`Filter ${term}:${value}`}
     class={['cursor-pointer', children ? '' : 'opacity-50 hover:opacity-100 focus-visible:opacity-100', className]}
     {...props}
 >

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/date-faceted-filter-trigger.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/date-faceted-filter-trigger.svelte
@@ -16,7 +16,7 @@
     variant="ghost"
     size={children ? 'xs' : 'icon-xs'}
     onclick={() => changed(new DateFilter(term, value ?? undefined))}
-    title={`Search ${term}:${value}`}
+    title={`Filter ${term}:${value}`}
     class={['cursor-pointer', children ? '' : 'opacity-50 hover:opacity-100 focus-visible:opacity-100', className]}
     {...props}
 >

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/level-faceted-filter-trigger.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/level-faceted-filter-trigger.svelte
@@ -15,7 +15,7 @@
     variant="ghost"
     size={children ? 'xs' : 'icon-xs'}
     onclick={() => changed(new LevelFilter(value))}
-    title={`Search level:${value}`}
+    title={`Filter level:${value}`}
     class={['cursor-pointer', children ? '' : 'opacity-50 hover:opacity-100 focus-visible:opacity-100', className]}
     {...props}
 >

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/number-faceted-filter-trigger.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/number-faceted-filter-trigger.svelte
@@ -16,7 +16,7 @@
     variant="ghost"
     size={children ? 'xs' : 'icon-xs'}
     onclick={() => changed(new NumberFilter(term, value))}
-    title={`Search ${term}:${value}`}
+    title={`Filter ${term}:${value}`}
     class={['cursor-pointer', children ? '' : 'opacity-50 hover:opacity-100 focus-visible:opacity-100', className]}
     {...props}
 >

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/project-faceted-filter-trigger.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/project-faceted-filter-trigger.svelte
@@ -15,7 +15,7 @@
     variant="ghost"
     size={children ? 'xs' : 'icon-xs'}
     onclick={() => changed(new ProjectFilter(value))}
-    title={`Search project:${value}`}
+    title={`Filter project:${value}`}
     class={['cursor-pointer', children ? '' : 'opacity-50 hover:opacity-100 focus-visible:opacity-100', className]}
     {...props}
 >

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/reference-faceted-filter-trigger.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/reference-faceted-filter-trigger.svelte
@@ -15,7 +15,7 @@
     variant="ghost"
     size={children ? 'xs' : 'icon-xs'}
     onclick={() => changed(new ReferenceFilter(value ?? undefined))}
-    title={`Search reference:${value}`}
+    title={`Filter reference:${value}`}
     class={['cursor-pointer', children ? '' : 'opacity-50 hover:opacity-100 focus-visible:opacity-100', className]}
     {...props}
 >

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/session-faceted-filter-trigger.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/session-faceted-filter-trigger.svelte
@@ -15,7 +15,7 @@
     variant="ghost"
     size={children ? 'xs' : 'icon-xs'}
     onclick={() => changed(new SessionFilter(value ?? undefined))}
-    title={`Search session:${value}`}
+    title={`Filter session:${value}`}
     class={['cursor-pointer', children ? '' : 'opacity-50 hover:opacity-100 focus-visible:opacity-100', className]}
     {...props}
 >

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/status-faceted-filter-trigger.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/status-faceted-filter-trigger.svelte
@@ -17,7 +17,7 @@
     variant="ghost"
     size={children ? 'xs' : 'icon-xs'}
     onclick={() => changed(new StatusFilter(value))}
-    title={`Search status:${value}`}
+    title={`Filter status:${value}`}
     class={['cursor-pointer', children ? '' : 'opacity-50 hover:opacity-100 focus-visible:opacity-100', className]}
     {...props}
 >

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/string-faceted-filter-trigger.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/string-faceted-filter-trigger.svelte
@@ -16,7 +16,7 @@
     variant="ghost"
     size={children ? 'xs' : 'icon-xs'}
     onclick={() => changed(new StringFilter(term, value ?? undefined))}
-    title={`Search ${term}:${value}`}
+    title={`Filter ${term}:${value}`}
     class={['cursor-pointer', children ? '' : 'opacity-50 hover:opacity-100 focus-visible:opacity-100', className]}
     {...props}
 >

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/type-faceted-filter-trigger.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/type-faceted-filter-trigger.svelte
@@ -15,7 +15,7 @@
     variant="ghost"
     size={children ? 'xs' : 'icon-xs'}
     onclick={() => changed(new TypeFilter(value))}
-    title={`Search type:${value}`}
+    title={`Filter type:${value}`}
     class={['cursor-pointer', children ? '' : 'opacity-50 hover:opacity-100 focus-visible:opacity-100', className]}
     {...props}
 >

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/version-faceted-filter-trigger.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/version-faceted-filter-trigger.svelte
@@ -16,7 +16,7 @@
     variant="ghost"
     size={children ? 'xs' : 'icon-xs'}
     onclick={() => changed(new VersionFilter(term, value ?? undefined))}
-    title={`Search ${term}:${value}`}
+    title={`Filter ${term}:${value}`}
     class={['cursor-pointer', children ? '' : 'opacity-50 hover:opacity-100 focus-visible:opacity-100', className]}
     {...props}
 >

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/detail-sheet.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+    import type { Snippet } from 'svelte';
+
+    import { Button } from '$comp/ui/button';
+    import * as Sheet from '$comp/ui/sheet';
+    import ExternalLink from '@lucide/svelte/icons/external-link';
+
+    interface Props {
+        children: Snippet;
+        detailsHref: string;
+        onClose: () => void;
+        open: boolean;
+        title: string;
+    }
+
+    let { children, detailsHref, onClose, open, title }: Props = $props();
+</script>
+
+<Sheet.Root onOpenChange={onClose} {open}>
+    <Sheet.Content
+        class="bg-background top-15.25! bottom-0! h-auto! w-full gap-0 overflow-y-auto scrollbar-gutter-stable rounded-l-lg border-l text-base shadow-2xl duration-150 ease-out will-change-transform sm:max-w-full! md:w-5/6!"
+        overlayProps={{ class: 'top-15.25! bg-black/5 dark:bg-black/40 supports-backdrop-filter:backdrop-blur-[0.5px]' }}
+        preventScroll={false}
+    >
+        <Button aria-label="Open details in new window" class="absolute top-3 right-12" href={detailsHref} size="icon-sm" title="Open in new window" variant="ghost">
+            <ExternalLink aria-hidden="true" />
+        </Button>
+        <Sheet.Header class="sr-only">
+            <Sheet.Title level={3}>{title}</Sheet.Title>
+        </Sheet.Header>
+        <div class="px-4 pt-4 pb-4">
+            {@render children()}
+        </div>
+    </Sheet.Content>
+</Sheet.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/detail-sheet.svelte
@@ -18,11 +18,18 @@
 
 <Sheet.Root onOpenChange={onClose} {open}>
     <Sheet.Content
-        class="bg-background top-15.25! bottom-0! h-auto! w-full gap-0 overflow-y-auto scrollbar-gutter-stable rounded-l-lg border-l text-base shadow-2xl duration-150 ease-out will-change-transform sm:max-w-full! md:w-5/6!"
+        class="bg-background top-15.25! bottom-0! h-auto! w-full scrollbar-gutter-stable gap-0 overflow-y-auto rounded-l-lg border-l text-base shadow-2xl duration-150 ease-out will-change-transform sm:max-w-full! md:w-5/6!"
         overlayProps={{ class: 'top-15.25! bg-black/5 dark:bg-black/40 supports-backdrop-filter:backdrop-blur-[0.5px]' }}
         preventScroll={false}
     >
-        <Button aria-label="Open details in new window" class="absolute top-3 right-12" href={detailsHref} size="icon-sm" title="Open in new window" variant="ghost">
+        <Button
+            aria-label="Open details in new window"
+            class="absolute top-3 right-12"
+            href={detailsHref}
+            size="icon-sm"
+            title="Open in new window"
+            variant="ghost"
+        >
             <ExternalLink aria-hidden="true" />
         </Button>
         <Sheet.Header class="sr-only">

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
@@ -128,7 +128,6 @@
             <Card.Title class="flex flex-row items-center justify-between text-lg font-semibold">
                 <div class="mb-2 flex w-0 min-w-0 flex-1 flex-col lg:mb-0">
                     <div class="flex min-w-0 items-center">
-                        <EventsFacetedFilter.StringTrigger changed={filterChanged} class="mr-2 shrink-0" term="stack" value={stack.id} />
                         <span class="block max-w-full min-w-0 truncate" title={stack.title}>{stack.title}</span>
                     </div>
                 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
@@ -22,6 +22,7 @@
     import Calendar from '@lucide/svelte/icons/calendar';
     import Clock from '@lucide/svelte/icons/clock';
     import Filter from '@lucide/svelte/icons/filter';
+    import Info from '@lucide/svelte/icons/info';
     import Users from '@lucide/svelte/icons/users';
 
     import StackLogLevel from './stack-log-level.svelte';
@@ -78,6 +79,13 @@
     const firstOccurrence = $derived(agg.min<string>(stackCountQuery?.data?.aggregations, 'min_date')?.value ?? stack?.first_occurrence);
     const lastOccurrence = $derived(agg.max<string>(stackCountQuery?.data?.aggregations, 'max_date')?.value ?? stack?.last_occurrence);
 
+    const metricCardClass =
+        'relative justify-between gap-1! bg-muted/50 py-2! ring-1 ring-border';
+    const metricHeaderClass = 'flex flex-row items-center justify-between gap-1.5 px-3 pb-0';
+    const metricTitleClass = 'min-w-0 truncate text-xs font-semibold text-muted-foreground';
+    const metricIconClass = 'size-3.5 shrink-0 text-muted-foreground';
+    const metricValueClass = 'truncate text-lg font-bold tabular-nums sm:text-xl';
+
     const chartData = $derived(() => {
         const now = new Date();
         const SEVEN_DAYS_IN_MS = 7 * 24 * 60 * 60 * 1000;
@@ -114,7 +122,7 @@
 
 {#if stackQuery.isSuccess}
     <Card.Root
-        class="relative overflow-hidden ring-[color-mix(in_oklab,var(--chart-1)_42%,transparent)] before:absolute before:inset-x-0 before:top-0 before:h-1 before:bg-[linear-gradient(90deg,var(--chart-1),var(--chart-2))] before:content-['']"
+        class="bg-background relative overflow-hidden ring-[color-mix(in_oklab,var(--chart-1)_42%,transparent)] before:absolute before:inset-x-0 before:top-0 before:h-1 before:bg-[linear-gradient(90deg,var(--chart-1),var(--chart-2))] before:content-['']"
     >
         <Card.Header>
             <Card.Title class="flex flex-row items-center justify-between text-lg font-semibold">
@@ -134,51 +142,98 @@
             </Card.Title>
         </Card.Header>
         <Card.Content class="space-y-2">
-            <div class="grid auto-rows-min grid-cols-2 gap-2 lg:grid-cols-4">
-                <Tooltip.Root>
-                    <Tooltip.Trigger
-                        class="bg-muted hover:bg-muted/80 flex cursor-pointer flex-col items-center rounded-lg p-2 transition-colors"
-                        onclick={() => filterChanged(new StringFilter('stack', stack.id))}
-                        aria-label="Filter by this stack"
-                        role="button"
-                        tabindex={0}
-                    >
-                        <Calendar class="text-primary mb-1 size-6" />
-                        <span class="text-lg font-bold"><Number value={totalOccurrences} /></span>
-                        <Muted>Total Events</Muted>
-                    </Tooltip.Trigger>
-                    <Tooltip.Content side="bottom">
-                        <Number value={totalOccurrences} /> All Time
-                    </Tooltip.Content>
-                </Tooltip.Root>
-                <Tooltip.Root>
-                    <Tooltip.Trigger class="bg-muted flex flex-col items-center rounded-lg p-2">
-                        <Users class="text-primary mb-1 size-6" />
-                        <span class="text-lg font-bold"><Percentage percent={(userCount / totalUserCount) * 100.0} /></span>
-                        <Muted>Users Affected</Muted>
-                    </Tooltip.Trigger>
-                    <Tooltip.Content side="bottom"><Number value={userCount} /> of <Number value={totalUserCount} /> Users Affected</Tooltip.Content>
-                </Tooltip.Root>
-                <Tooltip.Root>
-                    <Tooltip.Trigger class="bg-muted flex flex-col items-center rounded-lg p-2">
-                        <FirstOccurrence class="text-muted-foreground mb-1 size-6" />
-                        <span class="text-lg font-bold"><TimeAgo value={firstOccurrence} /></span>
-                        <Muted>First</Muted>
-                    </Tooltip.Trigger>
-                    <Tooltip.Content side="bottom">
-                        First Occurred On <DateTime value={stack.first_occurrence} />
-                    </Tooltip.Content>
-                </Tooltip.Root>
-                <Tooltip.Root>
-                    <Tooltip.Trigger class="bg-muted flex flex-col items-center rounded-lg p-2">
-                        <LastOccurrence class="text-muted-foreground mb-1 size-6" />
-                        <span class="text-lg font-bold"><TimeAgo value={lastOccurrence} /></span>
-                        <Muted>Last</Muted>
-                    </Tooltip.Trigger>
-                    <Tooltip.Content side="bottom">
-                        Last Occurred On <DateTime value={lastOccurrence} />
-                    </Tooltip.Content>
-                </Tooltip.Root>
+            <div class="grid grid-cols-2 gap-2 lg:grid-cols-4">
+                <Card.Root size="sm" class={metricCardClass}>
+                    <Card.Header class={metricHeaderClass}>
+                        <div class="flex min-w-0 items-center gap-1.5">
+                            <Calendar aria-hidden="true" class={metricIconClass} />
+                            <Card.Title class={metricTitleClass}>Total Events</Card.Title>
+                        </div>
+                        <Tooltip.Root>
+                            <Tooltip.Trigger
+                                class="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded-sm outline-none focus-visible:ring-2"
+                                aria-label="About total events"
+                            >
+                                <Info aria-hidden="true" class="size-3.5" />
+                            </Tooltip.Trigger>
+                            <Tooltip.Content sideOffset={6}><Number value={totalOccurrences} /> All Time</Tooltip.Content>
+                        </Tooltip.Root>
+                    </Card.Header>
+                    <Card.Content class="px-3">
+                        <button class={metricValueClass} onclick={() => filterChanged(new StringFilter('stack', stack.id))} type="button">
+                            <Number value={totalOccurrences} />
+                        </button>
+                    </Card.Content>
+                </Card.Root>
+
+                <Card.Root size="sm" class={metricCardClass}>
+                    <Card.Header class={metricHeaderClass}>
+                        <div class="flex min-w-0 items-center gap-1.5">
+                            <Users aria-hidden="true" class={metricIconClass} />
+                            <Card.Title class={metricTitleClass}>Users Affected</Card.Title>
+                        </div>
+                        <Tooltip.Root>
+                            <Tooltip.Trigger
+                                class="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded-sm outline-none focus-visible:ring-2"
+                                aria-label="About users affected"
+                            >
+                                <Info aria-hidden="true" class="size-3.5" />
+                            </Tooltip.Trigger>
+                            <Tooltip.Content sideOffset={6}><Number value={userCount} /> of <Number value={totalUserCount} /> Users Affected</Tooltip.Content>
+                        </Tooltip.Root>
+                    </Card.Header>
+                    <Card.Content class="px-3">
+                        <div class={metricValueClass}>
+                            <Percentage percent={(userCount / totalUserCount) * 100.0} />
+                        </div>
+                    </Card.Content>
+                </Card.Root>
+
+                <Card.Root size="sm" class={metricCardClass}>
+                    <Card.Header class={metricHeaderClass}>
+                        <div class="flex min-w-0 items-center gap-1.5">
+                            <FirstOccurrence aria-hidden="true" class={metricIconClass} />
+                            <Card.Title class={metricTitleClass}>First</Card.Title>
+                        </div>
+                        <Tooltip.Root>
+                            <Tooltip.Trigger
+                                class="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded-sm outline-none focus-visible:ring-2"
+                                aria-label="About first occurrence"
+                            >
+                                <Info aria-hidden="true" class="size-3.5" />
+                            </Tooltip.Trigger>
+                            <Tooltip.Content sideOffset={6}>First Occurred On <DateTime value={stack.first_occurrence} /></Tooltip.Content>
+                        </Tooltip.Root>
+                    </Card.Header>
+                    <Card.Content class="px-3">
+                        <div class={metricValueClass}>
+                            <TimeAgo value={firstOccurrence} />
+                        </div>
+                    </Card.Content>
+                </Card.Root>
+
+                <Card.Root size="sm" class={metricCardClass}>
+                    <Card.Header class={metricHeaderClass}>
+                        <div class="flex min-w-0 items-center gap-1.5">
+                            <LastOccurrence aria-hidden="true" class={metricIconClass} />
+                            <Card.Title class={metricTitleClass}>Last</Card.Title>
+                        </div>
+                        <Tooltip.Root>
+                            <Tooltip.Trigger
+                                class="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded-sm outline-none focus-visible:ring-2"
+                                aria-label="About last occurrence"
+                            >
+                                <Info aria-hidden="true" class="size-3.5" />
+                            </Tooltip.Trigger>
+                            <Tooltip.Content sideOffset={6}>Last Occurred On <DateTime value={lastOccurrence} /></Tooltip.Content>
+                        </Tooltip.Root>
+                    </Card.Header>
+                    <Card.Content class="px-3">
+                        <div class={metricValueClass}>
+                            <TimeAgo value={lastOccurrence} />
+                        </div>
+                    </Card.Content>
+                </Card.Root>
             </div>
 
             <div class="flex justify-end">
@@ -220,7 +275,7 @@
         </Card.Content>
     </Card.Root>
 {:else}
-    <Card.Root>
+    <Card.Root class="bg-background">
         <Card.Header>
             <Card.Title class="flex flex-row items-center justify-between text-lg font-semibold">
                 <span class="mb-2 flex flex-col lg:mb-0">
@@ -236,13 +291,16 @@
             </Card.Title>
         </Card.Header>
         <Card.Content class="space-y-2">
-            <div class="grid auto-rows-min grid-cols-2 gap-2 lg:grid-cols-4">
+            <div class="grid grid-cols-2 gap-2 lg:grid-cols-4">
                 {#each { length: 4 } as name, index (`${name}-${index}`)}
-                    <div class="bg-muted flex flex-col items-center rounded-lg p-2">
-                        <Skeleton class="mb-1 size-6" />
-                        <Skeleton class="mb-1 h-7 w-16" />
-                        <Skeleton class="h-6 w-20" />
-                    </div>
+                    <Card.Root size="sm" class={metricCardClass}>
+                        <Card.Header class={metricHeaderClass}>
+                            <Skeleton class="h-3.5 w-20" />
+                        </Card.Header>
+                        <Card.Content class="px-3">
+                            <Skeleton class="h-5 w-12" />
+                        </Card.Content>
+                    </Card.Root>
                 {/each}
             </div>
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
@@ -79,8 +79,7 @@
     const firstOccurrence = $derived(agg.min<string>(stackCountQuery?.data?.aggregations, 'min_date')?.value ?? stack?.first_occurrence);
     const lastOccurrence = $derived(agg.max<string>(stackCountQuery?.data?.aggregations, 'max_date')?.value ?? stack?.last_occurrence);
 
-    const metricCardClass =
-        'relative justify-between gap-1! bg-muted/50 py-2! ring-1 ring-border';
+    const metricCardClass = 'relative justify-between gap-1! bg-muted/50 py-2! ring-1 ring-border';
     const metricHeaderClass = 'flex flex-row items-center justify-between gap-1.5 px-3 pb-0';
     const metricTitleClass = 'min-w-0 truncate text-xs font-semibold text-muted-foreground';
     const metricIconClass = 'size-3.5 shrink-0 text-muted-foreground';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-detail-sheet.svelte
@@ -27,7 +27,7 @@
     }
 </script>
 
-<DetailSheet detailsHref={resolvedHref} {onClose} open={!!stackId} title="Stack Details">
+<DetailSheet detailsHref={resolvedHref} {onClose} open={!!stackId} title="Stack">
     {#if stackId}
         <StackDetails {filterChanged} {handleError} {stackId} />
     {/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-detail-sheet.svelte
@@ -3,9 +3,7 @@
     import type { ProblemDetails } from '@exceptionless/fetchclient';
 
     import { resolve } from '$app/paths';
-    import { Button } from '$comp/ui/button';
-    import * as Sheet from '$comp/ui/sheet';
-    import ExternalLink from '@lucide/svelte/icons/external-link';
+    import DetailSheet from '$comp/detail-sheet.svelte';
 
     import StackDetails from './stack-details.svelte';
 
@@ -20,10 +18,6 @@
 
     const resolvedHref = $derived(stackId ? resolve('/(app)/stacks/[stackId=objectid]', { stackId }) : '#');
 
-    function handleOpenChange() {
-        onClose();
-    }
-
     function handleError(problem: ProblemDetails) {
         if (onError) {
             onError(problem);
@@ -33,24 +27,8 @@
     }
 </script>
 
-<Sheet.Root onOpenChange={handleOpenChange} open={!!stackId}>
-    <Sheet.Content
-        class="top-15.25! bottom-0! h-auto! w-full transform-gpu overflow-y-auto rounded-l-lg border-l shadow-2xl duration-150 ease-out will-change-transform sm:max-w-full! md:w-5/6!"
-        overlayProps={{ class: 'top-15.25! bg-black/5 supports-backdrop-filter:backdrop-blur-none!' }}
-        preventScroll={false}
-    >
-        <Sheet.Header class="pt-4.5 pb-0">
-            <Sheet.Title class="flex items-center gap-2 text-2xl font-semibold tracking-tight" level={3}>
-                Stack Details
-                <Button aria-label="Open stack details in new window" href={resolvedHref} size="icon-sm" title="Open in new window" variant="ghost">
-                    <ExternalLink aria-hidden="true" />
-                </Button>
-            </Sheet.Title>
-        </Sheet.Header>
-        <div class="mt-0.5 px-4">
-            {#if stackId}
-                <StackDetails {filterChanged} {handleError} {stackId} />
-            {/if}
-        </div>
-    </Sheet.Content>
-</Sheet.Root>
+<DetailSheet detailsHref={resolvedHref} {onClose} open={!!stackId} title="Stack Details">
+    {#if stackId}
+        <StackDetails {filterChanged} {handleError} {stackId} />
+    {/if}
+</DetailSheet>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-details.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-details.svelte
@@ -53,7 +53,7 @@
     <EventsOverview {filterChanged} id={eventId} {handleError} onNavigate={handleNavigate} />
 {:else if stackEventsQuery.isSuccess}
     <section>
-        <h4 class="text-muted-foreground mb-3 text-sm font-semibold uppercase tracking-wide">Stack</h4>
+        <h4 class="text-muted-foreground mb-3 text-sm font-semibold tracking-wide uppercase">Stack</h4>
         <StackCard {filterChanged} id={stackId} />
     </section>
     <Muted class="mt-4">No events available for this stack.</Muted>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-details.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-details.svelte
@@ -43,11 +43,18 @@
             eventId = stackEventsQuery.data?.[0]?.id ?? null;
         }
     });
+
+    function handleNavigate(newEventId: string) {
+        eventId = newEventId;
+    }
 </script>
 
-{#if stackEventsQuery.isSuccess && !eventId}
-    <StackCard {filterChanged} id={stackId} />
-    <Muted>This stack has no events to display.</Muted>
-{:else if eventId}
-    <EventsOverview {filterChanged} id={eventId} {handleError} />
+{#if eventId}
+    <EventsOverview {filterChanged} id={eventId} {handleError} onNavigate={handleNavigate} />
+{:else if stackEventsQuery.isSuccess}
+    <section>
+        <h4 class="text-muted-foreground mb-3 text-sm font-semibold uppercase tracking-wide">Stack</h4>
+        <StackCard {filterChanged} id={stackId} />
+    </section>
+    <Muted class="mt-4">No events available for this stack.</Muted>
 {/if}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/events/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/events/+page.svelte
@@ -140,6 +140,10 @@
     });
     const pageTitle = $derived(savedViewsState.activeSavedView?.name ?? 'Events');
 
+    $effect(() => {
+        document.title = `${pageTitle} - Exceptionless`;
+    });
+
     // NOTE: This might be applying query string parameters when redirecting away.
     watch(
         () => organization.current,

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/events/[eventId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/events/[eventId=objectid]/+page.svelte
@@ -40,4 +40,9 @@
     });
 </script>
 
-<EventsOverview {filterChanged} id={page.params.eventId || ''} {handleError} onNavigate={(newId) => goto(resolve('/(app)/events/[eventId=objectid]', { eventId: newId }))} />
+<EventsOverview
+    {filterChanged}
+    id={page.params.eventId || ''}
+    {handleError}
+    onNavigate={(newId) => goto(resolve('/(app)/events/[eventId=objectid]', { eventId: newId }))}
+/>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/events/[eventId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/events/[eventId=objectid]/+page.svelte
@@ -5,7 +5,6 @@
     import { resolve } from '$app/paths';
     import { page } from '$app/state';
     import * as FacetedFilter from '$comp/faceted-filter';
-    import { H3 } from '$comp/typography';
     import { showBillingDialogOnUpgradeProblem } from '$features/billing';
     import EventsOverview from '$features/events/components/events-overview.svelte';
     import { organization } from '$features/organizations/context.svelte';
@@ -35,9 +34,10 @@
         toast.error(`The event "${page.params.eventId}" could not be found.`);
         await goto(resolve('/(app)/events'));
     }
+
+    $effect(() => {
+        document.title = 'Event Details - Exceptionless';
+    });
 </script>
 
-<div class="flex flex-col gap-4">
-    <H3>Event Details</H3>
-    <EventsOverview {filterChanged} id={page.params.eventId || ''} {handleError} />
-</div>
+<EventsOverview {filterChanged} id={page.params.eventId || ''} {handleError} onNavigate={(newId) => goto(resolve('/(app)/events/[eventId=objectid]', { eventId: newId }))} />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/[stackId]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/[stackId]/+page.svelte
@@ -5,37 +5,15 @@
     import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';
     import { page } from '$app/state';
-    import { H3, Muted } from '$comp/typography';
     import { showBillingDialogOnUpgradeProblem } from '$features/billing';
-    import { getStackEventsQuery } from '$features/events/api.svelte';
-    import EventsOverview from '$features/events/components/events-overview.svelte';
     import { organization } from '$features/organizations/context.svelte';
-    import StackCard from '$features/stacks/components/stack-card.svelte';
+    import StackDetails from '$features/stacks/components/stack-details.svelte';
     import { watch } from 'runed';
     import { toast } from 'svelte-sonner';
 
     import { redirectToEventsWithFilter } from '../../../../redirect-to-events.svelte.js';
 
     const stackId = $derived(page.params.stackId || '');
-    let eventId = $state<null | string>(null);
-
-    const stackEventsQuery = getStackEventsQuery({
-        params: {
-            limit: 1,
-            sort: '-date'
-        },
-        route: {
-            get stackId() {
-                return stackId;
-            }
-        }
-    });
-
-    $effect(() => {
-        if (stackEventsQuery.isSuccess) {
-            eventId = stackEventsQuery.data?.[0]?.id ?? null;
-        }
-    });
 
     watch(
         () => organization.current,
@@ -56,14 +34,10 @@
 
         toast.error('Unable to load stack event details.');
     }
+
+    $effect(() => {
+        document.title = 'Stack Details - Exceptionless';
+    });
 </script>
 
-<div class="flex flex-col gap-4">
-    <H3>Stack Details</H3>
-    {#if stackEventsQuery.isSuccess && !eventId}
-        <StackCard {filterChanged} id={stackId} />
-        <Muted>This stack has no events to display.</Muted>
-    {:else if eventId}
-        <EventsOverview {filterChanged} {handleError} id={eventId} />
-    {/if}
-</div>
+<StackDetails {filterChanged} {handleError} {stackId} />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stacks/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stacks/+page.svelte
@@ -133,6 +133,10 @@
     });
     const pageTitle = $derived(savedViewsState.activeSavedView?.name ?? 'Stacks');
 
+    $effect(() => {
+        document.title = `${pageTitle} - Exceptionless`;
+    });
+
     watch(
         () => organization.current,
         () => {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stacks/[stackId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stacks/[stackId=objectid]/+page.svelte
@@ -5,7 +5,6 @@
     import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';
     import { page } from '$app/state';
-    import { H3 } from '$comp/typography';
     import { showBillingDialogOnUpgradeProblem } from '$features/billing';
     import { organization } from '$features/organizations/context.svelte';
     import StackDetails from '$features/stacks/components/stack-details.svelte';
@@ -35,9 +34,10 @@
 
         toast.error('Unable to load stack event details.');
     }
+
+    $effect(() => {
+        document.title = 'Stack Details - Exceptionless';
+    });
 </script>
 
-<div class="flex flex-col gap-4">
-    <H3>Stack Details</H3>
-    <StackDetails {filterChanged} {handleError} {stackId} />
-</div>
+<StackDetails {filterChanged} {handleError} {stackId} />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -92,6 +92,10 @@
     });
     const pageTitle = $derived(savedViewsState.activeSavedView?.name ?? 'Event Stream');
 
+    $effect(() => {
+        document.title = `${pageTitle} - Exceptionless`;
+    });
+
     watch(
         () => organization.current,
         () => {

--- a/src/Exceptionless.Web/ClientApp/src/routes/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/+layout.svelte
@@ -57,7 +57,14 @@
         }
     });
 
+    const managedTitlePrefixes = [resolve('/(app)/stacks'), resolve('/(app)/events'), resolve('/(app)/stream')];
+
     $effect(() => {
+        // Skip title for pages that manage their own (stacks, events, stream with saved views)
+        if (managedTitlePrefixes.some((prefix) => page.url.pathname === prefix || page.url.pathname.startsWith(prefix + '/'))) {
+            return;
+        }
+
         const currentRoute = routes().find((route) => page.url.pathname === route.href);
         if (currentRoute) {
             document.title = `${currentRoute.title} - Exceptionless`;


### PR DESCRIPTION
## What changed

- **Shared `DetailSheet` component** — extracted common sheet chrome (overlay, close button, external link, padding) into a reusable component used by both `event-detail-sheet` and `stack-detail-sheet`
- **Stack detail page deduplication** — `project/[projectId]/stacks/[stackId]` page now uses the shared `StackDetails` component instead of duplicating its logic
- **Consistent page padding** — removed wrapper `<div>` from full page routes so content matches the sheet's padding
- **Sheet visual polish** — subtle blur overlay (`backdrop-blur-[0.5px]`), slide-in animation, proper z-ordering below navbar
- **Stack no-events state** — shows "STACK" heading + StackCard + muted message when a stack has no events in the index
- **Stack card stat boxes** — restyled to match the `EventsStatsDashboard` card pattern (Card.Root with header/content layout, muted background, 1px border)
- **Text clipping fix** — removed `leading-none` from stat values that was causing descender clipping on text like "3 days ago"

## Why

UI consistency pass — the detail sheets and stack cards now share code and have a polished, consistent look matching the saved view dashboard stats.