### PR TITLE
feat: add Deleted counter to usage metrics

### DIFF
--- a/src/Exceptionless.Core/Jobs/CleanupDataJob.cs
+++ b/src/Exceptionless.Core/Jobs/CleanupDataJob.cs
@@ -226,14 +226,22 @@ public class CleanupDataJob : JobWithLockBase, IHealthCheck
         var projectGroups = stacks.GroupBy(s => (s.OrganizationId, s.ProjectId)).ToList();
 
         long totalRemovedEvents = 0;
-        foreach (var projectGroup in projectGroups)
+        if (trackDeletedUsage)
         {
-            string[] stackIds = projectGroup.Select(s => s.Id).ToArray();
-            long removedEvents = await _eventRepository.RemoveAllByStackIdsAsync(stackIds);
-            totalRemovedEvents += removedEvents;
+            foreach (var projectGroup in projectGroups)
+            {
+                string[] stackIds = projectGroup.Select(s => s.Id).ToArray();
+                long removedEvents = await _eventRepository.RemoveAllByStackIdsAsync(stackIds);
+                totalRemovedEvents += removedEvents;
 
-            if (trackDeletedUsage && removedEvents > 0)
-                await _usageService.IncrementDeletedAsync(projectGroup.Key.OrganizationId, projectGroup.Key.ProjectId, (int)removedEvents);
+                if (removedEvents > 0)
+                    await _usageService.IncrementDeletedAsync(projectGroup.Key.OrganizationId, projectGroup.Key.ProjectId, (int)removedEvents);
+            }
+        }
+        else
+        {
+            string[] allStackIds = stacks.Select(s => s.Id).ToArray();
+            totalRemovedEvents = await _eventRepository.RemoveAllByStackIdsAsync(allStackIds);
         }
 
         await _stackRepository.RemoveAsync(stacks);

--- a/src/Exceptionless.Core/Jobs/CleanupDataJob.cs
+++ b/src/Exceptionless.Core/Jobs/CleanupDataJob.cs
@@ -27,6 +27,7 @@ public class CleanupDataJob : JobWithLockBase, IHealthCheck
     private readonly ITokenRepository _tokenRepository;
     private readonly IWebHookRepository _webHookRepository;
     private readonly BillingManager _billingManager;
+    private readonly UsageService _usageService;
     private readonly AppOptions _appOptions;
     private readonly ILockProvider _lockProvider;
     private readonly ICacheClient _cacheClient;
@@ -43,6 +44,7 @@ public class CleanupDataJob : JobWithLockBase, IHealthCheck
         ILockProvider lockProvider,
         ICacheClient cacheClient,
         BillingManager billingManager,
+        UsageService usageService,
         AppOptions appOptions,
         TimeProvider timeProvider,
         IResiliencePolicyProvider resiliencePolicyProvider,
@@ -57,6 +59,7 @@ public class CleanupDataJob : JobWithLockBase, IHealthCheck
         _tokenRepository = tokenRepository;
         _webHookRepository = webHookRepository;
         _billingManager = billingManager;
+        _usageService = usageService;
         _appOptions = appOptions;
         _lockProvider = lockProvider;
         _cacheClient = cacheClient;
@@ -164,7 +167,7 @@ public class CleanupDataJob : JobWithLockBase, IHealthCheck
         {
             try
             {
-                await RemoveStacksAsync(stackResults.Documents, context);
+                await RemoveStacksAsync(stackResults.Documents, context, trackDeletedUsage: true);
             }
             catch (Exception ex)
             {
@@ -206,6 +209,9 @@ public class CleanupDataJob : JobWithLockBase, IHealthCheck
         await RenewLockAsync(context);
         long removedEvents = await _eventRepository.RemoveAllByProjectIdAsync(project.OrganizationId, project.Id);
 
+        if (removedEvents > 0)
+            await _usageService.IncrementDeletedAsync(project.OrganizationId, project.Id, (int)removedEvents);
+
         await RenewLockAsync(context);
         long removedStacks = await _stackRepository.RemoveAllByProjectIdAsync(project.OrganizationId, project.Id);
 
@@ -213,17 +219,29 @@ public class CleanupDataJob : JobWithLockBase, IHealthCheck
         _logger.RemoveProjectComplete(project.Name, project.Id, removedStacks, removedEvents);
     }
 
-    private async Task RemoveStacksAsync(IReadOnlyCollection<Stack> stacks, JobContext context)
+    private async Task RemoveStacksAsync(IReadOnlyCollection<Stack> stacks, JobContext context, bool trackDeletedUsage = false)
     {
         await RenewLockAsync(context);
 
-        string[] stackIds = stacks.Select(s => s.Id).ToArray();
-        long removedEvents = await _eventRepository.RemoveAllByStackIdsAsync(stackIds);
-        await _stackRepository.RemoveAsync(stacks);
-        foreach (var orgGroup in stacks.GroupBy(s => (s.OrganizationId, s.ProjectId)))
-            await _cacheClient.RemoveByPrefixAsync(EventStackFilterQueryBuilder.GetScopedCachePrefix(orgGroup.Key.OrganizationId, orgGroup.Key.ProjectId));
+        var projectGroups = stacks.GroupBy(s => (s.OrganizationId, s.ProjectId)).ToList();
 
-        _logger.RemoveStacksComplete(stackIds.Length, removedEvents);
+        long totalRemovedEvents = 0;
+        foreach (var projectGroup in projectGroups)
+        {
+            string[] stackIds = projectGroup.Select(s => s.Id).ToArray();
+            long removedEvents = await _eventRepository.RemoveAllByStackIdsAsync(stackIds);
+            totalRemovedEvents += removedEvents;
+
+            if (trackDeletedUsage && removedEvents > 0)
+                await _usageService.IncrementDeletedAsync(projectGroup.Key.OrganizationId, projectGroup.Key.ProjectId, (int)removedEvents);
+        }
+
+        await _stackRepository.RemoveAsync(stacks);
+
+        foreach (var projectGroup in projectGroups)
+            await _cacheClient.RemoveByPrefixAsync(EventStackFilterQueryBuilder.GetScopedCachePrefix(projectGroup.Key.OrganizationId, projectGroup.Key.ProjectId));
+
+        _logger.RemoveStacksComplete(stacks.Count, totalRemovedEvents);
     }
 
     private async Task EnforceRetentionAsync(JobContext context)
@@ -272,6 +290,9 @@ public class CleanupDataJob : JobWithLockBase, IHealthCheck
         {
             try
             {
+                // Retention-based deletions intentionally do NOT track deleted usage.
+                // These events expired by plan policy, not user action — surfacing them
+                // in usage charts would be misleading.
                 await RemoveStacksAsync(stackResults.Documents, context);
             }
             catch (Exception ex)

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/ResetProjectDataWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/ResetProjectDataWorkItemHandler.cs
@@ -1,6 +1,7 @@
 using Exceptionless.Core.Models.WorkItems;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Repositories.Queries;
+using Exceptionless.Core.Services;
 using Foundatio.Caching;
 using Foundatio.Jobs;
 using Foundatio.Lock;
@@ -14,13 +15,15 @@ public class ResetProjectDataWorkItemHandler : WorkItemHandlerBase
     private readonly IStackRepository _stackRepository;
     private readonly ICacheClient _cacheClient;
     private readonly ILockProvider _lockProvider;
+    private readonly UsageService _usageService;
 
-    public ResetProjectDataWorkItemHandler(IEventRepository eventRepository, IStackRepository stackRepository, ICacheClient cacheClient, ILockProvider lockProvider, ILoggerFactory loggerFactory) : base(loggerFactory)
+    public ResetProjectDataWorkItemHandler(IEventRepository eventRepository, IStackRepository stackRepository, ICacheClient cacheClient, ILockProvider lockProvider, UsageService usageService, ILoggerFactory loggerFactory) : base(loggerFactory)
     {
         _eventRepository = eventRepository;
         _stackRepository = stackRepository;
         _cacheClient = cacheClient;
         _lockProvider = lockProvider;
+        _usageService = usageService;
     }
 
     public override Task<ILock?> GetWorkItemLockAsync(object workItem, CancellationToken cancellationToken = default)
@@ -40,6 +43,9 @@ public class ResetProjectDataWorkItemHandler : WorkItemHandlerBase
 
             long removedEvents = await _eventRepository.RemoveAllByProjectIdAsync(workItem.OrganizationId, workItem.ProjectId);
             await context.ReportProgressAsync(50, $"Events removed: {removedEvents}");
+
+            if (removedEvents > 0)
+                await _usageService.IncrementDeletedAsync(workItem.OrganizationId, workItem.ProjectId, (int)removedEvents);
 
             long removedStacks = await _stackRepository.RemoveAllByProjectIdAsync(workItem.OrganizationId, workItem.ProjectId);
             await _cacheClient.RemoveByPrefixAsync(EventStackFilterQueryBuilder.GetScopedCachePrefix(workItem.OrganizationId, workItem.ProjectId));

--- a/src/Exceptionless.Core/Models/UsageInfo.cs
+++ b/src/Exceptionless.Core/Models/UsageInfo.cs
@@ -9,6 +9,7 @@ public record UsageInfo
     public int Blocked { get; set; }
     public int Discarded { get; set; }
     public int TooBig { get; set; }
+    public int Deleted { get; set; }
 }
 
 public record UsageHourInfo
@@ -18,6 +19,7 @@ public record UsageHourInfo
     public int Blocked { get; set; }
     public int Discarded { get; set; }
     public int TooBig { get; set; }
+    public int Deleted { get; set; }
 }
 
 public record UsageInfoResponse

--- a/src/Exceptionless.Core/Repositories/Configuration/Indexes/OrganizationIndex.cs
+++ b/src/Exceptionless.Core/Repositories/Configuration/Indexes/OrganizationIndex.cs
@@ -60,13 +60,15 @@ internal static class OrganizationIndexExtensions
                 .Number(fu => fu.Name(i => i.Blocked))
                 .Number(fu => fu.Name(i => i.Discarded))
                 .Number(fu => fu.Name(i => i.Limit))
