### PR TITLE
Fix duplicate plan limit overage emails

### DIFF
--- a/src/Exceptionless.Core/Bootstrapper.cs
+++ b/src/Exceptionless.Core/Bootstrapper.cs
@@ -43,6 +43,7 @@ using Foundatio.Resilience;
 using Foundatio.Serializer;
 using Foundatio.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using DataDictionary = Exceptionless.Core.Models.DataDictionary;
 using MaintainIndexesJob = Foundatio.Repositories.Elasticsearch.Jobs.MaintainIndexesJob;
@@ -127,6 +128,8 @@ public class Bootstrapper
         services.AddSingleton(s => CreateQueue<WebHookNotification>(s));
         services.AddSingleton(s => CreateQueue<MailMessage>(s));
         services.AddSingleton(s => CreateQueue<WorkItemData>(s, TimeSpan.FromHours(1)));
+
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IQueueBehavior<WorkItemData>, WorkItemDuplicateDetectionQueueBehavior>());
 
         services.AddSingleton<IConnectionMapping, ConnectionMapping>();
         services.AddSingleton<MessageService>();
@@ -301,10 +304,14 @@ public class Bootstrapper
         return new InMemoryQueue<T>(new InMemoryQueueOptions<T>
         {
             WorkItemTimeout = workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5.0)),
+            Behaviors = container.GetServices<IQueueBehavior<T>>().ToList(),
             Serializer = container.GetRequiredService<ISerializer>(),
             TimeProvider = container.GetRequiredService<TimeProvider>(),
             ResiliencePolicyProvider = container.GetRequiredService<IResiliencePolicyProvider>(),
             LoggerFactory = loggerFactory
         });
     }
+
+    private sealed class WorkItemDuplicateDetectionQueueBehavior(ICacheClient cacheClient, ILoggerFactory loggerFactory)
+        : DuplicateDetectionQueueBehavior<WorkItemData>(cacheClient, loggerFactory, TimeSpan.FromHours(24));
 }

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandler.cs
@@ -4,8 +4,7 @@ using Exceptionless.Core.Messaging.Models;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Models.WorkItems;
 using Exceptionless.Core.Repositories;
-using Exceptionless.DateTimeExtensions;
-using Foundatio.Caching;
+using Exceptionless.Core.Services;
 using Foundatio.Extensions.Hosting.Startup;
 using Foundatio.Jobs;
 using Foundatio.Lock;
@@ -66,7 +65,7 @@ public class EnqueueOrganizationNotificationOnPlanOverage : IStartupAction
 ///   </description></item>
 ///   <item><description>
 ///     Handler-level idempotency: a distributed lock serializes concurrent processing, and a
-///     sent marker (<see cref="GetNotificationSentKey"/>) ensures that any stale duplicates
+///     sent marker ensures that any stale duplicates
 ///     already in the queue before the fix deployed cannot re-trigger an email in the same UTC
 ///     month. The marker is reset when a monthly plan limit change re-evaluates the overage state.
 ///   </description></item>
@@ -80,27 +79,19 @@ public class EnqueueOrganizationNotificationOnPlanOverage : IStartupAction
 /// </summary>
 public class OrganizationNotificationWorkItemHandler : WorkItemHandlerBase
 {
-    private static readonly TimeSpan WorkItemLockTimeout = TimeSpan.FromMinutes(90);
-
     private readonly IOrganizationRepository _organizationRepository;
     private readonly IUserRepository _userRepository;
     private readonly IMailer _mailer;
-    private readonly ICacheClient _cacheClient;
+    private readonly NotificationService _notificationService;
     private readonly TimeProvider _timeProvider;
 
-    // ILockProvider is kept local rather than pushed to WorkItemHandlerBase because the
-    // lock/sent-key contract is specific to plan-limit email idempotency. Passing it through
-    // the base class would force every unrelated handler to acquire unnecessary plan-limit locks.
-    private readonly ILockProvider _lockProvider;
-
-    public OrganizationNotificationWorkItemHandler(IOrganizationRepository organizationRepository, IUserRepository userRepository, IMailer mailer, ICacheClient cacheClient, TimeProvider timeProvider, ILockProvider lockProvider, ILoggerFactory loggerFactory) : base(loggerFactory)
+    public OrganizationNotificationWorkItemHandler(IOrganizationRepository organizationRepository, IUserRepository userRepository, IMailer mailer, NotificationService notificationService, TimeProvider timeProvider, ILoggerFactory loggerFactory) : base(loggerFactory)
     {
         _organizationRepository = organizationRepository;
         _userRepository = userRepository;
         _mailer = mailer;
-        _cacheClient = cacheClient;
+        _notificationService = notificationService;
         _timeProvider = timeProvider;
-        _lockProvider = lockProvider;
     }
 
     public override Task<ILock?> GetWorkItemLockAsync(object workItem, CancellationToken cancellationToken = default)
@@ -114,14 +105,15 @@ public class OrganizationNotificationWorkItemHandler : WorkItemHandlerBase
         if (!ShouldSendNotificationEmail(wi))
             return base.GetWorkItemLockAsync(workItem, cancellationToken);
 
-        // timeUntilExpires: comfortably exceed the 1-hour work-item queue timeout so a slow send
-        // does not let a duplicate worker acquire the notification lock at the queue visibility boundary.
+        // The notification service uses a 90-minute lease, comfortably exceeding the 1-hour
+        // work-item queue timeout so a slow send does not let a duplicate worker acquire the
+        // notification lock at the queue visibility boundary.
         //
         // acquireTimeout: TimeSpan.Zero — if another worker already holds the lock, return null
         // immediately so WorkItemJob calls AbandonAsync. The item is retried later, at which point
         // the sent marker is already set and the handler skips. Blocking here instead would stall
         // a worker slot for up to the lock timeout with no correctness benefit.
-        return _lockProvider.TryAcquireAsync(GetNotificationLockKey(wi.OrganizationId, wi.IsOverMonthlyLimit), WorkItemLockTimeout, TimeSpan.Zero);
+        return _notificationService.TryAcquireOrganizationNotificationLockAsync(wi.OrganizationId, wi.IsOverMonthlyLimit);
     }
 
     public override async Task HandleItemAsync(WorkItemContext context)
@@ -142,14 +134,14 @@ public class OrganizationNotificationWorkItemHandler : WorkItemHandlerBase
             return;
         }
 
-        if (await WasNotificationSentAsync(wi.OrganizationId, wi.IsOverMonthlyLimit))
+        if (await _notificationService.IsOrganizationNotificationSentAsync(wi.OrganizationId, wi.IsOverMonthlyLimit))
         {
             Log.LogInformation("Skipping duplicate monthly overage notification for organization: {OrganizationId}", wi.OrganizationId);
             return;
         }
 
         await SendOverageNotificationsAsync(organization, wi.IsOverHourlyLimit, wi.IsOverMonthlyLimit);
-        await _cacheClient.SetAsync(GetNotificationSentKey(wi.OrganizationId, wi.IsOverMonthlyLimit), true, GetNotificationSentExpiresAtUtc());
+        await _notificationService.SetOrganizationNotificationSentAsync(wi.OrganizationId, wi.IsOverMonthlyLimit);
     }
 
     private async Task SendOverageNotificationsAsync(Organization organization, bool isOverHourlyLimit, bool isOverMonthlyLimit)
@@ -183,26 +175,5 @@ public class OrganizationNotificationWorkItemHandler : WorkItemHandlerBase
     private static bool ShouldSendNotificationEmail(OrganizationNotificationWorkItem workItem)
     {
         return workItem.IsOverMonthlyLimit;
-    }
-
-    private async Task<bool> WasNotificationSentAsync(string organizationId, bool isOverMonthlyLimit)
-    {
-        var sent = await _cacheClient.GetAsync<bool>(GetNotificationSentKey(organizationId, isOverMonthlyLimit));
-        return sent.HasValue && sent.Value;
-    }
-
-    private DateTime GetNotificationSentExpiresAtUtc()
-    {
-        return _timeProvider.GetUtcNow().UtcDateTime.EndOfMonth();
-    }
-
-    public static string GetNotificationLockKey(string organizationId, bool isOverMonthlyLimit)
-    {
-        return $"{OrganizationNotificationWorkItem.GetNotificationKey(organizationId, isOverMonthlyLimit)}-lock";
-    }
-
-    public static string GetNotificationSentKey(string organizationId, bool isOverMonthlyLimit)
-    {
-        return $"{OrganizationNotificationWorkItem.GetNotificationKey(organizationId, isOverMonthlyLimit)}-sent";
     }
 }

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandler.cs
@@ -127,10 +127,10 @@ public class OrganizationNotificationWorkItemHandler : WorkItemHandlerBase
     public override async Task HandleItemAsync(WorkItemContext context)
     {
         var wi = context.GetData<OrganizationNotificationWorkItem>()!;
+        Log.LogInformation("Received organization notification work item for: {OrganizationId} IsOverHourlyLimit: {IsOverHourlyLimit} IsOverMonthlyLimit: {IsOverMonthlyLimit}", wi.OrganizationId, wi.IsOverHourlyLimit, wi.IsOverMonthlyLimit);
+
         if (!ShouldSendNotificationEmail(wi))
             return;
-
-        Log.LogInformation("Received organization notification work item for: {OrganizationId} IsOverHourlyLimit: {IsOverHourlyLimit} IsOverMonthlyLimit: {IsOverMonthlyLimit}", wi.OrganizationId, wi.IsOverHourlyLimit, wi.IsOverMonthlyLimit);
 
         var organization = await _organizationRepository.GetByIdAsync(wi.OrganizationId, o => o.Cache());
         if (organization is null)

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandler.cs
@@ -80,7 +80,7 @@ public class EnqueueOrganizationNotificationOnPlanOverage : IStartupAction
 /// </summary>
 public class OrganizationNotificationWorkItemHandler : WorkItemHandlerBase
 {
-    private static readonly TimeSpan WorkItemLockTimeout = TimeSpan.FromMinutes(65);
+    private static readonly TimeSpan WorkItemLockTimeout = TimeSpan.FromMinutes(90);
 
     private readonly IOrganizationRepository _organizationRepository;
     private readonly IUserRepository _userRepository;
@@ -114,8 +114,8 @@ public class OrganizationNotificationWorkItemHandler : WorkItemHandlerBase
         if (!ShouldSendNotificationEmail(wi))
             return base.GetWorkItemLockAsync(workItem, cancellationToken);
 
-        // timeUntilExpires: exceed the 1-hour work-item queue timeout so a slow send does not let
-        // a duplicate worker acquire the notification lock at the queue visibility boundary.
+        // timeUntilExpires: comfortably exceed the 1-hour work-item queue timeout so a slow send
+        // does not let a duplicate worker acquire the notification lock at the queue visibility boundary.
         //
         // acquireTimeout: TimeSpan.Zero — if another worker already holds the lock, return null
         // immediately so WorkItemJob calls AbandonAsync. The item is retried later, at which point

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandler.cs
@@ -65,7 +65,7 @@ public class EnqueueOrganizationNotificationOnPlanOverage : IStartupAction
 ///     queue entry, preventing duplicates from being enqueued in the first place.
 ///   </description></item>
 ///   <item><description>
-///     Handler-level idempotency: a distributed lock serialises concurrent processing, and a
+///     Handler-level idempotency: a distributed lock serializes concurrent processing, and a
 ///     sent marker (<see cref="GetNotificationSentKey"/>) ensures that any stale duplicates
 ///     already in the queue before the fix deployed cannot re-trigger an email in the same UTC
 ///     month. The marker is reset when a monthly plan limit change re-evaluates the overage state.
@@ -203,6 +203,6 @@ public class OrganizationNotificationWorkItemHandler : WorkItemHandlerBase
 
     public static string GetNotificationSentKey(string organizationId, bool isOverMonthlyLimit)
     {
-        return OrganizationNotificationWorkItem.GetNotificationSentKey(organizationId, isOverMonthlyLimit);
+        return $"{OrganizationNotificationWorkItem.GetNotificationKey(organizationId, isOverMonthlyLimit)}-sent";
     }
 }

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandler.cs
@@ -1,8 +1,10 @@
+using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Mail;
 using Exceptionless.Core.Messaging.Models;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Models.WorkItems;
 using Exceptionless.Core.Repositories;
+using Exceptionless.DateTimeExtensions;
 using Foundatio.Caching;
 using Foundatio.Extensions.Hosting.Startup;
 using Foundatio.Jobs;
@@ -10,7 +12,6 @@ using Foundatio.Lock;
 using Foundatio.Messaging;
 using Foundatio.Queues;
 using Foundatio.Repositories;
-using Foundatio.Resilience;
 using Microsoft.Extensions.Logging;
 
 namespace Exceptionless.Core.Jobs.WorkItemHandlers;
@@ -44,37 +45,111 @@ public class EnqueueOrganizationNotificationOnPlanOverage : IStartupAction
     }
 }
 
