### PR TITLE
Add sticky preview deployment comment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   packages: write
   pull-requests: write
 
@@ -17,6 +18,64 @@ env:
   DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
 jobs:
+  preview-context:
+    if: ${{ github.event_name == 'workflow_dispatch' && github.ref == format('refs/heads/{0}', vars.DEV_DEPLOY_BRANCH || 'main') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      pr-number: ${{ steps.pr.outputs.pr-number }}
+      pr-sha: ${{ steps.pr.outputs.pr-sha }}
+      pr-short-sha: ${{ steps.pr.outputs.pr-short-sha }}
+      branch: ${{ steps.pr.outputs.branch }}
+
+    steps:
+      - name: Resolve preview pull request
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = context.ref.replace("refs/heads/", "");
+
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: "open",
+              head: `${owner}:${branch}`,
+              per_page: 10
+            });
+
+            if (pullRequests.length === 0) {
+              core.info(`No open pull request found for ${owner}:${branch}.`);
+              return;
+            }
+
+            const pullRequest = pullRequests[0];
+            core.setOutput("pr-number", String(pullRequest.number));
+            core.setOutput("pr-sha", pullRequest.head.sha);
+            core.setOutput("pr-short-sha", pullRequest.head.sha.slice(0, 12));
+            core.setOutput("branch", branch);
+
+  preview-comment-running:
+    needs: [preview-context]
+    if: ${{ always() && needs.preview-context.outputs.pr-number != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Post sticky running comment
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          number: ${{ needs.preview-context.outputs.pr-number }}
+          header: exceptionless-preview
+          message: |
+            Preview deploy running - [view progress](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            Building images and deploying the shared dev environment. This comment will update with the dev URL when the deploy finishes.
+
+            - Branch: `${{ needs.preview-context.outputs.branch }}`
+            - Commit: [`${{ needs.preview-context.outputs.pr-short-sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ needs.preview-context.outputs.pr-sha }})
+
   version:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -393,3 +452,37 @@ jobs:
           else
             echo "- **Deployment**: Skipped" >> $GITHUB_STEP_SUMMARY
           fi
+
+  preview-comment-result:
+    needs: [preview-context, version, test-api, test-client, docker-build, docker-publish, deploy]
+    if: ${{ always() && needs.preview-context.outputs.pr-number != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Post sticky deployed comment
+        if: ${{ needs.deploy.result == 'success' }}
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          number: ${{ needs.preview-context.outputs.pr-number }}
+          header: exceptionless-preview
+          message: |
+            Preview deployed
+
+            - **App:** https://dev-app.exceptionless.io
+            - **Collector:** https://dev-collector.exceptionless.io
+            - Commit: [`${{ needs.preview-context.outputs.pr-short-sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ needs.preview-context.outputs.pr-sha }})
+            - Version: `${{ needs.version.outputs.version }}`
+            - Workflow run: [view logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+      - name: Post sticky failed comment
+        if: ${{ needs.deploy.result != 'success' }}
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          number: ${{ needs.preview-context.outputs.pr-number }}
+          header: exceptionless-preview
+          message: |
+            Preview deploy failed or did not complete. See [run logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+            - Branch: `${{ needs.preview-context.outputs.branch }}`
+            - Commit: [`${{ needs.preview-context.outputs.pr-short-sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ needs.preview-context.outputs.pr-sha }})
+            - Version: `${{ needs.version.outputs.version || 'not computed' }}`

--- a/.github/workflows/preview-command.yml
+++ b/.github/workflows/preview-command.yml
@@ -20,7 +20,8 @@ jobs:
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/preview') }}
     runs-on: ubuntu-latest
     steps:
-      - name: Dispatch Preview
+      - name: Prepare Preview
+        id: preview
         uses: actions/github-script@v7
         with:
           script: |
@@ -34,6 +35,13 @@ jobs:
               core.info("Comment starts with /preview but does not match the command format.");
               return;
             }
+
+            await github.rest.reactions.createForIssueComment({
+              owner,
+              repo,
+              comment_id: context.payload.comment.id,
+              content: "eyes"
+            });
 
             if (!trustedAssociations.has(association)) {
               await github.rest.issues.createComment({
@@ -67,6 +75,7 @@ jobs:
             const headRef = pullRequest.head.ref;
             const headSha = pullRequest.head.sha;
             const headLabel = pullRequest.head.label;
+            const headShortSha = headSha.slice(0, 12);
 
             if (headRepository !== `${owner}/${repo}`) {
               await github.rest.issues.createComment({
@@ -99,20 +108,36 @@ jobs:
               });
             }
 
-            await github.rest.actions.createWorkflowDispatch({
-              owner,
-              repo,
-              workflow_id: "build.yaml",
-              ref: headRef
-            });
+            core.setOutput("pr-number", String(pullRequest.number));
+            core.setOutput("head-ref", headRef);
+            core.setOutput("head-label", headLabel);
+            core.setOutput("head-sha", headSha);
+            core.setOutput("head-short-sha", headShortSha);
 
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: pullRequest.number,
-              body: [
-                `Preview deployment requested for \`${headLabel}\` at \`${headSha.slice(0, 12)}\`.`,
-                "",
-                `The build workflow was dispatched for \`${headRef}\` and will deploy to https://dev-app.exceptionless.io when it completes.`
-              ].join("\n")
+      - name: Post sticky queued comment
+        if: ${{ steps.preview.outputs.pr-number != '' }}
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          number: ${{ steps.preview.outputs.pr-number }}
+          header: exceptionless-preview
+          message: |
+            Preview deploy queued.
+
+            The build workflow will start shortly. This comment will update with a progress link when the run starts and with the dev URL when deployment finishes.
+
+            - Branch: `${{ steps.preview.outputs.head-label }}`
+            - Commit: [`${{ steps.preview.outputs.head-short-sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ steps.preview.outputs.head-sha }})
+
+      - name: Dispatch Preview
+        if: ${{ steps.preview.outputs.pr-number != '' }}
+        uses: actions/github-script@v7
+        env:
+          HEAD_REF: ${{ steps.preview.outputs.head-ref }}
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "build.yaml",
+              ref: process.env.HEAD_REF
             });


### PR DESCRIPTION
## What changed

- /preview now adds an eyes reaction to the command comment when accepted by the workflow.
- /preview creates or updates a single sticky preview comment using the exceptionless-preview header.
- The sticky comment starts as queued with branch and commit details.
- When the Build workflow starts, it updates the sticky comment to running with a direct workflow run link.
- When the workflow completes, it updates the same sticky comment with either:
  - the dev app URL, collector URL, deployed version, commit, and run logs on success
  - a failure / did-not-complete message with run logs, branch, commit, and computed version when available

## Why

This keeps preview status in one predictable PR comment, gives reviewers a progress link while the deploy is running, and leaves an actionable run-log link even when the deploy fails.

## Compatibility / security

- No public API, WebSocket, config key, or SDK contract changes.
- No new Build workflow inputs or repository variables.
- Build gets issues: write so it can update the sticky PR comment after deployment.

## Validation

- Parsed edited workflow YAML with ConvertFrom-Yaml.
- Ran git diff --check and staged diff check.