### PR TITLE
[codex] Update Aspire to 13.4.2

### DIFF
--- a/src/Exceptionless.AppHost/Exceptionless.AppHost.csproj
+++ b/src/Exceptionless.AppHost/Exceptionless.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.2">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,10 +8,10 @@
     <NoWarn>$(NoWarn);ASPIRECERTIFICATES001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.4.0" />
-    <PackageReference Include="Aspire.Hosting.Browsers" Version="13.4.0-preview.1.26281.18" />
-    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.4.0" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.4.2" />
+    <PackageReference Include="Aspire.Hosting.Browsers" Version="13.4.2-preview.1.26303.6" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.4.2" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.2" />
     <PackageReference Include="AspNetCore.HealthChecks.Elasticsearch" Version="9.0.0" />
   </ItemGroup>
 

--- a/tests/Exceptionless.Tests/Exceptionless.Tests.csproj
+++ b/tests/Exceptionless.Tests/Exceptionless.Tests.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="FluentRest" Version="11.1.0" />
 
-    <PackageReference Include="Aspire.Hosting.Testing" Version="13.4.0" />
+    <PackageReference Include="Aspire.Hosting.Testing" Version="13.4.2" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />


### PR DESCRIPTION
## Summary
- Update the AppHost SDK and Aspire hosting packages to 13.4.2.
- Update `Aspire.Hosting.Browsers` to the matching 13.4.2 preview build.
- Update `Aspire.Hosting.Testing` to 13.4.2.

## Impact
Keeps local Aspire orchestration and integration test infrastructure on the latest 13.4 patch line. No public API, config key, or runtime behavior changes are intended.

## Validation
- `dotnet restore Exceptionless.slnx`
- `dotnet build src\Exceptionless.AppHost\Exceptionless.AppHost.csproj --no-restore -m:1 -p:UseSharedCompilation=false`
- `dotnet build tests\Exceptionless.Tests\Exceptionless.Tests.csproj --no-restore -m:1 -p:UseSharedCompilation=false`
- `dotnet test tests\Exceptionless.Tests\Exceptionless.Tests.csproj --no-build -p:UseSharedCompilation=false -- --filter-class Exceptionless.Tests.Controllers.StatusControllerTests`