+/// <summary>
+/// Handles <see cref="OrganizationNotificationWorkItem"/> by sending a plan-overage email at most
+/// once per overage state per organization.
+///
+/// <b>Root cause of duplicate emails (fixed here):</b>
+/// Every web pod registers the same <see cref="EnqueueOrganizationNotificationOnPlanOverage"/>
+/// startup action, so a single <c>PlanOverage</c> message fanned out to all pods and each pod
+/// enqueued its own copy of the work item. The previous
+/// <c>ThrottlingLockProvider(slotsPerPeriod: 1, period: 1 hour)</c> allowed exactly one item
+/// through per calendar-hour bucket. Abandoned duplicates were re-queued and reprocessed once
+/// each new bucket opened — producing one email per hour for as many duplicate items existed.
+///
+/// <b>Fix layers (both required):</b>
+/// <list type="number">
+///   <item><description>
+///     Queue-level dedup: <see cref="OrganizationNotificationWorkItem.UniqueIdentifier"/> plus
+///     <c>DuplicateDetectionQueueBehavior</c> collapses identical fanout enqueues to a single
+///     queue entry, preventing duplicates from being enqueued in the first place.
+///   </description></item>
+///   <item><description>
+///     Handler-level idempotency: a distributed lock serialises concurrent processing, and a
+///     sent marker (<see cref="GetNotificationSentKey"/>) ensures that any stale duplicates
+///     already in the queue before the fix deployed cannot re-trigger an email in the same UTC
+///     month. The marker is reset when a monthly plan limit change re-evaluates the overage state.
+///   </description></item>
+/// </list>
+///
+/// Only monthly overages send email. Hourly items use the base work-item lock and return from
+/// <see cref="HandleItemAsync"/> before touching the monthly notification lock/sent-key path, so
+/// they can never block or suppress a later monthly notification.
+/// Monthly items also re-check the current organization usage before sending so delayed queue
+/// entries do not email after a plan or usage-state change leaves the organization under limit.
+/// </summary>
 public class OrganizationNotificationWorkItemHandler : WorkItemHandlerBase
 {
+    private static readonly TimeSpan WorkItemLockTimeout = TimeSpan.FromMinutes(65);
+
     private readonly IOrganizationRepository _organizationRepository;
     private readonly IUserRepository _userRepository;
     private readonly IMailer _mailer;
+    private readonly ICacheClient _cacheClient;
+    private readonly TimeProvider _timeProvider;
+
+    // ILockProvider is kept local rather than pushed to WorkItemHandlerBase because the
+    // lock/sent-key contract is specific to plan-limit email idempotency. Passing it through
+    // the base class would force every unrelated handler to acquire unnecessary plan-limit locks.
     private readonly ILockProvider _lockProvider;
 
-    public OrganizationNotificationWorkItemHandler(IOrganizationRepository organizationRepository, IUserRepository userRepository, IMailer mailer, ICacheClient cacheClient, TimeProvider timeProvider, IResiliencePolicyProvider resiliencePolicyProvider, ILoggerFactory loggerFactory) : base(loggerFactory)
+    public OrganizationNotificationWorkItemHandler(IOrganizationRepository organizationRepository, IUserRepository userRepository, IMailer mailer, ICacheClient cacheClient, TimeProvider timeProvider, ILockProvider lockProvider, ILoggerFactory loggerFactory) : base(loggerFactory)
     {
         _organizationRepository = organizationRepository;
         _userRepository = userRepository;
         _mailer = mailer;
-        _lockProvider = new ThrottlingLockProvider(cacheClient, 1, TimeSpan.FromHours(1), timeProvider, resiliencePolicyProvider, loggerFactory);
+        _cacheClient = cacheClient;
+        _timeProvider = timeProvider;
+        _lockProvider = lockProvider;
     }
 
-    public override Task HandleItemAsync(WorkItemContext context)
+    public override Task<ILock?> GetWorkItemLockAsync(object workItem, CancellationToken cancellationToken = default)
+    {
+        var wi = (OrganizationNotificationWorkItem)workItem;
+
+        // Hourly overages do not send email. Return the base EmptyLock so WorkItemJob calls
+        // HandleItemAsync and then marks the queue entry as completed. Returning null instead
+        // would cause WorkItemJob to call AbandonAsync, creating an infinite retry loop where
+        // the item is re-queued and abandoned on every dequeue attempt.
+        if (!ShouldSendNotificationEmail(wi))
+            return base.GetWorkItemLockAsync(workItem, cancellationToken);
+
+        // timeUntilExpires: exceed the 1-hour work-item queue timeout so a slow send does not let
+        // a duplicate worker acquire the notification lock at the queue visibility boundary.
+        //
+        // acquireTimeout: TimeSpan.Zero — if another worker already holds the lock, return null
+        // immediately so WorkItemJob calls AbandonAsync. The item is retried later, at which point
+        // the sent marker is already set and the handler skips. Blocking here instead would stall
+        // a worker slot for up to the lock timeout with no correctness benefit.
+        return _lockProvider.TryAcquireAsync(GetNotificationLockKey(wi.OrganizationId, wi.IsOverMonthlyLimit), WorkItemLockTimeout, TimeSpan.Zero);
+    }
+
+    public override async Task HandleItemAsync(WorkItemContext context)
     {
         var wi = context.GetData<OrganizationNotificationWorkItem>()!;
+        if (!ShouldSendNotificationEmail(wi))
+            return;
 
-        string cacheKey = $"{nameof(OrganizationNotificationWorkItemHandler)}:{wi.OrganizationId}";
+        Log.LogInformation("Received organization notification work item for: {OrganizationId} IsOverHourlyLimit: {IsOverHourlyLimit} IsOverMonthlyLimit: {IsOverMonthlyLimit}", wi.OrganizationId, wi.IsOverHourlyLimit, wi.IsOverMonthlyLimit);
 
-        return _lockProvider.TryUsingAsync(cacheKey, async () =>
+        var organization = await _organizationRepository.GetByIdAsync(wi.OrganizationId, o => o.Cache());
+        if (organization is null)
+            return;
+
+        if (!organization.IsOverMonthlyLimit(_timeProvider))
         {
-            Log.LogInformation("Received organization notification work item for: {Organization} IsOverHourlyLimit: {IsOverHourlyLimit} IsOverMonthlyLimit: {IsOverMonthlyLimit}", wi.OrganizationId, wi.IsOverHourlyLimit, wi.IsOverMonthlyLimit);
-            var organization = await _organizationRepository.GetByIdAsync(wi.OrganizationId, o => o.Cache());
-            if (organization is null)
-                return;
+            Log.LogInformation("Skipping stale monthly overage notification for organization: {OrganizationId} because it is no longer over the monthly limit", wi.OrganizationId);
+            return;
+        }
 
-            if (wi.IsOverMonthlyLimit)
-                await SendOverageNotificationsAsync(organization, wi.IsOverHourlyLimit, wi.IsOverMonthlyLimit);
-        }, TimeSpan.FromMinutes(15), context.CancellationToken);
+        if (await WasNotificationSentAsync(wi.OrganizationId, wi.IsOverMonthlyLimit))
+        {
+            Log.LogInformation("Skipping duplicate monthly overage notification for organization: {OrganizationId}", wi.OrganizationId);
+            return;
+        }
+
+        await SendOverageNotificationsAsync(organization, wi.IsOverHourlyLimit, wi.IsOverMonthlyLimit);
+        await _cacheClient.SetAsync(GetNotificationSentKey(wi.OrganizationId, wi.IsOverMonthlyLimit), true, GetNotificationSentExpiresAtUtc());
     }
 
     private async Task SendOverageNotificationsAsync(Organization organization, bool isOverHourlyLimit, bool isOverMonthlyLimit)
@@ -99,5 +174,35 @@ public class OrganizationNotificationWorkItemHandler : WorkItemHandlerBase
         }
 
         Log.LogTrace("Done sending email");
+    }
+
+    // Only monthly overages send email. Hourly overages still trigger real-time websocket
+    // budget updates in the UI but do not warrant a separate notification email.
+    // Keeping hourly items out of the lock/sent-key path also means a burst of hourly events
+    // cannot suppress the monthly notification that follows.
+    private static bool ShouldSendNotificationEmail(OrganizationNotificationWorkItem workItem)
+    {
+        return workItem.IsOverMonthlyLimit;
+    }
+
+    private async Task<bool> WasNotificationSentAsync(string organizationId, bool isOverMonthlyLimit)
+    {
+        var sent = await _cacheClient.GetAsync<bool>(GetNotificationSentKey(organizationId, isOverMonthlyLimit));
+        return sent.HasValue && sent.Value;
+    }
+
+    private DateTime GetNotificationSentExpiresAtUtc()
+    {
+        return _timeProvider.GetUtcNow().UtcDateTime.EndOfMonth();
+    }
+
+    public static string GetNotificationLockKey(string organizationId, bool isOverMonthlyLimit)
+    {
+        return $"{OrganizationNotificationWorkItem.GetNotificationKey(organizationId, isOverMonthlyLimit)}-lock";
+    }
+
+    public static string GetNotificationSentKey(string organizationId, bool isOverMonthlyLimit)
+    {
+        return OrganizationNotificationWorkItem.GetNotificationSentKey(organizationId, isOverMonthlyLimit);
     }
 }

--- a/src/Exceptionless.Core/Models/WorkItems/OrganizationNotificationWorkItem.cs
+++ b/src/Exceptionless.Core/Models/WorkItems/OrganizationNotificationWorkItem.cs
@@ -15,6 +15,8 @@ public record OrganizationNotificationWorkItem : IHaveUniqueIdentifier
 
     public static string GetNotificationKey(string organizationId, bool isOverMonthlyLimit)
     {
+        ArgumentException.ThrowIfNullOrEmpty(organizationId);
+
         return $"Organization:{organizationId}:notification:{(isOverMonthlyLimit ? MonthlyNotificationType : HourlyNotificationType)}";
     }
 }

--- a/src/Exceptionless.Core/Models/WorkItems/OrganizationNotificationWorkItem.cs
+++ b/src/Exceptionless.Core/Models/WorkItems/OrganizationNotificationWorkItem.cs
@@ -17,9 +17,4 @@ public record OrganizationNotificationWorkItem : IHaveUniqueIdentifier
     {
         return $"Organization:{organizationId}:notification:{(isOverMonthlyLimit ? MonthlyNotificationType : HourlyNotificationType)}";
     }
-
-    public static string GetNotificationSentKey(string organizationId, bool isOverMonthlyLimit)
-    {
-        return $"{GetNotificationKey(organizationId, isOverMonthlyLimit)}-sent";
-    }
 }

--- a/src/Exceptionless.Core/Models/WorkItems/OrganizationNotificationWorkItem.cs
+++ b/src/Exceptionless.Core/Models/WorkItems/OrganizationNotificationWorkItem.cs
@@ -11,7 +11,7 @@ public record OrganizationNotificationWorkItem : IHaveUniqueIdentifier
     public required bool IsOverHourlyLimit { get; init; }
     public required bool IsOverMonthlyLimit { get; init; }
 