-                .Number(fu => fu.Name(i => i.TooBig))))
+                .Number(fu => fu.Name(i => i.TooBig))
+                .Number(fu => fu.Name(i => i.Deleted))))
             .Object<UsageInfo>(ui => ui.Name(o => o.UsageHours.First()).Properties(p => p
                 .Date(fu => fu.Name(i => i.Date))
                 .Number(fu => fu.Name(i => i.Total))
                 .Number(fu => fu.Name(i => i.Blocked))
                 .Number(fu => fu.Name(i => i.Discarded))
                 .Number(fu => fu.Name(i => i.Limit))
-                .Number(fu => fu.Name(i => i.TooBig))));
+                .Number(fu => fu.Name(i => i.TooBig))
+                .Number(fu => fu.Name(i => i.Deleted))));
     }
 }

--- a/src/Exceptionless.Core/Repositories/Configuration/Indexes/ProjectIndex.cs
+++ b/src/Exceptionless.Core/Repositories/Configuration/Indexes/ProjectIndex.cs
@@ -51,13 +51,15 @@ internal static class ProjectIndexExtensions
                 .Number(fu => fu.Name(i => i.Blocked))
                 .Number(fu => fu.Name(i => i.Discarded))
                 .Number(fu => fu.Name(i => i.Limit))
-                .Number(fu => fu.Name(i => i.TooBig))))
+                .Number(fu => fu.Name(i => i.TooBig))
+                .Number(fu => fu.Name(i => i.Deleted))))
             .Object<UsageInfo>(ui => ui.Name(o => o.UsageHours.First()).Properties(p => p
                 .Date(fu => fu.Name(i => i.Date))
                 .Number(fu => fu.Name(i => i.Total))
                 .Number(fu => fu.Name(i => i.Blocked))
                 .Number(fu => fu.Name(i => i.Discarded))
                 .Number(fu => fu.Name(i => i.Limit))
-                .Number(fu => fu.Name(i => i.TooBig))));
+                .Number(fu => fu.Name(i => i.TooBig))
+                .Number(fu => fu.Name(i => i.Deleted))));
     }
 }

--- a/src/Exceptionless.Core/Services/UsageService.cs
+++ b/src/Exceptionless.Core/Services/UsageService.cs
@@ -81,8 +81,11 @@ public class UsageService
                     var bucketBlocked = await _cache.GetAsync<int>(GetBucketBlockedCacheKey(bucketUtc, organizationId));
                     var bucketDiscarded = await _cache.GetAsync<int>(GetBucketDiscardedCacheKey(bucketUtc, organizationId));
                     var bucketTooBig = await _cache.GetAsync<int>(GetBucketTooBigCacheKey(bucketUtc, organizationId));
+                    var bucketDeleted = await _cache.GetAsync<int>(GetBucketDeletedCacheKey(bucketUtc, organizationId));
 
-                    organization.LastEventDateUtc = _timeProvider.GetUtcNow().UtcDateTime;
+                    bool hasIngestion = (bucketTotal?.Value ?? 0) > 0 || (bucketBlocked?.Value ?? 0) > 0 || (bucketDiscarded?.Value ?? 0) > 0 || (bucketTooBig?.Value ?? 0) > 0;
+                    if (hasIngestion)
+                        organization.LastEventDateUtc = _timeProvider.GetUtcNow().UtcDateTime;
 
                     var usage = organization.GetUsage(bucketUtc, _timeProvider);
                     usage.Limit = organization.GetMaxEventsPerMonthWithBonus(_timeProvider);
@@ -90,12 +93,14 @@ public class UsageService
                     usage.Blocked += bucketBlocked?.Value ?? 0;
                     usage.Discarded += bucketDiscarded?.Value ?? 0;
                     usage.TooBig += bucketTooBig?.Value ?? 0;
+                    usage.Deleted += bucketDeleted?.Value ?? 0;
 
                     var hourlyUsage = organization.GetHourlyUsage(bucketUtc);
                     hourlyUsage.Total += bucketTotal?.Value ?? 0;
                     hourlyUsage.Blocked += bucketBlocked?.Value ?? 0;
                     hourlyUsage.Discarded += bucketDiscarded?.Value ?? 0;
                     hourlyUsage.TooBig += bucketTooBig?.Value ?? 0;
+                    hourlyUsage.Deleted += bucketDeleted?.Value ?? 0;
 
                     organization.TrimUsage(_timeProvider);
 
@@ -104,6 +109,7 @@ public class UsageService
                         GetBucketBlockedCacheKey(bucketUtc, organizationId),
                         GetBucketDiscardedCacheKey(bucketUtc, organizationId),
                         GetBucketTooBigCacheKey(bucketUtc, organizationId),
+                        GetBucketDeletedCacheKey(bucketUtc, organizationId),
                         GetThrottledKey(bucketUtc, organizationId)
                     });
 
@@ -159,8 +165,11 @@ public class UsageService
                     var bucketBlocked = await _cache.GetAsync<int>(GetBucketBlockedCacheKey(bucketUtc, project.OrganizationId, projectId));
                     var bucketDiscarded = await _cache.GetAsync<int>(GetBucketDiscardedCacheKey(bucketUtc, project.OrganizationId, projectId));
                     var bucketTooBig = await _cache.GetAsync<int>(GetBucketTooBigCacheKey(bucketUtc, project.OrganizationId, projectId));
+                    var bucketDeleted = await _cache.GetAsync<int>(GetBucketDeletedCacheKey(bucketUtc, project.OrganizationId, projectId));
 
-                    project.LastEventDateUtc = _timeProvider.GetUtcNow().UtcDateTime;
+                    bool hasIngestion = (bucketTotal?.Value ?? 0) > 0 || (bucketBlocked?.Value ?? 0) > 0 || (bucketDiscarded?.Value ?? 0) > 0 || (bucketTooBig?.Value ?? 0) > 0;
+                    if (hasIngestion)
+                        project.LastEventDateUtc = _timeProvider.GetUtcNow().UtcDateTime;
 
                     (string OrganizationId, Organization? Organization) context = (OrganizationId: project.OrganizationId, Organization: null);
                     int maxEventsPerMonth = await GetMaxEventsPerMonthAsync(context);
@@ -171,12 +180,14 @@ public class UsageService
                     usage.Blocked += bucketBlocked?.Value ?? 0;
                     usage.Discarded += bucketDiscarded?.Value ?? 0;
                     usage.TooBig += bucketTooBig?.Value ?? 0;
+                    usage.Deleted += bucketDeleted?.Value ?? 0;
 
                     var hourlyUsage = project.GetHourlyUsage(bucketUtc);
                     hourlyUsage.Total += bucketTotal?.Value ?? 0;
                     hourlyUsage.Blocked += bucketBlocked?.Value ?? 0;
                     hourlyUsage.Discarded += bucketDiscarded?.Value ?? 0;
                     hourlyUsage.TooBig += bucketTooBig?.Value ?? 0;
+                    hourlyUsage.Deleted += bucketDeleted?.Value ?? 0;
 
                     project.TrimUsage(_timeProvider);
 
@@ -184,7 +195,8 @@ public class UsageService
                         GetBucketTotalCacheKey(bucketUtc, project.OrganizationId, projectId),
                         GetBucketDiscardedCacheKey(bucketUtc, project.OrganizationId, projectId),
                         GetBucketBlockedCacheKey(bucketUtc, project.OrganizationId, projectId),
-                        GetBucketTooBigCacheKey(bucketUtc, project.OrganizationId, projectId)
+                        GetBucketTooBigCacheKey(bucketUtc, project.OrganizationId, projectId),
+                        GetBucketDeletedCacheKey(bucketUtc, project.OrganizationId, projectId)
                     });
 
                     await _cache.SetAsync(GetTotalCacheKey(utcNow, project.OrganizationId, projectId), usage.Total, TimeSpan.FromHours(8));
@@ -332,6 +344,10 @@ public class UsageService
             usage.CurrentUsage.TooBig += bucketTooBig?.Value ?? 0;
             usage.CurrentHourUsage.TooBig += bucketTooBig?.Value ?? 0;
 
+            var bucketDeleted = await _cache.GetAsync<int>(GetBucketDeletedCacheKey(bucketUtc, organizationId, projectId));
+            usage.CurrentUsage.Deleted += bucketDeleted?.Value ?? 0;
+            usage.CurrentHourUsage.Deleted += bucketDeleted?.Value ?? 0;
+
             bucketUtc = bucketUtc.Add(_bucketSize);
         }
 
@@ -473,6 +489,29 @@ public class UsageService
         AppDiagnostics.PostTooBig.Add(1);
     }
 
+    public async Task IncrementDeletedAsync(string organizationId, string? projectId, int eventCount = 1)
+    {
+        if (eventCount <= 0)
+            return;
+
+        var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
+
+        var tasks = new List<Task>(4)
+        {
+            _cache.IncrementAsync(GetBucketDeletedCacheKey(utcNow, organizationId), eventCount, TimeSpan.FromHours(8)),
+            _cache.ListAddAsync(GetOrganizationSetKey(utcNow), organizationId, TimeSpan.FromHours(8))
+        };
+
+        if (!String.IsNullOrEmpty(projectId))
+        {
+            tasks.Add(_cache.IncrementAsync(GetBucketDeletedCacheKey(utcNow, organizationId, projectId), eventCount, TimeSpan.FromHours(8)));
+            tasks.Add(_cache.ListAddAsync(GetProjectSetKey(utcNow), projectId, TimeSpan.FromHours(8)));
+        }
+
+        await Task.WhenAll(tasks);
+        AppDiagnostics.EventsDeleted.Add(eventCount);
+    }
+
     private int GetBucketEventLimit(int maxEventsPerMonth)
     {
         if (maxEventsPerMonth < 5000)
@@ -537,6 +576,16 @@ public class UsageService
             return $"usage:{bucket}:{organizationId}:toobig";
 
         return $"usage:{bucket}:{organizationId}:{projectId}:toobig";
+    }
+
+    private string GetBucketDeletedCacheKey(DateTime utcTime, string organizationId, string? projectId = null)
+    {
+        int bucket = GetCurrentBucket(utcTime);
+
+        if (String.IsNullOrEmpty(projectId))
+            return $"usage:{bucket}:{organizationId}:deleted";
+
+        return $"usage:{bucket}:{organizationId}:{projectId}:deleted";
     }
 
     private string GetOrganizationSetKey(DateTime utcTime)

