### PR TITLE
Add Svelte error page handling

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/route-guards.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/route-guards.ts
@@ -1,0 +1,47 @@
+import { browser } from '$app/environment';
+import { error } from '@sveltejs/kit';
+
+import type { SavedView } from './models';
+
+type SavedViewRoute = 'events' | 'stacks';
+
+export async function requireSavedViewSlug(fetch: typeof globalThis.fetch, view: SavedViewRoute, slug: string): Promise<void> {
+    if (!browser) {
+        return;
+    }
+
+    const accessToken = getStoredString('satellizer_token');
+    const organizationId = getStoredString('organization');
+    if (!accessToken || !organizationId) {
+        return;
+    }
+
+    const response = await fetch(`/api/v2/organizations/${organizationId}/saved-views/${view}`, {
+        headers: {
+            Authorization: `Bearer ${accessToken}`
+        }
+    });
+
+    if (!response.ok) {
+        return;
+    }
+
+    const savedViews = (await response.json()) as SavedView[];
+    if (!savedViews.some((savedView) => savedView.slug === slug)) {
+        throw error(404, `The saved ${view === 'events' ? 'Events' : 'Stacks'} view "${slug}" could not be found.`);
+    }
+}
+
+function getStoredString(key: string): string | undefined {
+    const value = localStorage.getItem(key);
+    if (!value) {
+        return undefined;
+    }
+
+    try {
+        const parsed = JSON.parse(value) as unknown;
+        return typeof parsed === 'string' ? parsed : value;
+    } catch {
+        return value;
+    }
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -2,7 +2,7 @@ import type { IFilter } from '$comp/faceted-filter';
 import type { ColumnOrderState, ColumnVisibilityState } from '@tanstack/svelte-table';
 
 import { goto } from '$app/navigation';
-import { buildFilterCacheKey, deserializeFilters } from '$features/events/components/filters/helpers.svelte';
+import { buildFilterCacheKey, deserializeFilters, serializeFilters } from '$features/events/components/filters/helpers.svelte';
 import { organization } from '$features/organizations/context.svelte';
 
 import type { SavedView } from './models';
@@ -46,8 +46,22 @@ export interface UseSavedViewsReturn {
     handleResetToSaved: () => void;
     isEnabled: boolean;
     isLoading: boolean;
+    isMissing: boolean;
     isModified: boolean;
     savedViews: SavedView[];
+}
+
+export function filterDefinitionsEqual(a: null | string | undefined, b: null | string | undefined): boolean {
+    return normalizeFilterDefinitions(a) === normalizeFilterDefinitions(b);
+}
+
+export function hasMissingSavedViewSlug(options: {
+    activeSavedView: SavedView | undefined;
+    isLoading: boolean;
+    savedViews: SavedView[] | undefined;
+    slug: string | undefined;
+}): boolean {
+    return !!options.slug && !options.activeSavedView && !!options.savedViews && !options.isLoading;
 }
 
 export function setSortQueryParam(queryParams: SavedViewQueryParams, value: null | string): void {
@@ -214,6 +228,15 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         return false;
     });
 
+    const isMissing = $derived(
+        hasMissingSavedViewSlug({
+            activeSavedView,
+            isLoading: savedViewsListQuery.isLoading,
+            savedViews: savedViewsListQuery.data,
+            slug: options.slug
+        })
+    );
+
     function handleLoadView(view: SavedView) {
         if (options.baseHref) {
             goto(savedViewHref(view));
@@ -274,6 +297,9 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         get isLoading() {
             return savedViewsListQuery.isLoading;
         },
+        get isMissing() {
+            return isMissing;
+        },
         get isModified() {
             return isModified;
         },
@@ -314,10 +340,6 @@ function columnsEqual(
     });
 }
 