-    public string? UniqueIdentifier => GetNotificationKey(OrganizationId, IsOverMonthlyLimit);
+    public string UniqueIdentifier => GetNotificationKey(OrganizationId, IsOverMonthlyLimit);
 
     public static string GetNotificationKey(string organizationId, bool isOverMonthlyLimit)
     {

--- a/src/Exceptionless.Core/Models/WorkItems/OrganizationNotificationWorkItem.cs
+++ b/src/Exceptionless.Core/Models/WorkItems/OrganizationNotificationWorkItem.cs
@@ -1,8 +1,25 @@
-﻿namespace Exceptionless.Core.Models.WorkItems;
+﻿using Foundatio.Queues;
 
-public record OrganizationNotificationWorkItem
+namespace Exceptionless.Core.Models.WorkItems;
+
+public record OrganizationNotificationWorkItem : IHaveUniqueIdentifier
 {
+    public const string HourlyNotificationType = "hourly";
+    public const string MonthlyNotificationType = "monthly";
+
     public required string OrganizationId { get; init; }
     public required bool IsOverHourlyLimit { get; init; }
     public required bool IsOverMonthlyLimit { get; init; }
+
+    public string? UniqueIdentifier => GetNotificationKey(OrganizationId, IsOverMonthlyLimit);
+
+    public static string GetNotificationKey(string organizationId, bool isOverMonthlyLimit)
+    {
+        return $"Organization:{organizationId}:notification:{(isOverMonthlyLimit ? MonthlyNotificationType : HourlyNotificationType)}";
+    }
+
+    public static string GetNotificationSentKey(string organizationId, bool isOverMonthlyLimit)
+    {
+        return $"{GetNotificationKey(organizationId, isOverMonthlyLimit)}-sent";
+    }
 }

--- a/src/Exceptionless.Core/Services/NotificationService.cs
+++ b/src/Exceptionless.Core/Services/NotificationService.cs
@@ -1,12 +1,16 @@
 using Exceptionless.Core.Messaging.Models;
+using Exceptionless.Core.Models.WorkItems;
+using Exceptionless.DateTimeExtensions;
 using Foundatio.Caching;
+using Foundatio.Lock;
 using Foundatio.Messaging;
 
 namespace Exceptionless.Core.Services;
 
-public class NotificationService(ICacheClient cacheClient, IMessagePublisher messagePublisher, TimeProvider timeProvider)
+public class NotificationService(ICacheClient cacheClient, IMessagePublisher messagePublisher, TimeProvider timeProvider, CacheLockProvider lockProvider)
 {
     private const string SystemNotificationCacheKey = "system-notification";
+    private static readonly TimeSpan OrganizationNotificationLockTimeout = TimeSpan.FromMinutes(90);
 
     public async Task<SystemNotification?> GetSystemNotificationAsync()
     {
@@ -36,5 +40,55 @@ public class NotificationService(ICacheClient cacheClient, IMessagePublisher mes
         if (publish)
             await messagePublisher.PublishAsync(notification);
         return notification;
+    }
+
+    public async Task<bool> IsOrganizationNotificationSentAsync(string organizationId, bool isOverMonthlyLimit)
+    {
+        var sent = await cacheClient.GetAsync<bool>(GetOrganizationNotificationSentKey(organizationId, isOverMonthlyLimit));
+        return sent.HasValue && sent.Value;
+    }
+
+    public Task SetOrganizationNotificationSentAsync(string organizationId, bool isOverMonthlyLimit)
+    {
+        return cacheClient.SetAsync(GetOrganizationNotificationSentKey(organizationId, isOverMonthlyLimit), true, GetOrganizationNotificationSentExpiresAtUtc());
+    }
+
+    public Task RemoveOrganizationNotificationSentAsync(string organizationId, bool isOverMonthlyLimit)
+    {
+        return cacheClient.RemoveAsync(GetOrganizationNotificationSentKey(organizationId, isOverMonthlyLimit));
+    }
+
+    public Task<ILock?> TryAcquireOrganizationNotificationLockAsync(string organizationId, bool isOverMonthlyLimit)
+    {
+        return lockProvider.TryAcquireAsync(GetOrganizationNotificationLockKey(organizationId, isOverMonthlyLimit), OrganizationNotificationLockTimeout, TimeSpan.Zero);
+    }
+
+    public async Task<bool> IsOrganizationNotificationLockedAsync(string organizationId, bool isOverMonthlyLimit)
+    {
+        await using var notificationLock = await TryAcquireOrganizationNotificationLockAsync(organizationId, isOverMonthlyLimit);
+        return notificationLock is null;
+    }
+
+    private static string GetOrganizationNotificationLockKey(string organizationId, bool isOverMonthlyLimit)
+    {
+        return $"{OrganizationNotificationWorkItem.GetNotificationKey(organizationId, isOverMonthlyLimit)}-lock";
+    }
+
+    private static string GetOrganizationNotificationSentKey(string organizationId, bool isOverMonthlyLimit)
+    {
+        return $"{OrganizationNotificationWorkItem.GetNotificationKey(organizationId, isOverMonthlyLimit)}-sent";
+    }
+
+    private DateTime GetOrganizationNotificationSentExpiresAtUtc()
+    {
+        var utcNow = timeProvider.GetUtcNow().UtcDateTime;
+        var expiresAtUtc = utcNow.StartOfMonth().AddMonths(1);
+
+        // Foundatio treats absolute cache expirations less than 5ms in the future as already expired.
+        // Keep the marker observable for sends that complete in the final milliseconds of the UTC month.
+        if (expiresAtUtc - utcNow < CacheClientExtensions.MinimumExpiration)
+            return utcNow.Add(CacheClientExtensions.MinimumExpiration);
+
+        return expiresAtUtc;
     }
 }

--- a/src/Exceptionless.Core/Services/NotificationService.cs
+++ b/src/Exceptionless.Core/Services/NotificationService.cs
@@ -44,29 +44,38 @@ public class NotificationService(ICacheClient cacheClient, IMessagePublisher mes
 
     public async Task<bool> IsOrganizationNotificationSentAsync(string organizationId, bool isOverMonthlyLimit)
     {
+        ArgumentException.ThrowIfNullOrEmpty(organizationId);
+
         var sent = await cacheClient.GetAsync<bool>(GetOrganizationNotificationSentKey(organizationId, isOverMonthlyLimit));
         return sent.HasValue && sent.Value;
     }
 
     public Task SetOrganizationNotificationSentAsync(string organizationId, bool isOverMonthlyLimit)
     {
+        ArgumentException.ThrowIfNullOrEmpty(organizationId);
+
         return cacheClient.SetAsync(GetOrganizationNotificationSentKey(organizationId, isOverMonthlyLimit), true, GetOrganizationNotificationSentExpiresAtUtc());
     }
 
     public Task RemoveOrganizationNotificationSentAsync(string organizationId, bool isOverMonthlyLimit)
     {
+        ArgumentException.ThrowIfNullOrEmpty(organizationId);
+
         return cacheClient.RemoveAsync(GetOrganizationNotificationSentKey(organizationId, isOverMonthlyLimit));
     }
 
     public Task<ILock?> TryAcquireOrganizationNotificationLockAsync(string organizationId, bool isOverMonthlyLimit)
     {
+        ArgumentException.ThrowIfNullOrEmpty(organizationId);
+
         return lockProvider.TryAcquireAsync(GetOrganizationNotificationLockKey(organizationId, isOverMonthlyLimit), OrganizationNotificationLockTimeout, TimeSpan.Zero);
     }
 
-    public async Task<bool> IsOrganizationNotificationLockedAsync(string organizationId, bool isOverMonthlyLimit)
+    public Task<bool> IsOrganizationNotificationLockedAsync(string organizationId, bool isOverMonthlyLimit)
     {
-        await using var notificationLock = await TryAcquireOrganizationNotificationLockAsync(organizationId, isOverMonthlyLimit);
-        return notificationLock is null;
+        ArgumentException.ThrowIfNullOrEmpty(organizationId);
+
+        return lockProvider.IsLockedAsync(GetOrganizationNotificationLockKey(organizationId, isOverMonthlyLimit));
     }
 
     private static string GetOrganizationNotificationLockKey(string organizationId, bool isOverMonthlyLimit)

--- a/src/Exceptionless.Core/Services/UsageService.cs
+++ b/src/Exceptionless.Core/Services/UsageService.cs
@@ -1,5 +1,4 @@
 ﻿using Exceptionless.Core.Extensions;
-using Exceptionless.Core.Jobs.WorkItemHandlers;
 using Exceptionless.Core.Messaging.Models;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
@@ -17,11 +16,13 @@ public class UsageService
     private readonly IProjectRepository _projectRepository;
     private readonly ICacheClient _cache;
     private readonly IMessagePublisher _messagePublisher;
+    private readonly NotificationService _notificationService;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger _logger;
     private readonly TimeSpan _bucketSize = TimeSpan.FromMinutes(5);
 
     public UsageService(IOrganizationRepository organizationRepository, IProjectRepository projectRepository, ICacheClient cache, IMessagePublisher messagePublisher,
+        NotificationService notificationService,
         TimeProvider timeProvider,
         ILoggerFactory loggerFactory)
     {
@@ -29,6 +30,7 @@ public class UsageService
         _projectRepository = projectRepository;
         _cache = cache;
         _messagePublisher = messagePublisher;
+        _notificationService = notificationService;
         _timeProvider = timeProvider;
         _logger = loggerFactory.CreateLogger<UsageService>();
     }
@@ -227,7 +229,8 @@ public class UsageService
         bool isMonthlyLimitIncrease = modifiedMaxEvents < 0 || (originalMaxEvents >= 0 && modifiedMaxEvents > originalMaxEvents);
         if (isMonthlyLimitIncrease)
         {
-            await _cache.RemoveAsync(OrganizationNotificationWorkItemHandler.GetNotificationSentKey(modified.Id, isOverMonthlyLimit: true));
+            // A higher monthly limit ends the current overage state: allow a future monthly overage email and clear the hourly throttle window.
+            await _notificationService.RemoveOrganizationNotificationSentAsync(modified.Id, isOverMonthlyLimit: true);
             await _cache.RemoveAsync(GetThrottledKey(utcNow, modified.Id));
             return;
         }
@@ -236,7 +239,7 @@ public class UsageService
         bool isOverMonthlyLimit = modified.IsOverMonthlyLimit(_timeProvider);
         if (!wasOverMonthlyLimit && isOverMonthlyLimit)
         {
-            await _cache.RemoveAsync(OrganizationNotificationWorkItemHandler.GetNotificationSentKey(modified.Id, isOverMonthlyLimit: true));
+            await _notificationService.RemoveOrganizationNotificationSentAsync(modified.Id, isOverMonthlyLimit: true);
             await _messagePublisher.PublishAsync(new PlanOverage { OrganizationId = modified.Id });
         }
 

--- a/src/Exceptionless.Core/Services/UsageService.cs
+++ b/src/Exceptionless.Core/Services/UsageService.cs
@@ -1,6 +1,7 @@
 ﻿using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Messaging.Models;
 using Exceptionless.Core.Models;
+using Exceptionless.Core.Models.WorkItems;
 using Exceptionless.Core.Repositories;
 using Exceptionless.DateTimeExtensions;
 using Foundatio.Caching;
@@ -223,28 +224,36 @@ public class UsageService
         if (modifiedMaxEvents == originalMaxEvents)
             return;
 
-        if (modifiedMaxEvents > originalMaxEvents)
+        bool isMonthlyLimitIncrease = modifiedMaxEvents < 0 || (originalMaxEvents >= 0 && modifiedMaxEvents > originalMaxEvents);
+        if (isMonthlyLimitIncrease)
         {
-            // remove is throttled flag
+            await _cache.RemoveAsync(OrganizationNotificationWorkItem.GetNotificationSentKey(modified.Id, isOverMonthlyLimit: true));
             await _cache.RemoveAsync(GetThrottledKey(utcNow, modified.Id));
+            return;
         }
-        else
+
+        bool wasOverMonthlyLimit = original.IsOverMonthlyLimit(_timeProvider);
+        bool isOverMonthlyLimit = modified.IsOverMonthlyLimit(_timeProvider);
+        if (!wasOverMonthlyLimit && isOverMonthlyLimit)
         {
-            var bucketTotal = await _cache.GetAsync<int>(GetBucketTotalCacheKey(utcNow, modified.Id));
-            if (!bucketTotal.HasValue)
-                return;
+            await _cache.RemoveAsync(OrganizationNotificationWorkItem.GetNotificationSentKey(modified.Id, isOverMonthlyLimit: true));
+            await _messagePublisher.PublishAsync(new PlanOverage { OrganizationId = modified.Id });
+        }
 
-            int bucketLimit = GetBucketEventLimit(modifiedMaxEvents);
+        var bucketTotal = await _cache.GetAsync<int>(GetBucketTotalCacheKey(utcNow, modified.Id));
+        if (!bucketTotal.HasValue)
+            return;
 
-            // unlimited
-            if (bucketLimit < 0)
-                return;
+        int bucketLimit = GetBucketEventLimit(modifiedMaxEvents);
 
-            if (bucketTotal.Value >= bucketLimit)
-            {
-                await _messagePublisher.PublishAsync(new PlanOverage { OrganizationId = modified.Id, IsHourly = true });
-                await _cache.SetAsync(GetThrottledKey(utcNow, modified.Id), true, TimeSpan.FromMinutes(5));
-            }
+        // unlimited
+        if (bucketLimit < 0)
+            return;
+
+        if (bucketTotal.Value >= bucketLimit)
+        {
+            await _messagePublisher.PublishAsync(new PlanOverage { OrganizationId = modified.Id, IsHourly = true });
+            await _cache.SetAsync(GetThrottledKey(utcNow, modified.Id), true, TimeSpan.FromMinutes(5));
         }
     }
 

--- a/src/Exceptionless.Core/Services/UsageService.cs
+++ b/src/Exceptionless.Core/Services/UsageService.cs
@@ -229,8 +229,10 @@ public class UsageService
         bool isMonthlyLimitIncrease = modifiedMaxEvents < 0 || (originalMaxEvents >= 0 && modifiedMaxEvents > originalMaxEvents);
         if (isMonthlyLimitIncrease)
         {
-            // A higher monthly limit ends the current overage state: allow a future monthly overage email and clear the hourly throttle window.
-            await _notificationService.RemoveOrganizationNotificationSentAsync(modified.Id, isOverMonthlyLimit: true);
+            // A higher monthly limit only resets monthly notification state when it actually ends the current overage.
+            if (!modified.IsOverMonthlyLimit(_timeProvider))
+                await _notificationService.RemoveOrganizationNotificationSentAsync(modified.Id, isOverMonthlyLimit: true);
+
             await _cache.RemoveAsync(GetThrottledKey(utcNow, modified.Id));
             return;
         }

--- a/src/Exceptionless.Core/Services/UsageService.cs
+++ b/src/Exceptionless.Core/Services/UsageService.cs
@@ -1,7 +1,7 @@
 ﻿using Exceptionless.Core.Extensions;
+using Exceptionless.Core.Jobs.WorkItemHandlers;
 using Exceptionless.Core.Messaging.Models;
 using Exceptionless.Core.Models;
-using Exceptionless.Core.Models.WorkItems;
 using Exceptionless.Core.Repositories;
 using Exceptionless.DateTimeExtensions;
 using Foundatio.Caching;
@@ -227,7 +227,7 @@ public class UsageService
         bool isMonthlyLimitIncrease = modifiedMaxEvents < 0 || (originalMaxEvents >= 0 && modifiedMaxEvents > originalMaxEvents);
         if (isMonthlyLimitIncrease)
         {
-            await _cache.RemoveAsync(OrganizationNotificationWorkItem.GetNotificationSentKey(modified.Id, isOverMonthlyLimit: true));
+            await _cache.RemoveAsync(OrganizationNotificationWorkItemHandler.GetNotificationSentKey(modified.Id, isOverMonthlyLimit: true));
             await _cache.RemoveAsync(GetThrottledKey(utcNow, modified.Id));
             return;
         }
@@ -236,7 +236,7 @@ public class UsageService
         bool isOverMonthlyLimit = modified.IsOverMonthlyLimit(_timeProvider);
         if (!wasOverMonthlyLimit && isOverMonthlyLimit)
         {
-            await _cache.RemoveAsync(OrganizationNotificationWorkItem.GetNotificationSentKey(modified.Id, isOverMonthlyLimit: true));
+            await _cache.RemoveAsync(OrganizationNotificationWorkItemHandler.GetNotificationSentKey(modified.Id, isOverMonthlyLimit: true));
             await _messagePublisher.PublishAsync(new PlanOverage { OrganizationId = modified.Id });
         }
 

--- a/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerIntegrationTests.cs
+++ b/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerIntegrationTests.cs
@@ -1,0 +1,426 @@
+using Exceptionless.Core;
+using Exceptionless.Core.Billing;
+using Exceptionless.Core.Extensions;
+using Exceptionless.Core.Jobs.WorkItemHandlers;
+using Exceptionless.Core.Mail;
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Models.WorkItems;
+using Exceptionless.Core.Repositories;
+using Exceptionless.DateTimeExtensions;
+using Exceptionless.Tests.Mail;
+using Exceptionless.Tests.Utility;
+using Foundatio.Caching;
+using Foundatio.Jobs;
+using Foundatio.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Exceptionless.Tests.Jobs.WorkItemHandlers;
+
+public class OrganizationNotificationWorkItemHandlerIntegrationTests : IntegrationTestsBase
+{
+    private const string PrimaryOrganizationId = "664ec4c1f12e4f2b7a0d1001";
+    private const string SecondaryOrganizationId = "664ec4c1f12e4f2b7a0d1002";
+    private const string MissingOrganizationId = "664ec4c1f12e4f2b7a0d1003";
+    private const string PrimaryUserId = "664ec4c1f12e4f2b7a0d2001";
+    private const string SecondaryUserId = "664ec4c1f12e4f2b7a0d2002";
+    private const string UnverifiedUserId = "664ec4c1f12e4f2b7a0d2003";
+    private const string DisabledNotificationsUserId = "664ec4c1f12e4f2b7a0d2004";
+
+    public OrganizationNotificationWorkItemHandlerIntegrationTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory) { }
+
+    private CountingMailer Mailer => GetService<CountingMailer>();
+    private ICacheClient CacheClient => GetService<ICacheClient>();
+    private OrganizationNotificationWorkItemHandler Handler => GetService<OrganizationNotificationWorkItemHandler>();
+    private IOrganizationRepository OrganizationRepository => GetService<IOrganizationRepository>();
+    private IUserRepository UserRepository => GetService<IUserRepository>();
+    private BillingManager BillingManager => GetService<BillingManager>();
+    private BillingPlans BillingPlans => GetService<BillingPlans>();
+    private OrganizationData OrganizationData => GetService<OrganizationData>();
+    private UserData UserData => GetService<UserData>();
+
+    private Task SetMonthlySentMarkerAsync(string organizationId)
+    {
+        return CacheClient.SetAsync(
+            OrganizationNotificationWorkItemHandler.GetNotificationSentKey(organizationId, isOverMonthlyLimit: true),
+            true,
+            TimeProvider.GetUtcNow().UtcDateTime.EndOfMonth());
+    }
+
+    protected override void RegisterServices(IServiceCollection services)
+    {
+        base.RegisterServices(services);
+        services.AddSingleton<CountingMailer>();
+        services.ReplaceSingleton<IMailer>(sp => sp.GetRequiredService<CountingMailer>());
+    }
+
+    protected override async Task ResetDataAsync()
+    {
+        await base.ResetDataAsync();
+        Mailer.Reset();
+
+        var organizations = new[]
+        {
+            OrganizationData.GenerateOrganization(BillingManager, BillingPlans, id: PrimaryOrganizationId, name: "Primary Organization", plan: BillingPlans.SmallPlan),
+            OrganizationData.GenerateOrganization(BillingManager, BillingPlans, id: SecondaryOrganizationId, name: "Secondary Organization", plan: BillingPlans.SmallPlan)
+        };
+
+        foreach (var organization in organizations)
+            organization.GetCurrentUsage(TimeProvider).Total = organization.GetMaxEventsPerMonthWithBonus(TimeProvider);
+
+        await OrganizationRepository.AddAsync(organizations, options => options.ImmediateConsistency());
+
+        var primaryUser = UserData.GenerateUser(id: PrimaryUserId, organizationId: PrimaryOrganizationId, emailAddress: "primary-owner@example.org");
+        primaryUser.FullName = "Primary Owner";
+        primaryUser.IsEmailAddressVerified = true;
+
+        var secondaryUser = UserData.GenerateUser(id: SecondaryUserId, organizationId: SecondaryOrganizationId, emailAddress: "secondary-owner@example.org");
+        secondaryUser.FullName = "Secondary Owner";
+        secondaryUser.IsEmailAddressVerified = true;
+
+        await UserRepository.AddAsync([primaryUser, secondaryUser], options => options.ImmediateConsistency());
+    }
+
+    [Fact]
+    public async Task HandleItemAsync_WhenDuplicateMonthlyNotificationsAreProcessedAcrossHours_ShouldSendOneEmail()
+    {
+        // Arrange
+        // Act
+        await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
+
+        TimeProvider.Advance(TimeSpan.FromHours(1).Add(TimeSpan.FromMinutes(1)));
+        await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
+
+        TimeProvider.Advance(TimeSpan.FromHours(1).Add(TimeSpan.FromMinutes(1)));
+        await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
+
+        // Assert
+        Assert.Equal(1, Mailer.OrganizationNoticeCount);
+    }
+
+    [Fact]
+    public async Task HandleItemAsync_WhenMonthlyNotificationsTargetDifferentOrganizations_ShouldSendOneEmailPerOrganization()
+    {
+        // Arrange
+        // Act
+        for (int i = 0; i < 3; i++)
+        {
+            await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
+            await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(SecondaryOrganizationId));
+        }
+
+        // Assert
+        var callsByOrganization = Mailer.OrganizationNoticeCalls
+            .GroupBy(call => call.OrganizationId)
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        Assert.Equal(2, callsByOrganization.Count);
+        Assert.Equal(1, callsByOrganization[PrimaryOrganizationId]);
+        Assert.Equal(1, callsByOrganization[SecondaryOrganizationId]);
+    }
+
+    [Fact]
+    public async Task HandleItemAsync_WhenTwentyFourHoursPass_ShouldNotSendAnotherMonthlyNotification()
+    {
+        // Arrange
+        TimeProvider.SetUtcNow(new DateTime(2026, 5, 15, 12, 0, 0, DateTimeKind.Utc));
+        await SetOrganizationOverMonthlyLimitAsync(PrimaryOrganizationId);
+
+        // Act
+        await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
+
+        TimeProvider.Advance(TimeSpan.FromHours(25));
+        await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
+
+        // Assert
+        Assert.Equal(1, Mailer.OrganizationNoticeCount);
+    }
+
+    [Fact]
+    public async Task HandleItemAsync_WhenUtcMonthEndsAndOrganizationIsStillOverMonthlyLimit_ShouldAllowAnotherMonthlyNotification()
+    {
+        // Arrange
+        TimeProvider.SetUtcNow(new DateTime(2026, 5, 31, 23, 50, 0, DateTimeKind.Utc));
+        await SetOrganizationOverMonthlyLimitAsync(PrimaryOrganizationId);
+
+        // Act
+        await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
+
+        TimeProvider.Advance(TimeSpan.FromMinutes(20));
+        await SetOrganizationOverMonthlyLimitAsync(PrimaryOrganizationId);
+        await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
+
+        // Assert
+        Assert.Equal(2, Mailer.OrganizationNoticeCount);
+    }
+
+    /// <summary>
+    /// Regression test: returning null from GetWorkItemLockAsync causes WorkItemJob to call
+    /// AbandonAsync instead of HandleItemAsync, creating an infinite retry loop for hourly items.
+    /// The fix returns EmptyLock (via base) so the item is completed normally.
+    /// </summary>
+    [Fact]
+    public async Task GetWorkItemLockAsync_WhenWorkItemIsHourly_ShouldReturnNonNullLockSoItemIsNotAbandoned()
+    {
+        // Arrange
+        var workItem = CreateHourlyNotificationWorkItem(PrimaryOrganizationId);
+
+        // Act
+        // null → WorkItemJob calls AbandonAsync (infinite retry loop)
+        // non-null → WorkItemJob calls HandleItemAsync and completes the entry
+        await using var workItemLock = await Handler.GetWorkItemLockAsync(workItem, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(workItemLock);
+    }
+
+    [Fact]
+    public async Task GetWorkItemLockAsync_WhenMonthlyLockIsAlreadyHeld_ShouldReturnNullSoConcurrentItemIsAbandoned()
+    {
+        // Arrange
+        var workItem = CreateMonthlyNotificationWorkItem(PrimaryOrganizationId);
+
+        // Act
+        await using var firstLock = await Handler.GetWorkItemLockAsync(workItem, TestContext.Current.CancellationToken);
+        await using var secondLock = await Handler.GetWorkItemLockAsync(workItem, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(firstLock);   // First worker acquires the lock
+        Assert.Null(secondLock);     // Concurrent duplicate is correctly abandoned
+    }
+
+    /// <summary>
+    /// Regression test for the <see cref="HandleWorkItemAsync"/> helper bug:
+    /// the helper must NOT call <see cref="OrganizationNotificationWorkItemHandler.HandleItemAsync"/>
+    /// when the lock is null, because in production WorkItemJob calls <c>AbandonAsync</c> instead.
+    /// Without this guard a concurrent item could bypass the lock, find no sent marker, and send
+    /// a duplicate email — a bug that would be invisible to all other integration tests.
+    /// </summary>
+    [Fact]
+    public async Task HandleItemAsync_WhenConcurrentWorkerHoldsMonthlyLock_ShouldNotSendEmail()
+    {
+        // Arrange: a concurrent worker already holds the monthly notification lock
+        var workItem = CreateMonthlyNotificationWorkItem(PrimaryOrganizationId);
+        await using var concurrentWorkerLock = await Handler.GetWorkItemLockAsync(workItem, TestContext.Current.CancellationToken);
+        Assert.NotNull(concurrentWorkerLock);
+
+        // Act: a second worker attempts to process the same item while the lock is held;
+        // GetWorkItemLockAsync returns null so WorkItemJob abandons the item (never calls HandleItemAsync)
+        await HandleWorkItemAsync(workItem);
+
+        // Assert: no email was sent because the item was abandoned, not processed
+        Assert.Equal(0, Mailer.OrganizationNoticeCount);
+    }
+
+    [Fact]
+    public async Task HandleItemAsync_WhenOnlyAnHourlyOverageIsProcessed_ShouldNotSendEmail()
+    {
+        // Arrange
+        // Act
+        await HandleWorkItemAsync(CreateHourlyNotificationWorkItem(PrimaryOrganizationId));
+
+        // Assert
+        Assert.Equal(0, Mailer.OrganizationNoticeCount);
+    }
+
+    [Fact]
+    public async Task HandleItemAsync_WhenTheMonthlySentMarkerAlreadyExists_ShouldNotSendEmail()
+    {
+        // Arrange
+        await SetMonthlySentMarkerAsync(PrimaryOrganizationId);
+
+        // Act
+        await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
+
+        // Assert
+        Assert.Equal(0, Mailer.OrganizationNoticeCount);
+    }
+
+    [Fact]
+    public async Task HandleItemAsync_WhenMonthlyEmailIsSent_ShouldWriteSentMarker()
+    {
+        // Arrange
+        var workItem = CreateMonthlyNotificationWorkItem(PrimaryOrganizationId);
+
+        // Act
+        await HandleWorkItemAsync(workItem);
+
+        // Assert
+        var sentMarkerExists = await CacheClient.ExistsAsync(
+            OrganizationNotificationWorkItemHandler.GetNotificationSentKey(PrimaryOrganizationId, isOverMonthlyLimit: true));
+        Assert.True(sentMarkerExists);
+    }
+
+    [Fact]
+    public async Task HandleItemAsync_WhenMonthlyWorkItemIsStaleAndOrganizationIsNoLongerOverMonthlyLimit_ShouldNotSendEmailOrWriteSentMarker()
+    {
+        // Arrange
+        var organization = await OrganizationRepository.GetByIdAsync(PrimaryOrganizationId, options => options.Cache());
+        Assert.NotNull(organization);
+
+        organization.GetCurrentUsage(TimeProvider).Total = 0;
+        await OrganizationRepository.SaveAsync(organization, options => options.ImmediateConsistency().Cache());
+
+        // Act
+        await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
+
+        // Assert
+        var sentMarkerExists = await CacheClient.ExistsAsync(
+            OrganizationNotificationWorkItemHandler.GetNotificationSentKey(PrimaryOrganizationId, isOverMonthlyLimit: true));
+        Assert.False(sentMarkerExists);
+        Assert.Equal(0, Mailer.OrganizationNoticeCount);
+    }
+
+    [Fact]
+    public async Task HandleItemAsync_WhenOrganizationNoLongerExists_ShouldNotWriteSentMarkerOrSendEmail()
+    {
+        // Arrange
+        var workItem = CreateMonthlyNotificationWorkItem(MissingOrganizationId);
+
+        // Act
+        await HandleWorkItemAsync(workItem);
+
+        // Assert
+        var sentMarkerExists = await CacheClient.ExistsAsync(
+            OrganizationNotificationWorkItemHandler.GetNotificationSentKey(MissingOrganizationId, isOverMonthlyLimit: true));
+        Assert.False(sentMarkerExists);
+        Assert.Equal(0, Mailer.OrganizationNoticeCount);
+    }
+
+    [Fact]
+    public async Task HandleItemAsync_WhenUsersAreUnverifiedOrDisabled_ShouldOnlySendToEligibleUsers()
+    {
+        // Arrange
+        var unverifiedUser = UserData.GenerateUser(id: UnverifiedUserId, organizationId: PrimaryOrganizationId, emailAddress: "unverified-owner@example.org");
+        unverifiedUser.FullName = "Unverified Owner";
+        unverifiedUser.IsEmailAddressVerified = false;
+        unverifiedUser.EmailNotificationsEnabled = true;
+        unverifiedUser.ResetVerifyEmailAddressTokenAndExpiration(TimeProvider);
+
+        var disabledNotificationsUser = UserData.GenerateUser(id: DisabledNotificationsUserId, organizationId: PrimaryOrganizationId, emailAddress: "disabled-owner@example.org");
+        disabledNotificationsUser.FullName = "Disabled Owner";
+        disabledNotificationsUser.IsEmailAddressVerified = true;
+        disabledNotificationsUser.EmailNotificationsEnabled = false;
+
+        await UserRepository.AddAsync([unverifiedUser, disabledNotificationsUser], options => options.ImmediateConsistency());
+
+        // Act
+        await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
+
+        // Assert
+        var call = Assert.Single(Mailer.OrganizationNoticeCalls);
+        Assert.Equal(PrimaryUserId, call.UserId);
+        Assert.Equal(PrimaryOrganizationId, call.OrganizationId);
+        Assert.True(call.IsOverMonthlyLimit);
+        Assert.False(call.IsOverHourlyLimit);
+    }
+
+    [Fact]
+    public async Task HandleItemAsync_WhenHourlyOveragePrecedesMonthlyOverage_ShouldSendTheMonthlyEmail()
+    {
+        // Arrange
+        // Act
+        await HandleWorkItemAsync(CreateHourlyNotificationWorkItem(PrimaryOrganizationId));
+        await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
+
+        // Assert
+        Assert.Equal(1, Mailer.OrganizationNoticeCount);
+    }
+
+    [Fact]
+    public async Task HandleItemAsync_WhenHourlyOverageArrivesAfterMonthlyEmail_ShouldNotSendAnotherEmail()
+    {
+        // Arrange
+        // Act
+        await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
+
+        TimeProvider.Advance(TimeSpan.FromHours(1).Add(TimeSpan.FromMinutes(1)));
+        await HandleWorkItemAsync(CreateHourlyNotificationWorkItem(PrimaryOrganizationId));
+
+        // Assert
+        var call = Assert.Single(Mailer.OrganizationNoticeCalls);
+        Assert.True(call.IsOverMonthlyLimit);
+        Assert.False(call.IsOverHourlyLimit);
+    }
+
+    [Fact]
+    public async Task GetWorkItemLockAsync_WhenMonthlyWorkerReachesWorkItemTimeout_ShouldKeepConcurrentItemAbandoned()
+    {
+        // Arrange
+        var workItem = CreateMonthlyNotificationWorkItem(PrimaryOrganizationId);
+        await using var workerALock = await Handler.GetWorkItemLockAsync(workItem, TestContext.Current.CancellationToken);
+        Assert.NotNull(workerALock);
+
+        TimeProvider.Advance(TimeSpan.FromMinutes(61));
+
+        // Act
+        await using var workerBLock = await Handler.GetWorkItemLockAsync(workItem, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(workerBLock);
+    }
+
+    [Fact]
+    public async Task HandleItemAsync_WhenEmailSendFails_ShouldNotWriteSentMarkerSoRetryCanSend()
+    {
+        // Arrange
+        var workItem = CreateMonthlyNotificationWorkItem(PrimaryOrganizationId);
+        Mailer.ShouldThrow = true;
+
+        // Act
+        await Assert.ThrowsAsync<InvalidOperationException>(() => HandleWorkItemAsync(workItem));
+
+        var sentMarkerExists = await CacheClient.ExistsAsync(
+            OrganizationNotificationWorkItemHandler.GetNotificationSentKey(PrimaryOrganizationId, isOverMonthlyLimit: true));
+
+        Mailer.ShouldThrow = false;
+        await HandleWorkItemAsync(workItem);
+
+        // Assert
+        Assert.False(sentMarkerExists);
+        Assert.Equal(1, Mailer.OrganizationNoticeCount);
+    }
+
+    private async Task HandleWorkItemAsync(OrganizationNotificationWorkItem workItem)
+    {
+        await using var workItemLock = await Handler.GetWorkItemLockAsync(workItem, TestContext.Current.CancellationToken);
+
+        // Mirror production WorkItemJob semantics: when GetWorkItemLockAsync returns null,
+        // WorkItemJob calls AbandonAsync and never calls HandleItemAsync. Omitting this guard
+        // would let tests call HandleItemAsync without the lock, masking concurrent-access bugs.
+        if (workItemLock is null)
+            return;
+
+        var context = new WorkItemContext(workItem, "test-job", workItemLock, TestContext.Current.CancellationToken, static (_, _) => Task.CompletedTask);
+        await Handler.HandleItemAsync(context);
+    }
+
+    private async Task SetOrganizationOverMonthlyLimitAsync(string organizationId)
+    {
+        var organization = await OrganizationRepository.GetByIdAsync(organizationId, options => options.Cache());
+        Assert.NotNull(organization);
+
+        organization.GetCurrentUsage(TimeProvider).Total = organization.GetMaxEventsPerMonthWithBonus(TimeProvider);
+        await OrganizationRepository.SaveAsync(organization, options => options.ImmediateConsistency().Cache());
+    }
+
+    private static OrganizationNotificationWorkItem CreateMonthlyNotificationWorkItem(string organizationId)
+    {
+        return new OrganizationNotificationWorkItem
+        {
+            OrganizationId = organizationId,
+            IsOverHourlyLimit = false,
+            IsOverMonthlyLimit = true
+        };
+    }
+
+    private static OrganizationNotificationWorkItem CreateHourlyNotificationWorkItem(string organizationId)
+    {
+        return new OrganizationNotificationWorkItem
+        {
+            OrganizationId = organizationId,
+            IsOverHourlyLimit = true,
+            IsOverMonthlyLimit = false
+        };
+    }
+}

--- a/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerIntegrationTests.cs
+++ b/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerIntegrationTests.cs
@@ -6,10 +6,9 @@ using Exceptionless.Core.Mail;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Models.WorkItems;
 using Exceptionless.Core.Repositories;
-using Exceptionless.DateTimeExtensions;
+using Exceptionless.Core.Services;
 using Exceptionless.Tests.Mail;
 using Exceptionless.Tests.Utility;
-using Foundatio.Caching;
 using Foundatio.Jobs;
 using Foundatio.Repositories;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,7 +29,7 @@ public class OrganizationNotificationWorkItemHandlerIntegrationTests : Integrati
     public OrganizationNotificationWorkItemHandlerIntegrationTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory) { }
 
     private CountingMailer Mailer => GetService<CountingMailer>();
-    private ICacheClient CacheClient => GetService<ICacheClient>();
+    private NotificationService NotificationService => GetService<NotificationService>();
     private OrganizationNotificationWorkItemHandler Handler => GetService<OrganizationNotificationWorkItemHandler>();
     private IOrganizationRepository OrganizationRepository => GetService<IOrganizationRepository>();
     private IUserRepository UserRepository => GetService<IUserRepository>();
@@ -41,10 +40,7 @@ public class OrganizationNotificationWorkItemHandlerIntegrationTests : Integrati
 
     private Task SetMonthlySentMarkerAsync(string organizationId)
     {
-        return CacheClient.SetAsync(
-            OrganizationNotificationWorkItemHandler.GetNotificationSentKey(organizationId, isOverMonthlyLimit: true),
-            true,
-            TimeProvider.GetUtcNow().UtcDateTime.EndOfMonth());
+        return NotificationService.SetOrganizationNotificationSentAsync(organizationId, isOverMonthlyLimit: true);
     }
 
     protected override void RegisterServices(IServiceCollection services)
@@ -85,6 +81,9 @@ public class OrganizationNotificationWorkItemHandlerIntegrationTests : Integrati
     public async Task HandleItemAsync_WhenDuplicateMonthlyNotificationsAreProcessedAcrossHours_ShouldSendOneEmail()
     {
         // Arrange
+        TimeProvider.SetUtcNow(new DateTime(2026, 5, 15, 12, 0, 0, DateTimeKind.Utc));
+        await SetOrganizationOverMonthlyLimitAsync(PrimaryOrganizationId);
+
         // Act
         await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
 
@@ -246,9 +245,22 @@ public class OrganizationNotificationWorkItemHandlerIntegrationTests : Integrati
         await HandleWorkItemAsync(workItem);
 
         // Assert
-        var sentMarkerExists = await CacheClient.ExistsAsync(
-            OrganizationNotificationWorkItemHandler.GetNotificationSentKey(PrimaryOrganizationId, isOverMonthlyLimit: true));
-        Assert.True(sentMarkerExists);
+        Assert.True(await NotificationService.IsOrganizationNotificationSentAsync(PrimaryOrganizationId, isOverMonthlyLimit: true));
+    }
+
+    [Fact]
+    public async Task HandleItemAsync_WhenMonthlyEmailIsSentInLastMillisecondOfUtcMonth_ShouldWriteObservableSentMarker()
+    {
+        // Arrange
+        TimeProvider.SetUtcNow(new DateTime(2026, 5, 31, 23, 59, 59, 999, DateTimeKind.Utc));
+        await SetOrganizationOverMonthlyLimitAsync(PrimaryOrganizationId);
+
+        // Act
+        await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
+
+        // Assert
+        Assert.True(await NotificationService.IsOrganizationNotificationSentAsync(PrimaryOrganizationId, isOverMonthlyLimit: true));
+        Assert.Equal(1, Mailer.OrganizationNoticeCount);
     }
 
     [Fact]
@@ -265,9 +277,7 @@ public class OrganizationNotificationWorkItemHandlerIntegrationTests : Integrati
         await HandleWorkItemAsync(CreateMonthlyNotificationWorkItem(PrimaryOrganizationId));
 
         // Assert
-        var sentMarkerExists = await CacheClient.ExistsAsync(
-            OrganizationNotificationWorkItemHandler.GetNotificationSentKey(PrimaryOrganizationId, isOverMonthlyLimit: true));
-        Assert.False(sentMarkerExists);
+        Assert.False(await NotificationService.IsOrganizationNotificationSentAsync(PrimaryOrganizationId, isOverMonthlyLimit: true));
         Assert.Equal(0, Mailer.OrganizationNoticeCount);
     }
 
@@ -281,9 +291,7 @@ public class OrganizationNotificationWorkItemHandlerIntegrationTests : Integrati
         await HandleWorkItemAsync(workItem);
 
         // Assert
-        var sentMarkerExists = await CacheClient.ExistsAsync(
-            OrganizationNotificationWorkItemHandler.GetNotificationSentKey(MissingOrganizationId, isOverMonthlyLimit: true));
-        Assert.False(sentMarkerExists);
+        Assert.False(await NotificationService.IsOrganizationNotificationSentAsync(MissingOrganizationId, isOverMonthlyLimit: true));
         Assert.Equal(0, Mailer.OrganizationNoticeCount);
     }
 