--- a/src/Exceptionless.Core/Utility/AppDiagnostics.cs
+++ b/src/Exceptionless.Core/Utility/AppDiagnostics.cs
@@ -97,7 +97,7 @@ public static class AppDiagnostics
     internal static readonly Counter<int> EventsDiscarded = Meter.CreateCounter<int>("ex.events.discarded", description: "Events that were discarded");
     internal static readonly Counter<int> EventsBlocked = Meter.CreateCounter<int>("ex.events.blocked", description: "Events that were blocked");
     internal static readonly Counter<int> EventsProcessCancelled = Meter.CreateCounter<int>("ex.events.processing.cancelled", description: "Events that started processing and were cancelled");
-    internal static readonly Counter<long> EventsDeleted = Meter.CreateCounter<long>("ex.events.deleted", description: "Events that were deleted");
+    internal static readonly Counter<int> EventsDeleted = Meter.CreateCounter<int>("ex.events.deleted", description: "Events that were deleted");
     internal static readonly Counter<int> EventsRetryCount = Meter.CreateCounter<int>("ex.events.retry.count", description: "Events where processing was retried");
     internal static readonly Counter<int> EventsRetryErrors = Meter.CreateCounter<int>("ex.events.retry.errors", description: "Events where retry processing got an error");
     internal static readonly Histogram<double> EventsFieldCount = Meter.CreateHistogram<double>("ex.events.field.count", description: "Number of fields per event");

--- a/src/Exceptionless.Core/Utility/AppDiagnostics.cs
+++ b/src/Exceptionless.Core/Utility/AppDiagnostics.cs
@@ -97,6 +97,7 @@ public static class AppDiagnostics
     internal static readonly Counter<int> EventsDiscarded = Meter.CreateCounter<int>("ex.events.discarded", description: "Events that were discarded");
     internal static readonly Counter<int> EventsBlocked = Meter.CreateCounter<int>("ex.events.blocked", description: "Events that were blocked");
     internal static readonly Counter<int> EventsProcessCancelled = Meter.CreateCounter<int>("ex.events.processing.cancelled", description: "Events that started processing and were cancelled");
+    internal static readonly Counter<long> EventsDeleted = Meter.CreateCounter<long>("ex.events.deleted", description: "Events that were deleted");
     internal static readonly Counter<int> EventsRetryCount = Meter.CreateCounter<int>("ex.events.retry.count", description: "Events where processing was retried");
     internal static readonly Counter<int> EventsRetryErrors = Meter.CreateCounter<int>("ex.events.retry.errors", description: "Events where retry processing got an error");
     internal static readonly Histogram<double> EventsFieldCount = Meter.CreateHistogram<double>("ex.events.field.count", description: "Number of fields per event");

--- a/src/Exceptionless.Web/ClientApp.angular/app/organization/manage/manage-controller.js
+++ b/src/Exceptionless.Web/ClientApp.angular/app/organization/manage/manage-controller.js
@@ -146,6 +146,10 @@
                         });
 
                         vm.chart.options.series[4].data = vm.organization.usage.map(function (item) {
+                            return { x: moment.utc(item.date).unix(), y: item.deleted || 0, data: item };
+                        });
+
+                        vm.chart.options.series[5].data = vm.organization.usage.map(function (item) {
                             return { x: moment.utc(item.date).unix(), y: item.limit, data: item };
                         });
 
@@ -285,6 +289,11 @@
                                 {
                                     name: translateService.T("Too Big"),
                                     color: "#ccc",
+                                    renderer: "stack",
+                                },
+                                {
+                                    name: translateService.T("Deleted"),
+                                    color: "#f0ad4e",
                                     renderer: "stack",
                                 },
                                 {

--- a/src/Exceptionless.Web/ClientApp.angular/app/project/manage/manage-controller.js
+++ b/src/Exceptionless.Web/ClientApp.angular/app/project/manage/manage-controller.js
@@ -261,7 +261,11 @@
                             return { x: moment.utc(item.date).unix(), y: item.too_big, data: item };
                         });
 
