### PR TITLE
Add PR preview command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       should_publish: ${{ (github.event_name != 'pull_request' || (github.head_ref == vars.DEV_DEPLOY_BRANCH && vars.DEV_DEPLOY_BRANCH != 'main' && vars.DEV_DEPLOY_BRANCH != '')) && secrets.DOCKER_USERNAME != '' && secrets.DOCKER_PASSWORD != '' }}
       is_prod_deploy: ${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request' }}
-      is_dev_deploy: ${{ (github.event_name == 'push' && github.ref == format('refs/heads/{0}', vars.DEV_DEPLOY_BRANCH || 'main')) || (github.event_name == 'pull_request' && github.head_ref == vars.DEV_DEPLOY_BRANCH && vars.DEV_DEPLOY_BRANCH != 'main' && vars.DEV_DEPLOY_BRANCH != '') }}
+      is_dev_deploy: ${{ (github.event_name == 'workflow_dispatch' && github.ref == format('refs/heads/{0}', vars.DEV_DEPLOY_BRANCH || 'main')) || (github.event_name == 'push' && github.ref == format('refs/heads/{0}', vars.DEV_DEPLOY_BRANCH || 'main')) || (github.event_name == 'pull_request' && github.head_ref == vars.DEV_DEPLOY_BRANCH && vars.DEV_DEPLOY_BRANCH != 'main' && vars.DEV_DEPLOY_BRANCH != '') }}
 
     steps:
       - name: Checkout
@@ -303,8 +303,14 @@ jobs:
     needs: [version, docker-publish]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency:
+      group: ${{ needs.version.outputs.is_dev_deploy == 'true' && 'dev-environment-deploy' || format('deploy-{0}', github.run_id) }}
+      cancel-in-progress: false
     env:
       VERSION: ${{ needs.version.outputs.version }}
+      CLUSTER_NAME: ex-k8s-v6
+      RESOURCE_GROUP: exceptionless-v6
+      DEV_NAMESPACE: ex-dev
 
     steps:
       - name: Checkout
@@ -313,19 +319,60 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
 
+      - name: Azure Login
+        if: ${{ needs.version.outputs.is_dev_deploy == 'true' || needs.version.outputs.is_prod_deploy == 'true' }}
+        run: az login --service-principal --username ${{ secrets.AZ_USERNAME }} --password ${{ secrets.AZ_PASSWORD }} --tenant ${{ secrets.AZ_TENANT }} --output none
+
+      - name: Get AKS Credentials
+        if: ${{ needs.version.outputs.is_dev_deploy == 'true' || needs.version.outputs.is_prod_deploy == 'true' }}
+        run: az aks get-credentials --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME --overwrite-existing
+
+      - name: Ensure Development Infrastructure is Running
+        if: ${{ needs.version.outputs.is_dev_deploy == 'true' }}
+        run: |
+          kubectl scale statefulset/ex-dev-es-main --replicas=1 --namespace $DEV_NAMESPACE
+          kubectl apply -f k8s/ex-dev-redis.yaml
+          kubectl wait --for=condition=ready --timeout=300s pod ex-dev-es-main-0 --namespace $DEV_NAMESPACE
+          kubectl scale deployment/ex-dev-kb --replicas=1 --namespace $DEV_NAMESPACE
+
       - name: Deploy Changes to Development Environment
         if: ${{ needs.version.outputs.is_dev_deploy == 'true' }}
         run: |
-          az login --service-principal --username ${{ secrets.AZ_USERNAME }} --password ${{ secrets.AZ_PASSWORD }} --tenant ${{ secrets.AZ_TENANT }} --output none
-          az aks get-credentials --resource-group exceptionless-v6 --name ex-k8s-v6
           sed -i "s/^appVersion:.*$/appVersion: '${VERSION}'/" ./k8s/exceptionless/Chart.yaml
-          helm upgrade --set "version=${VERSION}" --reuse-values --values ./k8s/ex-dev-values.yaml ex-dev --namespace ex-dev ./k8s/exceptionless
+          helm upgrade --set "version=${VERSION}" --reuse-values --values ./k8s/ex-dev-values.yaml ex-dev --namespace $DEV_NAMESPACE ./k8s/exceptionless
+
+      - name: Ensure Development Workloads are Running
+        if: ${{ needs.version.outputs.is_dev_deploy == 'true' }}
+        run: |
+          kubectl scale deployment/ex-dev-app --replicas=1 --namespace $DEV_NAMESPACE
+          kubectl scale deployment/ex-dev-api --replicas=1 --namespace $DEV_NAMESPACE
+          kubectl scale deployment/ex-dev-jobs-close-inactive-sessions --replicas=1 --namespace $DEV_NAMESPACE
+          kubectl scale deployment/ex-dev-jobs-daily-summary --replicas=1 --namespace $DEV_NAMESPACE
+          kubectl scale deployment/ex-dev-jobs-event-notifications --replicas=1 --namespace $DEV_NAMESPACE
+          kubectl scale deployment/ex-dev-jobs-event-usage --replicas=1 --namespace $DEV_NAMESPACE
+          kubectl scale deployment/ex-dev-jobs-event-posts --replicas=1 --namespace $DEV_NAMESPACE
+          kubectl scale deployment/ex-dev-jobs-event-user-descriptions --replicas=1 --namespace $DEV_NAMESPACE
+          kubectl scale deployment/ex-dev-jobs-mail-message --replicas=1 --namespace $DEV_NAMESPACE
+          kubectl scale deployment/ex-dev-jobs-stack-event-count --replicas=1 --namespace $DEV_NAMESPACE
+          kubectl scale deployment/ex-dev-jobs-web-hooks --replicas=1 --namespace $DEV_NAMESPACE
+          kubectl scale deployment/ex-dev-jobs-work-item --replicas=1 --namespace $DEV_NAMESPACE
+
+          kubectl patch cronjob/ex-dev-jobs-cleanup-data -p '{"spec":{"suspend": false}}' --namespace $DEV_NAMESPACE
+          kubectl patch cronjob/ex-dev-jobs-cleanup-orphaned-data -p '{"spec":{"suspend": false}}' --namespace $DEV_NAMESPACE
+          kubectl patch cronjob/ex-dev-jobs-download-geoip-database -p '{"spec":{"suspend": false}}' --namespace $DEV_NAMESPACE
+          kubectl patch cronjob/ex-dev-jobs-maintain-indexes -p '{"spec":{"suspend": false}}' --namespace $DEV_NAMESPACE
+          kubectl patch cronjob/ex-dev-jobs-migration -p '{"spec":{"suspend": false}}' --namespace $DEV_NAMESPACE
+
+          kubectl wait --for=condition=available --timeout=300s deployment/ex-dev-app --namespace $DEV_NAMESPACE
+          kubectl wait --for=condition=available --timeout=300s deployment/ex-dev-api --namespace $DEV_NAMESPACE
+
+          kubectl annotate namespace $DEV_NAMESPACE exceptionless.io/dev-started-at="$(date -u +%Y-%m-%dT%H:%M:%SZ)" --overwrite
+          kubectl annotate namespace $DEV_NAMESPACE exceptionless.io/dev-auto-stop-days="1" --overwrite
+          kubectl annotate namespace $DEV_NAMESPACE exceptionless.io/dev-auto-stop-hours- --overwrite 2>/dev/null || true
 
       - name: Deploy Changes to Production Environment
         if: ${{ needs.version.outputs.is_prod_deploy == 'true' }}
         run: |
-          az login --service-principal --username ${{ secrets.AZ_USERNAME }} --password ${{ secrets.AZ_PASSWORD }} --tenant ${{ secrets.AZ_TENANT }} --output none
-          az aks get-credentials --resource-group exceptionless-v6 --name ex-k8s-v6
           sed -i "s/^appVersion:.*$/appVersion: '${VERSION}'/" ./k8s/exceptionless/Chart.yaml
           helm upgrade --set "version=${VERSION}" --reuse-values --values ./k8s/ex-prod-values.yaml ex-prod --namespace ex-prod ./k8s/exceptionless
 

--- a/.github/workflows/preview-command.yml
+++ b/.github/workflows/preview-command.yml
@@ -1,0 +1,118 @@
+name: Preview Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: dev-preview-command
+  cancel-in-progress: false
+
+jobs:
+  preview:
+    name: Dispatch preview deployment
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/preview') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Preview
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const body = context.payload.comment.body.trim();
+            const association = context.payload.comment.author_association;
+            const trustedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
+            if (!/^\/preview(?:\s|$)/.test(body)) {
+              core.info("Comment starts with /preview but does not match the command format.");
+              return;
+            }
+
+            if (!trustedAssociations.has(association)) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: context.payload.issue.number,
+                body: "I can only deploy previews when `/preview` is requested by a repository owner, member, or collaborator."
+              });
+              core.setFailed(`Unauthorized preview requester association: ${association}`);
+              return;
+            }
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: context.payload.issue.number
+            });
+
+            if (pullRequest.state !== "open") {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: context.payload.issue.number,
+                body: "I can only deploy previews for open pull requests."
+              });
+              core.setFailed(`Pull request #${pullRequest.number} is ${pullRequest.state}.`);
+              return;
+            }
+
+            const headRepository = pullRequest.head.repo.full_name;
+            const headRef = pullRequest.head.ref;
+            const headSha = pullRequest.head.sha;
+            const headLabel = pullRequest.head.label;
+
+            if (headRepository !== `${owner}/${repo}`) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pullRequest.number,
+                body: "I can only deploy previews for branches in this repository right now. Fork previews need a mirrored branch before the shared dev environment can build and deploy them."
+              });
+              core.setFailed(`Unsupported fork preview source: ${headRepository}`);
+              return;
+            }
+
+            try {
+              await github.request("PATCH /repos/{owner}/{repo}/actions/variables/{name}", {
+                owner,
+                repo,
+                name: "DEV_DEPLOY_BRANCH",
+                value: headRef
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+
+              await github.request("POST /repos/{owner}/{repo}/actions/variables", {
+                owner,
+                repo,
+                name: "DEV_DEPLOY_BRANCH",
+                value: headRef
+              });
+            }
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: "build.yaml",
+              ref: headRef
+            });
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pullRequest.number,
+              body: [
+                `Preview deployment requested for \`${headLabel}\` at \`${headSha.slice(0, 12)}\`.`,
+                "",
+                `The build workflow was dispatched for \`${headRef}\` and will deploy to https://dev-app.exceptionless.io when it completes.`
+              ].join("\n")
+            });


### PR DESCRIPTION
## What changed

- Added a /preview issue comment workflow for pull requests.
- The command updates the existing DEV_DEPLOY_BRANCH repository variable to the PR branch and dispatches the existing Build workflow at that branch.
- Updated Build so a manual dispatch on DEV_DEPLOY_BRANCH is treated as a development deploy.
- Dev deployments now ensure ex-dev infrastructure and workloads are running before finishing.
- Preview-started dev environments annotate exceptionless.io/dev-auto-stop-days=1, so they run for one day.

## Why

This lets trusted repo users switch the shared dev environment to a PR branch from a /preview comment without adding preview-specific inputs to the build workflow.

## Compatibility / security

- No public API, WebSocket, config key, or SDK contract changes.
- The build workflow remains input-free for manual dispatch.
- /preview uses the existing DEV_DEPLOY_BRANCH deployment contract.
- The comment command is limited to repository owners, members, and collaborators.
- Fork PRs are rejected for now because deploying fork code into the shared secret-backed dev namespace needs a mirrored base-repo branch or a separate trust model.

## Validation

- Parsed edited workflow YAML with ConvertFrom-Yaml.
- Ran git diff --check and staged diff check.