@@ -370,8 +378,7 @@ public class OrganizationNotificationWorkItemHandlerIntegrationTests : Integrati
         // Act
         await Assert.ThrowsAsync<InvalidOperationException>(() => HandleWorkItemAsync(workItem));
 
-        var sentMarkerExists = await CacheClient.ExistsAsync(
-            OrganizationNotificationWorkItemHandler.GetNotificationSentKey(PrimaryOrganizationId, isOverMonthlyLimit: true));
+        var sentMarkerExists = await NotificationService.IsOrganizationNotificationSentAsync(PrimaryOrganizationId, isOverMonthlyLimit: true);
 
         Mailer.ShouldThrow = false;
         await HandleWorkItemAsync(workItem);

--- a/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerTests.cs
+++ b/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerTests.cs
@@ -1,19 +1,14 @@
 using Exceptionless.Core;
 using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Jobs.WorkItemHandlers;
-using Exceptionless.Core.Mail;
 using Exceptionless.Core.Messaging.Models;
-using Exceptionless.Core.Models;
 using Exceptionless.Core.Models.WorkItems;
-using Exceptionless.Tests.Mail;
 using Foundatio.Caching;
 using Foundatio.Jobs;
-using Foundatio.Lock;
 using Foundatio.Messaging;
 using Foundatio.Queues;
 using Foundatio.Resilience;
 using Foundatio.Serializer;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Exceptionless.Tests.Jobs.WorkItemHandlers;
