### PR TITLE
Fix UI list filters, stack navigation, and pagination

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
@@ -174,6 +174,7 @@ export interface GetStackCountRequest {
 }
 
 export interface GetStackEventsRequest {
+    enabled?: () => boolean;
     params?: {
         after?: string;
         before?: string;
@@ -409,7 +410,7 @@ export function getStackEventsQuery(request: GetStackEventsRequest) {
     const queryClient = useQueryClient();
 
     return createQuery<PersistentEvent[], ProblemDetails>(() => ({
-        enabled: () => !!accessToken.current && !!request.route.stackId,
+        enabled: () => !!accessToken.current && !!request.route.stackId && (request.enabled?.() ?? true),
         onSuccess: (data: PersistentEvent[]) => {
             data.forEach((event) => {
                 queryClient.setQueryData(queryKeys.id(event.id!), event);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/event-detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/event-detail-sheet.svelte
@@ -2,10 +2,12 @@
     import type { IFilter } from '$comp/faceted-filter';
     import type { ProblemDetails } from '@exceptionless/fetchclient';
 
-    import { resolve } from '$app/paths';
     import DetailSheet from '$comp/detail-sheet.svelte';
 
+    import type { PersistentEvent } from '../models';
+
     import EventsOverview from './events-overview.svelte';
+    import { buildEventDetailsHref } from './summary';
 
     interface Props {
         detailsHref?: string;
@@ -17,7 +19,15 @@
 
     let { detailsHref, eventId = $bindable(), filterChanged, onClose, onError }: Props = $props();
 
-    const resolvedHref = $derived(detailsHref ?? (eventId ? resolve('/(app)/event/[eventId=objectid]', { eventId }) : '#'));
+    let currentEventDetails = $state<{ eventId: string; stackId: string }>();
+
+    const resolvedHref = $derived(
+        detailsHref ?? (eventId ? buildEventDetailsHref(eventId, currentEventDetails?.eventId === eventId ? currentEventDetails.stackId : undefined) : '#')
+    );
+
+    function handleEventLoaded(event: PersistentEvent): void {
+        currentEventDetails = { eventId: event.id, stackId: event.stack_id };
+    }
 
     function handleError(problem: ProblemDetails) {
         if (onError) {
@@ -30,6 +40,6 @@
 
 <DetailSheet detailsHref={resolvedHref} {onClose} open={!!eventId} title="Event">
     {#if eventId}
-        <EventsOverview {filterChanged} id={eventId} {handleError} onNavigate={(newId) => (eventId = newId)} />
+        <EventsOverview {filterChanged} id={eventId} {handleError} onEventLoaded={handleEventLoaded} onNavigate={(newId) => (eventId = newId)} />
     {/if}
 </DetailSheet>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
@@ -39,10 +39,11 @@
         filterChanged: (filter: IFilter) => void;
         handleError: (problem: ProblemDetails) => void;
         id: string;
+        onEventLoaded?: (event: PersistentEvent) => void;
         onNavigate?: (eventId: string) => void;
     }
 
-    let { filterChanged, handleError, id, onNavigate }: Props = $props();
+    let { filterChanged, handleError, id, onEventLoaded, onNavigate }: Props = $props();
 
     function getTabs(event?: null | PersistentEvent, project?: ViewProject): TabType[] {
         if (!event) {
@@ -128,6 +129,7 @@
     let tabsListRef = $state<HTMLElement | null>(null);
     let canScrollTabsLeft = $state(false);
     let canScrollTabsRight = $state(false);
+    let notifiedEventId = $state('');
     let showJsonDialog = $state(false);
 
     function updateTabsOverflow(): void {
@@ -177,6 +179,13 @@
 
         if (eventQuery.isError) {
             handleError(eventQuery.error);
+        }
+    });
+
+    $effect(() => {
+        if (event && event.id !== notifiedEventId) {
+            notifiedEventId = event.id;
+            onEventLoaded?.(event);
         }
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/helpers.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/helpers.svelte.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { deserializeFilters, quoteIfSpecialCharacters, serializeFilters, toFilter } from './helpers.svelte';
+import { applyTimeFilter, deserializeFilters, quoteIfSpecialCharacters, serializeFilters, toFilter, toFilterFromSerializedFilters } from './helpers.svelte';
 import {
     BooleanFilter,
     DateFilter,
@@ -60,6 +60,19 @@ describe('helpers.svelte', () => {
             expect(quoteIfSpecialCharacters(char)).toBe(`"${char}"`);
             expect(quoteIfSpecialCharacters(`foo${char}bar`)).toBe(`"foo${char}bar"`);
         }
+    });
+});
+
+describe('applyTimeFilter', () => {
+    it('removes an existing date filter when time is explicitly empty', () => {
+        // Arrange
+        const filters = [new DateFilter('date', '[now-7d TO now]'), new StringFilter('stack', 'stack-1')];
+
+        // Act
+        const result = applyTimeFilter(filters, null);
+
+        // Assert
+        expect(result.map((filter) => filter.key)).toEqual(['string-stack']);
     });
 });
 
@@ -183,6 +196,30 @@ describe('serializeFilters', () => {
         expect(result[0].type).toBe('keyword');
         expect(result[1].type).toBe('status');
         expect(result[2].type).toBe('boolean');
+    });
+});
+
+describe('toFilterFromSerializedFilters', () => {
+    it('derives the filter expression from serialized filter controls', () => {
+        // Arrange
+        const serialized = serializeFilters([new DateFilter('date', '[now-7d TO now]'), new StringFilter('stack', 'stack-1')]);
+
+        // Act
+        const result = toFilterFromSerializedFilters(serialized);
+
+        // Assert
+        expect(result).toBe('stack:"stack-1"');
+    });
+
+    it('returns null when serialized filters contain only date controls', () => {
+        // Arrange
+        const serialized = serializeFilters([new DateFilter('date', '[now-7d TO now]')]);
+
+        // Act
+        const result = toFilterFromSerializedFilters(serialized);
+
+        // Assert
+        expect(result).toBeNull();
     });
 });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/helpers.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/helpers.svelte.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { applyTimeFilter, deserializeFilters, quoteIfSpecialCharacters, serializeFilters, toFilter, toFilterFromSerializedFilters } from './helpers.svelte';
+import {
+    applyTimeFilter,
+    deserializeFilters,
+    filterChanged,
+    quoteIfSpecialCharacters,
+    serializeFilters,
+    toFilter,
+    toFilterFromSerializedFilters
+} from './helpers.svelte';
 import {
     BooleanFilter,
     DateFilter,
@@ -73,6 +81,52 @@ describe('applyTimeFilter', () => {
 
         // Assert
         expect(result.map((filter) => filter.key)).toEqual(['string-stack']);
+    });
+});
+
+describe('filterChanged', () => {
+    it('merges duplicate multi-value filters by key', () => {
+        // Arrange
+        const existing = new StatusFilter(['open'] as never[]);
+        const added = new StatusFilter(['regressed'] as never[]);
+
+        // Act
+        const result = filterChanged([existing], added);
+
+        // Assert
+        expect(result).toHaveLength(1);
+        expect(result[0]).toBeInstanceOf(StatusFilter);
+        expect((result[0] as StatusFilter).value).toEqual(['open', 'regressed']);
+    });
+
+    it('replaces duplicate scalar filters by key', () => {
+        // Arrange
+        const existing = new ReferenceFilter('ref-1');
+        const added = new ReferenceFilter('ref-2');
+
+        // Act
+        const result = filterChanged([existing], added);
+
+        // Assert
+        expect(result).toHaveLength(1);
+        expect(result[0]).toBeInstanceOf(ReferenceFilter);
+        expect((result[0] as ReferenceFilter).value).toBe('ref-2');
+    });
+
+    it('deduplicates hidden filters by key', () => {
+        // Arrange
+        const existing = new BooleanFilter('bot', true);
+        existing.hidden = true;
+        const added = new BooleanFilter('bot');
+
+        // Act
+        const result = filterChanged([existing], added);
+
+        // Assert
+        expect(result).toHaveLength(1);
+        expect(result[0]).toBeInstanceOf(BooleanFilter);
+        expect((result[0] as BooleanFilter).value).toBe(true);
+        expect(result[0]?.hidden).toBe(false);
     });
 });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/helpers.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/helpers.svelte.ts
@@ -37,6 +37,8 @@ export function applyTimeFilter(filters: IFilter[], time: null | string): IFilte
         if (time) {
             const dateFilter = filters[dateFilterIndex] as DateFilter;
             dateFilter.value = time;
+        } else {
+            filters.splice(dateFilterIndex, 1);
         }
     } else if (time) {
         filters.push(new DateFilter('date', time));
@@ -220,6 +222,11 @@ export function toFilter(filters: IFilter[]): string {
         .filter(Boolean)
         .join(' ')
         .trim();
+}
+
+export function toFilterFromSerializedFilters(json: string): null | string {
+    const filter = toFilter(deserializeFilters(json).filter((f) => f.type !== 'date'));
+    return filter || null;
 }
 
 export function updateFilterCache(cacheKey: string, filters: IFilter[]) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/helpers.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/helpers.svelte.ts
@@ -240,31 +240,34 @@ export function updateFilterCache(cacheKey: string, filters: IFilter[]) {
     filterCache.set(cacheKey, filters);
 }
 
+function mergeDuplicateFilter(existingFilter: IFilter, filter: IFilter): void {
+    existingFilter.id = filter.id;
+    existingFilter.hidden = filter.hidden;
+
+    if (!('value' in existingFilter) || !('value' in filter)) {
+        return;
+    }
+
+    if (Array.isArray(existingFilter.value) && Array.isArray(filter.value)) {
+        existingFilter.value = [...new Set([...existingFilter.value, ...filter.value])];
+        return;
+    }
+
+    if (filter.value !== undefined) {
+        existingFilter.value = filter.value;
+    }
+}
+
 function processFilterRules(filters: IFilter[]): IFilter[] {
     const uniqueFilters = new SvelteMap<string, IFilter>();
     for (const filter of filters) {
-        const singletonFilterKeys = ['date-date', 'level', 'project', 'string-stack', 'tag', 'type'];
-        if (singletonFilterKeys.includes(filter.key)) {
-            const existingFilter = uniqueFilters.get(filter.key);
-            if (existingFilter) {
-                existingFilter.id = filter.id;
-                if ('value' in existingFilter && 'value' in filter) {
-                    if (Array.isArray(existingFilter.value) && Array.isArray(filter.value)) {
-                        existingFilter.value = [...new Set([...existingFilter.value, ...filter.value])];
-                    } else if (filter.value !== undefined) {
-                        existingFilter.value = filter.value;
-                    }
-
-                    existingFilter.hidden = filter.hidden;
-                } else {
-                    throw new Error('Unable to merge filters');
-                }
-            }
-
-            uniqueFilters.set(filter.key, existingFilter ?? filter);
-        } else {
-            uniqueFilters.set(filter.id, filter);
+        const existingFilter = uniqueFilters.get(filter.key);
+        if (existingFilter) {
+            mergeDuplicateFilter(existingFilter, filter);
+            continue;
         }
+
+        uniqueFilters.set(filter.key, filter);
     }
 
     return Array.from(uniqueFilters.values());

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/index.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/index.ts
@@ -1,6 +1,10 @@
 import type { LogLevel } from '$features/events/models/event-data';
 import type { StackStatus } from '$features/stacks/models';
 
+import { resolve } from '$app/paths';
+import { StringFilter } from '$features/events/components/filters';
+import { serializeFilters } from '$features/events/components/filters/helpers.svelte';
+
 export interface EventErrorSummaryData {
     Message?: string;
     Method?: string;
@@ -146,3 +150,12 @@ export type SummaryTemplateKeys =
     | 'stack-session-summary'
     | 'stack-simple-summary'
     | 'stack-summary';
+
+export function buildStackEventsHref(stackId: string): string {
+    const queryParams = new URLSearchParams({
+        filters: serializeFilters([new StringFilter('stack', stackId)]),
+        time: 'all'
+    });
+
+    return `${resolve('/(app)/event')}?${queryParams}`;
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/index.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/index.ts
@@ -2,8 +2,6 @@ import type { LogLevel } from '$features/events/models/event-data';
 import type { StackStatus } from '$features/stacks/models';
 
 import { resolve } from '$app/paths';
-import { StringFilter } from '$features/events/components/filters';
-import { serializeFilters } from '$features/events/components/filters/helpers.svelte';
 
 export interface EventErrorSummaryData {
     Message?: string;
@@ -153,7 +151,7 @@ export type SummaryTemplateKeys =
 
 export function buildStackEventsHref(stackId: string): string {
     const queryParams = new URLSearchParams({
-        filters: serializeFilters([new StringFilter('stack', stackId)]),
+        stack: stackId,
         time: 'all'
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/index.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/index.ts
@@ -149,6 +149,14 @@ export type SummaryTemplateKeys =
     | 'stack-simple-summary'
     | 'stack-summary';
 
+export function buildEventDetailsHref(eventId: string, stackId?: string): string {
+    if (stackId) {
+        return resolve('/(app)/stack/[stackId=objectid]/event/[eventId=objectid]', { eventId, stackId });
+    }
+
+    return resolve('/(app)/event/[eventId=objectid]', { eventId });
+}
+
 export function buildStackEventsHref(stackId: string): string {
     const queryParams = new URLSearchParams({
         stack: stackId,

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-error-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-error-summary.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
     import type { StackStatus } from '$features/stacks/models';
 
-    import { resolve } from '$app/paths';
     import { A, Muted } from '$comp/typography';
     import StackStatusBadge from '$features/stacks/components/stack-status-badge.svelte';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
 
-    import type { StackSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
+    import { buildStackEventsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         badgeStatus: StackStatus;
@@ -37,7 +36,7 @@
         </strong>
     {/if}
 
-    <A class="inline" href={`${resolve('/(app)/event')}?filter=stack:${source.id}`}>
+    <A class="inline" href={buildStackEventsHref(source.id)}>
         {source.title}
     </A>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-feature-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-feature-summary.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
     import type { StackStatus } from '$features/stacks/models';
 
-    import { resolve } from '$app/paths';
     import { A } from '$comp/typography';
     import StackStatusBadge from '$features/stacks/components/stack-status-badge.svelte';
 
-    import type { StackSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
+    import { buildStackEventsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         badgeStatus: StackStatus;
@@ -27,7 +26,7 @@
         <strong>Feature</strong>:&nbsp;
     {/if}
 
-    <A class="inline" href={`${resolve('/(app)/event')}?filter=stack:${source.id}`}>
+    <A class="inline" href={buildStackEventsHref(source.id)}>
         {source.title}
     </A>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-log-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-log-summary.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
     import type { StackStatus } from '$features/stacks/models';
 
-    import { resolve } from '$app/paths';
     import { A } from '$comp/typography';
     import StackStatusBadge from '$features/stacks/components/stack-status-badge.svelte';
 
-    import type { StackSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
+    import { buildStackEventsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         badgeStatus: StackStatus;
@@ -27,7 +26,7 @@
         <strong>Log source:</strong>&nbsp;
     {/if}
 
-    <A class="inline" href={`${resolve('/(app)/event')}?filter=stack:${source.id}`}>
+    <A class="inline" href={buildStackEventsHref(source.id)}>
         {#if source.data?.Source}
             <abbr title={source.data.Source}>{source.data.SourceShortName}</abbr>
         {:else}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-not-found-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-not-found-summary.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
     import type { StackStatus } from '$features/stacks/models';
 
-    import { resolve } from '$app/paths';
     import { A } from '$comp/typography';
     import StackStatusBadge from '$features/stacks/components/stack-status-badge.svelte';
 
-    import type { StackSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
+    import { buildStackEventsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         badgeStatus: StackStatus;
@@ -26,7 +25,7 @@
     {#if showType}
         <strong>404</strong>:&nbsp;
     {/if}
-    <A class="inline" href={`${resolve('/(app)/event')}?filter=stack:${source.id}`}>
+    <A class="inline" href={buildStackEventsHref(source.id)}>
         {source.title}
     </A>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-session-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-session-summary.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
     import type { StackStatus } from '$features/stacks/models';
 
-    import { resolve } from '$app/paths';
     import { A } from '$comp/typography';
     import StackStatusBadge from '$features/stacks/components/stack-status-badge.svelte';
 
-    import type { StackSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
+    import { buildStackEventsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         badgeStatus: StackStatus;
@@ -27,7 +26,7 @@
         <strong>Session</strong>:&nbsp;
     {/if}
 
-    <A class="inline" href={`${resolve('/(app)/event')}?filter=stack:${source.id}`}>
+    <A class="inline" href={buildStackEventsHref(source.id)}>
         {source.title}
     </A>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-simple-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-simple-summary.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
     import type { StackStatus } from '$features/stacks/models';
 
-    import { resolve } from '$app/paths';
     import { A, Muted } from '$comp/typography';
     import StackStatusBadge from '$features/stacks/components/stack-status-badge.svelte';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
 
-    import type { StackSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
+    import { buildStackEventsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         badgeStatus: StackStatus;
@@ -27,7 +26,7 @@
         <abbr title={source.data.TypeFullName}>{source.data.Type}</abbr>:
     </strong>
 
-    <A class="inline" href={`${resolve('/(app)/event')}?filter=stack:${source.id}`}>{source.title}</A>
+    <A class="inline" href={buildStackEventsHref(source.id)}>{source.title}</A>
 </div>
 
 {#if source.data.Path}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-summary.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
     import type { StackStatus } from '$features/stacks/models';
 
-    import { resolve } from '$app/paths';
     import { A } from '$comp/typography';
     import StackStatusBadge from '$features/stacks/components/stack-status-badge.svelte';
 
-    import type { StackSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
+    import { buildStackEventsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         badgeStatus: StackStatus;
@@ -39,7 +38,7 @@
         :&nbsp;
     {/if}
 
-    <A class="inline" href={`${resolve('/(app)/event')}?filter=stack:${source.id}`}>
+    <A class="inline" href={buildStackEventsHref(source.id)}>
         {source.title}
     </A>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
@@ -15,7 +15,7 @@
     import Summary from '$features/events/components/summary/summary.svelte';
     import { getSessionId } from '$features/events/utils/index';
     import { organization } from '$features/organizations/context.svelte';
-    import FilterIcon from '@lucide/svelte/icons/filter';
+    import Funnel from '@lucide/svelte/icons/funnel';
     import InfoIcon from '@lucide/svelte/icons/info';
 
     import SessionEventDuration from '../session-event-duration.svelte';
@@ -140,15 +140,15 @@
     <div class="mb-2 flex items-center justify-between gap-2">
         <H3>Session Events</H3>
         <Button
+            aria-label="Open events filtered to this session"
             disabled={!sessionEventsHref}
             href={sessionEventsHref}
             onclick={handleSessionFilterClick}
-            size="sm"
+            size="icon-sm"
             title="Open events filtered to this session"
             variant="outline"
         >
-            <FilterIcon data-icon="inline-start" />
-            Filter
+            <Funnel class="size-4" />
         </Button>
     </div>
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -12,6 +12,7 @@ import { savedViewHref, savedViewResolvedSlug } from './slugs';
 
 export interface SavedViewQueryParams {
     filter: null | string | undefined;
+    filters?: null | string | undefined;
     saved?: null | string | undefined;
     sort?: null | string;
     time?: null | string;
@@ -262,6 +263,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         options.queryParams.filter = null;
+        options.queryParams.filters = null;
         setSortQueryParam(options.queryParams, null);
         setTimeQueryParam(options.queryParams, null);
         applyColumnState(view);
@@ -270,6 +272,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
     function handleClearSavedView() {
         options.queryParams.filter = null;
+        options.queryParams.filters = null;
         setSortQueryParam(options.queryParams, null);
         setTimeQueryParam(options.queryParams, null);
         applyColumnState(undefined);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-count.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-count.svelte
@@ -13,7 +13,7 @@
 
     let { table }: Props = $props();
 
-    const currentPage = $derived(table.store.state.pagination.pageIndex + 1);
+    const currentPage = $derived((table.options.state?.pagination?.pageIndex ?? table.store.state.pagination.pageIndex) + 1);
     const totalPages = $derived(Math.max(1, table.getPageCount()));
 </script>
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pagination.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pagination.svelte
@@ -5,32 +5,66 @@
 <script generics="TData extends RowData" lang="ts">
     import type { RowData, StockFeatures, Table } from '@tanstack/svelte-table';
 
-    import { Pagination, PaginationContent, PaginationFirstButton, PaginationItem, PaginationNext, PaginationPrevious } from '$comp/ui/pagination';
+    import { Button } from '$comp/ui/button';
+    import ChevronLeftIcon from '@lucide/svelte/icons/chevron-left';
+    import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
+    import ChevronsLeftIcon from '@lucide/svelte/icons/chevrons-left';
 
     interface Props {
         table: Table<StockFeatures, TData>;
     }
 
     let { table }: Props = $props();
-    const page = $derived(table.store.state.pagination.pageIndex + 1);
-
+    const page = $derived((table.options.state?.pagination?.pageIndex ?? table.store.state.pagination.pageIndex) + 1);
     const pageCount = $derived(Math.max(1, table.getPageCount() || 1));
+    const canGoNext = $derived(page < pageCount);
+    const canGoPrevious = $derived(page > 1);
+    const showFirst = $derived(page >= 3);
 
-    function handlePageChange(nextPage: number) {
-        table.setPageIndex(nextPage - 1);
+    function goToFirstPage(): void {
+        table.setPageIndex(0);
+    }
+
+    function goToNextPage(): void {
+        if (canGoNext) {
+            table.setPageIndex(page);
+        }
+    }
+
+    function goToPreviousPage(): void {
+        if (canGoPrevious) {
+            table.setPageIndex(page - 2);
+        }
     }
 </script>
 
-<Pagination count={pageCount} onPageChange={handlePageChange} {page} perPage={1} siblingCount={0} class="mx-0 w-auto justify-start">
-    <PaginationContent class="gap-1">
-        <PaginationItem>
-            <PaginationFirstButton currentPage={page} />
-        </PaginationItem>
-        <PaginationItem>
-            <PaginationPrevious page={{ type: 'page', value: Math.max(1, page - 1) }} isActive={false} />
-        </PaginationItem>
-        <PaginationItem>
-            <PaginationNext page={{ type: 'page', value: Math.min(pageCount, page + 1) }} isActive={false} />
-        </PaginationItem>
-    </PaginationContent>
-</Pagination>
+<nav aria-label="pagination" class="mx-0 flex w-auto justify-start">
+    <ul class="flex flex-row items-center gap-1">
+        <li>
+            <Button
+                aria-hidden={showFirst ? undefined : true}
+                aria-label="Go to first page"
+                class={showFirst ? undefined : 'invisible pointer-events-none'}
+                disabled={!showFirst}
+                onclick={goToFirstPage}
+                title="First page"
+                variant="ghost"
+            >
+                <ChevronsLeftIcon class="size-4" />
+                <span class="sr-only">Go to first page</span>
+            </Button>
+        </li>
+        <li>
+            <Button aria-label="Go to previous page" disabled={!canGoPrevious} onclick={goToPreviousPage} title="Previous page" variant="ghost">
+                <ChevronLeftIcon data-icon="inline-start" />
+                <span class="cn-pagination-previous-text hidden sm:block">Previous</span>
+            </Button>
+        </li>
+        <li>
+            <Button aria-label="Go to next page" disabled={!canGoNext} onclick={goToNextPage} title="Next page" variant="ghost">
+                <span class="cn-pagination-next-text hidden sm:block">Next</span>
+                <ChevronRightIcon data-icon="inline-end" />
+            </Button>
+        </li>
+    </ul>
+</nav>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/faceted-filter/faceted-filter-builder.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/faceted-filter/faceted-filter-builder.svelte
@@ -96,6 +96,22 @@
         facets.forEach((f) => (f.open = false));
 
         const filter = builder.create();
+        const existingFilter = filters.find((f) => f.key === filter.key);
+        if (existingFilter) {
+            if (existingFilter.hidden) {
+                showHiddenFilters = true;
+            }
+
+            const existingFacet = facets.find((facet) => facet.filter.id === existingFilter.id);
+            if (existingFacet) {
+                existingFacet.open = true;
+            }
+
+            open = false;
+            lastOpenFilterId = existingFilter.id;
+            return;
+        }
+
         changed(filter);
 
         open = false;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolvePaginationChange } from './table.svelte';
+
+describe('resolvePaginationChange', () => {
+    it('keeps the requested page when only the page index changes', () => {
+        // Arrange
+        const previousPageInfo = {
+            pageIndex: 0,
+            pageSize: 50
+        };
+        const requestedPageInfo = {
+            pageIndex: 1,
+            pageSize: 50
+        };
+
+        // Act
+        const result = resolvePaginationChange(previousPageInfo, requestedPageInfo);
+
+        // Assert
+        expect(result).toEqual({
+            currentPageInfo: requestedPageInfo,
+            pageIndexChanged: false,
+            pageSizeChanged: false,
+            previousPageInfo
+        });
+    });
+
+    it('resets to the first page when the page size changes from another page', () => {
+        // Arrange
+        const previousPageInfo = {
+            pageIndex: 2,
+            pageSize: 10
+        };
+        const requestedPageInfo = {
+            pageIndex: 2,
+            pageSize: 50
+        };
+
+        // Act
+        const result = resolvePaginationChange(previousPageInfo, requestedPageInfo);
+
+        // Assert
+        expect(result).toEqual({
+            currentPageInfo: {
+                pageIndex: 0,
+                pageSize: 50
+            },
+            pageIndexChanged: true,
+            pageSizeChanged: true,
+            previousPageInfo
+        });
+    });
+
+    it('keeps the first page when changing page size from the first page', () => {
+        // Arrange
+        const previousPageInfo = {
+            pageIndex: 0,
+            pageSize: 10
+        };
+        const requestedPageInfo = {
+            pageIndex: 0,
+            pageSize: 50
+        };
+
+        // Act
+        const result = resolvePaginationChange(previousPageInfo, requestedPageInfo);
+
+        // Assert
+        expect(result).toEqual({
+            currentPageInfo: requestedPageInfo,
+            pageIndexChanged: false,
+            pageSizeChanged: true,
+            previousPageInfo
+        });
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
@@ -61,6 +61,19 @@ export type TablePagingParameters<T extends PaginationStrategy = PaginationStrat
         ? TableMemoryPagingParameters
         : never;
 
+export function createPageSizePreference(key: string) {
+    const persistedPageSize = new PersistedState<number>(key, DEFAULT_LIMIT);
+
+    return {
+        get current() {
+            return normalizePageSize(persistedPageSize.current);
+        },
+        set current(value: number) {
+            persistedPageSize.current = normalizePageSize(value);
+        }
+    };
+}
+
 export function getSharedTableOptions<TData extends RowData, TPaginationStrategy extends PaginationStrategy = PaginationStrategy>(
     configuration: TableConfiguration<TData, TPaginationStrategy>
 ): TableOptions<StockFeatures, TData> {
@@ -435,6 +448,10 @@ function getPageIndexFromParameters(strategy: PaginationStrategy, parameters: Ta
 
 function hasSortQueryParameter(parameters: TablePagingParameters): parameters is TableCursorPagingParameters | TableOffsetPagingParameters {
     return Object.prototype.hasOwnProperty.call(parameters, 'sort');
+}
+
+function normalizePageSize(value: number | undefined): number {
+    return value && Number.isFinite(value) && value > 0 ? value : DEFAULT_LIMIT;
 }
 
 function parseSortString(sort: string | undefined): ColumnSort[] {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
@@ -112,12 +112,9 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
 
     const onPaginationChange = (updaterOrValue: Updater<PaginationState>) => {
         const previousPageInfo = pagination();
-
-        setPagination(updaterOrValue);
-        const paginationChange = getPaginationChange(previousPageInfo, pagination());
-        if (paginationChange.pageIndexChanged) {
-            setPagination(paginationChange.currentPageInfo);
-        }
+        const requestedPageInfo = resolveUpdater(previousPageInfo, updaterOrValue);
+        const paginationChange = resolvePaginationChange(previousPageInfo, requestedPageInfo);
+        setPagination(paginationChange.currentPageInfo);
 
         const currentPageInfo = paginationChange.currentPageInfo;
         if (configuration.queryParameters.limit !== currentPageInfo.pageSize) {
@@ -339,6 +336,28 @@ export function removeTableSelection<TData extends RowData>(table: Table<StockFe
     return false;
 }
 
+export function resolvePaginationChange(previousPageInfo: PaginationState, currentPageInfo: PaginationState) {
+    const pageSizeChanged = previousPageInfo.pageSize !== currentPageInfo.pageSize;
+    if (!pageSizeChanged || currentPageInfo.pageIndex === 0) {
+        return {
+            currentPageInfo,
+            pageIndexChanged: false,
+            pageSizeChanged,
+            previousPageInfo
+        };
+    }
+
+    return {
+        currentPageInfo: {
+            ...currentPageInfo,
+            pageIndex: 0
+        },
+        pageIndexChanged: true,
+        pageSizeChanged,
+        previousPageInfo
+    };
+}
+
 function createPersistedTableState<T>(key: string, initialValue: T): [() => T, (updater: Updater<T>) => void] {
     const persistedValue = new PersistedState<T>(key, initialValue);
 
@@ -409,28 +428,6 @@ function getPageIndexFromParameters(strategy: PaginationStrategy, parameters: Ta
     return Math.max(0, (((parameters as TableMemoryPagingParameters | TableOffsetPagingParameters).page ?? 1) as number) - 1);
 }
 
-function getPaginationChange(previousPageInfo: PaginationState, currentPageInfo: PaginationState) {
-    const pageSizeChanged = previousPageInfo.pageSize !== currentPageInfo.pageSize;
-    if (!pageSizeChanged || currentPageInfo.pageIndex === 0) {
-        return {
-            currentPageInfo,
-            pageIndexChanged: false,
-            pageSizeChanged,
-            previousPageInfo
-        };
-    }
-
-    return {
-        currentPageInfo: {
-            ...currentPageInfo,
-            pageIndex: 0
-        },
-        pageIndexChanged: true,
-        pageSizeChanged,
-        previousPageInfo
-    };
-}
-
 function hasSortQueryParameter(parameters: TablePagingParameters): parameters is TableCursorPagingParameters | TableOffsetPagingParameters {
     return Object.prototype.hasOwnProperty.call(parameters, 'sort');
 }
@@ -459,6 +456,14 @@ function resolveColumnOrder<TData extends RowData>(columnOrder: ColumnOrderState
     return defaultColumnOrder.includes('select') ? ['select', ...nextColumnOrder.filter((columnId) => columnId !== 'select')] : nextColumnOrder;
 }
 
+function resolveUpdater<T>(currentValue: T, updaterOrValue: Updater<T>): T {
+    if (updaterOrValue instanceof Function) {
+        return updaterOrValue(currentValue);
+    }
+
+    return updaterOrValue;
+}
+
 function sanitizeColumnOrder<TData extends RowData>(columnOrder: ColumnOrderState, columns: ColumnDef<StockFeatures, TData, unknown>[]): ColumnOrderState {
     return columnOrder.length === 0 ? columnOrder : resolveColumnOrder(columnOrder, columns);
 }
@@ -470,7 +475,7 @@ function serializeSortState(sorting: ColumnSort[]): string | undefined {
 function updateCursorPagingParameters(
     parameters: TableCursorPagingParameters,
     meta: QueryMeta | undefined,
-    paginationChange: ReturnType<typeof getPaginationChange>
+    paginationChange: ReturnType<typeof resolvePaginationChange>
 ): void {
     const movingForward = paginationChange.currentPageInfo.pageIndex > paginationChange.previousPageInfo.pageIndex;
     const movingBackward = paginationChange.currentPageInfo.pageIndex < paginationChange.previousPageInfo.pageIndex;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
@@ -38,6 +38,7 @@ export interface TableCursorPagingParameters {
     after?: string;
     before?: string;
     limit?: number;
+    page?: number;
     sort?: string;
 }
 
@@ -90,12 +91,7 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
     };
 
     // Initialize pagination state from parameters
-    const initialPageIndex =
-        configuration.paginationStrategy === 'offset'
-            ? (configuration.queryParameters as TableOffsetPagingParameters).page !== undefined
-                ? Number((configuration.queryParameters as TableOffsetPagingParameters).page) - 1
-                : 0
-            : 0;
+    const initialPageIndex = getPageIndexFromParameters(configuration.paginationStrategy, configuration.queryParameters, 0);
 
     const [pagination, setPagination] = createTableState<PaginationState>({
         pageIndex: initialPageIndex,
@@ -421,6 +417,15 @@ function getLinkQueryParameter(link: QueryMeta['links'][string] | undefined, nam
 }
 
 function getPageIndexFromParameters(strategy: PaginationStrategy, parameters: TablePagingParameters, fallbackPageIndex: number): number {
+    if (strategy === 'cursor') {
+        const cursorParameters = parameters as TableCursorPagingParameters;
+        if (cursorParameters.page !== undefined) {
+            return Math.max(0, cursorParameters.page - 1);
+        }
+
+        return cursorParameters.after || cursorParameters.before ? fallbackPageIndex : 0;
+    }
+
     if (strategy !== 'offset' && strategy !== 'memory') {
         return fallbackPageIndex;
     }
@@ -487,8 +492,9 @@ function updateCursorPagingParameters(
         !paginationChange.pageSizeChanged && movingBackward && paginationChange.currentPageInfo.pageIndex > 0
             ? getLinkQueryParameter(meta?.links?.previous, 'before')
             : undefined;
+    parameters.page = paginationChange.currentPageInfo.pageIndex > 0 ? paginationChange.currentPageInfo.pageIndex + 1 : undefined;
 }
 
 function updatePageNumberPagingParameters(parameters: TableMemoryPagingParameters | TableOffsetPagingParameters, currentPageInfo: PaginationState): void {
-    parameters.page = currentPageInfo.pageIndex + 1; // API uses 1-based indexes.
+    parameters.page = currentPageInfo.pageIndex > 0 ? currentPageInfo.pageIndex + 1 : undefined; // API uses 1-based indexes.
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
@@ -384,6 +384,23 @@ function getColumnIds<TData extends RowData>(columns: ColumnDef<StockFeatures, T
     });
 }
 
+function getLinkQueryParameter(link: QueryMeta['links'][string] | undefined, name: string): string | undefined {
+    const value = link?.[name];
+    if (value) {
+        return value;
+    }
+
+    if (!link?.url) {
+        return undefined;
+    }
+
+    try {
+        return new URL(link.url, 'https://example.com').searchParams.get(name) ?? undefined;
+    } catch {
+        return undefined;
+    }
+}
+
 function getPageIndexFromParameters(strategy: PaginationStrategy, parameters: TablePagingParameters, fallbackPageIndex: number): number {
     if (strategy !== 'offset' && strategy !== 'memory') {
         return fallbackPageIndex;
@@ -460,9 +477,11 @@ function updateCursorPagingParameters(
 
     // Cursor tokens are only valid for the current page size and direction.
     // When the page size changes, clear both tokens and let the first page reload.
-    parameters.after = !paginationChange.pageSizeChanged && movingForward ? meta?.links?.next?.after : undefined;
+    parameters.after = !paginationChange.pageSizeChanged && movingForward ? getLinkQueryParameter(meta?.links?.next, 'after') : undefined;
     parameters.before =
-        !paginationChange.pageSizeChanged && movingBackward && paginationChange.currentPageInfo.pageIndex > 0 ? meta?.links?.previous?.before : undefined;
+        !paginationChange.pageSizeChanged && movingBackward && paginationChange.currentPageInfo.pageIndex > 0
+            ? getLinkQueryParameter(meta?.links?.previous, 'before')
+            : undefined;
 }
 
 function updatePageNumberPagingParameters(parameters: TableMemoryPagingParameters | TableOffsetPagingParameters, currentPageInfo: PaginationState): void {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
@@ -112,20 +112,14 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
 
     const onPaginationChange = (updaterOrValue: Updater<PaginationState>) => {
         const previousPageInfo = pagination();
-        const previousPageIndex = previousPageInfo.pageIndex;
 
         setPagination(updaterOrValue);
-        let currentPageInfo = pagination();
-        const pageSizeChanged = previousPageInfo.pageSize !== currentPageInfo.pageSize;
-
-        if (pageSizeChanged && currentPageInfo.pageIndex !== 0) {
-            currentPageInfo = {
-                ...currentPageInfo,
-                pageIndex: 0
-            };
-            setPagination(currentPageInfo);
+        const paginationChange = getPaginationChange(previousPageInfo, pagination());
+        if (paginationChange.pageIndexChanged) {
+            setPagination(paginationChange.currentPageInfo);
         }
 
+        const currentPageInfo = paginationChange.currentPageInfo;
         if (configuration.queryParameters.limit !== currentPageInfo.pageSize) {
             configuration.queryParameters.limit = currentPageInfo.pageSize;
         }
@@ -135,16 +129,9 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
             const start = currentPageInfo.pageIndex * currentPageInfo.pageSize;
             setData(allData().slice(start, start + currentPageInfo.pageSize));
         } else if (isCursorPaging) {
-            const queryMeta = meta();
-            const nextLink = queryMeta?.links?.next?.after;
-            const previousLink = queryMeta?.links?.previous?.before;
-
-            const parameters = configuration.queryParameters as TableCursorPagingParameters;
-            parameters.after = !pageSizeChanged && currentPageInfo.pageIndex > previousPageIndex ? nextLink : undefined;
-            // Ensure previousLink is only used when actually moving back and not on the first page
-            parameters.before = !pageSizeChanged && currentPageInfo.pageIndex < previousPageIndex && currentPageInfo.pageIndex > 0 ? previousLink : undefined;
+            updateCursorPagingParameters(configuration.queryParameters as TableCursorPagingParameters, meta(), paginationChange);
         } else if (isOffsetPaging || isMemoryPaging) {
-            (configuration.queryParameters as TableMemoryPagingParameters | TableOffsetPagingParameters).page = currentPageInfo.pageIndex + 1; // API uses 1-based index
+            updatePageNumberPagingParameters(configuration.queryParameters as TableMemoryPagingParameters | TableOffsetPagingParameters, currentPageInfo);
         }
     };
 
@@ -226,10 +213,7 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
     $effect(() => setMetaImpl(configuration.queryMeta));
     $effect(() => {
         const nextPageSize = configuration.queryParameters.limit ?? DEFAULT_LIMIT;
-        const nextPageIndex =
-            isOffsetPaging || isMemoryPaging
-                ? Math.max(0, (((configuration.queryParameters as TableMemoryPagingParameters | TableOffsetPagingParameters).page ?? 1) as number) - 1)
-                : pagination().pageIndex;
+        const nextPageIndex = getPageIndexFromParameters(configuration.paginationStrategy, configuration.queryParameters, pagination().pageIndex);
         const currentPageInfo = pagination();
 
         if (currentPageInfo.pageSize !== nextPageSize || currentPageInfo.pageIndex !== nextPageIndex) {
@@ -400,6 +384,36 @@ function getColumnIds<TData extends RowData>(columns: ColumnDef<StockFeatures, T
     });
 }
 
+function getPageIndexFromParameters(strategy: PaginationStrategy, parameters: TablePagingParameters, fallbackPageIndex: number): number {
+    if (strategy !== 'offset' && strategy !== 'memory') {
+        return fallbackPageIndex;
+    }
+
+    return Math.max(0, (((parameters as TableMemoryPagingParameters | TableOffsetPagingParameters).page ?? 1) as number) - 1);
+}
+
+function getPaginationChange(previousPageInfo: PaginationState, currentPageInfo: PaginationState) {
+    const pageSizeChanged = previousPageInfo.pageSize !== currentPageInfo.pageSize;
+    if (!pageSizeChanged || currentPageInfo.pageIndex === 0) {
+        return {
+            currentPageInfo,
+            pageIndexChanged: false,
+            pageSizeChanged,
+            previousPageInfo
+        };
+    }
+
+    return {
+        currentPageInfo: {
+            ...currentPageInfo,
+            pageIndex: 0
+        },
+        pageIndexChanged: true,
+        pageSizeChanged,
+        previousPageInfo
+    };
+}
+
 function hasSortQueryParameter(parameters: TablePagingParameters): parameters is TableCursorPagingParameters | TableOffsetPagingParameters {
     return Object.prototype.hasOwnProperty.call(parameters, 'sort');
 }
@@ -434,4 +448,23 @@ function sanitizeColumnOrder<TData extends RowData>(columnOrder: ColumnOrderStat
 
 function serializeSortState(sorting: ColumnSort[]): string | undefined {
     return sorting.length > 0 ? sorting.map((sort) => `${sort.desc ? '-' : ''}${sort.id}`).join(',') : undefined;
+}
+
+function updateCursorPagingParameters(
+    parameters: TableCursorPagingParameters,
+    meta: QueryMeta | undefined,
+    paginationChange: ReturnType<typeof getPaginationChange>
+): void {
+    const movingForward = paginationChange.currentPageInfo.pageIndex > paginationChange.previousPageInfo.pageIndex;
+    const movingBackward = paginationChange.currentPageInfo.pageIndex < paginationChange.previousPageInfo.pageIndex;
+
+    // Cursor tokens are only valid for the current page size and direction.
+    // When the page size changes, clear both tokens and let the first page reload.
+    parameters.after = !paginationChange.pageSizeChanged && movingForward ? meta?.links?.next?.after : undefined;
+    parameters.before =
+        !paginationChange.pageSizeChanged && movingBackward && paginationChange.currentPageInfo.pageIndex > 0 ? meta?.links?.previous?.before : undefined;
+}
+
+function updatePageNumberPagingParameters(parameters: TableMemoryPagingParameters | TableOffsetPagingParameters, currentPageInfo: PaginationState): void {
+    parameters.page = currentPageInfo.pageIndex + 1; // API uses 1-based indexes.
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
@@ -111,10 +111,20 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
     const [rowSelection, setRowSelection] = createTableState<RowSelectionState>({});
 
     const onPaginationChange = (updaterOrValue: Updater<PaginationState>) => {
-        const previousPageIndex = pagination().pageIndex;
+        const previousPageInfo = pagination();
+        const previousPageIndex = previousPageInfo.pageIndex;
 
         setPagination(updaterOrValue);
-        const currentPageInfo = pagination();
+        let currentPageInfo = pagination();
+        const pageSizeChanged = previousPageInfo.pageSize !== currentPageInfo.pageSize;
+
+        if (pageSizeChanged && currentPageInfo.pageIndex !== 0) {
+            currentPageInfo = {
+                ...currentPageInfo,
+                pageIndex: 0
+            };
+            setPagination(currentPageInfo);
+        }
 
         if (configuration.queryParameters.limit !== currentPageInfo.pageSize) {
             configuration.queryParameters.limit = currentPageInfo.pageSize;
@@ -130,9 +140,9 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
             const previousLink = queryMeta?.links?.previous?.before;
 
             const parameters = configuration.queryParameters as TableCursorPagingParameters;
-            parameters.after = currentPageInfo.pageIndex > previousPageIndex ? nextLink : undefined;
+            parameters.after = !pageSizeChanged && currentPageInfo.pageIndex > previousPageIndex ? nextLink : undefined;
             // Ensure previousLink is only used when actually moving back and not on the first page
-            parameters.before = currentPageInfo.pageIndex < previousPageIndex && currentPageInfo.pageIndex > 0 ? previousLink : undefined;
+            parameters.before = !pageSizeChanged && currentPageInfo.pageIndex < previousPageIndex && currentPageInfo.pageIndex > 0 ? previousLink : undefined;
         } else if (isOffsetPaging || isMemoryPaging) {
             (configuration.queryParameters as TableMemoryPagingParameters | TableOffsetPagingParameters).page = currentPageInfo.pageIndex + 1; // API uses 1-based index
         }
@@ -214,6 +224,21 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
     // NOTE: Two different effects are used here to avoid circular dependency issues with in memory paging.
     $effect(() => setDataImpl(configuration.queryData ?? []));
     $effect(() => setMetaImpl(configuration.queryMeta));
+    $effect(() => {
+        const nextPageSize = configuration.queryParameters.limit ?? DEFAULT_LIMIT;
+        const nextPageIndex =
+            isOffsetPaging || isMemoryPaging
+                ? Math.max(0, (((configuration.queryParameters as TableMemoryPagingParameters | TableOffsetPagingParameters).page ?? 1) as number) - 1)
+                : pagination().pageIndex;
+        const currentPageInfo = pagination();
+
+        if (currentPageInfo.pageSize !== nextPageSize || currentPageInfo.pageIndex !== nextPageIndex) {
+            setPagination({
+                pageIndex: nextPageIndex,
+                pageSize: nextPageSize
+            });
+        }
+    });
     $effect(() => {
         if (!hasSortQueryParameter(configuration.queryParameters)) {
             return;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-    import { type IFilter } from '$comp/faceted-filter';
     import type { ProblemDetails } from '@exceptionless/fetchclient';
+
+    import { type IFilter } from '$comp/faceted-filter';
     import DateTime from '$comp/formatters/date-time.svelte';
     import Number from '$comp/formatters/number.svelte';
     import Percentage from '$comp/formatters/percentage.svelte';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { type IFilter } from '$comp/faceted-filter';
+    import type { ProblemDetails } from '@exceptionless/fetchclient';
     import DateTime from '$comp/formatters/date-time.svelte';
     import Number from '$comp/formatters/number.svelte';
     import Percentage from '$comp/formatters/percentage.svelte';
@@ -33,9 +34,12 @@
     interface Props {
         filterChanged: (filter: IFilter) => void;
         id: string | undefined;
+        onDeleted?: () => void;
+        onError?: (problem: ProblemDetails) => void;
     }
 
-    let { filterChanged, id }: Props = $props();
+    let { filterChanged, id, onDeleted, onError }: Props = $props();
+    let handledErrorForStackId = $state<string>();
 
     const stackQuery = getStackQuery({
         route: {
@@ -117,6 +121,15 @@
 
         return recentBuckets;
     });
+
+    $effect(() => {
+        if (!stackQuery.isError || handledErrorForStackId === id) {
+            return;
+        }
+
+        handledErrorForStackId = id;
+        onError?.(stackQuery.error);
+    });
 </script>
 
 {#if stackQuery.isSuccess}
@@ -134,7 +147,7 @@
                     <StackLogLevel {stack} />
                     <ButtonGroup.Root>
                         <StackStatusDropdownMenu {stack} />
-                        <StackOptionsDropdownMenu {stack} />
+                        <StackOptionsDropdownMenu {onDeleted} {stack} />
                     </ButtonGroup.Root>
                 </div>
             </Card.Title>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-detail-sheet.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
     import type { IFilter } from '$comp/faceted-filter';
+    import type { PersistentEvent } from '$features/events/models';
     import type { ProblemDetails } from '@exceptionless/fetchclient';
 
     import { resolve } from '$app/paths';
     import DetailSheet from '$comp/detail-sheet.svelte';
+    import { buildEventDetailsHref } from '$features/events/components/summary';
 
     import StackDetails from './stack-details.svelte';
 
@@ -16,7 +18,27 @@
 
     let { filterChanged, onClose, onError, stackId = $bindable() }: Props = $props();
 
-    const resolvedHref = $derived(stackId ? resolve('/(app)/stack/[stackId=objectid]', { stackId }) : '#');
+    let currentEventDetails = $state<{ eventId: string; stackId: string }>();
+    let lastStackId = $state<null | string>(null);
+
+    const resolvedHref = $derived(
+        currentEventDetails
+            ? buildEventDetailsHref(currentEventDetails.eventId, currentEventDetails.stackId)
+            : stackId
+              ? resolve('/(app)/stack/[stackId=objectid]', { stackId })
+              : '#'
+    );
+
+    function handleEventLoaded(event: PersistentEvent): void {
+        currentEventDetails = { eventId: event.id, stackId: event.stack_id };
+    }
+
+    $effect(() => {
+        if (stackId !== lastStackId) {
+            lastStackId = stackId ?? null;
+            currentEventDetails = undefined;
+        }
+    });
 
     function handleError(problem: ProblemDetails) {
         if (onError) {
@@ -29,6 +51,6 @@
 
 <DetailSheet detailsHref={resolvedHref} {onClose} open={!!stackId} title="Stack">
     {#if stackId}
-        <StackDetails {filterChanged} {handleError} onDeleted={onClose} {stackId} />
+        <StackDetails {filterChanged} {handleError} onDeleted={onClose} onEventLoaded={handleEventLoaded} {stackId} />
     {/if}
 </DetailSheet>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-detail-sheet.svelte
@@ -29,6 +29,6 @@
 
 <DetailSheet detailsHref={resolvedHref} {onClose} open={!!stackId} title="Stack">
     {#if stackId}
-        <StackDetails {filterChanged} {handleError} {stackId} />
+        <StackDetails {filterChanged} {handleError} onDeleted={onClose} {stackId} />
     {/if}
 </DetailSheet>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-details.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-details.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import type { IFilter } from '$comp/faceted-filter';
+    import type { PersistentEvent } from '$features/events/models';
     import type { ProblemDetails } from '@exceptionless/fetchclient';
 
     import { Muted } from '$comp/typography';
@@ -9,19 +10,23 @@
     import StackCard from './stack-card.svelte';
 
     interface Props {
+        eventId?: null | string;
         filterChanged: (filter: IFilter) => void;
         handleError: (problem: ProblemDetails) => void;
         onDeleted?: () => void;
+        onEventLoaded?: (event: PersistentEvent) => void;
+        onNavigate?: (eventId: string) => void;
         stackId: string;
     }
 
-    let { filterChanged, handleError, onDeleted, stackId }: Props = $props();
+    let { eventId: initialEventId, filterChanged, handleError, onDeleted, onEventLoaded, onNavigate, stackId }: Props = $props();
 
-    let eventId = $state<null | string>(null);
+    let selectedEventId = $state<null | string>(null);
     let lastStackId = $state('');
     let handledEventsErrorForStackId = $state('');
 
     const stackEventsQuery = getStackEventsQuery({
+        enabled: () => !initialEventId,
         params: {
             limit: 1,
             sort: '-date'
@@ -34,16 +39,18 @@
     });
 
     $effect(() => {
-        if (stackId !== lastStackId) {
+        if (initialEventId) {
+            selectedEventId = initialEventId;
+        } else if (stackId !== lastStackId) {
             lastStackId = stackId;
             handledEventsErrorForStackId = '';
-            eventId = null;
+            selectedEventId = null;
         }
     });
 
     $effect(() => {
-        if (stackEventsQuery.isSuccess) {
-            eventId = stackEventsQuery.data?.[0]?.id ?? null;
+        if (!initialEventId && stackEventsQuery.isSuccess) {
+            selectedEventId = stackEventsQuery.data?.[0]?.id ?? null;
         }
     });
 
@@ -55,12 +62,16 @@
     });
 
     function handleNavigate(newEventId: string) {
-        eventId = newEventId;
+        if (onNavigate) {
+            onNavigate(newEventId);
+        } else {
+            selectedEventId = newEventId;
+        }
     }
 </script>
 
-{#if eventId}
-    <EventsOverview {filterChanged} id={eventId} {handleError} onNavigate={handleNavigate} />
+{#if selectedEventId}
+    <EventsOverview {filterChanged} id={selectedEventId} {handleError} {onEventLoaded} onNavigate={handleNavigate} />
 {:else if stackEventsQuery.isSuccess}
     <section>
         <h4 class="text-muted-foreground mb-3 text-sm font-semibold tracking-wide uppercase">Stack</h4>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-details.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-details.svelte
@@ -11,13 +11,15 @@
     interface Props {
         filterChanged: (filter: IFilter) => void;
         handleError: (problem: ProblemDetails) => void;
+        onDeleted?: () => void;
         stackId: string;
     }
 
-    let { filterChanged, handleError, stackId }: Props = $props();
+    let { filterChanged, handleError, onDeleted, stackId }: Props = $props();
 
     let eventId = $state<null | string>(null);
     let lastStackId = $state('');
+    let handledEventsErrorForStackId = $state('');
 
     const stackEventsQuery = getStackEventsQuery({
         params: {
@@ -34,6 +36,7 @@
     $effect(() => {
         if (stackId !== lastStackId) {
             lastStackId = stackId;
+            handledEventsErrorForStackId = '';
             eventId = null;
         }
     });
@@ -41,6 +44,13 @@
     $effect(() => {
         if (stackEventsQuery.isSuccess) {
             eventId = stackEventsQuery.data?.[0]?.id ?? null;
+        }
+    });
+
+    $effect(() => {
+        if (stackEventsQuery.isError && handledEventsErrorForStackId !== stackId) {
+            handledEventsErrorForStackId = stackId;
+            handleError(stackEventsQuery.error);
         }
     });
 
@@ -54,7 +64,7 @@
 {:else if stackEventsQuery.isSuccess}
     <section>
         <h4 class="text-muted-foreground mb-3 text-sm font-semibold tracking-wide uppercase">Stack</h4>
-        <StackCard {filterChanged} id={stackId} />
+        <StackCard {filterChanged} id={stackId} {onDeleted} onError={handleError} />
     </section>
     <Muted class="mt-4">No events available for this stack.</Muted>
 {/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-options-dropdown-menu.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-options-dropdown-menu.svelte
@@ -18,10 +18,11 @@
     import RequiresPromotedWebHookDialog from './dialogs/requires-promoted-web-hook-dialog.svelte';
 
     interface Props {
+        onDeleted?: () => void;
         stack: Stack;
     }
 
-    let { stack }: Props = $props();
+    let { onDeleted, stack }: Props = $props();
     let openAddStackReferenceDialog = $state<boolean>(false);
     let openRemoveStackDialog = $state<boolean>(false);
     let openRequiresPromotedWebHookDialog = $state<boolean>(false);
@@ -107,6 +108,7 @@
     async function remove() {
         await removeStacks.mutateAsync();
         toast.success('Successfully queued the stack for deletion.');
+        onDeleted?.();
     }
 </script>
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -50,6 +50,8 @@
     import { useEventListener, watch } from 'runed';
     import { debounce, throttle } from 'throttle-debounce';
 
+    import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../redirect-to-events.svelte';
+
     let selectedEventId: null | string = $state(null);
 
     function handleEventError(problem: ProblemDetails) {
@@ -205,7 +207,14 @@
         queryParams.limit ??= DEFAULT_LIMIT;
     });
 
-    function onFilterChanged(addedOrUpdated: FacetedFilter.IFilter): void {
+    async function onFilterChanged(addedOrUpdated: FacetedFilter.IFilter): Promise<void> {
+        const navigationOptions = getEventsNavigationOptionsForFilter(addedOrUpdated);
+        if (navigationOptions) {
+            selectedEventId = null;
+            await redirectToEventsWithFilter(organization.current, addedOrUpdated, navigationOptions);
+            return;
+        }
+
         const isNew = !filters?.some((f) => f.id === addedOrUpdated.id);
         const updatedFilters = filterChanged(filters ?? [], addedOrUpdated);
         updateFilters(updatedFilters);

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -13,7 +13,7 @@
     import EventDetailSheet from '$features/events/components/event-detail-sheet.svelte';
     import EventsDashboardChart from '$features/events/components/events-dashboard-chart.svelte';
     import EventsStatsDashboard from '$features/events/components/events-stats-dashboard.svelte';
-    import { DateFilter, ProjectFilter, StatusFilter } from '$features/events/components/filters';
+    import { DateFilter, ProjectFilter, StatusFilter, StringFilter } from '$features/events/components/filters';
     import {
         applyTimeFilter,
         buildFilterCacheKey,
@@ -25,7 +25,6 @@
         serializeFilters,
         shouldRefreshPersistentEventChanged,
         toFilter,
-        toFilterFromSerializedFilters,
         updateFilterCache
     } from '$features/events/components/filters/helpers.svelte';
     import OrganizationDefaultsFacetedFilterBuilder from '$features/events/components/filters/organization-defaults-faceted-filter-builder.svelte';
@@ -74,7 +73,9 @@
         filter: undefined as string | undefined,
         filters: undefined as string | undefined,
         limit: DEFAULT_LIMIT,
+        project: undefined as string | undefined,
         sort: undefined as string | undefined,
+        stack: undefined as string | undefined,
         time: undefined as string | undefined
     };
 
@@ -95,8 +96,10 @@
     }
 
     function getEffectiveFilter(): null | string {
-        if (queryParams.filters != null) {
-            return toFilterFromSerializedFilters(queryParams.filters);
+        const queryFilters = getQueryFilters();
+        if (queryFilters != null) {
+            const filter = toFilter(queryFilters.filter((f) => f.type !== 'date'));
+            return filter || null;
         }
 
         if (queryParams.filter != null) {
@@ -104,6 +107,20 @@
         }
 
         return savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
+    }
+
+    function getQueryFilters(): FacetedFilter.IFilter[] | null {
+        const filters = queryParams.filters != null ? deserializeFilters(queryParams.filters) : [];
+
+        if (queryParams.project) {
+            filters.push(new ProjectFilter([queryParams.project]));
+        }
+
+        if (queryParams.stack) {
+            filters.push(new StringFilter('stack', queryParams.stack));
+        }
+
+        return filters.length > 0 ? filters : null;
     }
 
     function getEffectiveSort(): null | string | undefined {
@@ -122,7 +139,9 @@
             filter: 'string',
             filters: 'string',
             limit: 'number',
+            project: 'string',
             sort: 'string',
+            stack: 'string',
             time: 'string'
         }
     });
@@ -179,8 +198,9 @@
         const filter = getEffectiveFilter();
         const savedView = savedViewsState.activeSavedView;
 
-        if (queryParams.filters != null) {
-            return applyTimeFilter(deserializeFilters(queryParams.filters), getQueryTime());
+        const queryFilters = getQueryFilters();
+        if (queryFilters != null) {
+            return applyTimeFilter(queryFilters, getQueryTime());
         }
 
         if (queryParams.filter == null && savedView?.filter_definitions && filter === (savedView.filter ?? null)) {
@@ -239,20 +259,33 @@
         const filter = toFilter(updatedFilters.filter((f) => f.type !== 'date'));
         const time = ((updatedFilters.find((f) => f.type === 'date') as DateFilter | undefined)?.value as string | undefined) ?? null;
         const baseTime = savedViewsState.activeSavedView?.time ?? DEFAULT_TIME_RANGE;
-        const filterDefinitions = serializeFilters(updatedFilters);
+        const stackFilter = updatedFilters.find((f): f is StringFilter => f.type === 'string' && f.key === 'string-stack');
+        const projectFilter = updatedFilters.find((f): f is ProjectFilter => f.type === 'project');
+        const filtersForDefinitions = updatedFilters.filter((f) => f !== stackFilter && f !== projectFilter);
+        const filterDefinitions = filtersForDefinitions.length > 0 ? serializeFilters(filtersForDefinitions) : null;
 
         const newFilterParam = null;
         const newTimeParam = time === baseTime ? null : (time ?? ALL_TIME_QUERY_VALUE);
         const newFiltersParam = filterDefinitions;
+        const newProjectParam = projectFilter?.value.length === 1 && projectFilter.value[0] ? projectFilter.value[0] : null;
+        const newStackParam = stackFilter?.value?.trim() ? stackFilter.value : null;
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
         // Only skip the watch when the URL will actually change from our update.
         // If the URL doesn't change, the watch won't fire and the flag would stay stale.
-        if (newFilterParam !== queryParams.filter || newTimeParam !== queryParams.time || newFiltersParam !== queryParams.filters) {
+        if (
+            newFilterParam !== queryParams.filter ||
+            newTimeParam !== queryParams.time ||
+            newFiltersParam !== queryParams.filters ||
+            newProjectParam !== queryParams.project ||
+            newStackParam !== queryParams.stack
+        ) {
             isInternalFilterUpdate = true;
         }
 
         queryParams.filters = newFiltersParam;
+        queryParams.project = newProjectParam;
+        queryParams.stack = newStackParam;
         queryParams.time = newTimeParam;
         queryParams.filter = newFilterParam;
     }

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -47,13 +47,13 @@
     import SavedViewPicker from '$features/saved-views/components/saved-view-picker.svelte';
     import { useSavedViews } from '$features/saved-views/use-saved-views.svelte';
     import * as agg from '$features/shared/api/aggregations';
-    import { getSharedTableOptions, isTableEmpty, removeTableData, removeTableSelection } from '$features/shared/table.svelte';
+    import { createPageSizePreference, getSharedTableOptions, isTableEmpty, removeTableData, removeTableSelection } from '$features/shared/table.svelte';
     import { fillDateSeries } from '$features/shared/utils/charts.js';
     import { toDateMathRange } from '$features/shared/utils/datemath';
     import { parseDateMathRange } from '$features/shared/utils/datemath.js';
     import { StackStatus } from '$features/stacks/models';
     import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
-    import { DEFAULT_LIMIT, DEFAULT_OFFSET, useFetchClientStatus } from '$shared/api/api.svelte';
+    import { DEFAULT_OFFSET, useFetchClientStatus } from '$shared/api/api.svelte';
     import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
     import { error } from '@sveltejs/kit';
     import { createTable } from '@tanstack/svelte-table';
@@ -88,6 +88,8 @@
     const DEFAULT_TIME_RANGE = '[now-7d TO now]';
     const DEFAULT_FILTER = '(status:open OR status:regressed)';
     const DEFAULT_FILTERS = [new DateFilter('date', DEFAULT_TIME_RANGE), new ProjectFilter([]), new StatusFilter([StackStatus.Open, StackStatus.Regressed])];
+    const PAGE_SIZE_PREFERENCE_KEY = 'event-stack-list-page-size';
+    const pageSizePreference = createPageSizePreference(PAGE_SIZE_PREFERENCE_KEY);
     const DEFAULT_PARAMS = {
         after: undefined as string | undefined,
         before: undefined as string | undefined,
@@ -95,7 +97,7 @@
         filter: undefined as string | undefined,
         first: undefined as string | undefined,
         level: undefined as string | undefined,
-        limit: DEFAULT_LIMIT,
+        limit: undefined as number | undefined,
         page: undefined as number | undefined,
         project: undefined as string | undefined,
         reference: undefined as string | undefined,
@@ -406,11 +408,6 @@
         { lazy: true }
     );
 
-    $effect(() => {
-        // Handle case where pop state loses the limit
-        queryParams.limit ??= DEFAULT_LIMIT;
-    });
-
     async function onFilterChanged(addedOrUpdated: FacetedFilter.IFilter): Promise<void> {
         const navigationOptions = getEventsNavigationOptionsForFilter(addedOrUpdated);
         if (navigationOptions) {
@@ -576,6 +573,21 @@
         return ['level', 'project', 'reference', 'session', 'status', 'tag', 'type', 'version'].includes(filter.type);
     }
 
+    function getPageSize(): number {
+        return queryParams.limit ?? pageSizePreference.current;
+    }
+
+    function setPageSize(value: number): void {
+        pageSizePreference.current = value;
+        queryParams.limit = null;
+    }
+
+    $effect(() => {
+        if (queryParams.limit === pageSizePreference.current) {
+            queryParams.limit = null;
+        }
+    });
+
     const eventsQueryParameters: GetEventsParams = $state({
         get after() {
             return queryParams.after ?? undefined;
@@ -596,10 +608,10 @@
             queryParams.filter = value;
         },
         get limit() {
-            return queryParams.limit!;
+            return getPageSize();
         },
         set limit(value) {
-            queryParams.limit = value;
+            setPageSize(value);
         },
         mode: 'summary',
         offset: DEFAULT_OFFSET,
@@ -853,7 +865,7 @@
             <EventsDashboardChart data={chartData()} isLoading={chartDataQuery.isLoading && !chartDataQuery.isSuccess} {onRangeSelect} />
         {/if}
 
-        <EventsDataTable bind:limit={queryParams.limit!} isLoading={clientStatus.isLoading} {rowClick} {rowHref} {table}>
+        <EventsDataTable bind:limit={eventsQueryParameters.limit!} isLoading={clientStatus.isLoading} {rowClick} {rowHref} {table}>
             {#snippet footerChildren()}
                 <div class="h-9 min-w-35">
                     {#if table.getSelectedRowModel().flatRows.length}
@@ -862,7 +874,7 @@
                 </div>
 
                 <DataTable.Selection {table} />
-                <DataTable.PageSize bind:value={queryParams.limit!} {table}></DataTable.PageSize>
+                <DataTable.PageSize bind:value={eventsQueryParameters.limit!} {table}></DataTable.PageSize>
                 <div class="flex items-center space-x-6 lg:space-x-8">
                     <DataTable.PageCount {table} />
                     <DataTable.Pagination {table} />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -281,7 +281,10 @@
     function getCurrentFiltersWithoutTime(): FacetedFilter.IFilter[] {
         const savedViewFilters = getSavedViewFilters();
         const queryFilters = getQueryFilters() ?? [];
-        const expressionFilters = queryParams.filter != null ? getFiltersFromCache(filterCacheKey(queryParams.filter), queryParams.filter) : [];
+        const expressionFilters =
+            queryParams.filter != null
+                ? getFiltersFromCache(filterCacheKey(queryParams.filter), queryParams.filter).filter((filter) => filter.type !== 'date')
+                : [];
 
         if (savedViewFilters) {
             return mergeFilterOverrides(
@@ -296,7 +299,7 @@
         }
 
         const filter = savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
-        return getFiltersFromCache(filterCacheKey(filter), filter);
+        return getFiltersFromCache(filterCacheKey(filter), filter).filter((filter) => filter.type !== 'date');
     }
 
     function getSavedViewFilters(): FacetedFilter.IFilter[] | null {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -13,7 +13,19 @@
     import EventDetailSheet from '$features/events/components/event-detail-sheet.svelte';
     import EventsDashboardChart from '$features/events/components/events-dashboard-chart.svelte';
     import EventsStatsDashboard from '$features/events/components/events-stats-dashboard.svelte';
-    import { DateFilter, ProjectFilter, StatusFilter, StringFilter } from '$features/events/components/filters';
+    import {
+        BooleanFilter,
+        DateFilter,
+        LevelFilter,
+        ProjectFilter,
+        ReferenceFilter,
+        SessionFilter,
+        StatusFilter,
+        StringFilter,
+        TagFilter,
+        TypeFilter,
+        VersionFilter
+    } from '$features/events/components/filters';
     import {
         applyTimeFilter,
         buildFilterCacheKey,
@@ -70,13 +82,21 @@
     const DEFAULT_FILTER = '(status:open OR status:regressed)';
     const DEFAULT_FILTERS = [new DateFilter('date', DEFAULT_TIME_RANGE), new ProjectFilter([]), new StatusFilter([StackStatus.Open, StackStatus.Regressed])];
     const DEFAULT_PARAMS = {
+        bot: undefined as string | undefined,
         filter: undefined as string | undefined,
-        filters: undefined as string | undefined,
+        first: undefined as string | undefined,
+        level: undefined as string | undefined,
         limit: DEFAULT_LIMIT,
         project: undefined as string | undefined,
+        reference: undefined as string | undefined,
+        session: undefined as string | undefined,
         sort: undefined as string | undefined,
         stack: undefined as string | undefined,
-        time: undefined as string | undefined
+        status: undefined as string | undefined,
+        tag: undefined as string | undefined,
+        time: undefined as string | undefined,
+        type: undefined as string | undefined,
+        version: undefined as string | undefined
     };
 
     function filterCacheKey(filter: null | string): string {
@@ -97,30 +117,88 @@
 
     function getEffectiveFilter(): null | string {
         const queryFilters = getQueryFilters();
-        if (queryFilters != null) {
-            const filter = toFilter(queryFilters.filter((f) => f.type !== 'date'));
-            return filter || null;
+        if (queryParams.filter != null) {
+            const queryFilter = toFilter((queryFilters ?? []).filter((f) => f.type !== 'date'));
+            return [queryParams.filter, queryFilter].filter((filter) => filter).join(' ') || null;
         }
 
-        if (queryParams.filter != null) {
-            return queryParams.filter;
+        if (queryFilters != null) {
+            const queryFilter = toFilter(queryFilters.filter((f) => f.type !== 'date'));
+            return queryFilter || null;
         }
 
         return savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
     }
 
     function getQueryFilters(): FacetedFilter.IFilter[] | null {
-        const filters = queryParams.filters != null ? deserializeFilters(queryParams.filters) : [];
+        const filters: FacetedFilter.IFilter[] = [];
 
         if (queryParams.project) {
-            filters.push(new ProjectFilter([queryParams.project]));
+            filters.push(new ProjectFilter(splitQueryParam(queryParams.project)));
         }
 
         if (queryParams.stack) {
             filters.push(new StringFilter('stack', queryParams.stack));
         }
 
+        const bot = parseBooleanQueryParam(queryParams.bot);
+        if (bot !== undefined) {
+            filters.push(new BooleanFilter('bot', bot));
+        }
+
+        const first = parseBooleanQueryParam(queryParams.first);
+        if (first !== undefined) {
+            filters.push(new BooleanFilter('first', first));
+        }
+
+        if (queryParams.level) {
+            filters.push(new LevelFilter(splitQueryParam(queryParams.level) as never[]));
+        }
+
+        if (queryParams.reference) {
+            filters.push(new ReferenceFilter(queryParams.reference));
+        }
+
+        if (queryParams.session) {
+            filters.push(new SessionFilter(queryParams.session));
+        }
+
+        if (queryParams.status) {
+            filters.push(new StatusFilter(splitQueryParam(queryParams.status) as never[]));
+        }
+
+        if (queryParams.tag) {
+            filters.push(new TagFilter(splitQueryParam(queryParams.tag) as never[]));
+        }
+
+        if (queryParams.type) {
+            filters.push(new TypeFilter(splitQueryParam(queryParams.type) as never[]));
+        }
+
+        if (queryParams.version) {
+            filters.push(new VersionFilter('version', queryParams.version));
+        }
+
         return filters.length > 0 ? filters : null;
+    }
+
+    function parseBooleanQueryParam(value: null | string | undefined): boolean | undefined {
+        if (value === 'true') {
+            return true;
+        }
+
+        if (value === 'false') {
+            return false;
+        }
+
+        return undefined;
+    }
+
+    function splitQueryParam(value: string): string[] {
+        return value
+            .split(',')
+            .map((item) => item.trim())
+            .filter((item) => item);
     }
 
     function getEffectiveSort(): null | string | undefined {
@@ -136,13 +214,21 @@
         default: DEFAULT_PARAMS,
         pushHistory: true,
         schema: {
+            bot: 'string',
             filter: 'string',
-            filters: 'string',
+            first: 'string',
+            level: 'string',
             limit: 'number',
             project: 'string',
+            reference: 'string',
+            session: 'string',
             sort: 'string',
             stack: 'string',
-            time: 'string'
+            status: 'string',
+            tag: 'string',
+            time: 'string',
+            type: 'string',
+            version: 'string'
         }
     });
 
@@ -185,7 +271,11 @@
     // NOTE: This might be applying query string parameters when redirecting away.
     watch(
         () => organization.current,
-        () => {
+        (_currentOrganizationId, previousOrganizationId) => {
+            if (previousOrganizationId === undefined) {
+                return;
+            }
+
             updateFilterCache(filterCacheKey(DEFAULT_FILTER), DEFAULT_FILTERS);
             //params.$reset(); // Work around for https://github.com/beynar/kit-query-params/issues/7
             Object.assign(queryParams, DEFAULT_PARAMS);
@@ -199,8 +289,9 @@
         const savedView = savedViewsState.activeSavedView;
 
         const queryFilters = getQueryFilters();
-        if (queryFilters != null) {
-            return applyTimeFilter(queryFilters, getQueryTime());
+        if (queryFilters != null || queryParams.filter != null) {
+            const expressionFilters = queryParams.filter != null ? getFiltersFromCache(filterCacheKey(queryParams.filter), queryParams.filter) : [];
+            return applyTimeFilter([...expressionFilters, ...(queryFilters ?? [])], getQueryTime());
         }
 
         if (queryParams.filter == null && savedView?.filter_definitions && filter === (savedView.filter ?? null)) {
@@ -257,18 +348,15 @@
 
     function updateFilters(updatedFilters: FacetedFilter.IFilter[]): void {
         const filter = toFilter(updatedFilters.filter((f) => f.type !== 'date'));
+        const expressionFilters = updatedFilters.filter((f) => f.type !== 'date' && !isQueryParamFilter(f));
+        const filterParam = toFilter(expressionFilters);
         const time = ((updatedFilters.find((f) => f.type === 'date') as DateFilter | undefined)?.value as string | undefined) ?? null;
         const baseTime = savedViewsState.activeSavedView?.time ?? DEFAULT_TIME_RANGE;
-        const stackFilter = updatedFilters.find((f): f is StringFilter => f.type === 'string' && f.key === 'string-stack');
-        const projectFilter = updatedFilters.find((f): f is ProjectFilter => f.type === 'project');
-        const filtersForDefinitions = updatedFilters.filter((f) => f !== stackFilter && f !== projectFilter);
-        const filterDefinitions = filtersForDefinitions.length > 0 ? serializeFilters(filtersForDefinitions) : null;
+        const baseFilter = savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
+        const queryFilterParams = getQueryFilterParams(updatedFilters);
 
-        const newFilterParam = null;
+        const newFilterParam = filterParam === baseFilter ? null : filterParam || null;
         const newTimeParam = time === baseTime ? null : (time ?? ALL_TIME_QUERY_VALUE);
-        const newFiltersParam = filterDefinitions;
-        const newProjectParam = projectFilter?.value.length === 1 && projectFilter.value[0] ? projectFilter.value[0] : null;
-        const newStackParam = stackFilter?.value?.trim() ? stackFilter.value : null;
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
         // Only skip the watch when the URL will actually change from our update.
@@ -276,18 +364,78 @@
         if (
             newFilterParam !== queryParams.filter ||
             newTimeParam !== queryParams.time ||
-            newFiltersParam !== queryParams.filters ||
-            newProjectParam !== queryParams.project ||
-            newStackParam !== queryParams.stack
+            queryFilterParams.bot !== queryParams.bot ||
+            queryFilterParams.first !== queryParams.first ||
+            queryFilterParams.level !== queryParams.level ||
+            queryFilterParams.project !== queryParams.project ||
+            queryFilterParams.reference !== queryParams.reference ||
+            queryFilterParams.session !== queryParams.session ||
+            queryFilterParams.stack !== queryParams.stack ||
+            queryFilterParams.status !== queryParams.status ||
+            queryFilterParams.tag !== queryParams.tag ||
+            queryFilterParams.type !== queryParams.type ||
+            queryFilterParams.version !== queryParams.version
         ) {
             isInternalFilterUpdate = true;
         }
 
-        queryParams.filters = newFiltersParam;
-        queryParams.project = newProjectParam;
-        queryParams.stack = newStackParam;
+        queryParams.bot = queryFilterParams.bot;
+        queryParams.first = queryFilterParams.first;
+        queryParams.level = queryFilterParams.level;
+        queryParams.project = queryFilterParams.project;
+        queryParams.reference = queryFilterParams.reference;
+        queryParams.session = queryFilterParams.session;
+        queryParams.stack = queryFilterParams.stack;
+        queryParams.status = queryFilterParams.status;
+        queryParams.tag = queryFilterParams.tag;
+        queryParams.type = queryFilterParams.type;
+        queryParams.version = queryFilterParams.version;
         queryParams.time = newTimeParam;
         queryParams.filter = newFilterParam;
+    }
+
+    function getQueryFilterParams(filters: FacetedFilter.IFilter[]) {
+        const botFilter = filters.find((f): f is BooleanFilter => f instanceof BooleanFilter && f.term === 'bot');
+        const firstFilter = filters.find((f): f is BooleanFilter => f instanceof BooleanFilter && f.term === 'first');
+        const levelFilter = filters.find((f): f is LevelFilter => f.type === 'level');
+        const projectFilter = filters.find((f): f is ProjectFilter => f.type === 'project');
+        const referenceFilter = filters.find((f): f is ReferenceFilter => f.type === 'reference');
+        const sessionFilter = filters.find((f): f is SessionFilter => f.type === 'session');
+        const stackFilter = filters.find((f): f is StringFilter => f.type === 'string' && f.key === 'string-stack');
+        const statusFilter = filters.find((f): f is StatusFilter => f.type === 'status');
+        const tagFilter = filters.find((f): f is TagFilter => f.type === 'tag');
+        const typeFilter = filters.find((f): f is TypeFilter => f.type === 'type');
+        const versionFilter = filters.find((f): f is VersionFilter => f instanceof VersionFilter && f.term === 'version');
+
+        return {
+            bot: botFilter?.value === undefined ? null : String(botFilter.value),
+            first: firstFilter?.value === undefined ? null : String(firstFilter.value),
+            level: levelFilter?.value.length ? levelFilter.value.join(',') : null,
+            project: projectFilter?.value.length ? projectFilter.value.join(',') : null,
+            reference: referenceFilter?.value?.trim() ? referenceFilter.value : null,
+            session: sessionFilter?.value?.trim() ? sessionFilter.value : null,
+            stack: stackFilter?.value?.trim() ? stackFilter.value : null,
+            status: statusFilter?.value.length ? statusFilter.value.join(',') : null,
+            tag: tagFilter?.value.length ? tagFilter.value.join(',') : null,
+            type: typeFilter?.value.length ? typeFilter.value.join(',') : null,
+            version: versionFilter?.value?.trim() ? versionFilter.value : null
+        };
+    }
+
+    function isQueryParamFilter(filter: FacetedFilter.IFilter): boolean {
+        if (filter.type === 'string' && filter.key === 'string-stack') {
+            return true;
+        }
+
+        if (filter.type === 'boolean' && filter instanceof BooleanFilter && (filter.term === 'bot' || filter.term === 'first') && filter.value !== undefined) {
+            return true;
+        }
+
+        if (filter.type === 'version' && filter instanceof VersionFilter && filter.term !== 'version') {
+            return false;
+        }
+
+        return ['level', 'project', 'reference', 'session', 'status', 'tag', 'type', 'version'].includes(filter.type);
     }
 
     const eventsQueryParameters: GetEventsParams = $state({

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -89,11 +89,14 @@
     const DEFAULT_FILTER = '(status:open OR status:regressed)';
     const DEFAULT_FILTERS = [new DateFilter('date', DEFAULT_TIME_RANGE), new ProjectFilter([]), new StatusFilter([StackStatus.Open, StackStatus.Regressed])];
     const DEFAULT_PARAMS = {
+        after: undefined as string | undefined,
+        before: undefined as string | undefined,
         bot: undefined as string | undefined,
         filter: undefined as string | undefined,
         first: undefined as string | undefined,
         level: undefined as string | undefined,
         limit: DEFAULT_LIMIT,
+        page: undefined as number | undefined,
         project: undefined as string | undefined,
         reference: undefined as string | undefined,
         session: undefined as string | undefined,
@@ -211,11 +214,14 @@
         default: DEFAULT_PARAMS,
         pushHistory: true,
         schema: {
+            after: 'string',
+            before: 'string',
             bot: 'string',
             filter: 'string',
             first: 'string',
             level: 'string',
             limit: 'number',
+            page: 'number',
             project: 'string',
             reference: 'string',
             session: 'string',
@@ -429,7 +435,8 @@
         filters = updatedFilters;
     }
 
-    function updateFilters(updatedFilters: FacetedFilter.IFilter[]): void {
+    function updateFilters(updatedFilters: FacetedFilter.IFilter[], options: { clearPagination?: boolean } = {}): void {
+        const shouldClearPagination = options.clearPagination ?? true;
         const filter = toFilter(updatedFilters.filter((f) => f.type !== 'date'));
         const expressionFilters = updatedFilters.filter((f) => f.type !== 'date' && !isQueryParamFilter(f));
         const filterParam = toFilter(expressionFilters);
@@ -445,6 +452,10 @@
         const newTimeParam = time === baseTime ? null : time ? serializeTimeQueryParam(time) : ALL_TIME_QUERY_VALUE;
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
+        if (shouldClearPagination) {
+            clearPaginationQueryParams();
+        }
+
         // Only skip the watch when the URL will actually change from our update.
         // If the URL doesn't change, the watch won't fire and the flag would stay stale.
         if (
@@ -480,6 +491,12 @@
         queryParams.filter = newFilterParam;
     }
 
+    function clearPaginationQueryParams(): void {
+        queryParams.after = null;
+        queryParams.before = null;
+        queryParams.page = null;
+    }
+
     $effect(() => {
         const activeSavedViewId = savedViewsState.activeSavedView?.id;
         if (!activeSavedViewId) {
@@ -487,7 +504,7 @@
         }
 
         untrack(() => {
-            updateFilters(getCurrentFilters());
+            updateFilters(getCurrentFilters(), { clearPagination: false });
         });
     });
 
@@ -560,8 +577,18 @@
     }
 
     const eventsQueryParameters: GetEventsParams = $state({
-        after: undefined,
-        before: undefined,
+        get after() {
+            return queryParams.after ?? undefined;
+        },
+        set after(value) {
+            queryParams.after = value ?? null;
+        },
+        get before() {
+            return queryParams.before ?? undefined;
+        },
+        set before(value) {
+            queryParams.before = value ?? null;
+        },
         get filter() {
             return getEffectiveFilter()!;
         },
@@ -576,6 +603,12 @@
         },
         mode: 'summary',
         offset: DEFAULT_OFFSET,
+        get page() {
+            return queryParams.page ?? undefined;
+        },
+        set page(value) {
+            queryParams.page = value ?? null;
+        },
         get sort() {
             return getEffectiveSort() ?? undefined;
         },
@@ -642,9 +675,9 @@
             return;
         }
 
-        clientResponse = await client.getJSON<EventSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organization.current}/events`, {
-            params: eventsQueryParameters as Record<string, unknown>
-        });
+        const params = { ...eventsQueryParameters };
+        delete params.page;
+        clientResponse = await client.getJSON<EventSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organization.current}/events`, { params });
 
         if (clientResponse.problem) {
             showBillingDialogOnUpgradeProblem(clientResponse.problem, organization.current, () => loadData());

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -62,7 +62,13 @@
     import { untrack } from 'svelte';
     import { debounce, throttle } from 'throttle-debounce';
 
-    import { ALL_TIME_QUERY_VALUE, getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../redirect-to-events.svelte';
+    import {
+        ALL_TIME_QUERY_VALUE,
+        deserializeTimeQueryParam,
+        getEventsNavigationOptionsForFilter,
+        redirectToEventsWithFilter,
+        serializeTimeQueryParam
+    } from '../redirect-to-events.svelte';
 
     let selectedEventId: null | string = $state(null);
 
@@ -110,7 +116,7 @@
                 return null;
             }
 
-            return queryParams.time || null;
+            return queryParams.time ? deserializeTimeQueryParam(queryParams.time) : null;
         }
 
         return savedViewsState.activeSavedView?.time ?? DEFAULT_TIME_RANGE;
@@ -436,7 +442,7 @@
         const baseExpressionFilterParam = savedViewFilters ? toFilter(savedViewFilters.filter((f) => f.type !== 'date' && !isQueryParamFilter(f))) : baseFilter;
 
         const newFilterParam = filterParam === baseExpressionFilterParam ? null : filterParam || (savedViewFilters && baseExpressionFilterParam ? '' : null);
-        const newTimeParam = time === baseTime ? null : (time ?? ALL_TIME_QUERY_VALUE);
+        const newTimeParam = time === baseTime ? null : time ? serializeTimeQueryParam(time) : ALL_TIME_QUERY_VALUE;
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
         // Only skip the watch when the URL will actually change from our update.
@@ -579,7 +585,7 @@
             return getQueryTime() ?? undefined;
         },
         set time(value) {
-            queryParams.time = value ?? ALL_TIME_QUERY_VALUE;
+            queryParams.time = value ? serializeTimeQueryParam(value) : ALL_TIME_QUERY_VALUE;
         }
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -59,6 +59,7 @@
     import { createTable } from '@tanstack/svelte-table';
     import { queryParamsState } from 'kit-query-params';
     import { useEventListener, watch } from 'runed';
+    import { untrack } from 'svelte';
     import { debounce, throttle } from 'throttle-debounce';
 
     import { ALL_TIME_QUERY_VALUE, getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../redirect-to-events.svelte';
@@ -474,11 +475,14 @@
     }
 
     $effect(() => {
-        if (!savedViewsState.activeSavedView) {
+        const activeSavedViewId = savedViewsState.activeSavedView?.id;
+        if (!activeSavedViewId) {
             return;
         }
 
-        updateFilters(getCurrentFilters());
+        untrack(() => {
+            updateFilters(getCurrentFilters());
+        });
     });
 
     function getQueryFilterParams(filters: FacetedFilter.IFilter[]) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -50,7 +50,7 @@
     import { useEventListener, watch } from 'runed';
     import { debounce, throttle } from 'throttle-debounce';
 
-    import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../redirect-to-events.svelte';
+    import { ALL_TIME_QUERY_VALUE, getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../redirect-to-events.svelte';
 
     let selectedEventId: null | string = $state(null);
 
@@ -84,6 +84,10 @@
 
     function getQueryTime(): null | string {
         if (queryParams.time != null) {
+            if (queryParams.time === ALL_TIME_QUERY_VALUE) {
+                return null;
+            }
+
             return queryParams.time || null;
         }
 
@@ -238,7 +242,7 @@
         const filterDefinitions = serializeFilters(updatedFilters);
 
         const newFilterParam = null;
-        const newTimeParam = time === baseTime ? null : (time ?? '');
+        const newTimeParam = time === baseTime ? null : (time ?? ALL_TIME_QUERY_VALUE);
         const newFiltersParam = filterDefinitions;
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
@@ -279,7 +283,7 @@
             return getQueryTime() ?? undefined;
         },
         set time(value) {
-            queryParams.time = value ?? null;
+            queryParams.time = value ?? ALL_TIME_QUERY_VALUE;
         }
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -25,6 +25,7 @@
         serializeFilters,
         shouldRefreshPersistentEventChanged,
         toFilter,
+        toFilterFromSerializedFilters,
         updateFilterCache
     } from '$features/events/components/filters/helpers.svelte';
     import OrganizationDefaultsFacetedFilterBuilder from '$features/events/components/filters/organization-defaults-faceted-filter-builder.svelte';
@@ -69,6 +70,7 @@
     const DEFAULT_FILTERS = [new DateFilter('date', DEFAULT_TIME_RANGE), new ProjectFilter([]), new StatusFilter([StackStatus.Open, StackStatus.Regressed])];
     const DEFAULT_PARAMS = {
         filter: undefined as string | undefined,
+        filters: undefined as string | undefined,
         limit: DEFAULT_LIMIT,
         sort: undefined as string | undefined,
         time: undefined as string | undefined
@@ -87,6 +89,10 @@
     }
 
     function getEffectiveFilter(): null | string {
+        if (queryParams.filters != null) {
+            return toFilterFromSerializedFilters(queryParams.filters);
+        }
+
         if (queryParams.filter != null) {
             return queryParams.filter;
         }
@@ -108,6 +114,7 @@
         pushHistory: true,
         schema: {
             filter: 'string',
+            filters: 'string',
             limit: 'number',
             sort: 'string',
             time: 'string'
@@ -166,6 +173,10 @@
         const filter = getEffectiveFilter();
         const savedView = savedViewsState.activeSavedView;
 
+        if (queryParams.filters != null) {
+            return applyTimeFilter(deserializeFilters(queryParams.filters), getQueryTime());
+        }
+
         if (queryParams.filter == null && savedView?.filter_definitions && filter === (savedView.filter ?? null)) {
             const hydrated = deserializeFilters(savedView.filter_definitions);
             return applyTimeFilter(hydrated, getQueryTime());
@@ -214,19 +225,21 @@
     function updateFilters(updatedFilters: FacetedFilter.IFilter[]): void {
         const filter = toFilter(updatedFilters.filter((f) => f.type !== 'date'));
         const time = ((updatedFilters.find((f) => f.type === 'date') as DateFilter | undefined)?.value as string | undefined) ?? null;
-        const baseFilter = savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
         const baseTime = savedViewsState.activeSavedView?.time ?? DEFAULT_TIME_RANGE;
+        const filterDefinitions = serializeFilters(updatedFilters);
 
-        const newFilterParam = filter === baseFilter ? null : filter;
+        const newFilterParam = null;
         const newTimeParam = time === baseTime ? null : (time ?? '');
+        const newFiltersParam = filterDefinitions;
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
         // Only skip the watch when the URL will actually change from our update.
         // If the URL doesn't change, the watch won't fire and the flag would stay stale.
-        if (newFilterParam !== queryParams.filter || newTimeParam !== queryParams.time) {
+        if (newFilterParam !== queryParams.filter || newTimeParam !== queryParams.time || newFiltersParam !== queryParams.filters) {
             isInternalFilterUpdate = true;
         }
 
+        queryParams.filters = newFiltersParam;
         queryParams.time = newTimeParam;
         queryParams.filter = newFilterParam;
     }

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -560,6 +560,8 @@
     }
 
     const eventsQueryParameters: GetEventsParams = $state({
+        after: undefined,
+        before: undefined,
         get filter() {
             return getEffectiveFilter()!;
         },

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -116,18 +116,8 @@
     }
 
     function getEffectiveFilter(): null | string {
-        const queryFilters = getQueryFilters();
-        if (queryParams.filter != null) {
-            const queryFilter = toFilter((queryFilters ?? []).filter((f) => f.type !== 'date'));
-            return [queryParams.filter, queryFilter].filter((filter) => filter).join(' ') || null;
-        }
-
-        if (queryFilters != null) {
-            const queryFilter = toFilter(queryFilters.filter((f) => f.type !== 'date'));
-            return queryFilter || null;
-        }
-
-        return savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
+        const filter = toFilter(getCurrentFiltersWithoutTime());
+        return filter || null;
     }
 
     function getQueryFilters(): FacetedFilter.IFilter[] | null {
@@ -285,21 +275,104 @@
     );
 
     function getCurrentFilters(): FacetedFilter.IFilter[] {
-        const filter = getEffectiveFilter();
+        return applyTimeFilter(getCurrentFiltersWithoutTime(), getQueryTime());
+    }
+
+    function getCurrentFiltersWithoutTime(): FacetedFilter.IFilter[] {
+        const savedViewFilters = getSavedViewFilters();
+        const queryFilters = getQueryFilters() ?? [];
+        const expressionFilters = queryParams.filter != null ? getFiltersFromCache(filterCacheKey(queryParams.filter), queryParams.filter) : [];
+
+        if (savedViewFilters) {
+            return mergeFilterOverrides(
+                savedViewFilters.filter((filter) => filter.type !== 'date'),
+                [...expressionFilters, ...queryFilters],
+                getQueryFilterRemovalKeys(savedViewFilters)
+            );
+        }
+
+        if (expressionFilters.length > 0 || queryFilters.length > 0) {
+            return [...expressionFilters, ...queryFilters];
+        }
+
+        const filter = savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
+        return getFiltersFromCache(filterCacheKey(filter), filter);
+    }
+
+    function getSavedViewFilters(): FacetedFilter.IFilter[] | null {
         const savedView = savedViewsState.activeSavedView;
-
-        const queryFilters = getQueryFilters();
-        if (queryFilters != null || queryParams.filter != null) {
-            const expressionFilters = queryParams.filter != null ? getFiltersFromCache(filterCacheKey(queryParams.filter), queryParams.filter) : [];
-            return applyTimeFilter([...expressionFilters, ...(queryFilters ?? [])], getQueryTime());
+        if (!savedView?.filter_definitions) {
+            return null;
         }
 
-        if (queryParams.filter == null && savedView?.filter_definitions && filter === (savedView.filter ?? null)) {
-            const hydrated = deserializeFilters(savedView.filter_definitions);
-            return applyTimeFilter(hydrated, getQueryTime());
+        return deserializeFilters(savedView.filter_definitions);
+    }
+
+    function getQueryFilterRemovalKeys(savedViewFilters: FacetedFilter.IFilter[]): string[] {
+        const removedKeys: string[] = [];
+
+        if (queryParams.bot === '') {
+            removedKeys.push('boolean-bot');
         }
 
-        return applyTimeFilter(getFiltersFromCache(filterCacheKey(filter), filter), getQueryTime());
+        if (queryParams.first === '') {
+            removedKeys.push('boolean-first');
+        }
+
+        if (queryParams.filter === '') {
+            removedKeys.push(...savedViewFilters.filter((filter) => filter.type !== 'date' && !isQueryParamFilter(filter)).map((filter) => filter.key));
+        }
+
+        if (queryParams.level === '') {
+            removedKeys.push('level');
+        }
+
+        if (queryParams.project === '') {
+            removedKeys.push('project');
+        }
+
+        if (queryParams.reference === '') {
+            removedKeys.push('reference');
+        }
+
+        if (queryParams.session === '') {
+            removedKeys.push('session');
+        }
+
+        if (queryParams.stack === '') {
+            removedKeys.push('string-stack');
+        }
+
+        if (queryParams.status === '') {
+            removedKeys.push('status');
+        }
+
+        if (queryParams.tag === '') {
+            removedKeys.push('tag');
+        }
+
+        if (queryParams.type === '') {
+            removedKeys.push('type');
+        }
+
+        if (queryParams.version === '') {
+            removedKeys.push('version-version');
+        }
+
+        return removedKeys;
+    }
+
+    function mergeFilterOverrides(
+        baseFilters: FacetedFilter.IFilter[],
+        overrideFilters: FacetedFilter.IFilter[],
+        removedFilterKeys: string[] = []
+    ): FacetedFilter.IFilter[] {
+        if (overrideFilters.length === 0 && removedFilterKeys.length === 0) {
+            return baseFilters;
+        }
+
+        const overrideKeys = new Set([...overrideFilters.map((filter) => filter.key), ...removedFilterKeys]);
+        return [...baseFilters.filter((filter) => !overrideKeys.has(filter.key)), ...overrideFilters];
     }
 
     let filters = $state(getCurrentFilters());
@@ -353,9 +426,12 @@
         const time = ((updatedFilters.find((f) => f.type === 'date') as DateFilter | undefined)?.value as string | undefined) ?? null;
         const baseTime = savedViewsState.activeSavedView?.time ?? DEFAULT_TIME_RANGE;
         const baseFilter = savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
-        const queryFilterParams = getQueryFilterParams(updatedFilters);
+        const savedViewFilters = getSavedViewFilters();
+        const baseQueryFilterParams = getQueryFilterParams(savedViewFilters ?? []);
+        const queryFilterParams = getQueryFilterParamDeltas(getQueryFilterParams(updatedFilters), baseQueryFilterParams);
+        const baseExpressionFilterParam = savedViewFilters ? toFilter(savedViewFilters.filter((f) => f.type !== 'date' && !isQueryParamFilter(f))) : baseFilter;
 
-        const newFilterParam = filterParam === baseFilter ? null : filterParam || null;
+        const newFilterParam = filterParam === baseExpressionFilterParam ? null : filterParam || (savedViewFilters && baseExpressionFilterParam ? '' : null);
         const newTimeParam = time === baseTime ? null : (time ?? ALL_TIME_QUERY_VALUE);
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
@@ -394,6 +470,14 @@
         queryParams.filter = newFilterParam;
     }
 
+    $effect(() => {
+        if (!savedViewsState.activeSavedView) {
+            return;
+        }
+
+        updateFilters(getCurrentFilters());
+    });
+
     function getQueryFilterParams(filters: FacetedFilter.IFilter[]) {
         const botFilter = filters.find((f): f is BooleanFilter => f instanceof BooleanFilter && f.term === 'bot');
         const firstFilter = filters.find((f): f is BooleanFilter => f instanceof BooleanFilter && f.term === 'first');
@@ -419,6 +503,30 @@
             tag: tagFilter?.value.length ? tagFilter.value.join(',') : null,
             type: typeFilter?.value.length ? typeFilter.value.join(',') : null,
             version: versionFilter?.value?.trim() ? versionFilter.value : null
+        };
+    }
+
+    function getQueryFilterParamDeltas(currentParams: ReturnType<typeof getQueryFilterParams>, baseParams: ReturnType<typeof getQueryFilterParams>) {
+        const getDelta = (currentValue: null | string, baseValue: null | string): null | string => {
+            if (currentValue === baseValue) {
+                return null;
+            }
+
+            return currentValue ?? (baseValue ? '' : null);
+        };
+
+        return {
+            bot: getDelta(currentParams.bot, baseParams.bot),
+            first: getDelta(currentParams.first, baseParams.first),
+            level: getDelta(currentParams.level, baseParams.level),
+            project: getDelta(currentParams.project, baseParams.project),
+            reference: getDelta(currentParams.reference, baseParams.reference),
+            session: getDelta(currentParams.session, baseParams.session),
+            stack: getDelta(currentParams.stack, baseParams.stack),
+            status: getDelta(currentParams.status, baseParams.status),
+            tag: getDelta(currentParams.tag, baseParams.tag),
+            type: getDelta(currentParams.type, baseParams.type),
+            version: getDelta(currentParams.version, baseParams.version)
         };
     }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
@@ -11,7 +11,7 @@
     import { watch } from 'runed';
     import { toast } from 'svelte-sonner';
 
-    import { redirectToEventsWithFilter } from '../../redirect-to-events.svelte.js';
+    import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../../redirect-to-events.svelte.js';
 
     // TODO: Have this happen automatically when the organization changes.
     watch(
@@ -23,8 +23,7 @@
     );
 
     async function filterChanged(addedOrUpdated: FacetedFilter.IFilter) {
-        const options = addedOrUpdated.type === 'string' && addedOrUpdated.key === 'string-stack' ? { time: null } : undefined;
-        await redirectToEventsWithFilter(organization.current, addedOrUpdated, options);
+        await redirectToEventsWithFilter(organization.current, addedOrUpdated, getEventsNavigationOptionsForFilter(addedOrUpdated));
     }
 
     async function handleError(problem: ProblemDetails) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
@@ -23,7 +23,8 @@
     );
 
     async function filterChanged(addedOrUpdated: FacetedFilter.IFilter) {
-        await redirectToEventsWithFilter(organization.current, addedOrUpdated);
+        const options = addedOrUpdated.type === 'string' && addedOrUpdated.key === 'string-stack' ? { time: null } : undefined;
+        await redirectToEventsWithFilter(organization.current, addedOrUpdated, options);
     }
 
     async function handleError(problem: ProblemDetails) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import type { PersistentEvent } from '$features/events/models';
     import type { ProblemDetails } from '@exceptionless/fetchclient';
 
     import { goto } from '$app/navigation';
@@ -7,6 +8,7 @@
     import * as FacetedFilter from '$comp/faceted-filter';
     import { showBillingDialogOnUpgradeProblem } from '$features/billing';
     import EventsOverview from '$features/events/components/events-overview.svelte';
+    import { buildEventDetailsHref } from '$features/events/components/summary';
     import { organization } from '$features/organizations/context.svelte';
     import { watch } from 'runed';
     import { toast } from 'svelte-sonner';
@@ -35,6 +37,10 @@
         await goto(resolve('/(app)/event'));
     }
 
+    async function handleEventLoaded(event: PersistentEvent) {
+        await goto(buildEventDetailsHref(event.id, event.stack_id), { replaceState: true });
+    }
+
     $effect(() => {
         document.title = 'Event Details - Exceptionless';
     });
@@ -44,5 +50,6 @@
     {filterChanged}
     id={page.params.eventId || ''}
     {handleError}
+    onEventLoaded={handleEventLoaded}
     onNavigate={(newId) => goto(resolve('/(app)/event/[eventId=objectid]', { eventId: newId }))}
 />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/[stackId]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/[stackId]/+page.svelte
@@ -24,7 +24,8 @@
     );
 
     async function filterChanged(addedOrUpdated: IFilter) {
-        await redirectToEventsWithFilter(organization.current, addedOrUpdated);
+        const options = addedOrUpdated.type === 'string' && addedOrUpdated.key === 'string-stack' ? { time: null } : undefined;
+        await redirectToEventsWithFilter(organization.current, addedOrUpdated, options);
     }
 
     function handleError(problem: ProblemDetails) {
@@ -35,9 +36,13 @@
         toast.error('Unable to load stack event details.');
     }
 
+    async function handleDeleted() {
+        await goto(resolve('/(app)/project/[projectId]/stacks', { projectId: page.params.projectId || '' }));
+    }
+
     $effect(() => {
         document.title = 'Stack Details - Exceptionless';
     });
 </script>
 
-<StackDetails {filterChanged} {handleError} {stackId} />
+<StackDetails {filterChanged} {handleError} onDeleted={handleDeleted} {stackId} />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/[stackId]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/[stackId]/+page.svelte
@@ -11,7 +11,7 @@
     import { watch } from 'runed';
     import { toast } from 'svelte-sonner';
 
-    import { redirectToEventsWithFilter } from '../../../../redirect-to-events.svelte.js';
+    import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../../../../redirect-to-events.svelte.js';
 
     const stackId = $derived(page.params.stackId || '');
 
@@ -24,8 +24,7 @@
     );
 
     async function filterChanged(addedOrUpdated: IFilter) {
-        const options = addedOrUpdated.type === 'string' && addedOrUpdated.key === 'string-stack' ? { time: null } : undefined;
-        await redirectToEventsWithFilter(organization.current, addedOrUpdated, options);
+        await redirectToEventsWithFilter(organization.current, addedOrUpdated, getEventsNavigationOptionsForFilter(addedOrUpdated));
     }
 
     function handleError(problem: ProblemDetails) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.test.ts
@@ -1,4 +1,4 @@
-import { DateFilter, StringFilter } from '$features/events/components/filters/models.svelte';
+import { DateFilter, ProjectFilter, StringFilter } from '$features/events/components/filters/models.svelte';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('$app/navigation', () => ({
@@ -23,6 +23,21 @@ describe('redirect-to-events', () => {
         // Assert
         expect(url.pathname).toBe('/(app)/event');
         expect(url.searchParams.get('time')).toBe(ALL_TIME_QUERY_VALUE);
-        expect(url.searchParams.get('filters')).toBe('[{"type":"string","term":"stack","value":"stack-1"}]');
+        expect(url.searchParams.get('stack')).toBe('stack-1');
+        expect(url.searchParams.has('filters')).toBe(false);
+    });
+
+    it('maps project filters to the project query parameter', async () => {
+        // Arrange
+        const { buildListPageHref } = await import('./redirect-to-events.svelte');
+
+        // Act
+        const href = buildListPageHref('events', 'org-1', [new ProjectFilter(['project-1'])]);
+        const url = new URL(href, 'https://example.test');
+
+        // Assert
+        expect(url.pathname).toBe('/(app)/event');
+        expect(url.searchParams.get('project')).toBe('project-1');
+        expect(url.searchParams.has('filters')).toBe(false);
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.test.ts
@@ -27,7 +27,7 @@ describe('redirect-to-events', () => {
         expect(url.searchParams.has('filters')).toBe(false);
     });
 
-    it('omits date range brackets from time query parameters', async () => {
+    it('uses relative duration shortcuts for time query parameters', async () => {
         // Arrange
         const { buildListPageHref, deserializeTimeQueryParam } = await import('./redirect-to-events.svelte');
 
@@ -36,8 +36,32 @@ describe('redirect-to-events', () => {
         const url = new URL(href, 'https://example.test');
 
         // Assert
-        expect(url.searchParams.get('time')).toBe('now-1h TO now');
+        expect(url.searchParams.get('time')).toBe('1h');
         expect(deserializeTimeQueryParam(url.searchParams.get('time')!)).toBe('[now-1h TO now]');
+    });
+
+    it('omits date range brackets from custom time query parameters', async () => {
+        // Arrange
+        const { buildListPageHref, deserializeTimeQueryParam } = await import('./redirect-to-events.svelte');
+
+        // Act
+        const href = buildListPageHref('events', 'org-1', [new DateFilter('date', '[2025-01-01 TO 2025-02-01]')]);
+        const url = new URL(href, 'https://example.test');
+
+        // Assert
+        expect(url.searchParams.get('time')).toBe('2025-01-01 TO 2025-02-01');
+        expect(deserializeTimeQueryParam(url.searchParams.get('time')!)).toBe('[2025-01-01 TO 2025-02-01]');
+    });
+
+    it('accepts existing expanded time query parameters', async () => {
+        // Arrange
+        const { deserializeTimeQueryParam } = await import('./redirect-to-events.svelte');
+
+        // Act
+        const time = deserializeTimeQueryParam('now-1h TO now');
+
+        // Assert
+        expect(time).toBe('[now-1h TO now]');
     });
 
     it('accepts existing bracketed time query parameters', async () => {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.test.ts
@@ -1,4 +1,4 @@
-import { DateFilter, ProjectFilter, StringFilter } from '$features/events/components/filters/models.svelte';
+import { DateFilter, ProjectFilter, StatusFilter, StringFilter } from '$features/events/components/filters/models.svelte';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('$app/navigation', () => ({
@@ -38,6 +38,35 @@ describe('redirect-to-events', () => {
         // Assert
         expect(url.pathname).toBe('/(app)/event');
         expect(url.searchParams.get('project')).toBe('project-1');
+        expect(url.searchParams.has('filters')).toBe(false);
+    });
+
+    it('maps registered filters to explicit query parameters', async () => {
+        // Arrange
+        const { buildListPageHref } = await import('./redirect-to-events.svelte');
+
+        // Act
+        const href = buildListPageHref('events', 'org-1', [new StatusFilter(['open', 'regressed'] as never[])]);
+        const url = new URL(href, 'https://example.test');
+
+        // Assert
+        expect(url.pathname).toBe('/(app)/event');
+        expect(url.searchParams.get('status')).toBe('open,regressed');
+        expect(url.searchParams.has('filter')).toBe(false);
+        expect(url.searchParams.has('filters')).toBe(false);
+    });
+
+    it('falls back to raw filter expressions for unmapped filters', async () => {
+        // Arrange
+        const { buildListPageHref } = await import('./redirect-to-events.svelte');
+
+        // Act
+        const href = buildListPageHref('events', 'org-1', [new StringFilter('message', 'hello')]);
+        const url = new URL(href, 'https://example.test');
+
+        // Assert
+        expect(url.pathname).toBe('/(app)/event');
+        expect(url.searchParams.get('filter')).toBe('message:hello');
         expect(url.searchParams.has('filters')).toBe(false);
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import { DateFilter, StringFilter } from '$features/events/components/filters/models.svelte';
+import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('$app/navigation', () => ({
     goto: vi.fn()

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.test.ts
@@ -27,6 +27,30 @@ describe('redirect-to-events', () => {
         expect(url.searchParams.has('filters')).toBe(false);
     });
 
+    it('omits date range brackets from time query parameters', async () => {
+        // Arrange
+        const { buildListPageHref, deserializeTimeQueryParam } = await import('./redirect-to-events.svelte');
+
+        // Act
+        const href = buildListPageHref('events', 'org-1', [new DateFilter('date', '[now-1h TO now]')]);
+        const url = new URL(href, 'https://example.test');
+
+        // Assert
+        expect(url.searchParams.get('time')).toBe('now-1h TO now');
+        expect(deserializeTimeQueryParam(url.searchParams.get('time')!)).toBe('[now-1h TO now]');
+    });
+
+    it('accepts existing bracketed time query parameters', async () => {
+        // Arrange
+        const { deserializeTimeQueryParam } = await import('./redirect-to-events.svelte');
+
+        // Act
+        const time = deserializeTimeQueryParam('[now-1h TO now]');
+
+        // Assert
+        expect(time).toBe('[now-1h TO now]');
+    });
+
     it('maps project filters to the project query parameter', async () => {
         // Arrange
         const { buildListPageHref } = await import('./redirect-to-events.svelte');

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DateFilter, StringFilter } from '$features/events/components/filters/models.svelte';
+
+vi.mock('$app/navigation', () => ({
+    goto: vi.fn()
+}));
+
+vi.mock('$app/paths', () => ({
+    resolve: (path: string) => path
+}));
+
+describe('redirect-to-events', () => {
+    it('uses an explicit all-time query value for stack event drilldowns', async () => {
+        // Arrange
+        const { ALL_TIME_QUERY_VALUE, buildListPageHref, getEventsNavigationOptionsForFilter } = await import('./redirect-to-events.svelte');
+        const stackFilter = new StringFilter('stack', 'stack-1');
+        const options = getEventsNavigationOptionsForFilter(stackFilter);
+
+        // Act
+        const href = buildListPageHref('events', 'org-1', [new DateFilter('date', '[now-7d TO now]'), stackFilter], options);
+        const url = new URL(href, 'https://example.test');
+
+        // Assert
+        expect(url.pathname).toBe('/(app)/event');
+        expect(url.searchParams.get('time')).toBe(ALL_TIME_QUERY_VALUE);
+        expect(url.searchParams.get('filters')).toBe('[{"type":"string","term":"stack","value":"stack-1"}]');
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
@@ -3,12 +3,13 @@ import type { IFilter } from '$comp/faceted-filter';
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
 import { serializeFilters } from '$features/events/components/filters/helpers.svelte';
-
-type ListPage = 'events' | 'stacks';
+import { SvelteURLSearchParams } from 'svelte/reactivity';
 
 interface ListNavigationOptions {
     time?: null | string;
 }
+
+type ListPage = 'events' | 'stacks';
 
 const listPagePaths = {
     events: '/(app)/event',
@@ -20,7 +21,7 @@ export function buildListPageHref(page: ListPage, _organizationId: string | unde
     const filtersForNavigation = options.time === null ? filters.filter((filter) => filter.type !== 'date') : filters;
     const serializedFilters = serializeFilters(filtersForNavigation);
 
-    const queryParams = new URLSearchParams({ filters: serializedFilters });
+    const queryParams = new SvelteURLSearchParams({ filters: serializedFilters });
 
     const dateFilter = filters.find((filter): filter is IFilter & { value: unknown } => filter.type === 'date' && 'value' in filter);
     const time = options.time ?? dateFilter?.value;

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
@@ -2,6 +2,7 @@ import type { IFilter } from '$comp/faceted-filter';
 
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
+import { toFilter } from '$features/events/components/filters/helpers.svelte';
 import { SvelteURLSearchParams } from 'svelte/reactivity';
 
 interface ListNavigationOptions {
@@ -21,7 +22,11 @@ export function buildListPageHref(page: ListPage, _organizationId: string | unde
     const path = resolve(listPagePaths[page]);
     const filtersForNavigation = options.time === null ? filters.filter((filter) => filter.type !== 'date') : filters;
     const queryParams = new SvelteURLSearchParams();
-    filtersForNavigation.forEach((filter) => trySetRegisteredFilterQueryParam(queryParams, filter));
+    const rawFilters = filtersForNavigation.filter((filter) => filter.type !== 'date' && !trySetRegisteredFilterQueryParam(queryParams, filter));
+    const rawFilter = toFilter(rawFilters);
+    if (rawFilter) {
+        queryParams.set('filter', rawFilter);
+    }
 
     const dateFilter = filters.find((filter): filter is IFilter & { value: unknown } => filter.type === 'date' && 'value' in filter);
     const time = 'time' in options ? options.time : dateFilter?.value;
@@ -66,8 +71,61 @@ function trySetRegisteredFilterQueryParam(queryParams: SvelteURLSearchParams, fi
         return true;
     }
 
-    if (filter.type === 'project' && 'value' in filter && Array.isArray(filter.value) && filter.value.length === 1) {
-        queryParams.set('project', filter.value[0]);
+    if (filter.type === 'project' && 'value' in filter && Array.isArray(filter.value) && filter.value.length > 0) {
+        queryParams.set('project', filter.value.join(','));
+        return true;
+    }
+
+    if (
+        filter.type === 'boolean' &&
+        'term' in filter &&
+        (filter.term === 'bot' || filter.term === 'first') &&
+        'value' in filter &&
+        typeof filter.value === 'boolean'
+    ) {
+        queryParams.set(filter.term, String(filter.value));
+        return true;
+    }
+
+    if (filter.type === 'level' && 'value' in filter && Array.isArray(filter.value) && filter.value.length > 0) {
+        queryParams.set('level', filter.value.join(','));
+        return true;
+    }
+
+    if (filter.type === 'reference' && 'value' in filter && typeof filter.value === 'string' && filter.value.trim()) {
+        queryParams.set('reference', filter.value);
+        return true;
+    }
+
+    if (filter.type === 'session' && 'value' in filter && typeof filter.value === 'string' && filter.value.trim()) {
+        queryParams.set('session', filter.value);
+        return true;
+    }
+
+    if (filter.type === 'status' && 'value' in filter && Array.isArray(filter.value) && filter.value.length > 0) {
+        queryParams.set('status', filter.value.join(','));
+        return true;
+    }
+
+    if (filter.type === 'tag' && 'value' in filter && Array.isArray(filter.value) && filter.value.length > 0) {
+        queryParams.set('tag', filter.value.join(','));
+        return true;
+    }
+
+    if (filter.type === 'type' && 'value' in filter && Array.isArray(filter.value) && filter.value.length > 0) {
+        queryParams.set('type', filter.value.join(','));
+        return true;
+    }
+
+    if (
+        filter.type === 'version' &&
+        'term' in filter &&
+        filter.term === 'version' &&
+        'value' in filter &&
+        typeof filter.value === 'string' &&
+        filter.value.trim()
+    ) {
+        queryParams.set('version', filter.value);
         return true;
     }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
@@ -11,6 +11,8 @@ interface ListNavigationOptions {
 
 type ListPage = 'events' | 'stacks';
 
+export const ALL_TIME_QUERY_VALUE = 'all';
+
 const listPagePaths = {
     events: '/(app)/event',
     stacks: '/(app)/stack'
@@ -24,9 +26,9 @@ export function buildListPageHref(page: ListPage, _organizationId: string | unde
     const queryParams = new SvelteURLSearchParams({ filters: serializedFilters });
 
     const dateFilter = filters.find((filter): filter is IFilter & { value: unknown } => filter.type === 'date' && 'value' in filter);
-    const time = options.time ?? dateFilter?.value;
+    const time = 'time' in options ? options.time : dateFilter?.value;
     if ('time' in options || typeof time === 'string') {
-        queryParams.set('time', typeof time === 'string' ? time : '');
+        queryParams.set('time', typeof time === 'string' ? time : ALL_TIME_QUERY_VALUE);
     }
 
     return `${path}?${queryParams}`;

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
@@ -32,6 +32,18 @@ export function buildListPageHref(page: ListPage, _organizationId: string | unde
     return `${path}?${queryParams}`;
 }
 
+/**
+ * Stack filter drilldowns mean "show every event for this stack".
+ * Clear any active date range so the destination cannot hide older stack events.
+ */
+export function getEventsNavigationOptionsForFilter(filter: IFilter): ListNavigationOptions | undefined {
+    if (filter.type === 'string' && filter.key === 'string-stack') {
+        return { time: null };
+    }
+
+    return undefined;
+}
+
 export async function navigateToListPage(page: ListPage, organizationId: string | undefined, filters: IFilter[], options: ListNavigationOptions = {}) {
     await goto(buildListPageHref(page, organizationId, filters, options));
 }

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
@@ -2,16 +2,47 @@ import type { IFilter } from '$comp/faceted-filter';
 
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
-import { buildFilterCacheKey, toFilter, updateFilterCache } from '$features/events/components/filters/helpers.svelte';
+import { serializeFilters } from '$features/events/components/filters/helpers.svelte';
+
+type ListPage = 'events' | 'stacks';
+
+interface ListNavigationOptions {
+    time?: null | string;
+}
+
+const listPagePaths = {
+    events: '/(app)/event',
+    stacks: '/(app)/stack'
+} as const;
+
+export function buildListPageHref(page: ListPage, _organizationId: string | undefined, filters: IFilter[], options: ListNavigationOptions = {}): string {
+    const path = resolve(listPagePaths[page]);
+    const filtersForNavigation = options.time === null ? filters.filter((filter) => filter.type !== 'date') : filters;
+    const serializedFilters = serializeFilters(filtersForNavigation);
+
+    const queryParams = new URLSearchParams({ filters: serializedFilters });
+
+    const dateFilter = filters.find((filter): filter is IFilter & { value: unknown } => filter.type === 'date' && 'value' in filter);
+    const time = options.time ?? dateFilter?.value;
+    if ('time' in options || typeof time === 'string') {
+        queryParams.set('time', typeof time === 'string' ? time : '');
+    }
+
+    return `${path}?${queryParams}`;
+}
+
+export async function navigateToListPage(page: ListPage, organizationId: string | undefined, filters: IFilter[], options: ListNavigationOptions = {}) {
+    await goto(buildListPageHref(page, organizationId, filters, options));
+}
 
 /**
  * Redirects to the events page with the given filter.
  * Primes the filter cache so the filter is preserved.
  */
-export async function redirectToEventsWithFilter(organizationId: string | undefined, addedOrUpdated: IFilter): Promise<void> {
-    const filter = toFilter([addedOrUpdated]);
-    const filterCacheKey = buildFilterCacheKey(organizationId, resolve('/(app)/event'), filter);
-    updateFilterCache(filterCacheKey, [addedOrUpdated]);
-
-    await goto(`${resolve('/(app)/event')}?filter=${encodeURIComponent(filter)}`);
+export async function redirectToEventsWithFilter(
+    organizationId: string | undefined,
+    addedOrUpdated: IFilter,
+    options: { time?: null | string } = {}
+): Promise<void> {
+    await navigateToListPage('events', organizationId, [addedOrUpdated], options);
 }

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
@@ -13,6 +13,10 @@ type ListPage = 'events' | 'stacks';
 
 export const ALL_TIME_QUERY_VALUE = 'all';
 
+const DATE_RANGE_PATTERN = /^\[?(?<start>.+?)\s+TO\s+(?<end>.+?)\]?$/i;
+const RELATIVE_TO_NOW_PATTERN = /^now-(?<duration>\d+[Mdhmswy])$/;
+const TIME_SHORTCUT_PATTERN = /^(?<duration>\d+[Mdhmswy])$/;
+
 const listPagePaths = {
     events: '/(app)/event',
     stacks: '/(app)/stack'
@@ -39,6 +43,11 @@ export function buildListPageHref(page: ListPage, _organizationId: string | unde
 
 export function deserializeTimeQueryParam(time: string): string {
     const trimmed = time.trim();
+    const shortcutMatch = TIME_SHORTCUT_PATTERN.exec(trimmed);
+    if (shortcutMatch?.groups?.duration) {
+        return `[now-${shortcutMatch.groups.duration} TO now]`;
+    }
+
     if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
         return trimmed;
     }
@@ -80,8 +89,18 @@ export async function redirectToEventsWithFilter(
 
 export function serializeTimeQueryParam(time: string): string {
     const trimmed = time.trim();
-    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
-        return trimmed.slice(1, -1);
+    const rangeMatch = DATE_RANGE_PATTERN.exec(trimmed);
+    const rangeStart = rangeMatch?.groups?.start?.trim();
+    const rangeEnd = rangeMatch?.groups?.end?.trim();
+    if (rangeStart && rangeEnd?.toLowerCase() === 'now') {
+        const shortcutMatch = RELATIVE_TO_NOW_PATTERN.exec(rangeStart);
+        if (shortcutMatch?.groups?.duration) {
+            return shortcutMatch.groups.duration;
+        }
+    }
+
+    if (rangeStart && rangeEnd) {
+        return `${rangeStart} TO ${rangeEnd}`;
     }
 
     return trimmed;

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
@@ -2,7 +2,6 @@ import type { IFilter } from '$comp/faceted-filter';
 
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
-import { serializeFilters } from '$features/events/components/filters/helpers.svelte';
 import { SvelteURLSearchParams } from 'svelte/reactivity';
 
 interface ListNavigationOptions {
@@ -21,9 +20,8 @@ const listPagePaths = {
 export function buildListPageHref(page: ListPage, _organizationId: string | undefined, filters: IFilter[], options: ListNavigationOptions = {}): string {
     const path = resolve(listPagePaths[page]);
     const filtersForNavigation = options.time === null ? filters.filter((filter) => filter.type !== 'date') : filters;
-    const serializedFilters = serializeFilters(filtersForNavigation);
-
-    const queryParams = new SvelteURLSearchParams({ filters: serializedFilters });
+    const queryParams = new SvelteURLSearchParams();
+    filtersForNavigation.forEach((filter) => trySetRegisteredFilterQueryParam(queryParams, filter));
 
     const dateFilter = filters.find((filter): filter is IFilter & { value: unknown } => filter.type === 'date' && 'value' in filter);
     const time = 'time' in options ? options.time : dateFilter?.value;
@@ -60,4 +58,18 @@ export async function redirectToEventsWithFilter(
     options: { time?: null | string } = {}
 ): Promise<void> {
     await navigateToListPage('events', organizationId, [addedOrUpdated], options);
+}
+
+function trySetRegisteredFilterQueryParam(queryParams: SvelteURLSearchParams, filter: IFilter): boolean {
+    if (filter.type === 'string' && filter.key === 'string-stack' && 'value' in filter && typeof filter.value === 'string' && filter.value.trim()) {
+        queryParams.set('stack', filter.value);
+        return true;
+    }
+
+    if (filter.type === 'project' && 'value' in filter && Array.isArray(filter.value) && filter.value.length === 1) {
+        queryParams.set('project', filter.value[0]);
+        return true;
+    }
+
+    return false;
 }

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
@@ -31,10 +31,23 @@ export function buildListPageHref(page: ListPage, _organizationId: string | unde
     const dateFilter = filters.find((filter): filter is IFilter & { value: unknown } => filter.type === 'date' && 'value' in filter);
     const time = 'time' in options ? options.time : dateFilter?.value;
     if ('time' in options || typeof time === 'string') {
-        queryParams.set('time', typeof time === 'string' ? time : ALL_TIME_QUERY_VALUE);
+        queryParams.set('time', typeof time === 'string' ? serializeTimeQueryParam(time) : ALL_TIME_QUERY_VALUE);
     }
 
     return `${path}?${queryParams}`;
+}
+
+export function deserializeTimeQueryParam(time: string): string {
+    const trimmed = time.trim();
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+        return trimmed;
+    }
+
+    if (trimmed.includes(' TO ')) {
+        return `[${trimmed}]`;
+    }
+
+    return trimmed;
 }
 
 /**
@@ -63,6 +76,15 @@ export async function redirectToEventsWithFilter(
     options: { time?: null | string } = {}
 ): Promise<void> {
     await navigateToListPage('events', organizationId, [addedOrUpdated], options);
+}
+
+export function serializeTimeQueryParam(time: string): string {
+    const trimmed = time.trim();
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+        return trimmed.slice(1, -1);
+    }
+
+    return trimmed;
 }
 
 function trySetRegisteredFilterQueryParam(queryParams: SvelteURLSearchParams, filter: IFilter): boolean {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
@@ -153,6 +153,8 @@
     }
 
     const eventsQueryParameters: GetEventsParams = $state({
+        after: undefined,
+        before: undefined,
         get filter() {
             return activeFilter();
         },

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -59,7 +59,13 @@
     import { untrack } from 'svelte';
     import { throttle } from 'throttle-debounce';
 
-    import { ALL_TIME_QUERY_VALUE, getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../redirect-to-events.svelte';
+    import {
+        ALL_TIME_QUERY_VALUE,
+        deserializeTimeQueryParam,
+        getEventsNavigationOptionsForFilter,
+        redirectToEventsWithFilter,
+        serializeTimeQueryParam
+    } from '../redirect-to-events.svelte';
 
     // TODO: Update this page to use StackSummaryModel instead of EventSummaryModel.
     let selectedStackId = $state<string>();
@@ -112,7 +118,7 @@
                 return null;
             }
 
-            return queryParams.time || null;
+            return queryParams.time ? deserializeTimeQueryParam(queryParams.time) : null;
         }
 
         return savedViewsState.activeSavedView?.time ?? DEFAULT_TIME_RANGE;
@@ -428,7 +434,7 @@
         const baseExpressionFilterParam = savedViewFilters ? toFilter(savedViewFilters.filter((f) => f.type !== 'date' && !isQueryParamFilter(f))) : baseFilter;
 
         const newFilterParam = filterParam === baseExpressionFilterParam ? null : filterParam || (savedViewFilters && baseExpressionFilterParam ? '' : null);
-        const newTimeParam = time === baseTime ? null : (time ?? ALL_TIME_QUERY_VALUE);
+        const newTimeParam = time === baseTime ? null : time ? serializeTimeQueryParam(time) : ALL_TIME_QUERY_VALUE;
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
         // Only skip the watch when the URL will actually change from our update.
@@ -565,7 +571,7 @@
         },
         set time(value) {
             const baseTime = savedViewsState.activeSavedView?.time ?? DEFAULT_TIME_RANGE;
-            queryParams.time = value === baseTime ? null : (value ?? ALL_TIME_QUERY_VALUE);
+            queryParams.time = value === baseTime ? null : value ? serializeTimeQueryParam(value) : ALL_TIME_QUERY_VALUE;
         }
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -271,7 +271,10 @@
     function getCurrentFiltersWithoutTime(): FacetedFilter.IFilter[] {
         const savedViewFilters = getSavedViewFilters();
         const queryFilters = getQueryFilters() ?? [];
-        const expressionFilters = queryParams.filter != null ? getFiltersFromCache(filterCacheKey(queryParams.filter), queryParams.filter) : [];
+        const expressionFilters =
+            queryParams.filter != null
+                ? getFiltersFromCache(filterCacheKey(queryParams.filter), queryParams.filter).filter((filter) => filter.type !== 'date')
+                : [];
 
         if (savedViewFilters) {
             return mergeFilterOverrides(
@@ -286,7 +289,7 @@
         }
 
         const filter = savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
-        return getFiltersFromCache(filterCacheKey(filter), filter);
+        return getFiltersFromCache(filterCacheKey(filter), filter).filter((filter) => filter.type !== 'date');
     }
 
     function getSavedViewFilters(): FacetedFilter.IFilter[] | null {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -47,7 +47,7 @@
     import { useEventListener, watch } from 'runed';
     import { throttle } from 'throttle-debounce';
 
-    import { redirectToEventsWithFilter } from '../redirect-to-events.svelte';
+    import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../redirect-to-events.svelte';
 
     // TODO: Update this page to use StackSummaryModel instead of EventSummaryModel.
     let selectedStackId = $state<string>();
@@ -200,7 +200,7 @@
     async function onFilterChanged(addedOrUpdated: FacetedFilter.IFilter) {
         // If this is a stack filter, redirect to the Events page
         if (addedOrUpdated.type === 'string' && addedOrUpdated.key === 'string-stack') {
-            await redirectToEventsWithFilter(organization.current, addedOrUpdated, { time: null });
+            await redirectToEventsWithFilter(organization.current, addedOrUpdated, getEventsNavigationOptionsForFilter(addedOrUpdated));
             return;
         }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -56,6 +56,7 @@
     import { createTable } from '@tanstack/svelte-table';
     import { queryParamsState } from 'kit-query-params';
     import { useEventListener, watch } from 'runed';
+    import { untrack } from 'svelte';
     import { throttle } from 'throttle-debounce';
 
     import { ALL_TIME_QUERY_VALUE, getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../redirect-to-events.svelte';
@@ -466,11 +467,14 @@
     }
 
     $effect(() => {
-        if (!savedViewsState.activeSavedView) {
+        const activeSavedViewId = savedViewsState.activeSavedView?.id;
+        if (!activeSavedViewId) {
             return;
         }
 
-        updateFilters(getCurrentFilters());
+        untrack(() => {
+            updateFilters(getCurrentFilters());
+        });
     });
 
     function getQueryFilterParams(filters: FacetedFilter.IFilter[]) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -22,6 +22,7 @@
         hasSingleTypeFilter,
         serializeFilters,
         toFilter,
+        toFilterFromSerializedFilters,
         updateFilterCache
     } from '$features/events/components/filters/helpers.svelte';
     import OrganizationDefaultsFacetedFilterBuilder from '$features/events/components/filters/organization-defaults-faceted-filter-builder.svelte';
@@ -74,6 +75,7 @@
     ];
     const DEFAULT_PARAMS = {
         filter: undefined as string | undefined,
+        filters: undefined as string | undefined,
         limit: DEFAULT_LIMIT,
         time: undefined as string | undefined
     };
@@ -91,6 +93,10 @@
     }
 
     function getEffectiveFilter(): null | string {
+        if (queryParams.filters != null) {
+            return toFilterFromSerializedFilters(queryParams.filters);
+        }
+
         if (queryParams.filter != null) {
             return queryParams.filter;
         }
@@ -104,6 +110,7 @@
         pushHistory: true,
         schema: {
             filter: 'string',
+            filters: 'string',
             limit: 'number',
             time: 'string'
         }
@@ -158,6 +165,10 @@
         const filter = getEffectiveFilter();
         const savedView = savedViewsState.activeSavedView;
 
+        if (queryParams.filters != null) {
+            return applyTimeFilter(deserializeFilters(queryParams.filters), getQueryTime());
+        }
+
         if (queryParams.filter == null && savedView?.filter_definitions && filter === (savedView.filter ?? null)) {
             const hydrated = deserializeFilters(savedView.filter_definitions);
             return applyTimeFilter(hydrated, getQueryTime());
@@ -189,7 +200,7 @@
     async function onFilterChanged(addedOrUpdated: FacetedFilter.IFilter) {
         // If this is a stack filter, redirect to the Events page
         if (addedOrUpdated.type === 'string' && addedOrUpdated.key === 'string-stack') {
-            await redirectToEventsWithFilter(organization.current, addedOrUpdated);
+            await redirectToEventsWithFilter(organization.current, addedOrUpdated, { time: null });
             return;
         }
 
@@ -215,19 +226,21 @@
     function updateFilters(updatedFilters: FacetedFilter.IFilter[]): void {
         const filter = toFilter(updatedFilters.filter((f) => f.type !== 'date'));
         const time = ((updatedFilters.find((f) => f.type === 'date') as DateFilter | undefined)?.value as string | undefined) ?? null;
-        const baseFilter = savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
         const baseTime = savedViewsState.activeSavedView?.time ?? DEFAULT_TIME_RANGE;
+        const filterDefinitions = serializeFilters(updatedFilters);
 
-        const newFilterParam = filter === baseFilter ? null : filter;
+        const newFilterParam = null;
         const newTimeParam = time === baseTime ? null : (time ?? '');
+        const newFiltersParam = filterDefinitions;
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
         // Only skip the watch when the URL will actually change from our update.
         // If the URL doesn't change, the watch won't fire and the flag would stay stale.
-        if (newFilterParam !== queryParams.filter || newTimeParam !== queryParams.time) {
+        if (newFilterParam !== queryParams.filter || newTimeParam !== queryParams.time || newFiltersParam !== queryParams.filters) {
             isInternalFilterUpdate = true;
         }
 
+        queryParams.filters = newFiltersParam;
         queryParams.time = newTimeParam;
         queryParams.filter = newFilterParam;
     }
@@ -317,6 +330,10 @@
 
     async function onStackChanged(message: WebSocketMessageValue<'StackChanged'>) {
         if (message.id && message.change_type === ChangeType.Removed) {
+            if (message.id === selectedStackId) {
+                selectedStackId = undefined;
+            }
+
             removeTableSelection(table, message.id);
 
             if (removeTableData(table, (doc: EventSummaryModel<SummaryTemplateKeys>) => doc.id === message.id)) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -118,18 +118,8 @@
     }
 
     function getEffectiveFilter(): null | string {
-        const queryFilters = getQueryFilters();
-        if (queryParams.filter != null) {
-            const queryFilter = toFilter((queryFilters ?? []).filter((f) => f.type !== 'date'));
-            return [queryParams.filter, queryFilter].filter((filter) => filter).join(' ') || null;
-        }
-
-        if (queryFilters != null) {
-            const queryFilter = toFilter(queryFilters.filter((f) => f.type !== 'date'));
-            return queryFilter || null;
-        }
-
-        return savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
+        const filter = toFilter(getCurrentFiltersWithoutTime());
+        return filter || null;
     }
 
     function getQueryFilters(): FacetedFilter.IFilter[] | null {
@@ -275,21 +265,104 @@
     );
 
     function getCurrentFilters(): FacetedFilter.IFilter[] {
-        const filter = getEffectiveFilter();
+        return applyTimeFilter(getCurrentFiltersWithoutTime(), getQueryTime());
+    }
+
+    function getCurrentFiltersWithoutTime(): FacetedFilter.IFilter[] {
+        const savedViewFilters = getSavedViewFilters();
+        const queryFilters = getQueryFilters() ?? [];
+        const expressionFilters = queryParams.filter != null ? getFiltersFromCache(filterCacheKey(queryParams.filter), queryParams.filter) : [];
+
+        if (savedViewFilters) {
+            return mergeFilterOverrides(
+                savedViewFilters.filter((filter) => filter.type !== 'date'),
+                [...expressionFilters, ...queryFilters],
+                getQueryFilterRemovalKeys(savedViewFilters)
+            );
+        }
+
+        if (expressionFilters.length > 0 || queryFilters.length > 0) {
+            return [...expressionFilters, ...queryFilters];
+        }
+
+        const filter = savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
+        return getFiltersFromCache(filterCacheKey(filter), filter);
+    }
+
+    function getSavedViewFilters(): FacetedFilter.IFilter[] | null {
         const savedView = savedViewsState.activeSavedView;
-
-        const queryFilters = getQueryFilters();
-        if (queryFilters != null || queryParams.filter != null) {
-            const expressionFilters = queryParams.filter != null ? getFiltersFromCache(filterCacheKey(queryParams.filter), queryParams.filter) : [];
-            return applyTimeFilter([...expressionFilters, ...(queryFilters ?? [])], getQueryTime());
+        if (!savedView?.filter_definitions) {
+            return null;
         }
 
-        if (queryParams.filter == null && savedView?.filter_definitions && filter === (savedView.filter ?? null)) {
-            const hydrated = deserializeFilters(savedView.filter_definitions);
-            return applyTimeFilter(hydrated, getQueryTime());
+        return deserializeFilters(savedView.filter_definitions);
+    }
+
+    function getQueryFilterRemovalKeys(savedViewFilters: FacetedFilter.IFilter[]): string[] {
+        const removedKeys: string[] = [];
+
+        if (queryParams.bot === '') {
+            removedKeys.push('boolean-bot');
         }
 
-        return applyTimeFilter(getFiltersFromCache(filterCacheKey(filter), filter), getQueryTime());
+        if (queryParams.first === '') {
+            removedKeys.push('boolean-first');
+        }
+
+        if (queryParams.filter === '') {
+            removedKeys.push(...savedViewFilters.filter((filter) => filter.type !== 'date' && !isQueryParamFilter(filter)).map((filter) => filter.key));
+        }
+
+        if (queryParams.level === '') {
+            removedKeys.push('level');
+        }
+
+        if (queryParams.project === '') {
+            removedKeys.push('project');
+        }
+
+        if (queryParams.reference === '') {
+            removedKeys.push('reference');
+        }
+
+        if (queryParams.session === '') {
+            removedKeys.push('session');
+        }
+
+        if (queryParams.stack === '') {
+            removedKeys.push('string-stack');
+        }
+
+        if (queryParams.status === '') {
+            removedKeys.push('status');
+        }
+
+        if (queryParams.tag === '') {
+            removedKeys.push('tag');
+        }
+
+        if (queryParams.type === '') {
+            removedKeys.push('type');
+        }
+
+        if (queryParams.version === '') {
+            removedKeys.push('version-version');
+        }
+
+        return removedKeys;
+    }
+
+    function mergeFilterOverrides(
+        baseFilters: FacetedFilter.IFilter[],
+        overrideFilters: FacetedFilter.IFilter[],
+        removedFilterKeys: string[] = []
+    ): FacetedFilter.IFilter[] {
+        if (overrideFilters.length === 0 && removedFilterKeys.length === 0) {
+            return baseFilters;
+        }
+
+        const overrideKeys = new Set([...overrideFilters.map((filter) => filter.key), ...removedFilterKeys]);
+        return [...baseFilters.filter((filter) => !overrideKeys.has(filter.key)), ...overrideFilters];
     }
 
     let filters = $state(getCurrentFilters());
@@ -345,9 +418,12 @@
         const time = ((updatedFilters.find((f) => f.type === 'date') as DateFilter | undefined)?.value as string | undefined) ?? null;
         const baseTime = savedViewsState.activeSavedView?.time ?? DEFAULT_TIME_RANGE;
         const baseFilter = savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
-        const queryFilterParams = getQueryFilterParams(updatedFilters);
+        const savedViewFilters = getSavedViewFilters();
+        const baseQueryFilterParams = getQueryFilterParams(savedViewFilters ?? []);
+        const queryFilterParams = getQueryFilterParamDeltas(getQueryFilterParams(updatedFilters), baseQueryFilterParams);
+        const baseExpressionFilterParam = savedViewFilters ? toFilter(savedViewFilters.filter((f) => f.type !== 'date' && !isQueryParamFilter(f))) : baseFilter;
 
-        const newFilterParam = filterParam === baseFilter ? null : filterParam || null;
+        const newFilterParam = filterParam === baseExpressionFilterParam ? null : filterParam || (savedViewFilters && baseExpressionFilterParam ? '' : null);
         const newTimeParam = time === baseTime ? null : (time ?? ALL_TIME_QUERY_VALUE);
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
@@ -386,6 +462,14 @@
         queryParams.filter = newFilterParam;
     }
 
+    $effect(() => {
+        if (!savedViewsState.activeSavedView) {
+            return;
+        }
+
+        updateFilters(getCurrentFilters());
+    });
+
     function getQueryFilterParams(filters: FacetedFilter.IFilter[]) {
         const botFilter = filters.find((f): f is BooleanFilter => f instanceof BooleanFilter && f.term === 'bot');
         const firstFilter = filters.find((f): f is BooleanFilter => f instanceof BooleanFilter && f.term === 'first');
@@ -411,6 +495,30 @@
             tag: tagFilter?.value.length ? tagFilter.value.join(',') : null,
             type: typeFilter?.value.length ? typeFilter.value.join(',') : null,
             version: versionFilter?.value?.trim() ? versionFilter.value : null
+        };
+    }
+
+    function getQueryFilterParamDeltas(currentParams: ReturnType<typeof getQueryFilterParams>, baseParams: ReturnType<typeof getQueryFilterParams>) {
+        const getDelta = (currentValue: null | string, baseValue: null | string): null | string => {
+            if (currentValue === baseValue) {
+                return null;
+            }
+
+            return currentValue ?? (baseValue ? '' : null);
+        };
+
+        return {
+            bot: getDelta(currentParams.bot, baseParams.bot),
+            first: getDelta(currentParams.first, baseParams.first),
+            level: getDelta(currentParams.level, baseParams.level),
+            project: getDelta(currentParams.project, baseParams.project),
+            reference: getDelta(currentParams.reference, baseParams.reference),
+            session: getDelta(currentParams.session, baseParams.session),
+            stack: getDelta(currentParams.stack, baseParams.stack),
+            status: getDelta(currentParams.status, baseParams.status),
+            tag: getDelta(currentParams.tag, baseParams.tag),
+            type: getDelta(currentParams.type, baseParams.type),
+            version: getDelta(currentParams.version, baseParams.version)
         };
     }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -47,7 +47,7 @@
     import { useEventListener, watch } from 'runed';
     import { throttle } from 'throttle-debounce';
 
-    import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../redirect-to-events.svelte';
+    import { ALL_TIME_QUERY_VALUE, getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../redirect-to-events.svelte';
 
     // TODO: Update this page to use StackSummaryModel instead of EventSummaryModel.
     let selectedStackId = $state<string>();
@@ -86,6 +86,10 @@
 
     function getQueryTime(): null | string {
         if (queryParams.time != null) {
+            if (queryParams.time === ALL_TIME_QUERY_VALUE) {
+                return null;
+            }
+
             return queryParams.time || null;
         }
 
@@ -230,7 +234,7 @@
         const filterDefinitions = serializeFilters(updatedFilters);
 
         const newFilterParam = null;
-        const newTimeParam = time === baseTime ? null : (time ?? '');
+        const newTimeParam = time === baseTime ? null : (time ?? ALL_TIME_QUERY_VALUE);
         const newFiltersParam = filterDefinitions;
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
@@ -261,11 +265,11 @@
         mode: 'stack_frequent',
         offset: DEFAULT_OFFSET,
         get time() {
-            return getQueryTime()!;
+            return getQueryTime() ?? undefined;
         },
         set time(value) {
             const baseTime = savedViewsState.activeSavedView?.time ?? DEFAULT_TIME_RANGE;
-            queryParams.time = value === baseTime ? null : (value ?? '');
+            queryParams.time = value === baseTime ? null : (value ?? ALL_TIME_QUERY_VALUE);
         }
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -43,14 +43,14 @@
     import SavedViewPicker from '$features/saved-views/components/saved-view-picker.svelte';
     import { useSavedViews } from '$features/saved-views/use-saved-views.svelte';
     import * as agg from '$features/shared/api/aggregations';
-    import { getSharedTableOptions, isTableEmpty, removeTableData, removeTableSelection } from '$features/shared/table.svelte';
+    import { createPageSizePreference, getSharedTableOptions, isTableEmpty, removeTableData, removeTableSelection } from '$features/shared/table.svelte';
     import { fillDateSeries } from '$features/shared/utils/charts';
     import { parseDateMathRange, toDateMathRange } from '$features/shared/utils/datemath';
     import StackDetailSheet from '$features/stacks/components/stack-detail-sheet.svelte';
     import TableStacksBulkActionsDropdownMenu from '$features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte';
     import { StackStatus } from '$features/stacks/models';
     import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
-    import { DEFAULT_LIMIT, DEFAULT_OFFSET, useFetchClientStatus } from '$shared/api/api.svelte';
+    import { DEFAULT_OFFSET, useFetchClientStatus } from '$shared/api/api.svelte';
     import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
     import { error } from '@sveltejs/kit';
     import { createTable } from '@tanstack/svelte-table';
@@ -91,12 +91,14 @@
         new TypeFilter(['404', 'error']),
         new StatusFilter([StackStatus.Open, StackStatus.Regressed])
     ];
+    const PAGE_SIZE_PREFERENCE_KEY = 'event-stack-list-page-size';
+    const pageSizePreference = createPageSizePreference(PAGE_SIZE_PREFERENCE_KEY);
     const DEFAULT_PARAMS = {
         bot: undefined as string | undefined,
         filter: undefined as string | undefined,
         first: undefined as string | undefined,
         level: undefined as string | undefined,
-        limit: DEFAULT_LIMIT,
+        limit: undefined as number | undefined,
         page: undefined as number | undefined,
         project: undefined as string | undefined,
         reference: undefined as string | undefined,
@@ -392,11 +394,6 @@
         { lazy: true }
     );
 
-    $effect(() => {
-        // Handle case where pop state loses the limit
-        queryParams.limit ??= DEFAULT_LIMIT;
-    });
-
     async function onFilterChanged(addedOrUpdated: FacetedFilter.IFilter) {
         // If this is a stack filter, redirect to the Events page
         if (addedOrUpdated.type === 'string' && addedOrUpdated.key === 'string-stack') {
@@ -562,6 +559,21 @@
         return ['level', 'project', 'reference', 'session', 'status', 'tag', 'type', 'version'].includes(filter.type);
     }
 
+    function getPageSize(): number {
+        return queryParams.limit ?? pageSizePreference.current;
+    }
+
+    function setPageSize(value: number): void {
+        pageSizePreference.current = value;
+        queryParams.limit = null;
+    }
+
+    $effect(() => {
+        if (queryParams.limit === pageSizePreference.current) {
+            queryParams.limit = null;
+        }
+    });
+
     const eventsQueryParameters: GetEventsParams = $state({
         get filter() {
             return getEffectiveFilter()!;
@@ -570,10 +582,10 @@
             queryParams.filter = value;
         },
         get limit() {
-            return queryParams.limit!;
+            return getPageSize();
         },
         set limit(value) {
-            queryParams.limit = value;
+            setPageSize(value);
         },
         mode: 'stack_frequent',
         offset: DEFAULT_OFFSET,
@@ -800,14 +812,14 @@
             <EventsDashboardChart data={chartData()} isLoading={clientStatus.isLoading || chartDataQuery.isLoading} {onRangeSelect} />
         {/if}
 
-        <EventsDataTable bind:limit={queryParams.limit!} isLoading={clientStatus.isLoading} {rowClick} {rowHref} {table}>
+        <EventsDataTable bind:limit={eventsQueryParameters.limit!} isLoading={clientStatus.isLoading} {rowClick} {rowHref} {table}>
             {#snippet footerChildren()}
                 <div class="h-9 min-w-35">
                     <TableStacksBulkActionsDropdownMenu {table} />
                 </div>
 
                 <DataTable.Selection {table} />
-                <DataTable.PageSize bind:value={queryParams.limit!} {table}></DataTable.PageSize>
+                <DataTable.PageSize bind:value={eventsQueryParameters.limit!} {table}></DataTable.PageSize>
                 <div class="flex items-center space-x-6 lg:space-x-8">
                     <DataTable.PageCount {table} />
                     <DataTable.Pagination {table} />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -97,6 +97,7 @@
         first: undefined as string | undefined,
         level: undefined as string | undefined,
         limit: DEFAULT_LIMIT,
+        page: undefined as number | undefined,
         project: undefined as string | undefined,
         reference: undefined as string | undefined,
         session: undefined as string | undefined,
@@ -210,6 +211,7 @@
             first: 'string',
             level: 'string',
             limit: 'number',
+            page: 'number',
             project: 'string',
             reference: 'string',
             session: 'string',
@@ -421,7 +423,8 @@
         filters = updatedFilters;
     }
 
-    function updateFilters(updatedFilters: FacetedFilter.IFilter[]): void {
+    function updateFilters(updatedFilters: FacetedFilter.IFilter[], options: { clearPagination?: boolean } = {}): void {
+        const shouldClearPagination = options.clearPagination ?? true;
         const filter = toFilter(updatedFilters.filter((f) => f.type !== 'date'));
         const expressionFilters = updatedFilters.filter((f) => f.type !== 'date' && !isQueryParamFilter(f));
         const filterParam = toFilter(expressionFilters);
@@ -437,6 +440,10 @@
         const newTimeParam = time === baseTime ? null : time ? serializeTimeQueryParam(time) : ALL_TIME_QUERY_VALUE;
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
+        if (shouldClearPagination) {
+            clearPaginationQueryParams();
+        }
+
         // Only skip the watch when the URL will actually change from our update.
         // If the URL doesn't change, the watch won't fire and the flag would stay stale.
         if (
@@ -472,6 +479,10 @@
         queryParams.filter = newFilterParam;
     }
 
+    function clearPaginationQueryParams(): void {
+        queryParams.page = null;
+    }
+
     $effect(() => {
         const activeSavedViewId = savedViewsState.activeSavedView?.id;
         if (!activeSavedViewId) {
@@ -479,7 +490,7 @@
         }
 
         untrack(() => {
-            updateFilters(getCurrentFilters());
+            updateFilters(getCurrentFilters(), { clearPagination: false });
         });
     });
 
@@ -566,6 +577,12 @@
         },
         mode: 'stack_frequent',
         offset: DEFAULT_OFFSET,
+        get page() {
+            return queryParams.page ?? undefined;
+        },
+        set page(value) {
+            queryParams.page = value ?? null;
+        },
         get time() {
             return getQueryTime() ?? undefined;
         },

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -11,7 +11,19 @@
     import { type GetEventsParams, getOrganizationCountQuery } from '$features/events/api.svelte';
     import EventsDashboardChart from '$features/events/components/events-dashboard-chart.svelte';
     import EventsStatsDashboard from '$features/events/components/events-stats-dashboard.svelte';
-    import { DateFilter, ProjectFilter, StatusFilter, TypeFilter } from '$features/events/components/filters';
+    import {
+        BooleanFilter,
+        DateFilter,
+        LevelFilter,
+        ProjectFilter,
+        ReferenceFilter,
+        SessionFilter,
+        StatusFilter,
+        StringFilter,
+        TagFilter,
+        TypeFilter,
+        VersionFilter
+    } from '$features/events/components/filters';
     import {
         applyTimeFilter,
         buildFilterCacheKey,
@@ -22,7 +34,6 @@
         hasSingleTypeFilter,
         serializeFilters,
         toFilter,
-        toFilterFromSerializedFilters,
         updateFilterCache
     } from '$features/events/components/filters/helpers.svelte';
     import OrganizationDefaultsFacetedFilterBuilder from '$features/events/components/filters/organization-defaults-faceted-filter-builder.svelte';
@@ -74,10 +85,20 @@
         new StatusFilter([StackStatus.Open, StackStatus.Regressed])
     ];
     const DEFAULT_PARAMS = {
+        bot: undefined as string | undefined,
         filter: undefined as string | undefined,
-        filters: undefined as string | undefined,
+        first: undefined as string | undefined,
+        level: undefined as string | undefined,
         limit: DEFAULT_LIMIT,
-        time: undefined as string | undefined
+        project: undefined as string | undefined,
+        reference: undefined as string | undefined,
+        session: undefined as string | undefined,
+        stack: undefined as string | undefined,
+        status: undefined as string | undefined,
+        tag: undefined as string | undefined,
+        time: undefined as string | undefined,
+        type: undefined as string | undefined,
+        version: undefined as string | undefined
     };
 
     function filterCacheKey(filter: null | string): string {
@@ -97,15 +118,89 @@
     }
 
     function getEffectiveFilter(): null | string {
-        if (queryParams.filters != null) {
-            return toFilterFromSerializedFilters(queryParams.filters);
+        const queryFilters = getQueryFilters();
+        if (queryParams.filter != null) {
+            const queryFilter = toFilter((queryFilters ?? []).filter((f) => f.type !== 'date'));
+            return [queryParams.filter, queryFilter].filter((filter) => filter).join(' ') || null;
         }
 
-        if (queryParams.filter != null) {
-            return queryParams.filter;
+        if (queryFilters != null) {
+            const queryFilter = toFilter(queryFilters.filter((f) => f.type !== 'date'));
+            return queryFilter || null;
         }
 
         return savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
+    }
+
+    function getQueryFilters(): FacetedFilter.IFilter[] | null {
+        const filters: FacetedFilter.IFilter[] = [];
+
+        if (queryParams.project) {
+            filters.push(new ProjectFilter(splitQueryParam(queryParams.project)));
+        }
+
+        if (queryParams.stack) {
+            filters.push(new StringFilter('stack', queryParams.stack));
+        }
+
+        const bot = parseBooleanQueryParam(queryParams.bot);
+        if (bot !== undefined) {
+            filters.push(new BooleanFilter('bot', bot));
+        }
+
+        const first = parseBooleanQueryParam(queryParams.first);
+        if (first !== undefined) {
+            filters.push(new BooleanFilter('first', first));
+        }
+
+        if (queryParams.level) {
+            filters.push(new LevelFilter(splitQueryParam(queryParams.level) as never[]));
+        }
+
+        if (queryParams.reference) {
+            filters.push(new ReferenceFilter(queryParams.reference));
+        }
+
+        if (queryParams.session) {
+            filters.push(new SessionFilter(queryParams.session));
+        }
+
+        if (queryParams.status) {
+            filters.push(new StatusFilter(splitQueryParam(queryParams.status) as never[]));
+        }
+
+        if (queryParams.tag) {
+            filters.push(new TagFilter(splitQueryParam(queryParams.tag) as never[]));
+        }
+
+        if (queryParams.type) {
+            filters.push(new TypeFilter(splitQueryParam(queryParams.type) as never[]));
+        }
+
+        if (queryParams.version) {
+            filters.push(new VersionFilter('version', queryParams.version));
+        }
+
+        return filters.length > 0 ? filters : null;
+    }
+
+    function parseBooleanQueryParam(value: null | string | undefined): boolean | undefined {
+        if (value === 'true') {
+            return true;
+        }
+
+        if (value === 'false') {
+            return false;
+        }
+
+        return undefined;
+    }
+
+    function splitQueryParam(value: string): string[] {
+        return value
+            .split(',')
+            .map((item) => item.trim())
+            .filter((item) => item);
     }
 
     updateFilterCache(filterCacheKey(DEFAULT_FILTER), DEFAULT_FILTERS);
@@ -113,10 +208,20 @@
         default: DEFAULT_PARAMS,
         pushHistory: true,
         schema: {
+            bot: 'string',
             filter: 'string',
-            filters: 'string',
+            first: 'string',
+            level: 'string',
             limit: 'number',
-            time: 'string'
+            project: 'string',
+            reference: 'string',
+            session: 'string',
+            stack: 'string',
+            status: 'string',
+            tag: 'string',
+            time: 'string',
+            type: 'string',
+            version: 'string'
         }
     });
 
@@ -156,7 +261,11 @@
 
     watch(
         () => organization.current,
-        () => {
+        (_currentOrganizationId, previousOrganizationId) => {
+            if (previousOrganizationId === undefined) {
+                return;
+            }
+
             updateFilterCache(filterCacheKey(DEFAULT_FILTER), DEFAULT_FILTERS);
             //params.$reset(); // Work around for https://github.com/beynar/kit-query-params/issues/7
             Object.assign(queryParams, DEFAULT_PARAMS);
@@ -169,8 +278,10 @@
         const filter = getEffectiveFilter();
         const savedView = savedViewsState.activeSavedView;
 
-        if (queryParams.filters != null) {
-            return applyTimeFilter(deserializeFilters(queryParams.filters), getQueryTime());
+        const queryFilters = getQueryFilters();
+        if (queryFilters != null || queryParams.filter != null) {
+            const expressionFilters = queryParams.filter != null ? getFiltersFromCache(filterCacheKey(queryParams.filter), queryParams.filter) : [];
+            return applyTimeFilter([...expressionFilters, ...(queryFilters ?? [])], getQueryTime());
         }
 
         if (queryParams.filter == null && savedView?.filter_definitions && filter === (savedView.filter ?? null)) {
@@ -229,24 +340,94 @@
 
     function updateFilters(updatedFilters: FacetedFilter.IFilter[]): void {
         const filter = toFilter(updatedFilters.filter((f) => f.type !== 'date'));
+        const expressionFilters = updatedFilters.filter((f) => f.type !== 'date' && !isQueryParamFilter(f));
+        const filterParam = toFilter(expressionFilters);
         const time = ((updatedFilters.find((f) => f.type === 'date') as DateFilter | undefined)?.value as string | undefined) ?? null;
         const baseTime = savedViewsState.activeSavedView?.time ?? DEFAULT_TIME_RANGE;
-        const filterDefinitions = serializeFilters(updatedFilters);
+        const baseFilter = savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
+        const queryFilterParams = getQueryFilterParams(updatedFilters);
 
-        const newFilterParam = null;
+        const newFilterParam = filterParam === baseFilter ? null : filterParam || null;
         const newTimeParam = time === baseTime ? null : (time ?? ALL_TIME_QUERY_VALUE);
-        const newFiltersParam = filterDefinitions;
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
         // Only skip the watch when the URL will actually change from our update.
         // If the URL doesn't change, the watch won't fire and the flag would stay stale.
-        if (newFilterParam !== queryParams.filter || newTimeParam !== queryParams.time || newFiltersParam !== queryParams.filters) {
+        if (
+            newFilterParam !== queryParams.filter ||
+            newTimeParam !== queryParams.time ||
+            queryFilterParams.bot !== queryParams.bot ||
+            queryFilterParams.first !== queryParams.first ||
+            queryFilterParams.level !== queryParams.level ||
+            queryFilterParams.project !== queryParams.project ||
+            queryFilterParams.reference !== queryParams.reference ||
+            queryFilterParams.session !== queryParams.session ||
+            queryFilterParams.stack !== queryParams.stack ||
+            queryFilterParams.status !== queryParams.status ||
+            queryFilterParams.tag !== queryParams.tag ||
+            queryFilterParams.type !== queryParams.type ||
+            queryFilterParams.version !== queryParams.version
+        ) {
             isInternalFilterUpdate = true;
         }
 
-        queryParams.filters = newFiltersParam;
+        queryParams.bot = queryFilterParams.bot;
+        queryParams.first = queryFilterParams.first;
+        queryParams.level = queryFilterParams.level;
+        queryParams.project = queryFilterParams.project;
+        queryParams.reference = queryFilterParams.reference;
+        queryParams.session = queryFilterParams.session;
+        queryParams.stack = queryFilterParams.stack;
+        queryParams.status = queryFilterParams.status;
+        queryParams.tag = queryFilterParams.tag;
+        queryParams.type = queryFilterParams.type;
+        queryParams.version = queryFilterParams.version;
         queryParams.time = newTimeParam;
         queryParams.filter = newFilterParam;
+    }
+
+    function getQueryFilterParams(filters: FacetedFilter.IFilter[]) {
+        const botFilter = filters.find((f): f is BooleanFilter => f instanceof BooleanFilter && f.term === 'bot');
+        const firstFilter = filters.find((f): f is BooleanFilter => f instanceof BooleanFilter && f.term === 'first');
+        const levelFilter = filters.find((f): f is LevelFilter => f.type === 'level');
+        const projectFilter = filters.find((f): f is ProjectFilter => f.type === 'project');
+        const referenceFilter = filters.find((f): f is ReferenceFilter => f.type === 'reference');
+        const sessionFilter = filters.find((f): f is SessionFilter => f.type === 'session');
+        const stackFilter = filters.find((f): f is StringFilter => f.type === 'string' && f.key === 'string-stack');
+        const statusFilter = filters.find((f): f is StatusFilter => f.type === 'status');
+        const tagFilter = filters.find((f): f is TagFilter => f.type === 'tag');
+        const typeFilter = filters.find((f): f is TypeFilter => f.type === 'type');
+        const versionFilter = filters.find((f): f is VersionFilter => f instanceof VersionFilter && f.term === 'version');
+
+        return {
+            bot: botFilter?.value === undefined ? null : String(botFilter.value),
+            first: firstFilter?.value === undefined ? null : String(firstFilter.value),
+            level: levelFilter?.value.length ? levelFilter.value.join(',') : null,
+            project: projectFilter?.value.length ? projectFilter.value.join(',') : null,
+            reference: referenceFilter?.value?.trim() ? referenceFilter.value : null,
+            session: sessionFilter?.value?.trim() ? sessionFilter.value : null,
+            stack: stackFilter?.value?.trim() ? stackFilter.value : null,
+            status: statusFilter?.value.length ? statusFilter.value.join(',') : null,
+            tag: tagFilter?.value.length ? tagFilter.value.join(',') : null,
+            type: typeFilter?.value.length ? typeFilter.value.join(',') : null,
+            version: versionFilter?.value?.trim() ? versionFilter.value : null
+        };
+    }
+
+    function isQueryParamFilter(filter: FacetedFilter.IFilter): boolean {
+        if (filter.type === 'string' && filter.key === 'string-stack') {
+            return true;
+        }
+
+        if (filter.type === 'boolean' && filter instanceof BooleanFilter && (filter.term === 'bot' || filter.term === 'first') && filter.value !== undefined) {
+            return true;
+        }
+
+        if (filter.type === 'version' && filter instanceof VersionFilter && filter.term !== 'version') {
+            return false;
+        }
+
+        return ['level', 'project', 'reference', 'session', 'status', 'tag', 'type', 'version'].includes(filter.type);
     }
 
     const eventsQueryParameters: GetEventsParams = $state({

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/+page.svelte
@@ -24,7 +24,8 @@
     );
 
     async function filterChanged(addedOrUpdated: IFilter) {
-        await redirectToEventsWithFilter(organization.current, addedOrUpdated);
+        const options = addedOrUpdated.type === 'string' && addedOrUpdated.key === 'string-stack' ? { time: null } : undefined;
+        await redirectToEventsWithFilter(organization.current, addedOrUpdated, options);
     }
 
     function handleError(problem: ProblemDetails) {
@@ -35,9 +36,13 @@
         toast.error('Unable to load stack event details.');
     }
 
+    async function handleDeleted() {
+        await goto(resolve('/(app)/stack'));
+    }
+
     $effect(() => {
         document.title = 'Stack Details - Exceptionless';
     });
 </script>
 
-<StackDetails {filterChanged} {handleError} {stackId} />
+<StackDetails {filterChanged} {handleError} onDeleted={handleDeleted} {stackId} />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/+page.svelte
@@ -11,7 +11,7 @@
     import { watch } from 'runed';
     import { toast } from 'svelte-sonner';
 
-    import { redirectToEventsWithFilter } from '../../redirect-to-events.svelte.js';
+    import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../../redirect-to-events.svelte.js';
 
     const stackId = $derived(page.params.stackId || '');
 
@@ -24,8 +24,7 @@
     );
 
     async function filterChanged(addedOrUpdated: IFilter) {
-        const options = addedOrUpdated.type === 'string' && addedOrUpdated.key === 'string-stack' ? { time: null } : undefined;
-        await redirectToEventsWithFilter(organization.current, addedOrUpdated, options);
+        await redirectToEventsWithFilter(organization.current, addedOrUpdated, getEventsNavigationOptionsForFilter(addedOrUpdated));
     }
 
     function handleError(problem: ProblemDetails) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/event/[eventId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/event/[eventId=objectid]/+page.svelte
@@ -13,9 +13,10 @@
     import { watch } from 'runed';
     import { toast } from 'svelte-sonner';
 
-    import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../../redirect-to-events.svelte.js';
+    import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../../../../redirect-to-events.svelte.js';
 
     const stackId = $derived(page.params.stackId || '');
+    const eventId = $derived(page.params.eventId || '');
 
     watch(
         () => organization.current,
@@ -42,7 +43,9 @@
     }
 
     async function handleEventLoaded(event: PersistentEvent) {
-        await goto(buildEventDetailsHref(event.id, event.stack_id), { replaceState: true });
+        if (event.id !== eventId || event.stack_id !== stackId) {
+            await goto(buildEventDetailsHref(event.id, event.stack_id), { replaceState: true });
+        }
     }
 
     async function handleNavigate(newEventId: string) {
@@ -50,8 +53,8 @@
     }
 
     $effect(() => {
-        document.title = 'Stack Details - Exceptionless';
+        document.title = 'Stack Event Details - Exceptionless';
     });
 </script>
 
-<StackDetails {filterChanged} {handleError} onDeleted={handleDeleted} onEventLoaded={handleEventLoaded} onNavigate={handleNavigate} {stackId} />
+<StackDetails {eventId} {filterChanged} {handleError} onDeleted={handleDeleted} onEventLoaded={handleEventLoaded} onNavigate={handleNavigate} {stackId} />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -120,7 +120,7 @@
     async function onFilterChanged(addedOrUpdated: FacetedFilter.IFilter) {
         // If this is a stack filter, redirect to the Events page
         if (addedOrUpdated.type === 'string' && addedOrUpdated.key === 'string-stack') {
-            await redirectToEventsWithFilter(organization.current, addedOrUpdated);
+            await redirectToEventsWithFilter(organization.current, addedOrUpdated, { time: null });
             return;
         }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -39,7 +39,7 @@
     import { useEventListener, watch } from 'runed';
     import { debounce } from 'throttle-debounce';
 
-    import { redirectToEventsWithFilter } from '../redirect-to-events.svelte';
+    import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../redirect-to-events.svelte';
 
     let selectedEventId: null | string = $state(null);
 
@@ -120,7 +120,7 @@
     async function onFilterChanged(addedOrUpdated: FacetedFilter.IFilter) {
         // If this is a stack filter, redirect to the Events page
         if (addedOrUpdated.type === 'string' && addedOrUpdated.key === 'string-stack') {
-            await redirectToEventsWithFilter(organization.current, addedOrUpdated, { time: null });
+            await redirectToEventsWithFilter(organization.current, addedOrUpdated, getEventsNavigationOptionsForFilter(addedOrUpdated));
             return;
         }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/overview/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/overview/+page.svelte
@@ -206,7 +206,7 @@
                     {:else if eventsAllTimeChartData.length === 0}
                         <p class="text-muted-foreground py-8 text-center text-sm">No event history available.</p>
                     {:else}
-                        <Chart.Container config={eventsAllTimeChartConfig} class="h-48 w-full">
+                        <Chart.Container config={eventsAllTimeChartConfig} class="h-48 w-full overflow-visible pl-16 pr-3">
                             <AreaChart
                                 data={eventsAllTimeChartData}
                                 x="date"
@@ -235,7 +235,7 @@
                     {:else if organizationGrowthChartData.length === 0}
                         <p class="text-muted-foreground py-8 text-center text-sm">No growth data available.</p>
                     {:else}
-                        <Chart.Container config={organizationGrowthChartConfig} class="h-48 w-full">
+                        <Chart.Container config={organizationGrowthChartConfig} class="h-48 w-full overflow-visible pl-16 pr-3">
                             <AreaChart
                                 data={organizationGrowthChartData}
                                 x="month"


### PR DESCRIPTION
## What changed
- Added shared Events/Stacks navigation helpers that map registered filter controls to direct query params like `stack=`, `status=`, `type=`, and `project=`; unmapped filters fall back to raw `filter=` expressions.
- Fixed saved-view URL normalization so saved filters stay out of the URL unless the user changes or removes them.
- Fixed stack-to-events drilldowns to support explicit all-time navigation and cleaner time query params such as `time=1h`.
- Fixed selected stack deletion and stack detail delete navigation so the UI does not remain stuck in loading state.
- Fixed cursor pagination controls so Next/Previous update the table page state and cursor params correctly, with pagination state normalized before applying table updates.
- Persisted Events and Stacks pagination in the URL so copied links reopen to the same list page.
- Omitted `limit` from Events/Stacks URLs when it matches the user's saved rows-per-page preference; explicit `limit` stays when a shared URL overrides that preference.
- Added canonical stack-scoped event detail URLs at `/stack/{stackId}/event/{eventId}` and kept full-page/detail-sheet next/previous navigation in sync with those URLs.
- Prevented duplicate faceted filters, including duplicate Status filters; re-adding a hidden filter now reveals the existing hidden filter instead.
- Fixed system overview all-time chart y-axis clipping.

## Why
User feedback surfaced several high-priority issues in the new Svelte UI around stack drilldowns, saved-view filter URLs, pagination, duplicate filters, stale selection state, and shareable detail URLs. The route contract now uses explicit query params for registered controls instead of serialized filter JSON, while still deriving API filter expressions from the active filter controls.

## Impact
- Users can deep-link to Events or Stacks with exact filter controls.
- Stack-to-events links can intentionally show all-time events without inheriting the current date range.
- Saved-view URLs stay clean and only show deltas from the saved view.
- Event list pagination works with larger page sizes.
- Events and Stacks pagination URLs can be shared and restored, including saved-view list routes.
- Saved rows-per-page preferences keep normal URLs clean while still allowing `limit` overrides in shared links.
- Event detail links include both stack and event ids once the event is loaded, so copied URLs and sheet external-link targets reopen the exact event context.
- Existing hidden filters are surfaced instead of duplicated.

## Breaking changes
None.

## Validation
- `npm run format`
- `npm run lint`
- `npm run check`
- `npm run test:unit -- helpers.svelte redirect-to-events use-saved-views`
- `npm run test:unit -- table.svelte`
- Local browser QA on `https://localhost:7131/next/event/all?limit=50`: verified event pagination Next/Previous and duplicate Status filter prevention, including hidden-filter reveal.
- Local browser QA on `https://localhost:7131/next/event/all?limit=50`: verified Next adds `after` and `page`, reload preserves `Page 2`, and Previous returns to the first-page URL.
- Local browser QA on `https://localhost:7131/next/stack?limit=20`: verified Next adds `page=2` and reload preserves `Page 2`.
- Local browser QA with saved rows-per-page preference set to 50: verified `?limit=50` is removed on Events/Stacks URLs, `?limit=20` remains as an override, and paging adds page/cursor params without re-adding `limit`.
- Local browser QA on stack/event routes: verified time query normalization and all-time stack drilldowns.
- Local browser QA on `https://localhost:7131/next/event/{eventId}`: verified the URL canonicalizes to `/next/stack/{stackId}/event/{eventId}`.
- Local browser QA on full-page stack event details: verified Older/Newer updates the event id in the canonical stack-scoped URL.
- Local browser QA on Events and Stacks detail sheets: verified the "Open details in new window" href uses `/next/stack/{stackId}/event/{eventId}` and follows Older/Newer navigation.