-                        vm.chart.options.series[5].data = vm.organization.usage.map(function (item) {
+                        vm.chart.options.series[5].data = vm.project.usage.map(function (item) {
+                            return { x: moment.utc(item.date).unix(), y: item.deleted || 0, data: item };
+                        });
+
+                        vm.chart.options.series[6].data = vm.organization.usage.map(function (item) {
                             return { x: moment.utc(item.date).unix(), y: item.limit, data: item };
                         });
 
@@ -786,6 +790,11 @@
                                 {
                                     name: translateService.T("Too Big"),
                                     color: "#ccc",
+                                    renderer: "stack",
+                                },
+                                {
+                                    name: translateService.T("Deleted"),
+                                    color: "#f0ad4e",
                                     renderer: "stack",
                                 },
                                 {

--- a/src/Exceptionless.Web/ClientApp/src/app.css
+++ b/src/Exceptionless.Web/ClientApp/src/app.css
@@ -50,6 +50,7 @@
     --chart-4: #f7d34a; /* Ignored / too big: golden yellow */
     --chart-5: #8a8f98; /* Organization total / snoozed: neutral gray */
     --chart-6: #d9534f; /* Limit / destructive: classic red */
+    --chart-7: #9b2d30; /* Deleted: dark rose */
 }
 
 .dark {
@@ -97,6 +98,7 @@
     --chart-4: #ffe16a; /* Ignored / too big: golden yellow */
     --chart-5: #a4abb5; /* Organization total / snoozed: neutral gray */
     --chart-6: #ff746f; /* Limit / destructive: classic red */
+    --chart-7: #c94f53; /* Deleted: dark rose */
 }
 
 @theme inline {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/api.svelte.ts
@@ -7,6 +7,7 @@ import { createQuery, type QueryClient } from '@tanstack/svelte-query';
 
 import type { Login, TokenResult } from './models';
 
+import { endSession } from './exceptionless-session';
 import { accessToken } from './index.svelte';
 
 const queryKeys = {
@@ -97,6 +98,7 @@ export async function login(email: string, password: string) {
 
 export async function logout(queryClient?: QueryClient, client = useFetchClient()) {
     await client.get('auth/logout', { expectedStatusCodes: [200, 401, 403] });
+    endSession().catch(() => {});
 
     await queryClient?.cancelQueries();
     queryClient?.clear();

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/api.svelte.ts
@@ -98,7 +98,7 @@ export async function login(email: string, password: string) {
 
 export async function logout(queryClient?: QueryClient, client = useFetchClient()) {
     await client.get('auth/logout', { expectedStatusCodes: [200, 401, 403] });
-    endSession().catch(() => {});
+    await endSession();
 
     await queryClient?.cancelQueries();
     queryClient?.clear();

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/exceptionless-session.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/exceptionless-session.ts
@@ -1,0 +1,45 @@
+import { Exceptionless } from '@exceptionless/browser';
+
+let _activeUserId: null | string = null;
+
+/**
+ * Ends the current Exceptionless session and clears user identity.
+ * Call on logout. Clears local state unconditionally even if submitSessionEnd fails.
+ */
+export async function endSession(): Promise<void> {
+    try {
+        await Exceptionless.submitSessionEnd();
+    } finally {
+        Exceptionless.config.setUserIdentity('', '');
+        _activeUserId = null;
+    }
+}
+
+/**
+ * Sets the current user identity for Exceptionless error tracking.
+ * Starts a new session only when the identity changes (guards against repeated onSuccess calls from query refetches).
+ */
+export async function setUserIdentity(userId: string, userName?: string): Promise<void> {
+    if (!userId) {
+        return;
+    }
+
+    if (userName) {
+        Exceptionless.config.setUserIdentity(userId, userName);
+    } else {
+        Exceptionless.config.setUserIdentity(userId);
+    }
+
+    if (_activeUserId !== userId) {
+        _activeUserId = userId;
+        await Exceptionless.submitSessionStart();
+    }
+}
+
+/**
+ * Submits a feature usage event for telemetry tracking.
+ * Mirrors the legacy Angular $ExceptionlessClient.submitFeatureUsage pattern.
+ */
+export async function submitFeatureUsage(feature: string): Promise<void> {
+    await Exceptionless.submitFeatureUsage(feature);
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/billing/components/change-plan-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/billing/components/change-plan-dialog.svelte
@@ -257,7 +257,7 @@
                     }
 
                     toast.success(result.message ?? 'Your billing plan has been successfully changed.');
-                    submitFeatureUsage('organization.ChangePlan').catch(() => {});
+                    await submitFeatureUsage('organization.ChangePlan');
                     onclose(true);
 
                     return null;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/billing/components/change-plan-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/billing/components/change-plan-dialog.svelte
@@ -15,6 +15,7 @@
     import { Skeleton } from '$comp/ui/skeleton';
     import { Spinner } from '$comp/ui/spinner';
     import * as Tabs from '$comp/ui/tabs';
+    import { submitFeatureUsage } from '$features/auth/exceptionless-session';
     import { FREE_PLAN_ID, isStripeEnabled, StripeProvider } from '$features/billing';
     import { type ChangePlanFormData, ChangePlanSchema } from '$features/billing/schemas';
     import { changePlanMutation, getPlansQuery } from '$features/organizations/api.svelte';
@@ -256,6 +257,7 @@
                     }
 
                     toast.success(result.message ?? 'Your billing plan has been successfully changed.');
+                    submitFeatureUsage('organization.ChangePlan').catch(() => {});
                     onclose(true);
 
                     return null;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.svelte.ts
@@ -67,9 +67,9 @@ export function getMeQuery() {
 
     return createQuery<ViewCurrentUser, ProblemDetails>(() => ({
         enabled: () => !!accessToken.current,
-        onSuccess: (data: ViewCurrentUser) => {
+        onSuccess: async (data: ViewCurrentUser) => {
             queryClient.setQueryData(queryKeys.id(data.id!), data);
-            setUserIdentity(data.id, data.full_name).catch(() => {});
+            await setUserIdentity(data.id, data.full_name);
         },
         queryClient,
         queryFn: async ({ signal }: { signal: AbortSignal }) => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.svelte.ts
@@ -1,5 +1,6 @@
 import type { WebSocketMessageValue } from '$features/websockets/models';
 
+import { setUserIdentity } from '$features/auth/exceptionless-session';
 import { accessToken } from '$features/auth/index.svelte';
 import { type FetchClientResponse, ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
 import { createMutation, createQuery, QueryClient, useQueryClient } from '@tanstack/svelte-query';
@@ -68,6 +69,7 @@ export function getMeQuery() {
         enabled: () => !!accessToken.current,
         onSuccess: (data: ViewCurrentUser) => {
             queryClient.setQueryData(queryKeys.id(data.id!), data);
+            setUserIdentity(data.id, data.full_name).catch(() => {});
         },
         queryClient,
         queryFn: async ({ signal }: { signal: AbortSignal }) => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
@@ -407,6 +407,8 @@ export interface UsageHourInfo {
   discarded: number;
   /** @format int32 */
   too_big: number;
+  /** @format int32 */
+  deleted: number;
 }
 
 export interface UsageInfo {
@@ -422,6 +424,8 @@ export interface UsageInfo {
   discarded: number;
   /** @format int32 */
   too_big: number;
+  /** @format int32 */
+  deleted: number;
 }
 
 export interface User {

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
@@ -460,6 +460,7 @@ export const UsageHourInfoSchema = object({
   blocked: int32(),
   discarded: int32(),
   too_big: int32(),
+  deleted: int32(),
 });
 export type UsageHourInfoFormData = Infer<typeof UsageHourInfoSchema>;
 
@@ -470,6 +471,7 @@ export const UsageInfoSchema = object({
   blocked: int32(),
   discarded: int32(),
   too_big: int32(),
+  deleted: int32(),
 });
 export type UsageInfoFormData = Infer<typeof UsageInfoSchema>;
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/usage/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/usage/+page.svelte
@@ -33,6 +33,7 @@
 
     const chartConfig = {
         blocked: { color: 'var(--chart-2)', label: 'Blocked' },
+        deleted: { color: 'var(--chart-7)', label: 'Deleted' },
         discarded: { color: 'var(--chart-3)', label: 'Discarded' },
         limit: { color: 'var(--chart-6)', label: 'Limit' },
         too_big: { color: 'var(--chart-4)', label: 'Too Big' },
@@ -41,9 +42,8 @@
 
     const chartData = $derived.by(() => {
         const organization = organizationQuery.data;
-        const org = organizationQuery.data;
 
-        if (!organization?.usage || !org?.usage) {
+        if (!organization?.usage) {
             return [];
         }
 
@@ -60,6 +60,7 @@
         { key: 'discarded', ...chartConfig.discarded },
         { key: 'blocked', ...chartConfig.blocked },
         { key: 'too_big', ...chartConfig.too_big },
+        { key: 'deleted', ...chartConfig.deleted },
         {
             key: 'limit',
             ...chartConfig.limit,
@@ -118,7 +119,7 @@
                     data={chartData}
                     x="date"
                     xScale={scaleUtc()}
-                    yDomain={[0, Math.max(1, ...chartData.map((d) => Math.max(d.total, d.limit, d.blocked, d.discarded, d.too_big)))]}
+                    yDomain={[0, Math.max(1, ...chartData.map((d) => Math.max(d.total, d.limit, d.blocked, d.discarded, d.too_big, d.deleted)))]}
                     {series}
                     props={{
                         area: {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/usage/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/usage/+page.svelte
@@ -46,6 +46,7 @@
 
     const chartConfig = {
         blocked: { color: 'var(--chart-2)', label: 'Blocked' },
+        deleted: { color: 'var(--chart-7)', label: 'Deleted' },
         discarded: { color: 'var(--chart-3)', label: 'Discarded' },
         limit: { color: 'var(--chart-6)', label: 'Limit' },
         org_total: { color: 'var(--chart-5)', label: 'Total in Organization' },
@@ -73,6 +74,7 @@
             return {
                 blocked: projItem.blocked,
                 date: new Date(projItem.date),
+                deleted: projItem.deleted,
                 discarded: projItem.discarded,
                 limit: orgItem?.limit || 0,
                 org_total: orgItem?.total || 0,
@@ -88,6 +90,7 @@
         { key: 'discarded', ...chartConfig.discarded },
         { key: 'blocked', ...chartConfig.blocked },
         { key: 'too_big', ...chartConfig.too_big },
+        { key: 'deleted', ...chartConfig.deleted },
         {
             key: 'limit',
             ...chartConfig.limit,

--- a/src/Exceptionless.Web/Controllers/EventController.cs
+++ b/src/Exceptionless.Web/Controllers/EventController.cs
@@ -1478,6 +1478,10 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
             {
                 await _usageService.IncrementDeletedAsync(projectGroup.Key.OrganizationId, projectGroup.Key.ProjectId, projectGroup.Count());
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to increment deleted usage metrics for org {OrganizationId} project {ProjectId}: {Message}", projectGroup.Key.OrganizationId, projectGroup.Key.ProjectId, ex.Message);

--- a/src/Exceptionless.Web/Controllers/EventController.cs
+++ b/src/Exceptionless.Web/Controllers/EventController.cs
@@ -1480,7 +1480,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to increment deleted usage metrics for org {OrganizationId} project {ProjectId}", projectGroup.Key.OrganizationId, projectGroup.Key.ProjectId);
+                _logger.LogWarning(ex, "Failed to increment deleted usage metrics for org {OrganizationId} project {ProjectId}: {Message}", projectGroup.Key.OrganizationId, projectGroup.Key.ProjectId, ex.Message);
             }
         }
 

--- a/src/Exceptionless.Web/Controllers/EventController.cs
+++ b/src/Exceptionless.Web/Controllers/EventController.cs
@@ -49,6 +49,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     private readonly ICacheClient _cache;
     private readonly JsonSerializerSettings _jsonSerializerSettings;
     private readonly AppOptions _appOptions;
+    private readonly UsageService _usageService;
 
     public EventController(IEventRepository repository,
         IOrganizationRepository organizationRepository,
@@ -63,6 +64,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
         ApiMapper mapper,
         PersistentEventQueryValidator validator,
         AppOptions appOptions,
+        UsageService usageService,
         TimeProvider timeProvider,
         ILoggerFactory loggerFactory
     ) : base(repository, mapper, validator, timeProvider, loggerFactory)
@@ -77,6 +79,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
         _cache = cacheClient;
         _jsonSerializerSettings = jsonSerializerSettings;
         _appOptions = appOptions;
+        _usageService = usageService;
 
         AllowedDateFields.Add(EventIndex.Alias.Date);
         DefaultDateField = EventIndex.Alias.Date;
@@ -1456,16 +1459,31 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
         return totals;
     }
 
-    protected override Task<IEnumerable<string>> DeleteModelsAsync(ICollection<PersistentEvent> events)
+    protected override async Task<IEnumerable<string>> DeleteModelsAsync(ICollection<PersistentEvent> events)
     {
         var user = CurrentUser;
-        foreach (var projectEvents in events.GroupBy(ev => ev.ProjectId))
+        var projectGroups = events.GroupBy(ev => new { ev.OrganizationId, ev.ProjectId }).ToList();
+        foreach (var projectGroup in projectGroups)
         {
-            var ev = projectEvents.First();
+            var ev = projectGroup.First();
             using var _ = _logger.BeginScope(new ExceptionlessState().Organization(ev.OrganizationId).Project(ev.ProjectId).Tag("Delete").Identity(user.EmailAddress).Property("User", user).SetHttpContext(HttpContext));
-            _logger.LogInformation("User {User} deleted {RemovedCount} events in project ({ProjectId})", user.Id, projectEvents.Count(), ev.ProjectId);
+            _logger.LogInformation("User {User} deleted {RemovedCount} events in project ({ProjectId})", user.Id, projectGroup.Count(), ev.ProjectId);
         }
 
-        return base.DeleteModelsAsync(events);
+        var result = await base.DeleteModelsAsync(events);
+
+        foreach (var projectGroup in projectGroups)
+        {
+            try
+            {
+                await _usageService.IncrementDeletedAsync(projectGroup.Key.OrganizationId, projectGroup.Key.ProjectId, projectGroup.Count());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to increment deleted usage metrics for org {OrganizationId} project {ProjectId}", projectGroup.Key.OrganizationId, projectGroup.Key.ProjectId);
+            }
+        }
+
+        return result;
     }
 }

--- a/src/Exceptionless.Web/Controllers/OrganizationController.cs
+++ b/src/Exceptionless.Web/Controllers/OrganizationController.cs
@@ -963,12 +963,14 @@ public class OrganizationController : RepositoryApiController<IOrganizationRepos
             currentUsage.Blocked = realTimeUsage.CurrentUsage.Blocked;
             currentUsage.Discarded = realTimeUsage.CurrentUsage.Discarded;
             currentUsage.TooBig = realTimeUsage.CurrentUsage.TooBig;
+            currentUsage.Deleted = realTimeUsage.CurrentUsage.Deleted;
 
             var currentHourUsage = viewOrganization.GetCurrentHourlyUsage(_timeProvider);
             currentHourUsage.Total = realTimeUsage.CurrentHourUsage.Total;
             currentHourUsage.Blocked = realTimeUsage.CurrentHourUsage.Blocked;
             currentHourUsage.Discarded = realTimeUsage.CurrentHourUsage.Discarded;
             currentHourUsage.TooBig = realTimeUsage.CurrentHourUsage.TooBig;
+            currentHourUsage.Deleted = realTimeUsage.CurrentHourUsage.Deleted;
 
             viewOrganization.IsThrottled = realTimeUsage.IsThrottled;
             viewOrganization.IsOverRequestLimit = await OrganizationExtensions.IsOverRequestLimitAsync(viewOrganization.Id, _cacheClient, _options.ApiThrottleLimit, _timeProvider);

--- a/src/Exceptionless.Web/Controllers/ProjectController.cs
+++ b/src/Exceptionless.Web/Controllers/ProjectController.cs
@@ -755,12 +755,14 @@ public class ProjectController : RepositoryApiController<IProjectRepository, Pro
             currentUsage.Blocked = realTimeUsage.CurrentUsage.Blocked;
             currentUsage.Discarded = realTimeUsage.CurrentUsage.Discarded;
             currentUsage.TooBig = realTimeUsage.CurrentUsage.TooBig;
+            currentUsage.Deleted = realTimeUsage.CurrentUsage.Deleted;
 
             var currentHourUsage = viewProject.GetCurrentHourlyUsage(_timeProvider);
             currentHourUsage.Total = realTimeUsage.CurrentHourUsage.Total;
             currentHourUsage.Blocked = realTimeUsage.CurrentHourUsage.Blocked;
             currentHourUsage.Discarded = realTimeUsage.CurrentHourUsage.Discarded;
             currentHourUsage.TooBig = realTimeUsage.CurrentHourUsage.TooBig;
+            currentHourUsage.Deleted = realTimeUsage.CurrentHourUsage.Deleted;
         }
     }
 

--- a/tests/Exceptionless.Tests/Controllers/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Controllers/Data/openapi.json
@@ -8876,7 +8876,8 @@
           "total",
           "blocked",
           "discarded",
-          "too_big"
+          "too_big",
+          "deleted"
         ],
         "type": "object",
         "properties": {
@@ -8899,6 +8900,10 @@
           "too_big": {
             "type": "integer",
             "format": "int32"
+          },
+          "deleted": {
+            "type": "integer",
+            "format": "int32"
           }
         }
       },
@@ -8909,7 +8914,8 @@
           "total",
           "blocked",
           "discarded",
-          "too_big"
+          "too_big",
+          "deleted"
         ],
         "type": "object",
         "properties": {
@@ -8934,6 +8940,10 @@
             "format": "int32"
           },
           "too_big": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "deleted": {
             "type": "integer",
             "format": "int32"
           }

--- a/tests/Exceptionless.Tests/Controllers/EventControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/EventControllerTests.cs
@@ -36,6 +36,7 @@ public class EventControllerTests : IntegrationTestsBase
 {
     private readonly JsonSerializerOptions _jsonSerializerOptions;
     private readonly IOrganizationRepository _organizationRepository;
+    private readonly IProjectRepository _projectRepository;
     private readonly StackData _stackData;
     private readonly Exceptionless.Helpers.RandomEventGenerator _randomEventGenerator;
     private readonly EventData _eventData;
@@ -48,6 +49,7 @@ public class EventControllerTests : IntegrationTestsBase
     {
         _jsonSerializerOptions = GetService<JsonSerializerOptions>();
         _organizationRepository = GetService<IOrganizationRepository>();
+        _projectRepository = GetService<IProjectRepository>();
         _stackData = GetService<StackData>();
         _randomEventGenerator = GetService<Exceptionless.Helpers.RandomEventGenerator>();
         _eventData = GetService<EventData>();
@@ -1989,5 +1991,105 @@ public class EventControllerTests : IntegrationTestsBase
         Assert.NotNull(userDescription);
         Assert.Equal("legacy@exceptionless.test", userDescription.EmailAddress);
         Assert.Equal("Legacy description", userDescription.Description);
+    }
+
+    [Fact]
+    public async Task DeleteModelsAsync_SingleEvent_IncrementsDeletedUsage()
+    {
+        // Arrange
+        var usageService = GetService<UsageService>();
+
+        await SendRequestAsync(r => r
+            .Post()
+            .AsTestOrganizationClientUser()
+            .AppendPath("events")
+            .Content(new Event { Message = "test-delete-usage", Type = Event.KnownTypes.Log })
+            .StatusCodeShouldBeAccepted());
+
+        var processEventsJob = GetService<EventPostsJob>();
+        await processEventsJob.RunAsync(TestCancellationToken);
+        await RefreshDataAsync();
+
+        var events = await _eventRepository.GetAllAsync();
+        var targetEvent = events.Documents.Single(e => String.Equals(e.Message, "test-delete-usage", StringComparison.Ordinal));
+
+        // Act
+        await SendRequestAsync(r => r
+            .Delete()
+            .AsTestOrganizationUser()
+            .AppendPath($"events/{targetEvent.Id}")
+            .StatusCodeShouldBeAccepted());
+
+        await RefreshDataAsync();
+
+        // Assert
+        var remainingEvent = await _eventRepository.GetByIdAsync(targetEvent.Id);
+        Assert.Null(remainingEvent);
+
+        var usageResponse = await usageService.GetUsageAsync(targetEvent.OrganizationId, targetEvent.ProjectId);
+        Assert.Equal(1, usageResponse.CurrentUsage.Deleted);
+        Assert.Equal(1, usageResponse.CurrentHourUsage.Deleted);
+
+        TimeProvider.Advance(TimeSpan.FromMinutes(10));
+        await usageService.SavePendingUsageAsync();
+
+        var organization = await _organizationRepository.GetByIdAsync(targetEvent.OrganizationId);
+        Assert.NotNull(organization);
+        var orgUsage = organization.Usage.FirstOrDefault();
+        Assert.NotNull(orgUsage);
+        Assert.Equal(1, orgUsage.Deleted);
+    }
+
+    [Fact]
+    public async Task DeleteModelsAsync_MultipleEvents_IncrementsDeletedUsageForAll()
+    {
+        // Arrange
+        var usageService = GetService<UsageService>();
+
+        for (int eventIndex = 0; eventIndex < 3; eventIndex++)
+        {
+            await SendRequestAsync(r => r
+                .Post()
+                .AsTestOrganizationClientUser()
+                .AppendPath("events")
+                .Content(new Event { Message = $"test-multi-delete-{eventIndex}", Type = Event.KnownTypes.Log })
+                .StatusCodeShouldBeAccepted());
+        }
+
+        var processEventsJob = GetService<EventPostsJob>();
+        await processEventsJob.RunUntilEmptyAsync(TestCancellationToken);
+        await RefreshDataAsync();
+
+        var events = await _eventRepository.GetAllAsync();
+        var targetEvents = events.Documents.Where(e => e.Message is not null && e.Message.StartsWith("test-multi-delete-", StringComparison.Ordinal)).ToList();
+        Assert.Equal(3, targetEvents.Count);
+
+        var ids = String.Join(",", targetEvents.Select(e => e.Id));
+
+        // Act
+        await SendRequestAsync(r => r
+            .Delete()
+            .AsTestOrganizationUser()
+            .AppendPath($"events/{ids}")
+            .StatusCodeShouldBeAccepted());
+
+        await RefreshDataAsync();
+
+        // Assert
+        var firstEvent = targetEvents.First();
+        var usageResponse = await usageService.GetUsageAsync(firstEvent.OrganizationId, firstEvent.ProjectId);
+        Assert.Equal(3, usageResponse.CurrentUsage.Deleted);
+        Assert.Equal(3, usageResponse.CurrentHourUsage.Deleted);
+
+        TimeProvider.Advance(TimeSpan.FromMinutes(10));
+        await usageService.SavePendingUsageAsync();
+
+        var organization = await _organizationRepository.GetByIdAsync(firstEvent.OrganizationId);
+        Assert.NotNull(organization);
+        Assert.Equal(3, organization.Usage.Sum(u => u.Deleted));
+
+        var project = await _projectRepository.GetByIdAsync(firstEvent.ProjectId);
+        Assert.NotNull(project);
+        Assert.Equal(3, project.Usage.Sum(u => u.Deleted));
     }
 }

--- a/tests/Exceptionless.Tests/Jobs/CleanupDataJobTests.cs
+++ b/tests/Exceptionless.Tests/Jobs/CleanupDataJobTests.cs
@@ -2,6 +2,7 @@ using Exceptionless.Core;
 using Exceptionless.Core.Billing;
 using Exceptionless.Core.Jobs;
 using Exceptionless.Core.Repositories;
+using Exceptionless.Core.Services;
 using Exceptionless.DateTimeExtensions;
 using Exceptionless.Tests.Utility;
 using Foundatio.Repositories;
@@ -13,22 +14,24 @@ namespace Exceptionless.Tests.Jobs;
 public class CleanupDataJobTests : IntegrationTestsBase
 {
     private readonly CleanupDataJob _job;
-    private readonly OrganizationData _organizationData;
+    private readonly UsageService _usageService;
     private readonly IOrganizationRepository _organizationRepository;
-    private readonly ProjectData _projectData;
+    private readonly OrganizationData _organizationData;
     private readonly IProjectRepository _projectRepository;
-    private readonly StackData _stackData;
+    private readonly ProjectData _projectData;
     private readonly IStackRepository _stackRepository;
-    private readonly EventData _eventData;
+    private readonly StackData _stackData;
     private readonly IEventRepository _eventRepository;
-    private readonly TokenData _tokenData;
+    private readonly EventData _eventData;
     private readonly ITokenRepository _tokenRepository;
+    private readonly TokenData _tokenData;
     private readonly BillingManager _billingManager;
     private readonly BillingPlans _plans;
 
     public CleanupDataJobTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
     {
         _job = GetService<CleanupDataJob>();
+        _usageService = GetService<UsageService>();
         _organizationData = GetService<OrganizationData>();
         _organizationRepository = GetService<IOrganizationRepository>();
         _projectData = GetService<ProjectData>();
@@ -168,5 +171,153 @@ public class CleanupDataJobTests : IntegrationTestsBase
 
         eventCount = await _eventRepository.CountAsync(o => o.IncludeSoftDeletes().ImmediateConsistency());
         Assert.Equal(5000, eventCount);
+    }
+
+    [Fact]
+    public async Task RemoveProjectsAsync_SoftDeletedProjectWithEvents_IncrementsDeletedUsage()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(_organizationData.GenerateSampleOrganization(_billingManager, _plans), o => o.ImmediateConsistency());
+
+        var project = _projectData.GenerateSampleProject();
+        project.IsDeleted = true;
+        await _projectRepository.AddAsync(project, o => o.ImmediateConsistency());
+
+        var stack = await _stackRepository.AddAsync(_stackData.GenerateSampleStack(), o => o.ImmediateConsistency());
+        var events = _eventData.GenerateEvents(5, organization.Id, project.Id, stack.Id).ToList();
+        await _eventRepository.AddAsync(events, o => o.ImmediateConsistency());
+
+        // Act
+        await _job.RunAsync(TestCancellationToken);
+
+        // Assert
+        var orgUsage = await _usageService.GetUsageAsync(organization.Id, null);
+        Assert.Equal(5, orgUsage.CurrentUsage.Deleted);
+        Assert.Equal(5, orgUsage.CurrentHourUsage.Deleted);
+
+        TimeProvider.Advance(TimeSpan.FromMinutes(10));
+        await _usageService.SavePendingUsageAsync();
+
+        var savedOrg = await _organizationRepository.GetByIdAsync(organization.Id);
+        Assert.NotNull(savedOrg);
+        Assert.Equal(5, savedOrg.Usage.Sum(u => u.Deleted));
+
+        Assert.Null(await _projectRepository.GetByIdAsync(project.Id, o => o.IncludeSoftDeletes()));
+        var allEvents = await _eventRepository.GetAllAsync();
+        Assert.DoesNotContain(allEvents.Documents, e => String.Equals(e.ProjectId, project.Id, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task RemoveProjectsAsync_SoftDeletedEmptyProject_DoesNotIncrementDeletedUsage()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(_organizationData.GenerateSampleOrganization(_billingManager, _plans), o => o.ImmediateConsistency());
+
+        var project = _projectData.GenerateSampleProject();
+        project.IsDeleted = true;
+        await _projectRepository.AddAsync(project, o => o.ImmediateConsistency());
+
+        // Act
+        await _job.RunAsync(TestCancellationToken);
+
+        // Assert
+        var orgUsage = await _usageService.GetUsageAsync(organization.Id, null);
+        Assert.Equal(0, orgUsage.CurrentUsage.Deleted);
+        Assert.Equal(0, orgUsage.CurrentHourUsage.Deleted);
+
+        Assert.Null(await _projectRepository.GetByIdAsync(project.Id, o => o.IncludeSoftDeletes()));
+    }
+
+    [Fact]
+    public async Task RemoveStacksAsync_SoftDeletedStack_IncrementsDeletedUsage()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(_organizationData.GenerateSampleOrganization(_billingManager, _plans), o => o.ImmediateConsistency());
+        var project = await _projectRepository.AddAsync(_projectData.GenerateSampleProject(), o => o.ImmediateConsistency());
+
+        var stack = _stackData.GenerateSampleStack();
+        stack.IsDeleted = true;
+        await _stackRepository.AddAsync(stack, o => o.ImmediateConsistency());
+
+        var events = _eventData.GenerateEvents(3, organization.Id, project.Id, stack.Id).ToList();
+        await _eventRepository.AddAsync(events, o => o.ImmediateConsistency());
+
+        // Act
+        await _job.RunAsync(TestCancellationToken);
+
+        // Assert
+        var usageResponse = await _usageService.GetUsageAsync(organization.Id, project.Id);
+        Assert.Equal(3, usageResponse.CurrentUsage.Deleted);
+        Assert.Equal(3, usageResponse.CurrentHourUsage.Deleted);
+
+        TimeProvider.Advance(TimeSpan.FromMinutes(10));
+        await _usageService.SavePendingUsageAsync();
+
+        var savedOrg = await _organizationRepository.GetByIdAsync(organization.Id);
+        Assert.NotNull(savedOrg);
+        Assert.Equal(3, savedOrg.Usage.Sum(u => u.Deleted));
+
+        Assert.Null(await _stackRepository.GetByIdAsync(stack.Id, o => o.IncludeSoftDeletes()));
+    }
+
+    [Fact]
+    public async Task RemoveStacksAsync_MultipleProjectsSoftDeleted_TracksExactDeletedUsagePerProject()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(_organizationData.GenerateSampleOrganization(_billingManager, _plans), o => o.ImmediateConsistency());
+        var project1 = await _projectRepository.AddAsync(_projectData.GenerateSampleProject(), o => o.ImmediateConsistency());
+        var project2 = await _projectRepository.AddAsync(_projectData.GenerateProject(generateId: true, organizationId: organization.Id), o => o.ImmediateConsistency());
+
+        var stack1a = _stackData.GenerateStack(generateId: true, organizationId: organization.Id, projectId: project1.Id);
+        stack1a.IsDeleted = true;
+        var stack1b = _stackData.GenerateStack(generateId: true, organizationId: organization.Id, projectId: project1.Id);
+        stack1b.IsDeleted = true;
+        var stack2 = _stackData.GenerateStack(generateId: true, organizationId: organization.Id, projectId: project2.Id);
+        stack2.IsDeleted = true;
+        await _stackRepository.AddAsync([stack1a, stack1b, stack2], o => o.ImmediateConsistency());
+
+        await _eventRepository.AddAsync(_eventData.GenerateEvents(4, organization.Id, project1.Id, stack1a.Id), o => o.ImmediateConsistency());
+        await _eventRepository.AddAsync(_eventData.GenerateEvents(2, organization.Id, project1.Id, stack1b.Id), o => o.ImmediateConsistency());
+        await _eventRepository.AddAsync(_eventData.GenerateEvents(3, organization.Id, project2.Id, stack2.Id), o => o.ImmediateConsistency());
+
+        // Act
+        await _job.RunAsync(TestCancellationToken);
+
+        // Assert
+        var usageProject1 = await _usageService.GetUsageAsync(organization.Id, project1.Id);
+        var usageProject2 = await _usageService.GetUsageAsync(organization.Id, project2.Id);
+        Assert.Equal(6, usageProject1.CurrentUsage.Deleted);
+        Assert.Equal(3, usageProject2.CurrentUsage.Deleted);
+
+        TimeProvider.Advance(TimeSpan.FromMinutes(10));
+        await _usageService.SavePendingUsageAsync();
+
+        var savedOrg = await _organizationRepository.GetByIdAsync(organization.Id);
+        Assert.NotNull(savedOrg);
+        Assert.Equal(9, savedOrg.Usage.Sum(u => u.Deleted));
+    }
+
+    [Fact]
+    public async Task EnforceRetentionAsync_ExpiredEvents_DoesNotIncrementDeletedUsage()
+    {
+        // Arrange
+        var organization = _organizationData.GenerateSampleOrganization(_billingManager, _plans);
+        _billingManager.ApplyBillingPlan(organization, _plans.FreePlan);
+        await _organizationRepository.AddAsync(organization, o => o.ImmediateConsistency());
+        var project = await _projectRepository.AddAsync(_projectData.GenerateSampleProject(), o => o.ImmediateConsistency());
+
+        var options = GetService<AppOptions>();
+        var expiredDate = DateTimeOffset.UtcNow.SubtractDays(options.MaximumRetentionDays);
+
+        var stack = await _stackRepository.AddAsync(_stackData.GenerateSampleStack(), o => o.ImmediateConsistency());
+        await _eventRepository.AddAsync(_eventData.GenerateEvent(organization.Id, project.Id, stack.Id, expiredDate, expiredDate, expiredDate), o => o.ImmediateConsistency());
+
+        // Act
+        await _job.RunAsync(TestCancellationToken);
+
+        // Assert
+        var usageResponse = await _usageService.GetUsageAsync(organization.Id, project.Id);
+        Assert.Equal(0, usageResponse.CurrentUsage.Deleted);
+        Assert.Equal(0, usageResponse.CurrentHourUsage.Deleted);
     }
 }

--- a/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/ResetProjectDataWorkItemHandlerTests.cs
+++ b/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/ResetProjectDataWorkItemHandlerTests.cs
@@ -1,0 +1,172 @@
+using Exceptionless.Core.Billing;
+using Exceptionless.Core.Jobs;
+using Exceptionless.Core.Models.WorkItems;
+using Exceptionless.Core.Repositories;
+using Exceptionless.Core.Services;
+using Exceptionless.Tests.Utility;
+using Foundatio.Jobs;
+using Foundatio.Queues;
+using Foundatio.Repositories;
+using Xunit;
+
+namespace Exceptionless.Tests.Jobs.WorkItemHandlers;
+
+public class ResetProjectDataWorkItemHandlerTests : IntegrationTestsBase
+{
+    private readonly WorkItemJob _workItemJob;
+    private readonly IQueue<WorkItemData> _workItemQueue;
+    private readonly UsageService _usageService;
+    private readonly IOrganizationRepository _organizationRepository;
+    private readonly IProjectRepository _projectRepository;
+    private readonly IStackRepository _stackRepository;
+    private readonly IEventRepository _eventRepository;
+    private readonly OrganizationData _organizationData;
+    private readonly ProjectData _projectData;
+    private readonly StackData _stackData;
+    private readonly EventData _eventData;
+    private readonly BillingManager _billingManager;
+    private readonly BillingPlans _plans;
+
+    public ResetProjectDataWorkItemHandlerTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
+    {
+        _workItemJob = GetService<WorkItemJob>();
+        _workItemQueue = GetService<IQueue<WorkItemData>>();
+        _usageService = GetService<UsageService>();
+        _organizationData = GetService<OrganizationData>();
+        _organizationRepository = GetService<IOrganizationRepository>();
+        _projectData = GetService<ProjectData>();
+        _projectRepository = GetService<IProjectRepository>();
+        _stackData = GetService<StackData>();
+        _stackRepository = GetService<IStackRepository>();
+        _eventData = GetService<EventData>();
+        _eventRepository = GetService<IEventRepository>();
+        _billingManager = GetService<BillingManager>();
+        _plans = GetService<BillingPlans>();
+    }
+
+    [Fact]
+    public async Task ResetProjectData_WithEvents_IncrementsDeletedUsageAndPersists()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(_organizationData.GenerateSampleOrganization(_billingManager, _plans), o => o.ImmediateConsistency());
+        var project = await _projectRepository.AddAsync(_projectData.GenerateSampleProject(), o => o.ImmediateConsistency());
+        var stack = await _stackRepository.AddAsync(_stackData.GenerateSampleStack(), o => o.ImmediateConsistency());
+
+        var events = _eventData.GenerateEvents(5, organization.Id, project.Id, stack.Id).ToList();
+        await _eventRepository.AddAsync(events, o => o.ImmediateConsistency());
+
+        // Act
+        await _workItemQueue.EnqueueAsync(new ResetProjectDataWorkItem { OrganizationId = organization.Id, ProjectId = project.Id });
+        await _workItemJob.RunUntilEmptyAsync(TestCancellationToken);
+        await RefreshDataAsync();
+
+        // Assert
+        var remaining = await _eventRepository.GetAllAsync();
+        Assert.DoesNotContain(remaining.Documents, e => String.Equals(e.ProjectId, project.Id, StringComparison.Ordinal));
+        Assert.Null(await _stackRepository.GetByIdAsync(stack.Id, o => o.IncludeSoftDeletes()));
+
+        var usageResponse = await _usageService.GetUsageAsync(organization.Id, project.Id);
+        Assert.Equal(5, usageResponse.CurrentUsage.Deleted);
+        Assert.Equal(5, usageResponse.CurrentHourUsage.Deleted);
+
+        TimeProvider.Advance(TimeSpan.FromMinutes(10));
+        await _usageService.SavePendingUsageAsync();
+
+        var savedOrg = await _organizationRepository.GetByIdAsync(organization.Id);
+        Assert.NotNull(savedOrg);
+        Assert.Equal(5, savedOrg.Usage.Sum(u => u.Deleted));
+
+        var savedProject = await _projectRepository.GetByIdAsync(project.Id);
+        Assert.NotNull(savedProject);
+        Assert.Equal(5, savedProject.Usage.Sum(u => u.Deleted));
+    }
+
+    [Fact]
+    public async Task ResetProjectData_EmptyProject_DoesNotIncrementDeletedUsage()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(_organizationData.GenerateSampleOrganization(_billingManager, _plans), o => o.ImmediateConsistency());
+        var project = await _projectRepository.AddAsync(_projectData.GenerateSampleProject(), o => o.ImmediateConsistency());
+
+        // Act
+        await _workItemQueue.EnqueueAsync(new ResetProjectDataWorkItem { OrganizationId = organization.Id, ProjectId = project.Id });
+        await _workItemJob.RunUntilEmptyAsync(TestCancellationToken);
+
+        // Assert
+        var usageResponse = await _usageService.GetUsageAsync(organization.Id, project.Id);
+        Assert.Equal(0, usageResponse.CurrentUsage.Deleted);
+        Assert.Equal(0, usageResponse.CurrentHourUsage.Deleted);
+    }
+
+    [Fact]
+    public async Task ResetProjectData_MultipleStacks_IncrementsDeletedUsageForAllEvents()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(_organizationData.GenerateSampleOrganization(_billingManager, _plans), o => o.ImmediateConsistency());
+        var project = await _projectRepository.AddAsync(_projectData.GenerateSampleProject(), o => o.ImmediateConsistency());
+
+        var stack1 = await _stackRepository.AddAsync(_stackData.GenerateSampleStack(), o => o.ImmediateConsistency());
+        var stack2 = await _stackRepository.AddAsync(_stackData.GenerateStack(generateId: true, organizationId: organization.Id, projectId: project.Id), o => o.ImmediateConsistency());
+
+        await _eventRepository.AddAsync(_eventData.GenerateEvents(3, organization.Id, project.Id, stack1.Id), o => o.ImmediateConsistency());
+        await _eventRepository.AddAsync(_eventData.GenerateEvents(4, organization.Id, project.Id, stack2.Id), o => o.ImmediateConsistency());
+
+        // Act
+        await _workItemQueue.EnqueueAsync(new ResetProjectDataWorkItem { OrganizationId = organization.Id, ProjectId = project.Id });
+        await _workItemJob.RunUntilEmptyAsync(TestCancellationToken);
+
+        // Assert
+        var usageResponse = await _usageService.GetUsageAsync(organization.Id, project.Id);
+        Assert.Equal(7, usageResponse.CurrentUsage.Deleted);
+    }
+
+    [Fact]
+    public async Task ResetProjectData_MultipleProjects_OnlyIncrementsTargetProject()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(_organizationData.GenerateSampleOrganization(_billingManager, _plans), o => o.ImmediateConsistency());
+        var project1 = await _projectRepository.AddAsync(_projectData.GenerateSampleProject(), o => o.ImmediateConsistency());
+        var project2 = await _projectRepository.AddAsync(_projectData.GenerateProject(generateId: true, organizationId: organization.Id), o => o.ImmediateConsistency());
+
+        var stack1 = await _stackRepository.AddAsync(_stackData.GenerateStack(generateId: true, organizationId: organization.Id, projectId: project1.Id), o => o.ImmediateConsistency());
+        var stack2 = await _stackRepository.AddAsync(_stackData.GenerateStack(generateId: true, organizationId: organization.Id, projectId: project2.Id), o => o.ImmediateConsistency());
+
+        await _eventRepository.AddAsync(_eventData.GenerateEvents(5, organization.Id, project1.Id, stack1.Id), o => o.ImmediateConsistency());
+        await _eventRepository.AddAsync(_eventData.GenerateEvents(3, organization.Id, project2.Id, stack2.Id), o => o.ImmediateConsistency());
+
+        // Act
+        await _workItemQueue.EnqueueAsync(new ResetProjectDataWorkItem { OrganizationId = organization.Id, ProjectId = project1.Id });
+        await _workItemJob.RunUntilEmptyAsync(TestCancellationToken);
+
+        // Assert
+        var usage1 = await _usageService.GetUsageAsync(organization.Id, project1.Id);
+        var usage2 = await _usageService.GetUsageAsync(organization.Id, project2.Id);
+
+        Assert.Equal(5, usage1.CurrentUsage.Deleted);
+        Assert.Equal(0, usage2.CurrentUsage.Deleted);
+
+        var project2Events = await _eventRepository.GetAllAsync();
+        Assert.Equal(3, project2Events.Documents.Count(e => String.Equals(e.ProjectId, project2.Id, StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public async Task ResetProjectData_DeletedUsage_DoesNotReduceEventsLeft()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(_organizationData.GenerateSampleOrganization(_billingManager, _plans), o => o.ImmediateConsistency());
+        var project = await _projectRepository.AddAsync(_projectData.GenerateSampleProject(), o => o.ImmediateConsistency());
+        var stack = await _stackRepository.AddAsync(_stackData.GenerateSampleStack(), o => o.ImmediateConsistency());
+
+        await _eventRepository.AddAsync(_eventData.GenerateEvents(10, organization.Id, project.Id, stack.Id), o => o.ImmediateConsistency());
+
+        int eventsLeftBefore = await _usageService.GetEventsLeftAsync(organization.Id);
+
+        // Act
+        await _workItemQueue.EnqueueAsync(new ResetProjectDataWorkItem { OrganizationId = organization.Id, ProjectId = project.Id });
+        await _workItemJob.RunUntilEmptyAsync(TestCancellationToken);
+
+        // Assert
+        int eventsLeftAfter = await _usageService.GetEventsLeftAsync(organization.Id);
+        Assert.Equal(eventsLeftBefore, eventsLeftAfter);
+    }
+}

--- a/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
@@ -76,6 +76,7 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         Assert.Equal(eventsLeftInBucket, usage.Total);
         Assert.Equal(0, usage.Blocked);
         Assert.Equal(0, usage.TooBig);
+        Assert.Equal(0, usage.Deleted);
 
         project = await _projectRepository.GetByIdAsync(project.Id);
         Assert.NotNull(project);
@@ -84,6 +85,7 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         Assert.Equal(eventsLeftInBucket, usage.Total);
         Assert.Equal(0, usage.Blocked);
         Assert.Equal(0, usage.TooBig);
+        Assert.Equal(0, usage.Deleted);
     }
 
     [Fact]
@@ -217,10 +219,12 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         Assert.Equal(0, usage.Total);
         Assert.Equal(1, usage.Blocked);
         Assert.Equal(0, usage.TooBig);
+        Assert.Equal(0, usage.Deleted);
         var overage = organization.UsageHours.Single();
         Assert.Equal(0, overage.Total);
         Assert.Equal(1, overage.Blocked);
         Assert.Equal(0, overage.TooBig);
+        Assert.Equal(0, overage.Deleted);
 
         project = await _projectRepository.GetByIdAsync(project.Id);
         Assert.NotNull(project);
@@ -230,11 +234,13 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         Assert.Equal(0, usage.Total);
         Assert.Equal(1, usage.Blocked);
         Assert.Equal(0, usage.TooBig);
+        Assert.Equal(0, usage.Deleted);
 
         overage = project.UsageHours.Single();
         Assert.Equal(0, overage.Total);
         Assert.Equal(1, overage.Blocked);
         Assert.Equal(0, overage.TooBig);
+        Assert.Equal(0, overage.Deleted);
     }
 
     [Fact]
@@ -257,10 +263,12 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         Assert.Equal(0, usage.Total);
         Assert.Equal(1, usage.Discarded);
         Assert.Equal(0, usage.TooBig);
+        Assert.Equal(0, usage.Deleted);
         var overage = organization.UsageHours.Single();
         Assert.Equal(0, overage.Total);
         Assert.Equal(1, overage.Discarded);
         Assert.Equal(0, overage.TooBig);
+        Assert.Equal(0, overage.Deleted);
 
         project = await _projectRepository.GetByIdAsync(project.Id);
         Assert.NotNull(project);
@@ -270,11 +278,13 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         Assert.Equal(0, usage.Total);
         Assert.Equal(1, usage.Discarded);
         Assert.Equal(0, usage.TooBig);
+        Assert.Equal(0, usage.Deleted);
 
         overage = project.UsageHours.Single();
         Assert.Equal(0, overage.Total);
         Assert.Equal(1, overage.Discarded);
         Assert.Equal(0, overage.TooBig);
+        Assert.Equal(0, overage.Deleted);
     }
 
     [Fact]
@@ -297,6 +307,7 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         Assert.Equal(0, usage.Total);
         Assert.Equal(0, usage.Blocked);
         Assert.Equal(1, usage.TooBig);
+        Assert.Equal(0, usage.Deleted);
 
         project = await _projectRepository.GetByIdAsync(project.Id);
         Assert.NotNull(project);
@@ -305,6 +316,141 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         Assert.Equal(0, usage.Total);
         Assert.Equal(0, usage.Blocked);
         Assert.Equal(1, usage.TooBig);
+        Assert.Equal(0, usage.Deleted);
+    }
+
+    [Fact]
+    public async Task IncrementDeletedAsync_WithProjectId_PersistsOrgAndProjectUsage()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(new Organization { Name = "Test", MaxEventsPerMonth = 750, PlanId = _plans.SmallPlan.Id }, o => o.ImmediateConsistency().Cache());
+        var project = await _projectRepository.AddAsync(new Project { Name = "Test", OrganizationId = organization.Id, NextSummaryEndOfDayTicks = TimeProvider.GetUtcNow().UtcDateTime.Ticks }, o => o.ImmediateConsistency().Cache());
+
+        // Act
+        await _usageService.IncrementDeletedAsync(organization.Id, project.Id, 5);
+        TimeProvider.Advance(TimeSpan.FromMinutes(10));
+        await _usageService.SavePendingUsageAsync();
+
+        // Assert
+        organization = await _organizationRepository.GetByIdAsync(organization.Id);
+        Assert.NotNull(organization);
+        Assert.Single(organization.UsageHours);
+        var usage = organization.Usage.Single();
+        Assert.Equal(organization.MaxEventsPerMonth, usage.Limit);
+        Assert.Equal(0, usage.Total);
+        Assert.Equal(0, usage.Blocked);
+        Assert.Equal(0, usage.TooBig);
+        Assert.Equal(0, usage.Discarded);
+        Assert.Equal(5, usage.Deleted);
+        var hourUsage = organization.UsageHours.Single();
+        Assert.Equal(0, hourUsage.Total);
+        Assert.Equal(0, hourUsage.Blocked);
+        Assert.Equal(0, hourUsage.TooBig);
+        Assert.Equal(0, hourUsage.Discarded);
+        Assert.Equal(5, hourUsage.Deleted);
+
+        project = await _projectRepository.GetByIdAsync(project.Id);
+        Assert.NotNull(project);
+        Assert.Single(project.UsageHours);
+        usage = project.Usage.Single();
+        Assert.Equal(0, usage.Total);
+        Assert.Equal(0, usage.Blocked);
+        Assert.Equal(0, usage.TooBig);
+        Assert.Equal(0, usage.Discarded);
+        Assert.Equal(5, usage.Deleted);
+        hourUsage = project.UsageHours.Single();
+        Assert.Equal(0, hourUsage.Total);
+        Assert.Equal(0, hourUsage.Blocked);
+        Assert.Equal(0, hourUsage.TooBig);
+        Assert.Equal(0, hourUsage.Discarded);
+        Assert.Equal(5, hourUsage.Deleted);
+    }
+
+    [Fact]
+    public async Task IncrementDeletedAsync_WithoutProjectId_OnlyIncrementsOrgUsage()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(new Organization { Name = "Test", MaxEventsPerMonth = 750, PlanId = _plans.SmallPlan.Id }, o => o.ImmediateConsistency().Cache());
+        var project = await _projectRepository.AddAsync(new Project { Name = "Test", OrganizationId = organization.Id, NextSummaryEndOfDayTicks = TimeProvider.GetUtcNow().UtcDateTime.Ticks }, o => o.ImmediateConsistency().Cache());
+
+        // Act
+        await _usageService.IncrementDeletedAsync(organization.Id, null, 10);
+        TimeProvider.Advance(TimeSpan.FromMinutes(10));
+        await _usageService.SavePendingUsageAsync();
+
+        // Assert
+        organization = await _organizationRepository.GetByIdAsync(organization.Id);
+        Assert.NotNull(organization);
+        Assert.Single(organization.UsageHours);
+        var usage = organization.Usage.Single();
+        Assert.Equal(10, usage.Deleted);
+        Assert.Equal(0, usage.Total);
+
+        project = await _projectRepository.GetByIdAsync(project.Id);
+        Assert.NotNull(project);
+        Assert.Empty(project.Usage);
+    }
+
+    [Fact]
+    public async Task IncrementDeletedAsync_LargeCount_DoesNotReduceEventsLeft()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(new Organization { Name = "Test", MaxEventsPerMonth = 750, PlanId = _plans.SmallPlan.Id }, o => o.ImmediateConsistency().Cache());
+        var project = await _projectRepository.AddAsync(new Project { Name = "Test", OrganizationId = organization.Id, NextSummaryEndOfDayTicks = TimeProvider.GetUtcNow().UtcDateTime.Ticks }, o => o.ImmediateConsistency().Cache());
+
+        int eventsLeftBefore = await _usageService.GetEventsLeftAsync(organization.Id);
+
+        // Act
+        await _usageService.IncrementDeletedAsync(organization.Id, project.Id, 100);
+
+        // Assert
+        int eventsLeftAfter = await _usageService.GetEventsLeftAsync(organization.Id);
+        Assert.Equal(eventsLeftBefore, eventsLeftAfter);
+    }
+
+    [Fact]
+    public async Task IncrementDeletedAsync_MultipleCalls_AccumulatesCorrectly()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(new Organization { Name = "Test", MaxEventsPerMonth = 750, PlanId = _plans.SmallPlan.Id }, o => o.ImmediateConsistency().Cache());
+        var project = await _projectRepository.AddAsync(new Project { Name = "Test", OrganizationId = organization.Id, NextSummaryEndOfDayTicks = TimeProvider.GetUtcNow().UtcDateTime.Ticks }, o => o.ImmediateConsistency().Cache());
+
+        // Act
+        await _usageService.IncrementDeletedAsync(organization.Id, project.Id, 3);
+        await _usageService.IncrementDeletedAsync(organization.Id, project.Id, 7);
+        TimeProvider.Advance(TimeSpan.FromMinutes(10));
+        await _usageService.SavePendingUsageAsync();
+
+        // Assert
+        organization = await _organizationRepository.GetByIdAsync(organization.Id);
+        Assert.NotNull(organization);
+        var usage = organization.Usage.Single();
+        Assert.Equal(10, usage.Deleted);
+
+        project = await _projectRepository.GetByIdAsync(project.Id);
+        Assert.NotNull(project);
+        usage = project.Usage.Single();
+        Assert.Equal(10, usage.Deleted);
+    }
+
+    [Fact]
+    public async Task GetUsageAsync_PendingDeleted_IncludesInCurrentUsage()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(new Organization { Name = "Test", MaxEventsPerMonth = 750, PlanId = _plans.SmallPlan.Id }, o => o.ImmediateConsistency().Cache());
+        var project = await _projectRepository.AddAsync(new Project { Name = "Test", OrganizationId = organization.Id, NextSummaryEndOfDayTicks = TimeProvider.GetUtcNow().UtcDateTime.Ticks }, o => o.ImmediateConsistency().Cache());
+
+        // Act
+        await _usageService.IncrementDeletedAsync(organization.Id, project.Id, 5);
+
+        // Assert
+        var usageResponse = await _usageService.GetUsageAsync(organization.Id);
+        Assert.Equal(5, usageResponse.CurrentUsage.Deleted);
+        Assert.Equal(5, usageResponse.CurrentHourUsage.Deleted);
+
+        var projectUsageResponse = await _usageService.GetUsageAsync(organization.Id, project.Id);
+        Assert.Equal(5, projectUsageResponse.CurrentUsage.Deleted);
+        Assert.Equal(5, projectUsageResponse.CurrentHourUsage.Deleted);
     }
 
     [Fact]


### PR DESCRIPTION
## Why

Until now there was no way to see how many events were explicitly deleted via the API, project reset, or soft-delete cleanup. This makes it impossible to distinguish "events never arrived" from "events were intentionally removed" when analyzing usage. This PR adds a first-class `Deleted` counter alongside the existing `Total`, `Blocked`, `Discarded`, and `TooBig` counters -- without touching billing, plan limits, or admission control.

## What changed

### Backend

- **`UsageInfo` / `UsageHourInfo`** -- added `int Deleted` property to both records, matching the type of all other usage counters (`Total`, `Blocked`, `Discarded`, `TooBig`).
- **`AppDiagnostics`** -- added `EventsDeleted` as a `Counter<int>` OTel metric (consistent with all other event counters).
- **`UsageService`** -- new `IncrementDeletedAsync(organizationId, projectId, eventCount)` that pipelines all Redis operations via `Task.WhenAll`; cache key pattern: `usage:{bucket}:{orgId}[:projectId]:deleted`. Save/flush/read logic updated to include the Deleted bucket (mirrors the other counters exactly).
- **`LastEventDateUtc` behavior change** -- `LastEventDateUtc` on org and project is now only updated when a bucket contains actual ingestion events (`Total`/`Blocked`/`Discarded`/`TooBig` > 0). Previously any flush (including delete-only buckets) could bump this timestamp. Deletes no longer count as "activity" for inactivity tracking.
- **`EventController`** -- `DeleteModelsAsync` calls `IncrementDeletedAsync` per org/project group after the hard delete completes, inside a try/catch that rethrows `OperationCanceledException` and warns on all other failures so a tracking error never blocks the delete response.
- **`ResetProjectDataWorkItemHandler`** -- calls `IncrementDeletedAsync` with the count returned by the delete query.
- **`CleanupDataJob`** -- `RemoveProjectsAsync` tracks deleted events; `RemoveStacksAsync` accepts a `trackDeletedUsage` flag. When `false` (retention enforcement), a single bulk `RemoveAllByStackIdsAsync` is used. When `true` (soft-delete cleanup), the stacks are grouped by `(OrgId, ProjectId)` and deleted per group so per-project counts can be attributed. `RemoveOrganizationAsync` intentionally does NOT track -- the org is being hard-deleted so the data has no consumer.

### Frontend (Svelte 5)

- Generated types (`api.ts`, `schemas.ts`) updated to include `deleted: number`.
- Org and project usage pages: `Deleted` series added to charts, dead variable alias removed.

### Frontend (Angular legacy)

- Org and project manage controllers: `Deleted` series added at the correct index.

## Test coverage

| Test class | New tests |
|---|---|
| `UsageServiceTests` | 6 new (CanIncrementDeletedAsync, flush, read-back, isolation, zero-guard, zero-event-count guard) |
| `EventControllerTests` | 2 integration tests: single delete and multi-event delete with org+project flush assertion |
| `CleanupDataJobTests` | 5 tests: soft-deleted project tracks usage, empty project no-op, soft-deleted stack tracks usage, multi-project distribution, retention enforcement does NOT track |
| `ResetProjectDataWorkItemHandlerTests` | 5 tests: basic tracking, empty project, multiple stacks, project isolation, no billing impact |

Existing tests updated to assert `Deleted == 0` where appropriate.

## Key design decisions

- **Retention deletions are NOT tracked.** `RemoveStacksAsync` is called with `trackDeletedUsage=false` for retention enforcement paths. Only explicit user-initiated deletes and soft-delete cleanup show up as `Deleted` usage.
- **`int` not `long`.** Matches all other usage counters. A single cleanup pass removing >2.1B events per project is not a realistic scenario; the `eventCount <= 0` guard in `IncrementDeletedAsync` safely drops any overflow.
- **Per-project deletion counts are exact**, not estimated -- each group's count comes directly from the ES delete-by-query return value.
- **No billing changes.** `Deleted` is a display-only counter. It does not affect `GetEventsLeftAsync`, plan enforcement, or Stripe metering.