@@ -43,18 +38,9 @@ public class OrganizationNotificationWorkItemHandlerTests : TestWithServices
 
     public OrganizationNotificationWorkItemHandlerTests(ITestOutputHelper output) : base(output) { }
 
-    private CountingMailer Mailer => GetService<CountingMailer>();
     private IMessagePublisher MessagePublisher => GetService<IMessagePublisher>();
     private IMessageSubscriber MessageSubscriber => GetService<IMessageSubscriber>();
     private ICacheClient CacheClient => GetService<ICacheClient>();
-    private IResiliencePolicyProvider ResiliencePolicyProvider => GetService<IResiliencePolicyProvider>();
-
-    protected override void RegisterServices(IServiceCollection services, AppOptions options)
-    {
-        base.RegisterServices(services, options);
-        services.AddSingleton<CountingMailer>();
-        services.ReplaceSingleton<IMailer>(sp => sp.GetRequiredService<CountingMailer>());
-    }
 
     [Fact]
     public async Task RunAsync_WhenOnePlanOverageIsObservedBySixSubscribersWithoutQueueDuplicateDetection_ShouldEnqueueSixWorkItems()
@@ -184,47 +170,6 @@ public class OrganizationNotificationWorkItemHandlerTests : TestWithServices
         Assert.Equal($"Organization:{PrimaryOrganizationId}:notification:monthly", monthlyKey);
         Assert.Equal($"Organization:{PrimaryOrganizationId}:notification:hourly", hourlyKey);
         Assert.NotEqual(monthlyKey, hourlyKey);
-    }
-
-    [Fact]
-    public async Task HandleItemAsync_WhenLegacyHourlyThrottleProcessesStaleMonthlyDuplicates_ShouldSendOneEmailPerHourBucket()
-    {
-        // Arrange
-        // Reproduce the pre-fix behavior: ThrottlingLockProvider(1/hour) allowed exactly one
-        // item through per calendar-hour bucket. When a duplicate was abandoned and re-queued,
-        // it could acquire a fresh lock once the next hour bucket opened — one email per hour.
-        var organization = new Organization { Id = PrimaryOrganizationId, Name = "Acme Corp" };
-        var user = new User
-        {
-            Id = "664ec4c1f12e4f2b7a0d2001",
-            FullName = "Jane Smith",
-            EmailAddress = "jane.smith@acmecorp.example",
-            IsEmailAddressVerified = true,
-            EmailNotificationsEnabled = true
-        };
-
-        var lockKey = OrganizationNotificationWorkItemHandler.GetNotificationLockKey(PrimaryOrganizationId, isOverMonthlyLimit: true);
-        var lockProvider = new ThrottlingLockProvider(CacheClient, 1, TimeSpan.FromHours(1), TimeProvider, ResiliencePolicyProvider, GetService<ILoggerFactory>());
-
-        Task ProcessDuplicateWithLegacyLockAsync()
-        {
-            return lockProvider.TryUsingAsync(lockKey, async () =>
-            {
-                await Mailer.SendOrganizationNoticeAsync(user, organization, isOverMonthlyLimit: true, isOverHourlyLimit: false);
-            }, TimeSpan.FromMinutes(15), TestContext.Current.CancellationToken);
-        }
-
-        // Act: each call simulates a stale duplicate item being dequeued in a new hour bucket
-        await ProcessDuplicateWithLegacyLockAsync();                                   // Hour 0: lock acquired, email sent
-
-        TimeProvider.Advance(TimeSpan.FromHours(1).Add(TimeSpan.FromMinutes(1)));
-        await ProcessDuplicateWithLegacyLockAsync();                                   // Hour 1: new bucket, email sent again
-
-        TimeProvider.Advance(TimeSpan.FromHours(1).Add(TimeSpan.FromMinutes(1)));
-        await ProcessDuplicateWithLegacyLockAsync();                                   // Hour 2: new bucket, email sent again
-
-        // Assert: the old code allowed one email per hour — this is the bug
-        Assert.Equal(3, Mailer.OrganizationNoticeCount);
     }
 
     private async Task SubscribeToPlanOverageAsync(IQueue<WorkItemData> workItemQueue, int subscriberCount)