-function filterDefinitionsEqual(a: null | string | undefined, b: null | string | undefined): boolean {
-    return normalizeFilterDefinitions(a) === normalizeFilterDefinitions(b);
-}
-
 function normalizeFilterDefinitions(value: null | string | undefined): string {
     if (!value) {
         return '[]';
@@ -329,7 +351,7 @@ function normalizeFilterDefinitions(value: null | string | undefined): string {
             return '[]';
         }
 
-        return JSON.stringify(parsed);
+        return serializeFilters(deserializeFilters(value));
     } catch {
         return value;
     }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -5,7 +5,19 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { SavedView } from './models';
 
 import { invalidateSavedViewQueries, queryKeys, removeSavedViewFromCaches, SAVED_VIEW_REFRESH_DELAY_MS, syncSavedViewCaches } from './api.svelte';
-import { type SavedViewQueryParams, setSortQueryParam, setTimeQueryParam, supportsSortQueryParam, supportsTimeQueryParam } from './use-saved-views.svelte';
+import {
+    filterDefinitionsEqual,
+    hasMissingSavedViewSlug,
+    type SavedViewQueryParams,
+    setSortQueryParam,
+    setTimeQueryParam,
+    supportsSortQueryParam,
+    supportsTimeQueryParam
+} from './use-saved-views.svelte';
+
+vi.mock('$features/auth/index.svelte', () => ({
+    accessToken: { current: 'token_123' }
+}));
 
 const TEST_ORG_ID = '507f1f77bcf86cd799439011';
 const TEST_USER_ID = '66a1b2c3d4e5f6a7b8c9d0e1';
@@ -45,6 +57,77 @@ function buildSavedView({ id, name, ...overrides }: Partial<SavedView> & Pick<Sa
 }
 
 describe('useSavedViews', () => {
+    describe('saved view slug resolution', () => {
+        it('reports a missing slug after saved views finish loading without a match', () => {
+            // Arrange
+            const savedView = buildSavedView({ id: 'view-1', name: 'My Saved View' });
+
+            // Act
+            const result = hasMissingSavedViewSlug({
+                activeSavedView: undefined,
+                isLoading: false,
+                savedViews: [savedView],
+                slug: 'most-frequent'
+            });
+
+            // Assert
+            expect(result).toBe(true);
+        });
+
+        it('reports a missing slug while cached saved-view data is background fetching', () => {
+            // Act
+            const result = hasMissingSavedViewSlug({
+                activeSavedView: undefined,
+                isLoading: false,
+                savedViews: [],
+                slug: 'most-frequent'
+            });
+
+            // Assert
+            expect(result).toBe(true);
+        });
+
+        it('does not report a missing slug before saved views are available', () => {
+            // Act
+            const result = hasMissingSavedViewSlug({
+                activeSavedView: undefined,
+                isLoading: false,
+                savedViews: undefined,
+                slug: 'most-frequent'
+            });
+
+            // Assert
+            expect(result).toBe(false);
+        });
+
+        it('does not report a missing slug when there is no slug route parameter', () => {
+            // Act
+            const result = hasMissingSavedViewSlug({
+                activeSavedView: undefined,
+                isLoading: false,
+                savedViews: [],
+                slug: undefined
+            });
+
+            // Assert
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('filter definition comparison', () => {
+        it('treats omitted empty filter values as equal to hydrated empty values', () => {
+            // Arrange
+            const seededDefinitions = '[{"type":"date","term":"date","value":"[now-7d TO now]"},{"type":"project"}]';
+            const serializedDefinitions = '[{"type":"date","term":"date","value":"[now-7d TO now]"},{"type":"project","value":[]}]';
+
+            // Act
+            const result = filterDefinitionsEqual(serializedDefinitions, seededDefinitions);
+
+            // Assert
+            expect(result).toBe(true);
+        });
+    });
+
     describe('time parameter detection', () => {
         it('detects when time is not in query params (stream page)', () => {
             // Arrange

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -43,6 +43,7 @@
     import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
     import { DEFAULT_LIMIT, DEFAULT_OFFSET, useFetchClientStatus } from '$shared/api/api.svelte';
     import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+    import { error } from '@sveltejs/kit';
     import { createTable } from '@tanstack/svelte-table';
     import { queryParamsState } from 'kit-query-params';
     import { useEventListener, watch } from 'runed';
@@ -144,6 +145,10 @@
     $effect(() => {
         document.title = `${pageTitle} - Exceptionless`;
     });
+
+    function throwSavedViewNotFound(): never {
+        throw error(404, `The saved Events view "${page.params.slug}" could not be found.`);
+    }
 
     // NOTE: This might be applying query string parameters when redirecting away.
     watch(
@@ -426,6 +431,10 @@
         onFilterChanged(new DateFilter('date', toDateMathRange(start, end)));
     }
 </script>
+
+{#if savedViewsState.isMissing}
+    {throwSavedViewNotFound()}
+{/if}
 
 <div class="flex flex-col">
     <div class="mb-4 flex flex-wrap items-start gap-2">

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[slug=savedview]/+page.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[slug=savedview]/+page.ts
@@ -1,0 +1,7 @@
+import { requireSavedViewSlug } from '$features/saved-views/route-guards';
+
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ fetch, params }) => {
+    await requireSavedViewSlug(fetch, 'events', params.slug);
+};

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -40,6 +40,7 @@
     import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
     import { DEFAULT_LIMIT, DEFAULT_OFFSET, useFetchClientStatus } from '$shared/api/api.svelte';
     import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+    import { error } from '@sveltejs/kit';
     import { createTable } from '@tanstack/svelte-table';
     import { queryParamsState } from 'kit-query-params';
     import { useEventListener, watch } from 'runed';
@@ -137,6 +138,10 @@
     $effect(() => {
         document.title = `${pageTitle} - Exceptionless`;
     });
+
+    function throwSavedViewNotFound(): never {
+        throw error(404, `The saved Stacks view "${page.params.slug}" could not be found.`);
+    }
 
     watch(
         () => organization.current,
@@ -397,6 +402,10 @@
         onFilterChanged(new DateFilter('date', toDateMathRange(start, end)));
     }
 </script>
+
+{#if savedViewsState.isMissing}
+    {throwSavedViewNotFound()}
+{/if}
 
 <div class="flex flex-col">
     <div class="mb-4 flex flex-wrap items-start gap-2">

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[slug=savedview]/+page.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[slug=savedview]/+page.ts
@@ -1,0 +1,7 @@
+import { requireSavedViewSlug } from '$features/saved-views/route-guards';
+
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ fetch, params }) => {
+    await requireSavedViewSlug(fetch, 'stacks', params.slug);
+};

--- a/src/Exceptionless.Web/ClientApp/src/routes/+error.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/+error.svelte
@@ -1,0 +1,177 @@
+<script lang="ts">
+    import { resolve } from '$app/paths';
+    import { page } from '$app/state';
+    import Logo from '$comp/logo.svelte';
+    import { Button } from '$comp/ui/button';
+    import { accessToken } from '$features/auth/index.svelte';
+    import { documentationHref, supportIssuesHref } from '$features/shared/help-links';
+    import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
+    import BookOpenIcon from '@lucide/svelte/icons/book-open';
+    import FolderKanbanIcon from '@lucide/svelte/icons/folder-kanban';
+    import LogInIcon from '@lucide/svelte/icons/log-in';
+    import SearchXIcon from '@lucide/svelte/icons/search-x';
+    import ShieldAlertIcon from '@lucide/svelte/icons/shield-alert';
+    import SparklesIcon from '@lucide/svelte/icons/sparkles';
+
+    const isAuthenticated = $derived(Boolean(accessToken.current));
+    const isNotFound = $derived(page.status === 404);
+    const statusLabel = $derived(isNotFound ? '404' : String(page.status));
+    const title = $derived(getErrorTitle(page.status));
+    const message = $derived(getErrorMessage(page.status, page.error?.message));
+    const primaryHref = $derived(isAuthenticated ? resolve('/(app)/event') : resolve('/(auth)/login'));
+    const primaryLabel = $derived(isAuthenticated ? 'Open Events' : 'Log in');
+
+    function getErrorTitle(status: number): string {
+        if (status === 403) {
+            return "You don't have access to this page";
+        }
+
+        if (status === 404) {
+            return "We couldn't find that page";
+        }
+
+        if (status === 410) {
+            return 'That page is no longer available';
+        }
+
+        if (status === 426) {
+            return 'This page needs a plan change';
+        }
+
+        if (status >= 500) {
+            return 'Something went wrong on our side';
+        }
+
+        return 'This page hit an error';
+    }
+
+    function getErrorMessage(status: number, fallback?: string): string {
+        if (status === 403) {
+            return 'Your account is signed in, but it does not have permission to open this resource.';
+        }
+
+        if (status === 404) {
+            return 'The page may have moved, the link may be stale, or the item may no longer exist.';
+        }
+
+        if (status === 410) {
+            return 'The item may have been removed, archived, or replaced by a newer location.';
+        }
+
+        if (status === 426) {
+            return 'The resource exists, but your current plan or account state cannot open it yet.';
+        }
+
+        if (status >= 500) {
+            return 'The request reached Exceptionless, but the service could not finish it. Try again in a moment.';
+        }
+
+        return fallback ?? 'Something unexpected happened while opening this page.';
+    }
+</script>
+
+<svelte:head>
+    <title>{isNotFound ? 'Page Not Found' : 'Error'} - Exceptionless</title>
+</svelte:head>
+
+<main class="relative flex min-h-screen overflow-hidden bg-background text-foreground" aria-labelledby="error-title">
+    <div
+        class="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--border))_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--border))_1px,transparent_1px)] bg-size-[48px_48px] opacity-20"
+    ></div>
+    <div class="absolute inset-x-0 top-0 h-px bg-linear-to-r from-transparent via-primary/70 to-transparent"></div>
+
+    <section
+        class="relative mx-auto grid w-full max-w-6xl items-center gap-10 px-6 py-12 lg:grid-cols-[minmax(0,1fr)_22rem] lg:px-10"
+        aria-describedby="error-description"
+    >
+        <div class="max-w-3xl">
+            <Logo class="mx-0 mb-12 max-h-12" />
+
+            <div class="mb-8 inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-sm font-medium text-primary">
+                {#if isNotFound}
+                    <SearchXIcon class="size-4" aria-hidden="true" />
+                {:else}
+                    <ShieldAlertIcon class="size-4" aria-hidden="true" />
+                {/if}
+                <span>Status {statusLabel}</span>
+            </div>
+
+            <h1 id="error-title" class="max-w-2xl text-4xl leading-tight font-semibold tracking-normal text-balance sm:text-5xl lg:text-6xl">{title}</h1>
+            <p id="error-description" class="mt-5 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">{message}</p>
+
+            <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+                <Button href={primaryHref} size="xl" class="w-full sm:w-auto">
+                    {#if isAuthenticated}
+                        <SparklesIcon aria-hidden="true" />
+                    {:else}
+                        <LogInIcon aria-hidden="true" />
+                    {/if}
+                    {primaryLabel}
+                </Button>
+                {#if isAuthenticated}
+                    <Button href={resolve('/(app)/project/list')} variant="outline" size="xl" class="w-full sm:w-auto">
+                        <FolderKanbanIcon aria-hidden="true" />
+                        View Projects
+                    </Button>
+                {:else}
+                    <Button href={documentationHref} variant="outline" size="xl" class="w-full sm:w-auto">
+                        <BookOpenIcon aria-hidden="true" />
+                        Documentation
+                    </Button>
+                {/if}
+            </div>
+        </div>
+
+        <aside class="rounded-xl border border-border bg-card/80 p-5 shadow-2xl shadow-black/30 backdrop-blur" aria-label="Recovery options">
+            <div class="mb-5 flex items-center justify-between gap-4">
+                <div>
+                    <p class="text-sm font-medium text-muted-foreground">Recovery</p>
+                    <h2 class="text-xl font-semibold">Next best places</h2>
+                </div>
+                <div class="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                    <ArrowRightIcon class="size-5" aria-hidden="true" />
+                </div>
+            </div>
+
+            <nav aria-label="Error page shortcuts" class="space-y-2">
+                <a
+                    class="group flex items-center justify-between rounded-lg border border-border bg-background/60 px-3 py-3 text-sm transition-colors hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+                    href={primaryHref}
+                >
+                    <span>{primaryLabel}</span>
+                    <ArrowRightIcon class="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+                </a>
+                {#if isAuthenticated}
+                    <a
+                        class="group flex items-center justify-between rounded-lg border border-border bg-background/60 px-3 py-3 text-sm transition-colors hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+                        href={resolve('/(app)/stack')}
+                    >
+                        <span>Open Stacks</span>
+                        <ArrowRightIcon class="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+                    </a>
+                    <a
+                        class="group flex items-center justify-between rounded-lg border border-border bg-background/60 px-3 py-3 text-sm transition-colors hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+                        href={resolve('/(app)/project/list')}
+                    >
+                        <span>View Projects</span>
+                        <ArrowRightIcon class="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+                    </a>
+                {/if}
+                <a
+                    class="group flex items-center justify-between rounded-lg border border-border bg-background/60 px-3 py-3 text-sm transition-colors hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+                    href={documentationHref}
+                >
+                    <span>Documentation</span>
+                    <ArrowRightIcon class="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+                </a>
+                <a
+                    class="group flex items-center justify-between rounded-lg border border-border bg-background/60 px-3 py-3 text-sm transition-colors hover:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-none"
+                    href={supportIssuesHref}
+                >
+                    <span>Support</span>
+                    <ArrowRightIcon class="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+                </a>
+            </nav>
+        </aside>
+    </section>
+</main>


### PR DESCRIPTION
Adds a shared Svelte error page for routed failures and makes missing saved-view slugs return a real 404 instead of rendering the Events or Stacks list pages.

Summary:
- Add a status-aware `+error.svelte` with recovery links for authenticated and unauthenticated users.
- Add client-side saved-view slug route guards for Events and Stacks routes.
- Surface missing saved-view slugs through the shared 404 page.
- Add regression coverage for missing saved-view slug detection.

Validation:
- `npm run format`
- `npm run test:unit -- src/lib/features/saved-views/use-saved-views.test.ts`
- `npm run check`
- `npm run lint`
- `npm run build`
- Browser verified `/next/stack/most-frequent-404s2` and `/next/event/this-view-does-not-exist` render the 404 page.