--- a/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerTests.cs
+++ b/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerTests.cs
@@ -1,0 +1,273 @@
+using Exceptionless.Core;
+using Exceptionless.Core.Extensions;
+using Exceptionless.Core.Jobs.WorkItemHandlers;
+using Exceptionless.Core.Mail;
+using Exceptionless.Core.Messaging.Models;
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Models.WorkItems;
+using Exceptionless.Tests.Mail;
+using Foundatio.Caching;
+using Foundatio.Jobs;
+using Foundatio.Lock;
+using Foundatio.Messaging;
+using Foundatio.Queues;
+using Foundatio.Resilience;
+using Foundatio.Serializer;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Exceptionless.Tests.Jobs.WorkItemHandlers;
+
+/// <summary>
+/// RCA-focused tests for duplicate plan-limit email notifications.
+///
+/// Root cause: every web pod registers the same <see cref="EnqueueOrganizationNotificationOnPlanOverage"/>
+/// startup action. Because Foundatio pub/sub delivers each message to all subscribers, a single
+/// monthly <c>PlanOverage</c> event enqueued one work item per running web pod. The original
+/// <c>ThrottlingLockProvider(slotsPerPeriod: 1, period: 1 hour)</c> allowed exactly one item
+/// through per calendar-hour bucket. Duplicate items were abandoned back to the queue and
+/// reprocessed once each new bucket opened — producing one email per hour.
+///
+/// Fix: queue-level dedup (<see cref="OrganizationNotificationWorkItem.UniqueIdentifier"/> +
+/// <c>DuplicateDetectionQueueBehavior</c>) collapses the fanout at enqueue time, and
+/// handler-level idempotency (per-org distributed lock + sent marker) ensures that stale
+/// duplicates already in the queue when the fix deployed cannot retrigger an email.
+/// </summary>
+public class OrganizationNotificationWorkItemHandlerTests : TestWithServices
+{
+    private const string PrimaryOrganizationId = "664ec4c1f12e4f2b7a0d1001";
+    private const string QueueDuplicateDetectionOrganizationId = "664ec4c1f12e4f2b7a0d1002";
+    private const string RegisteredQueueOrganizationId = "664ec4c1f12e4f2b7a0d1003";
+    private const string DequeuedNotificationOrganizationId = "664ec4c1f12e4f2b7a0d1004";
+    private const string HourlyOrganizationId = "664ec4c1f12e4f2b7a0d1005";
+
+    public OrganizationNotificationWorkItemHandlerTests(ITestOutputHelper output) : base(output) { }
+
+    private CountingMailer Mailer => GetService<CountingMailer>();
+    private IMessagePublisher MessagePublisher => GetService<IMessagePublisher>();
+    private IMessageSubscriber MessageSubscriber => GetService<IMessageSubscriber>();
+    private ICacheClient CacheClient => GetService<ICacheClient>();
+    private IResiliencePolicyProvider ResiliencePolicyProvider => GetService<IResiliencePolicyProvider>();
+
+    protected override void RegisterServices(IServiceCollection services, AppOptions options)
+    {
+        base.RegisterServices(services, options);
+        services.AddSingleton<CountingMailer>();
+        services.ReplaceSingleton<IMailer>(sp => sp.GetRequiredService<CountingMailer>());
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenOnePlanOverageIsObservedBySixSubscribersWithoutQueueDuplicateDetection_ShouldEnqueueSixWorkItems()
+    {
+        // Arrange
+        using var workItemQueue = CreateWorkItemQueue();
+        await SubscribeToPlanOverageAsync(workItemQueue, subscriberCount: 6);
+
+        // Act
+        await MessagePublisher.PublishAsync(new PlanOverage { OrganizationId = PrimaryOrganizationId }, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var queueStats = await workItemQueue.GetQueueStatsAsync();
+        Assert.Equal(6, queueStats.Enqueued);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenOnePlanOverageIsObservedBySixSubscribersWithQueueDuplicateDetection_ShouldEnqueueOneWorkItem()
+    {
+        // Arrange
+        using var dedupBehavior = new DuplicateDetectionQueueBehavior<WorkItemData>(CacheClient, GetService<ILoggerFactory>(), TimeSpan.FromHours(24));
+        using var workItemQueue = CreateWorkItemQueue(dedupBehavior);
+        await SubscribeToPlanOverageAsync(workItemQueue, subscriberCount: 6);
+
+        // Act
+        await MessagePublisher.PublishAsync(new PlanOverage { OrganizationId = QueueDuplicateDetectionOrganizationId }, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var queueStats = await workItemQueue.GetQueueStatsAsync();
+        Assert.Equal(1, queueStats.Enqueued);
+    }
+
+    [Fact]
+    public async Task EnqueueAsync_WhenDuplicateNotificationUsesRegisteredQueueBehavior_ShouldEnqueueOneWorkItem()
+    {
+        // Arrange
+        var workItemQueue = GetService<IQueue<WorkItemData>>();
+        var workItem = CreateMonthlyNotificationWorkItem(RegisteredQueueOrganizationId);
+
+        // Act
+        await workItemQueue.EnqueueAsync(workItem);
+        await workItemQueue.EnqueueAsync(workItem);
+
+        // Assert
+        var queueStats = await workItemQueue.GetQueueStatsAsync();
+        Assert.Equal(1, queueStats.Enqueued);
+    }
+
+    [Fact]
+    public async Task EnqueueAsync_WhenDuplicateNotificationIsDequeued_ShouldAllowFutureEnqueue()
+    {
+        // Arrange
+        using var dedupBehavior = new DuplicateDetectionQueueBehavior<WorkItemData>(CacheClient, GetService<ILoggerFactory>(), TimeSpan.FromHours(24));
+        using var workItemQueue = CreateWorkItemQueue(dedupBehavior);
+        var workItem = CreateMonthlyNotificationWorkItem(DequeuedNotificationOrganizationId);
+
+        await workItemQueue.EnqueueAsync(workItem);
+        var queueEntry = await workItemQueue.DequeueAsync(TestContext.Current.CancellationToken);
+        Assert.NotNull(queueEntry);
+        await queueEntry.CompleteAsync();
+
+        // Act
+        await workItemQueue.EnqueueAsync(workItem);
+
+        // Assert
+        var queueStats = await workItemQueue.GetQueueStatsAsync();
+        Assert.Equal(2, queueStats.Enqueued);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenHourlyPlanOverageIsObserved_ShouldEnqueueHourlyWorkItem()
+    {
+        // Arrange
+        using var workItemQueue = CreateWorkItemQueue();
+        await SubscribeToPlanOverageAsync(workItemQueue, subscriberCount: 1);
+
+        // Act
+        await MessagePublisher.PublishAsync(new PlanOverage { OrganizationId = HourlyOrganizationId, IsHourly = true }, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var queueEntry = await workItemQueue.DequeueAsync(TestContext.Current.CancellationToken);
+        Assert.NotNull(queueEntry);
+
+        var workItem = GetService<ISerializer>().Deserialize<OrganizationNotificationWorkItem>(queueEntry.Value.Data)!;
+        Assert.Equal(HourlyOrganizationId, workItem.OrganizationId);
+        Assert.True(workItem.IsOverHourlyLimit);
+        Assert.False(workItem.IsOverMonthlyLimit);
+
+        await queueEntry.CompleteAsync();
+    }
+
+    [Fact]
+    public void UniqueIdentifier_WhenMonthlyNotificationIsCreated_ShouldMatchCanonicalNotificationKey()
+    {
+        // Arrange
+        var workItem = CreateMonthlyNotificationWorkItem(PrimaryOrganizationId);
+
+        // Act
+        var uniqueIdentifier = workItem.UniqueIdentifier;
+
+        // Assert
+        Assert.Equal(OrganizationNotificationWorkItem.GetNotificationKey(PrimaryOrganizationId, isOverMonthlyLimit: true), uniqueIdentifier);
+    }
+
+    [Fact]
+    public void UniqueIdentifier_WhenHourlyNotificationIsCreated_ShouldMatchCanonicalNotificationKey()
+    {
+        // Arrange
+        var workItem = CreateHourlyNotificationWorkItem(PrimaryOrganizationId);
+
+        // Act
+        var uniqueIdentifier = workItem.UniqueIdentifier;
+
+        // Assert
+        Assert.Equal(OrganizationNotificationWorkItem.GetNotificationKey(PrimaryOrganizationId, isOverMonthlyLimit: false), uniqueIdentifier);
+    }
+
+    [Fact]
+    public void GetNotificationKey_WhenMonthlyAndHourlyNotificationsAreCreated_ShouldUseDifferentKeys()
+    {
+        // Arrange
+        // Act
+        var monthlyKey = OrganizationNotificationWorkItem.GetNotificationKey(PrimaryOrganizationId, isOverMonthlyLimit: true);
+        var hourlyKey = OrganizationNotificationWorkItem.GetNotificationKey(PrimaryOrganizationId, isOverMonthlyLimit: false);
+
+        // Assert
+        Assert.Equal($"Organization:{PrimaryOrganizationId}:notification:monthly", monthlyKey);
+        Assert.Equal($"Organization:{PrimaryOrganizationId}:notification:hourly", hourlyKey);
+        Assert.NotEqual(monthlyKey, hourlyKey);
+    }
+
+    [Fact]
+    public async Task HandleItemAsync_WhenLegacyHourlyThrottleProcessesStaleMonthlyDuplicates_ShouldSendOneEmailPerHourBucket()
+    {
+        // Arrange
+        // Reproduce the pre-fix behavior: ThrottlingLockProvider(1/hour) allowed exactly one
+        // item through per calendar-hour bucket. When a duplicate was abandoned and re-queued,
+        // it could acquire a fresh lock once the next hour bucket opened — one email per hour.
+        var organization = new Organization { Id = PrimaryOrganizationId, Name = "Acme Corp" };
+        var user = new User
+        {
+            Id = "664ec4c1f12e4f2b7a0d2001",
+            FullName = "Jane Smith",
+            EmailAddress = "jane.smith@acmecorp.example",
+            IsEmailAddressVerified = true,
+            EmailNotificationsEnabled = true
+        };
+
+        var lockKey = OrganizationNotificationWorkItemHandler.GetNotificationLockKey(PrimaryOrganizationId, isOverMonthlyLimit: true);
+        var lockProvider = new ThrottlingLockProvider(CacheClient, 1, TimeSpan.FromHours(1), TimeProvider, ResiliencePolicyProvider, GetService<ILoggerFactory>());
+
+        Task ProcessDuplicateWithLegacyLockAsync()
+        {
+            return lockProvider.TryUsingAsync(lockKey, async () =>
+            {
+                await Mailer.SendOrganizationNoticeAsync(user, organization, isOverMonthlyLimit: true, isOverHourlyLimit: false);
+            }, TimeSpan.FromMinutes(15), TestContext.Current.CancellationToken);
+        }
+
+        // Act: each call simulates a stale duplicate item being dequeued in a new hour bucket
+        await ProcessDuplicateWithLegacyLockAsync();                                   // Hour 0: lock acquired, email sent
+
+        TimeProvider.Advance(TimeSpan.FromHours(1).Add(TimeSpan.FromMinutes(1)));
+        await ProcessDuplicateWithLegacyLockAsync();                                   // Hour 1: new bucket, email sent again
+
+        TimeProvider.Advance(TimeSpan.FromHours(1).Add(TimeSpan.FromMinutes(1)));
+        await ProcessDuplicateWithLegacyLockAsync();                                   // Hour 2: new bucket, email sent again
+
+        // Assert: the old code allowed one email per hour — this is the bug
+        Assert.Equal(3, Mailer.OrganizationNoticeCount);
+    }
+
+    private async Task SubscribeToPlanOverageAsync(IQueue<WorkItemData> workItemQueue, int subscriberCount)
+    {
+        for (int i = 0; i < subscriberCount; i++)
+        {
+            var startupAction = new EnqueueOrganizationNotificationOnPlanOverage(workItemQueue, MessageSubscriber, GetService<ILoggerFactory>());
+            await startupAction.RunAsync();
+        }
+    }
+
+    private InMemoryQueue<WorkItemData> CreateWorkItemQueue(params IQueueBehavior<WorkItemData>[] behaviors)
+    {
+        var options = new InMemoryQueueOptions<WorkItemData>
+        {
+            Serializer = GetService<ISerializer>(),
+            TimeProvider = TimeProvider,
+            LoggerFactory = GetService<ILoggerFactory>()
+        };
+
+        if (behaviors.Length > 0)
+            options.Behaviors = behaviors;
+
+        return new InMemoryQueue<WorkItemData>(options);
+    }
+
+    private static OrganizationNotificationWorkItem CreateMonthlyNotificationWorkItem(string organizationId)
+    {
+        return new OrganizationNotificationWorkItem
+        {
+            OrganizationId = organizationId,
+            IsOverHourlyLimit = false,
+            IsOverMonthlyLimit = true
+        };
+    }
+
+    private static OrganizationNotificationWorkItem CreateHourlyNotificationWorkItem(string organizationId)
+    {
+        return new OrganizationNotificationWorkItem
+        {
+            OrganizationId = organizationId,
+            IsOverHourlyLimit = true,
+            IsOverMonthlyLimit = false
+        };
+    }
+}

--- a/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerTests.cs
+++ b/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerTests.cs
@@ -100,7 +100,7 @@ public class OrganizationNotificationWorkItemHandlerTests : TestWithServices
         var workItem = CreateMonthlyNotificationWorkItem(DequeuedNotificationOrganizationId);
 
         await workItemQueue.EnqueueAsync(workItem);
-        var queueEntry = await workItemQueue.DequeueAsync(TestContext.Current.CancellationToken);
+        var queueEntry = await workItemQueue.DequeueAsync(TestCancellationToken);
         Assert.NotNull(queueEntry);
         await queueEntry.CompleteAsync();
 
@@ -123,7 +123,7 @@ public class OrganizationNotificationWorkItemHandlerTests : TestWithServices
         await PublishPlanOverageAndWaitForQueueAsync(workItemQueue, new PlanOverage { OrganizationId = HourlyOrganizationId, IsHourly = true }, expectedEnqueueAttempts: 1, expectedEnqueuedCount: 1);
 
         // Assert
-        var queueEntry = await workItemQueue.DequeueAsync(TestContext.Current.CancellationToken);
+        var queueEntry = await workItemQueue.DequeueAsync(TestCancellationToken);
         Assert.NotNull(queueEntry);
 
         var workItem = GetService<ISerializer>().Deserialize<OrganizationNotificationWorkItem>(queueEntry.Value.Data)!;
@@ -208,7 +208,7 @@ public class OrganizationNotificationWorkItemHandlerTests : TestWithServices
             return Task.CompletedTask;
         });
 
-        await MessagePublisher.PublishAsync(overage, cancellationToken: TestContext.Current.CancellationToken);
+        await MessagePublisher.PublishAsync(overage, cancellationToken: TestCancellationToken);
         await enqueueAttempts.WaitAsync(TimeSpan.FromSeconds(5));
         await enqueued.WaitAsync(TimeSpan.FromSeconds(5));
     }

--- a/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerTests.cs
+++ b/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerTests.cs
@@ -172,6 +172,16 @@ public class OrganizationNotificationWorkItemHandlerTests : TestWithServices
         Assert.NotEqual(monthlyKey, hourlyKey);
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void GetNotificationKey_WhenOrganizationIdIsNullOrEmpty_ShouldThrowArgumentException(string? organizationId)
+    {
+        // Arrange
+        // Act & Assert
+        Assert.ThrowsAny<ArgumentException>(() => OrganizationNotificationWorkItem.GetNotificationKey(organizationId!, isOverMonthlyLimit: true));
+    }
+
     private async Task SubscribeToPlanOverageAsync(IQueue<WorkItemData> workItemQueue, int subscriberCount)
     {
         for (int i = 0; i < subscriberCount; i++)

--- a/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerTests.cs
+++ b/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerTests.cs
@@ -3,6 +3,7 @@ using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Jobs.WorkItemHandlers;
 using Exceptionless.Core.Messaging.Models;
 using Exceptionless.Core.Models.WorkItems;
+using Exceptionless.Tests.Extensions;
 using Foundatio.AsyncEx;
 using Foundatio.Caching;
 using Foundatio.Jobs;
@@ -194,8 +195,8 @@ public class OrganizationNotificationWorkItemHandlerTests : TestWithServices
 
     private async Task PublishPlanOverageAndWaitForQueueAsync(IQueue<WorkItemData> workItemQueue, PlanOverage overage, int expectedEnqueueAttempts, int expectedEnqueuedCount)
     {
-        using var enqueueAttempts = new AsyncCountdownEvent(expectedEnqueueAttempts);
-        using var enqueued = new AsyncCountdownEvent(expectedEnqueuedCount);
+        var enqueueAttempts = new AsyncCountdownEvent(expectedEnqueueAttempts);
+        var enqueued = new AsyncCountdownEvent(expectedEnqueuedCount);
         using var enqueueAttemptSubscription = workItemQueue.Enqueuing.AddHandler((_, _) =>
         {
             enqueueAttempts.Signal();

--- a/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerTests.cs
+++ b/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerTests.cs
@@ -30,7 +30,7 @@ namespace Exceptionless.Tests.Jobs.WorkItemHandlers;
 ///
 /// Fix: queue-level dedup (<see cref="OrganizationNotificationWorkItem.UniqueIdentifier"/> +
 /// <c>DuplicateDetectionQueueBehavior</c>) collapses the fanout at enqueue time, and
-/// handler-level idempotency (per-org distributed lock + sent marker) ensures that stale
+/// handler-level idempotency (per-organization distributed lock + sent marker) ensures that stale
 /// duplicates already in the queue when the fix deployed cannot retrigger an email.
 /// </summary>
 public class OrganizationNotificationWorkItemHandlerTests : TestWithServices
@@ -240,13 +240,12 @@ public class OrganizationNotificationWorkItemHandlerTests : TestWithServices
     {
         var options = new InMemoryQueueOptions<WorkItemData>
         {
+            Behaviors = behaviors,
             Serializer = GetService<ISerializer>(),
             TimeProvider = TimeProvider,
+            ResiliencePolicyProvider = GetService<IResiliencePolicyProvider>(),
             LoggerFactory = GetService<ILoggerFactory>()
         };
-
-        if (behaviors.Length > 0)
-            options.Behaviors = behaviors;
 
         return new InMemoryQueue<WorkItemData>(options);
     }

--- a/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerTests.cs
+++ b/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/OrganizationNotificationWorkItemHandlerTests.cs
@@ -3,6 +3,7 @@ using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Jobs.WorkItemHandlers;
 using Exceptionless.Core.Messaging.Models;
 using Exceptionless.Core.Models.WorkItems;
+using Foundatio.AsyncEx;
 using Foundatio.Caching;
 using Foundatio.Jobs;
 using Foundatio.Messaging;
@@ -50,7 +51,7 @@ public class OrganizationNotificationWorkItemHandlerTests : TestWithServices
         await SubscribeToPlanOverageAsync(workItemQueue, subscriberCount: 6);
 
         // Act
-        await MessagePublisher.PublishAsync(new PlanOverage { OrganizationId = PrimaryOrganizationId }, cancellationToken: TestContext.Current.CancellationToken);
+        await PublishPlanOverageAndWaitForQueueAsync(workItemQueue, new PlanOverage { OrganizationId = PrimaryOrganizationId }, expectedEnqueueAttempts: 6, expectedEnqueuedCount: 6);
 
         // Assert
         var queueStats = await workItemQueue.GetQueueStatsAsync();
@@ -66,7 +67,7 @@ public class OrganizationNotificationWorkItemHandlerTests : TestWithServices
         await SubscribeToPlanOverageAsync(workItemQueue, subscriberCount: 6);
 
         // Act
-        await MessagePublisher.PublishAsync(new PlanOverage { OrganizationId = QueueDuplicateDetectionOrganizationId }, cancellationToken: TestContext.Current.CancellationToken);
+        await PublishPlanOverageAndWaitForQueueAsync(workItemQueue, new PlanOverage { OrganizationId = QueueDuplicateDetectionOrganizationId }, expectedEnqueueAttempts: 6, expectedEnqueuedCount: 1);
 
         // Assert
         var queueStats = await workItemQueue.GetQueueStatsAsync();
@@ -118,7 +119,7 @@ public class OrganizationNotificationWorkItemHandlerTests : TestWithServices
         await SubscribeToPlanOverageAsync(workItemQueue, subscriberCount: 1);
 
         // Act
-        await MessagePublisher.PublishAsync(new PlanOverage { OrganizationId = HourlyOrganizationId, IsHourly = true }, cancellationToken: TestContext.Current.CancellationToken);
+        await PublishPlanOverageAndWaitForQueueAsync(workItemQueue, new PlanOverage { OrganizationId = HourlyOrganizationId, IsHourly = true }, expectedEnqueueAttempts: 1, expectedEnqueuedCount: 1);
 
         // Assert
         var queueEntry = await workItemQueue.DequeueAsync(TestContext.Current.CancellationToken);
@@ -189,6 +190,26 @@ public class OrganizationNotificationWorkItemHandlerTests : TestWithServices
             var startupAction = new EnqueueOrganizationNotificationOnPlanOverage(workItemQueue, MessageSubscriber, GetService<ILoggerFactory>());
             await startupAction.RunAsync();
         }
+    }
+
+    private async Task PublishPlanOverageAndWaitForQueueAsync(IQueue<WorkItemData> workItemQueue, PlanOverage overage, int expectedEnqueueAttempts, int expectedEnqueuedCount)
+    {
+        using var enqueueAttempts = new AsyncCountdownEvent(expectedEnqueueAttempts);
+        using var enqueued = new AsyncCountdownEvent(expectedEnqueuedCount);
+        using var enqueueAttemptSubscription = workItemQueue.Enqueuing.AddHandler((_, _) =>
+        {
+            enqueueAttempts.Signal();
+            return Task.CompletedTask;
+        });
+        using var enqueuedSubscription = workItemQueue.Enqueued.AddHandler((_, _) =>
+        {
+            enqueued.Signal();
+            return Task.CompletedTask;
+        });
+
+        await MessagePublisher.PublishAsync(overage, cancellationToken: TestContext.Current.CancellationToken);
+        await enqueueAttempts.WaitAsync(TimeSpan.FromSeconds(5));
+        await enqueued.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     private InMemoryQueue<WorkItemData> CreateWorkItemQueue(params IQueueBehavior<WorkItemData>[] behaviors)

--- a/tests/Exceptionless.Tests/Mail/CountingMailer.cs
+++ b/tests/Exceptionless.Tests/Mail/CountingMailer.cs
@@ -1,0 +1,79 @@
+using Exceptionless.Core.Mail;
+using Exceptionless.Core.Models;
+
+namespace Exceptionless.Tests.Mail;
+
+public class CountingMailer : IMailer
+{
+    private int _organizationNoticeCount;
+
+    public int OrganizationNoticeCount => _organizationNoticeCount;
+
+    public List<OrganizationNoticeCall> OrganizationNoticeCalls { get; } = [];
+
+    /// <summary>
+    /// When true, <see cref="SendOrganizationNoticeAsync"/> throws instead of recording a call.
+    /// Reset by <see cref="Reset"/>.
+    /// </summary>
+    public bool ShouldThrow { get; set; }
+
+    public Task<bool> SendEventNoticeAsync(User user, PersistentEvent ev, Project project, bool isNew, bool isRegression, int totalOccurrences)
+    {
+        return Task.FromResult(true);
+    }
+
+    public Task SendOrganizationAddedAsync(User sender, Organization organization, User user)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task SendOrganizationInviteAsync(User sender, Organization organization, Invite invite)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task SendOrganizationNoticeAsync(User user, Organization organization, bool isOverMonthlyLimit, bool isOverHourlyLimit)
+    {
+        if (ShouldThrow)
+            throw new InvalidOperationException("Simulated mailer failure.");
+
+        Interlocked.Increment(ref _organizationNoticeCount);
+        lock (OrganizationNoticeCalls)
+        {
+            OrganizationNoticeCalls.Add(new OrganizationNoticeCall(user.Id, organization.Id, isOverMonthlyLimit, isOverHourlyLimit));
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task SendOrganizationPaymentFailedAsync(User owner, Organization organization)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task SendProjectDailySummaryAsync(User user, Project project, IEnumerable<Stack>? mostFrequent, IEnumerable<Stack>? newest, DateTime startDate, bool hasSubmittedEvents, double count, double uniqueCount, double newCount, double fixedCount, int blockedCount, int tooBigCount, bool isFreePlan)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task SendUserEmailVerifyAsync(User user)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task SendUserPasswordResetAsync(User user)
+    {
+        return Task.CompletedTask;
+    }
+
+    public void Reset()
+    {
+        Interlocked.Exchange(ref _organizationNoticeCount, 0);
+        lock (OrganizationNoticeCalls)
+        {
+            OrganizationNoticeCalls.Clear();
+        }
+        ShouldThrow = false;
+    }
+}
+
+public record OrganizationNoticeCall(string UserId, string OrganizationId, bool IsOverMonthlyLimit, bool IsOverHourlyLimit);

--- a/tests/Exceptionless.Tests/Services/NotificationServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/NotificationServiceTests.cs
@@ -1,0 +1,42 @@
+using Exceptionless.Core.Services;
+using Xunit;
+
+namespace Exceptionless.Tests.Services;
+
+public sealed class NotificationServiceTests : TestWithServices
+{
+    private const string PrimaryOrganizationId = "664ec4c1f12e4f2b7a0d4001";
+
+    public NotificationServiceTests(ITestOutputHelper output) : base(output) { }
+
+    private NotificationService NotificationService => GetService<NotificationService>();
+
+    [Fact]
+    public async Task SetOrganizationNotificationSentAsync_WhenCalledInLastMillisecondOfUtcMonth_ShouldWriteObservableMarker()
+    {
+        // Arrange
+        TimeProvider.SetUtcNow(new DateTime(2026, 5, 31, 23, 59, 59, 999, DateTimeKind.Utc));
+
+        // Act
+        await NotificationService.SetOrganizationNotificationSentAsync(PrimaryOrganizationId, isOverMonthlyLimit: true);
+
+        // Assert
+        Assert.True(await NotificationService.IsOrganizationNotificationSentAsync(PrimaryOrganizationId, isOverMonthlyLimit: true));
+    }
+
+    [Fact]
+    public async Task TryAcquireOrganizationNotificationLockAsync_WhenOldHourlyBucketBoundaryPasses_ShouldRemainLocked()
+    {
+        // Arrange
+        await using var firstLock = await NotificationService.TryAcquireOrganizationNotificationLockAsync(PrimaryOrganizationId, isOverMonthlyLimit: true);
+        Assert.NotNull(firstLock);
+
+        // Act
+        TimeProvider.Advance(TimeSpan.FromHours(1).Add(TimeSpan.FromMinutes(1)));
+
+        // Assert
+        Assert.True(await NotificationService.IsOrganizationNotificationLockedAsync(PrimaryOrganizationId, isOverMonthlyLimit: true));
+        await using var secondLock = await NotificationService.TryAcquireOrganizationNotificationLockAsync(PrimaryOrganizationId, isOverMonthlyLimit: true);
+        Assert.Null(secondLock);
+    }
+}

--- a/tests/Exceptionless.Tests/Services/NotificationServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/NotificationServiceTests.cs
@@ -1,4 +1,7 @@
+using System.Threading;
 using Exceptionless.Core.Services;
+using Foundatio.Lock;
+using Foundatio.Messaging;
 using Xunit;
 
 namespace Exceptionless.Tests.Services;
@@ -10,6 +13,42 @@ public sealed class NotificationServiceTests : TestWithServices
     public NotificationServiceTests(ITestOutputHelper output) : base(output) { }
 
     private NotificationService NotificationService => GetService<NotificationService>();
+
+    [Fact]
+    public async Task IsOrganizationNotificationLockedAsync_WhenNoLockIsHeld_ShouldNotAcquireAndReleaseLock()
+    {
+        // Arrange
+        var messageBus = GetService<IMessageBus>();
+        var releaseCount = 0;
+        await messageBus.SubscribeAsync<CacheLockReleased>(_ =>
+        {
+            Interlocked.Increment(ref releaseCount);
+            return Task.CompletedTask;
+        }, TestCancellationToken);
+
+        // Act
+        var isLocked = await NotificationService.IsOrganizationNotificationLockedAsync(PrimaryOrganizationId, isOverMonthlyLimit: true);
+
+        // Assert
+        Assert.False(isLocked);
+        Assert.Equal(0, Volatile.Read(ref releaseCount));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task OrganizationNotificationMethods_WhenOrganizationIdIsNullOrEmpty_ShouldThrowArgumentException(string? organizationId)
+    {
+        // Arrange
+        const bool IsOverMonthlyLimit = true;
+
+        // Act & Assert
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => NotificationService.IsOrganizationNotificationSentAsync(organizationId!, IsOverMonthlyLimit));
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => NotificationService.SetOrganizationNotificationSentAsync(organizationId!, IsOverMonthlyLimit));
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => NotificationService.RemoveOrganizationNotificationSentAsync(organizationId!, IsOverMonthlyLimit));
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => NotificationService.TryAcquireOrganizationNotificationLockAsync(organizationId!, IsOverMonthlyLimit));
+        await Assert.ThrowsAnyAsync<ArgumentException>(() => NotificationService.IsOrganizationNotificationLockedAsync(organizationId!, IsOverMonthlyLimit));
+    }
 
     [Fact]
     public async Task SetOrganizationNotificationSentAsync_WhenCalledInLastMillisecondOfUtcMonth_ShouldWriteObservableMarker()

--- a/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
@@ -1,11 +1,15 @@
 using System.Diagnostics;
 using Exceptionless.Core.Billing;
+using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Messaging.Models;
 using Exceptionless.Core.Models;
+using Exceptionless.Core.Models.WorkItems;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Services;
+using Exceptionless.DateTimeExtensions;
 using Exceptionless.Tests.Extensions;
 using Foundatio.AsyncEx;
+using Foundatio.Caching;
 using Foundatio.Messaging;
 using Foundatio.Repositories;
 using Xunit;
@@ -19,6 +23,7 @@ public sealed class UsageServiceTests : IntegrationTestsBase
     private readonly IProjectRepository _projectRepository;
     private readonly UsageService _usageService;
     private readonly BillingPlans _plans;
+    private readonly ICacheClient _cache;
 
     public UsageServiceTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
     {
@@ -28,6 +33,161 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         _organizationRepository = GetService<IOrganizationRepository>();
         _projectRepository = GetService<IProjectRepository>();
         _plans = GetService<BillingPlans>();
+        _cache = GetService<ICacheClient>();
+    }
+
+    private Task SetMonthlySentMarkerAsync(string organizationId)
+    {
+        return _cache.SetAsync(
+            OrganizationNotificationWorkItem.GetNotificationSentKey(organizationId, isOverMonthlyLimit: true),
+            true,
+            TimeProvider.GetUtcNow().UtcDateTime.EndOfMonth());
+    }
+
+    private Task<bool> MonthlySentMarkerExistsAsync(string organizationId)
+    {
+        return _cache.ExistsAsync(OrganizationNotificationWorkItem.GetNotificationSentKey(organizationId, isOverMonthlyLimit: true));
+    }
+
+    [Fact]
+    public async Task HandleOrganizationChangeAsync_WhenMonthlyPlanLimitIncreases_ShouldResetOverageNotificationSentMarker()
+    {
+        // Arrange
+        var original = new Organization
+        {
+            Id = "664ec4c1f12e4f2b7a0d3001",
+            Name = "Primary Organization",
+            PlanId = _plans.SmallPlan.Id,
+            MaxEventsPerMonth = 100
+        };
+
+        var modified = new Organization
+        {
+            Id = original.Id,
+            Name = original.Name,
+            PlanId = _plans.MediumPlan.Id,
+            MaxEventsPerMonth = 200
+        };
+
+        await SetMonthlySentMarkerAsync(original.Id);
+
+        // Act
+        await _usageService.HandleOrganizationChangeAsync(modified, original);
+
+        // Assert
+        Assert.False(await MonthlySentMarkerExistsAsync(original.Id));
+    }
+
+    [Fact]
+    public async Task HandleOrganizationChangeAsync_WhenPlanChangesToUnlimited_ShouldResetOverageNotificationSentMarker()
+    {
+        // Arrange
+        var original = new Organization
+        {
+            Id = "664ec4c1f12e4f2b7a0d3002",
+            Name = "Primary Organization",
+            PlanId = _plans.EnterprisePlan.Id,
+            MaxEventsPerMonth = _plans.EnterprisePlan.MaxEventsPerMonth
+        };
+
+        var modified = new Organization
+        {
+            Id = original.Id,
+            Name = original.Name,
+            PlanId = _plans.UnlimitedPlan.Id,
+            MaxEventsPerMonth = _plans.UnlimitedPlan.MaxEventsPerMonth
+        };
+
+        await SetMonthlySentMarkerAsync(original.Id);
+
+        // Act
+        await _usageService.HandleOrganizationChangeAsync(modified, original);
+
+        // Assert
+        Assert.False(await MonthlySentMarkerExistsAsync(original.Id));
+    }
+
+    [Fact]
+    public async Task HandleOrganizationChangeAsync_WhenPlanLimitDecreasesBelowCurrentUsage_ShouldResetMarkerAndPublishMonthlyOverage()
+    {
+        // Arrange
+        var messageBus = GetService<IMessageBus>();
+        var countdown = new AsyncCountdownEvent(1);
+        PlanOverage? overage = null;
+        await messageBus.SubscribeAsync<PlanOverage>(po =>
+        {
+            overage = po;
+            countdown.Signal();
+        }, TestCancellationToken);
+
+        var original = new Organization
+        {
+            Id = "664ec4c1f12e4f2b7a0d3003",
+            Name = "Primary Organization",
+            PlanId = _plans.MediumPlan.Id,
+            MaxEventsPerMonth = 200
+        };
+
+        var modified = new Organization
+        {
+            Id = original.Id,
+            Name = original.Name,
+            PlanId = _plans.SmallPlan.Id,
+            MaxEventsPerMonth = 100
+        };
+        modified.GetCurrentUsage(TimeProvider).Total = 150;
+
+        await SetMonthlySentMarkerAsync(original.Id);
+
+        // Act
+        await _usageService.HandleOrganizationChangeAsync(modified, original);
+        await countdown.WaitAsync(TimeSpan.FromMilliseconds(150));
+
+        // Assert
+        Assert.False(await MonthlySentMarkerExistsAsync(original.Id));
+        Assert.NotNull(overage);
+        Assert.Equal(modified.Id, overage.OrganizationId);
+        Assert.False(overage.IsHourly);
+    }
+
+    [Fact]
+    public async Task HandleOrganizationChangeAsync_WhenAlreadyOverMonthlyLimitAndPlanLimitDecreases_ShouldKeepMarkerAndNotPublishMonthlyOverage()
+    {
+        // Arrange
+        var messageBus = GetService<IMessageBus>();
+        var countdown = new AsyncCountdownEvent(1);
+        await messageBus.SubscribeAsync<PlanOverage>(po =>
+        {
+            if (!po.IsHourly)
+                countdown.Signal();
+        }, TestCancellationToken);
+
+        var original = new Organization
+        {
+            Id = "664ec4c1f12e4f2b7a0d3004",
+            Name = "Primary Organization",
+            PlanId = _plans.MediumPlan.Id,
+            MaxEventsPerMonth = 200
+        };
+        original.GetCurrentUsage(TimeProvider).Total = 250;
+
+        var modified = new Organization
+        {
+            Id = original.Id,
+            Name = original.Name,
+            PlanId = _plans.SmallPlan.Id,
+            MaxEventsPerMonth = 100
+        };
+        modified.GetCurrentUsage(TimeProvider).Total = 250;
+
+        await SetMonthlySentMarkerAsync(original.Id);
+
+        // Act
+        await _usageService.HandleOrganizationChangeAsync(modified, original);
+
+        // Assert
+        await Assert.ThrowsAsync<TimeoutException>(() => countdown.WaitAsync(TimeSpan.FromMilliseconds(150)));
+        Assert.True(await MonthlySentMarkerExistsAsync(original.Id));
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
@@ -141,7 +141,7 @@ public sealed class UsageServiceTests : IntegrationTestsBase
 
         // Act
         await _usageService.HandleOrganizationChangeAsync(modified, original);
-        await countdown.WaitAsync(TimeSpan.FromMilliseconds(150));
+        await countdown.WaitAsync(TimeSpan.FromSeconds(5));
 
         // Assert
         Assert.False(await MonthlySentMarkerExistsAsync(original.Id));

--- a/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
@@ -76,6 +76,37 @@ public sealed class UsageServiceTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task HandleOrganizationChangeAsync_WhenMonthlyPlanLimitIncreasesButOrganizationIsStillOverLimit_ShouldKeepOverageNotificationSentMarker()
+    {
+        // Arrange
+        var original = new Organization
+        {
+            Id = "664ec4c1f12e4f2b7a0d3005",
+            Name = "Primary Organization",
+            PlanId = _plans.SmallPlan.Id,
+            MaxEventsPerMonth = 100
+        };
+        original.GetCurrentUsage(TimeProvider).Total = 250;
+
+        var modified = new Organization
+        {
+            Id = original.Id,
+            Name = original.Name,
+            PlanId = _plans.MediumPlan.Id,
+            MaxEventsPerMonth = 200
+        };
+        modified.GetCurrentUsage(TimeProvider).Total = 250;
+
+        await SetMonthlySentMarkerAsync(original.Id);
+
+        // Act
+        await _usageService.HandleOrganizationChangeAsync(modified, original);
+
+        // Assert
+        Assert.True(await MonthlySentMarkerExistsAsync(original.Id));
+    }
+
+    [Fact]
     public async Task HandleOrganizationChangeAsync_WhenPlanChangesToUnlimited_ShouldResetOverageNotificationSentMarker()
     {
         // Arrange

--- a/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
@@ -186,7 +186,7 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         await _usageService.HandleOrganizationChangeAsync(modified, original);
 
         // Assert
-        await Assert.ThrowsAsync<TimeoutException>(() => countdown.WaitAsync(TimeSpan.FromMilliseconds(150)));
+        await Assert.ThrowsAsync<TimeoutException>(() => countdown.WaitAsync(TimeSpan.FromSeconds(1)));
         Assert.True(await MonthlySentMarkerExistsAsync(original.Id));
     }
 

--- a/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
@@ -7,7 +7,6 @@ using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Services;
 using Exceptionless.Tests.Extensions;
 using Foundatio.AsyncEx;
-using Foundatio.Caching;
 using Foundatio.Messaging;
 using Foundatio.Repositories;
 using Xunit;
@@ -22,7 +21,6 @@ public sealed class UsageServiceTests : IntegrationTestsBase
     private readonly UsageService _usageService;
     private readonly NotificationService _notificationService;
     private readonly BillingPlans _plans;
-    private readonly ICacheClient _cache;
 
     public UsageServiceTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
     {
@@ -33,7 +31,6 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         _organizationRepository = GetService<IOrganizationRepository>();
         _projectRepository = GetService<IProjectRepository>();
         _plans = GetService<BillingPlans>();
-        _cache = GetService<ICacheClient>();
     }
 
     private Task SetMonthlySentMarkerAsync(string organizationId)

--- a/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
@@ -1,12 +1,10 @@
 using System.Diagnostics;
 using Exceptionless.Core.Billing;
 using Exceptionless.Core.Extensions;
-using Exceptionless.Core.Jobs.WorkItemHandlers;
 using Exceptionless.Core.Messaging.Models;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Services;
-using Exceptionless.DateTimeExtensions;
 using Exceptionless.Tests.Extensions;
 using Foundatio.AsyncEx;
 using Foundatio.Caching;
@@ -22,6 +20,7 @@ public sealed class UsageServiceTests : IntegrationTestsBase
     private readonly IOrganizationRepository _organizationRepository;
     private readonly IProjectRepository _projectRepository;
     private readonly UsageService _usageService;
+    private readonly NotificationService _notificationService;
     private readonly BillingPlans _plans;
     private readonly ICacheClient _cache;
 
@@ -30,6 +29,7 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         TimeProvider.SetUtcNow(new DateTime(2015, 2, 13, 0, 0, 0, DateTimeKind.Utc));
         Log.SetLogLevel<OrganizationRepository>(LogLevel.Information);
         _usageService = GetService<UsageService>();
+        _notificationService = GetService<NotificationService>();
         _organizationRepository = GetService<IOrganizationRepository>();
         _projectRepository = GetService<IProjectRepository>();
         _plans = GetService<BillingPlans>();
@@ -38,15 +38,12 @@ public sealed class UsageServiceTests : IntegrationTestsBase
 
     private Task SetMonthlySentMarkerAsync(string organizationId)
     {
-        return _cache.SetAsync(
-            OrganizationNotificationWorkItemHandler.GetNotificationSentKey(organizationId, isOverMonthlyLimit: true),
-            true,
-            TimeProvider.GetUtcNow().UtcDateTime.EndOfMonth());
+        return _notificationService.SetOrganizationNotificationSentAsync(organizationId, isOverMonthlyLimit: true);
     }
 
     private Task<bool> MonthlySentMarkerExistsAsync(string organizationId)
     {
-        return _cache.ExistsAsync(OrganizationNotificationWorkItemHandler.GetNotificationSentKey(organizationId, isOverMonthlyLimit: true));
+        return _notificationService.IsOrganizationNotificationSentAsync(organizationId, isOverMonthlyLimit: true);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
@@ -1,9 +1,9 @@
 using System.Diagnostics;
 using Exceptionless.Core.Billing;
 using Exceptionless.Core.Extensions;
+using Exceptionless.Core.Jobs.WorkItemHandlers;
 using Exceptionless.Core.Messaging.Models;
 using Exceptionless.Core.Models;
-using Exceptionless.Core.Models.WorkItems;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Services;
 using Exceptionless.DateTimeExtensions;
@@ -39,14 +39,14 @@ public sealed class UsageServiceTests : IntegrationTestsBase
     private Task SetMonthlySentMarkerAsync(string organizationId)
     {
         return _cache.SetAsync(
-            OrganizationNotificationWorkItem.GetNotificationSentKey(organizationId, isOverMonthlyLimit: true),
+            OrganizationNotificationWorkItemHandler.GetNotificationSentKey(organizationId, isOverMonthlyLimit: true),
             true,
             TimeProvider.GetUtcNow().UtcDateTime.EndOfMonth());
     }
 
     private Task<bool> MonthlySentMarkerExistsAsync(string organizationId)
     {
-        return _cache.ExistsAsync(OrganizationNotificationWorkItem.GetNotificationSentKey(organizationId, isOverMonthlyLimit: true));
+        return _cache.ExistsAsync(OrganizationNotificationWorkItemHandler.GetNotificationSentKey(organizationId, isOverMonthlyLimit: true));
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Users received 6 duplicate plan-limit overage emails in a single day.

## Root Cause

Every web pod registers `EnqueueOrganizationNotificationOnPlanOverage` as a startup action. Foundatio pub/sub delivers each `PlanOverage` message to all subscribers, so a single monthly overage event caused every running pod to enqueue its own copy of the work item.

The original `ThrottlingLockProvider(slotsPerPeriod: 1, period: 1 hour)` used the blocking `TryAcquireAsync` path. Duplicate items could wait for the next hourly bucket, acquire a fresh slot, and send one email per hour until the duplicate queue entries were drained.

## Fix

### Layer 1 - Queue-level dedup

- `OrganizationNotificationWorkItem` uses a stable unique identifier: `Organization:{orgId}:notification:{monthly|hourly}`.
- `DuplicateDetectionQueueBehavior<WorkItemData>` collapses identical fanout enqueues before they become multiple queue entries.
- Hourly and monthly work items intentionally use different dedup keys.

### Layer 2 - NotificationService idempotency

`NotificationService` owns the notification cache keys, monthly sent marker, and monthly notification lock. Callers do not construct or read those cache keys directly.

1. Monthly work items acquire the notification lock through `NotificationService` using a non-blocking `CacheLockProvider` lock with a 90-minute lease. The lease is longer than the 1-hour work-item timeout so a slow send does not let a duplicate worker acquire the notification lock at the queue visibility boundary.
2. Monthly work items re-check the current organization usage document before sending, so stale queued work items do not email after an upgrade or other state change leaves the organization under its monthly limit.
3. After a successful monthly send, `NotificationService` writes the sent marker with an absolute expiration at the next UTC month boundary. If the send completes in the final milliseconds of the month, the expiration is extended only enough to satisfy Foundatio's 5ms minimum cache TTL so the marker is not treated as already expired.
4. Effective monthly limit increases remove the sent marker so the new higher limit can notify later if crossed. Downgrades remove the marker and publish monthly `PlanOverage` only when the downgrade crosses the organization from not-over to over. Downgrades while already over monthly limit keep the marker and do not resend.
5. Hourly work items return the base empty lock, complete normally, and never enter the monthly email lock or sent-marker path.

The sent marker is intentionally written after `SendOverageNotificationsAsync`, not before it. This preserves existing retry behavior for mailer failures instead of silently dropping a notification after a pre-send marker write.

## Bugs fixed in this PR

| # | Bug | Impact |
|---|-----|--------|
| 1 | Hourly items returned `null` from `GetWorkItemLockAsync`, causing `WorkItemJob` to abandon them | Hourly items retried forever |
| 2 | Monthly duplicate lock acquisition used a blocking overload | Worker slot could wait up to the lock period |
| 3 | Test helper called `HandleItemAsync` even when the lock was `null` | Tests bypassed production abandon semantics |
| 4 | The monthly sent marker expired after 24 hours | Backed-up or stale monthly duplicates could send again later |
| 5 | Plan limit changes did not clear the monthly sent marker | New plan state could be suppressed by old overage state |
| 6 | Limited-to-unlimited upgrades compared as a decrease because unlimited is stored as `-1` | Unlimited upgrades would not reset overage email state |
| 7 | Downgrades that crossed current monthly usage did not publish monthly `PlanOverage` | Organization could become newly over limit without the overage email path being triggered |
| 8 | The handler trusted a stale queued monthly flag without re-checking current org usage | A delayed monthly work item could email after the org was no longer over limit |
| 9 | Month-boundary sent-marker expiration could be below Foundatio's 5ms minimum TTL | A duplicate processed in the final milliseconds of the month could bypass the sent marker |

## Tests

- 8 handler unit/RCA tests for fanout, queue dedup, unique keys, hourly flag mapping, and queue behavior registration.
- 2 `NotificationService` tests for the final-millisecond sent marker and the 90-minute lock remaining held across the old hourly bucket boundary.
- 18 handler integration tests for stale monthly duplicates, stale no-longer-over work items, 24-hour same-month delayed duplicates, UTC month-boundary resend when still over limit, final-millisecond sent-marker persistence, hourly-before-monthly, hourly-after-monthly, concurrent lock abandon behavior, send failure retry behavior, missing orgs, and recipient filtering.
- 16 `UsageService` integration tests including coverage for monthly limit increases, limited-to-unlimited upgrades, downgrade crossing into overage, and already-over downgrades not resending monthly overage.
