### PR TITLE
[codex] Update Aspire and .NET dependencies

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.300
+          dotnet-version: 10.0.301
       - name: Build Reason
         env:
           GITHUB_EVENT: ${{ toJson(github) }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,7 +110,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.300
+          dotnet-version: 10.0.301
 
       - name: Version
         id: version
@@ -142,7 +142,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.300
+          dotnet-version: 10.0.301
 
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,15 +25,15 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.300
+          dotnet-version: 10.0.301
 
       - name: Install Aspire CLI
         run: |
           export PATH="$HOME/.dotnet/tools:$PATH"
           if dotnet tool list --global | grep -Eiq '^aspire\.cli[[:space:]]'; then
-            dotnet tool update --global Aspire.Cli --version 13.3.4
+            dotnet tool update --global Aspire.Cli --version 13.4.4
           else
-            dotnet tool install --global Aspire.Cli --version 13.3.4
+            dotnet tool install --global Aspire.Cli --version 13.4.4
           fi
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
           aspire --version

--- a/.github/workflows/elasticsearch-docker-8.yml
+++ b/.github/workflows/elasticsearch-docker-8.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.300
+          dotnet-version: 10.0.301
       - name: Build Reason
         env:
           GITHUB_EVENT: ${{ toJson(github) }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0.300 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.301 AS build
 ARG MinVerVersionOverride
 WORKDIR /app
 
@@ -40,7 +40,7 @@ RUN dotnet publish -c Release -o out --no-build
 
 # job
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.8 AS job
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.9 AS job
 WORKDIR /app
 COPY --from=job-publish /app/src/Exceptionless.Job/out ./
 
@@ -57,7 +57,7 @@ RUN dotnet publish -c Release -o out --no-build /p:SkipSpaPublish=true
 
 # api
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.8 AS api
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.9 AS api
 WORKDIR /app
 COPY --from=api-publish /app/src/Exceptionless.Web/out ./
 
@@ -73,7 +73,7 @@ RUN dotnet publish -c Release -o out --no-build
 
 # app
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0.8 AS app
+FROM mcr.microsoft.com/dotnet/aspnet:10.0.9 AS app
 
 WORKDIR /app
 COPY --from=app-publish /app/src/Exceptionless.Web/out ./
@@ -147,7 +147,7 @@ USER elasticsearch
 
 RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh && \
     chmod +x dotnet-install.sh && \
-    ./dotnet-install.sh --version 10.0.8 --runtime aspnetcore && \
+    ./dotnet-install.sh --version 10.0.9 --runtime aspnetcore && \
     rm dotnet-install.sh
 
 EXPOSE 8080 9200

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "10.0.100",
+        "version": "10.0.301",
         "rollForward": "latestMinor",
         "allowPrerelease": false
     },

--- a/src/Exceptionless.AppHost/Exceptionless.AppHost.csproj
+++ b/src/Exceptionless.AppHost/Exceptionless.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.3">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.4">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,11 +8,12 @@
     <NoWarn>$(NoWarn);ASPIRECERTIFICATES001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.4.3" />
-    <PackageReference Include="Aspire.Hosting.Browsers" Version="13.4.3-preview.1.26305.13" />
-    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.4.3" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.3" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.4.4" />
+    <PackageReference Include="Aspire.Hosting.Browsers" Version="13.4.4-preview.1.26314.3" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.4.4" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.4.4" />
     <PackageReference Include="AspNetCore.HealthChecks.Elasticsearch" Version="9.0.0" />
+    <PackageReference Include="MessagePack" Version="3.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Exceptionless.Insulation/Exceptionless.Insulation.csproj
+++ b/src/Exceptionless.Insulation/Exceptionless.Insulation.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.ExceptionLess" Version="5.0.0" />
     <PackageReference Include="YamlDotNet" Version="18.0.0" />

--- a/src/Exceptionless.Web/ClientApp/src/app.css
+++ b/src/Exceptionless.Web/ClientApp/src/app.css
@@ -165,7 +165,7 @@
 }
 
 @utility no-scrollbar {
-	/* CUSTOM: HELPS KEEP CUSTOM SIDEBAR/OVERLAYS FROM CAUSING VISUAL LAYOUT JITTER. */
+    /* CUSTOM: HELPS KEEP CUSTOM SIDEBAR/OVERLAYS FROM CAUSING VISUAL LAYOUT JITTER. */
     -ms-overflow-style: none;
     scrollbar-width: none;
 

--- a/src/Exceptionless.Web/Exceptionless.Web.csproj
+++ b/src/Exceptionless.Web/Exceptionless.Web.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="MiniValidation" Version="0.10.0" />
     <PackageReference Include="NEST.JsonNetSerializer" Version="7.17.5" />
     <PackageReference Include="OAuth2" Version="1.0.0" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.16.2" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />

--- a/tests/Exceptionless.Tests/Exceptionless.Tests.csproj
+++ b/tests/Exceptionless.Tests/Exceptionless.Tests.csproj
@@ -11,7 +11,8 @@
 
     <PackageReference Include="FluentRest" Version="11.1.0" />
 
-    <PackageReference Include="Aspire.Hosting.Testing" Version="13.4.3" />
+    <PackageReference Include="Aspire.Hosting.Testing" Version="13.4.4" />
+    <PackageReference Include="MessagePack" Version="3.1.7" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />


### PR DESCRIPTION
## What changed

- Updated Aspire AppHost SDK and stable hosting packages from `13.4.3` to `13.4.4`.
- Updated `Aspire.Hosting.Browsers` preview from `13.4.3-preview.1.26305.13` to `13.4.4-preview.1.26314.3`.
- Updated `Aspire.Hosting.Testing` from `13.4.3` to `13.4.4`.
- Updated `Aspire.Cli` in the Copilot setup workflow from `13.3.4` to `13.4.4`.
- Updated .NET SDK pins from `10.0.300`/`10.0.100` to `10.0.301` in Docker, GitHub Actions, and `global.json`.
- Updated Docker ASP.NET runtime images and the all-in-one image runtime install from `10.0.8` to `10.0.9`.
- Updated stable package patches discovered by the dependency scan:
  - `Serilog.Settings.Configuration` `10.0.0` -> `10.0.1`
  - `Scalar.AspNetCore` `2.16.2` -> `2.16.3`
- Added direct `MessagePack` `3.1.7` references in the affected AppHost/test projects to avoid restoring vulnerable transitive `MessagePack` `2.5.192` as warnings-as-errors.

## Why

Keep the local Aspire hosting/test stack, .NET SDK/runtime pins, Docker images, and stable patch dependencies current while preserving the existing package shape.

## Impact

No public API, WebSocket, or frontend behavior changes expected. This affects build/runtime dependency pins, local Aspire orchestration, Aspire-backed test infrastructure, and OpenAPI UI package patching.

## Verification

- Installed SDK `10.0.301` into `/private/tmp/dotnet-10.0.301` for local verification because the machine-wide SDK is `10.0.300`.
- `/private/tmp/dotnet-10.0.301/dotnet restore Exceptionless.slnx`
- `/private/tmp/dotnet-10.0.301/dotnet build src/Exceptionless.AppHost/Exceptionless.AppHost.csproj --no-restore -p:UseSharedCompilation=false -p:BuildInParallel=false`
- `/private/tmp/dotnet-10.0.301/dotnet build tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-restore -p:UseSharedCompilation=false -p:BuildInParallel=false`
- `/private/tmp/dotnet-10.0.301/dotnet list Exceptionless.slnx package --vulnerable --include-transitive --no-restore`
- `/private/tmp/dotnet-10.0.301/dotnet list Exceptionless.slnx package --outdated --highest-patch`
- `/private/tmp/dotnet-10.0.301/dotnet list Exceptionless.slnx package --outdated --include-prerelease --highest-patch`
- `/private/tmp/dotnet-10.0.301/dotnet sdk check`
- `docker manifest inspect mcr.microsoft.com/dotnet/sdk:10.0.301`
- `docker manifest inspect mcr.microsoft.com/dotnet/aspnet:10.0.9`
- `/private/tmp/dotnet-10.0.301/dotnet test tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-restore --no-build` -> 1916 passed, 3 skipped, 0 failed

Notes:

- No stable package patch updates remain after this change. Remaining NuGet updates are prerelease/alpha-only for Exceptionless/Foundatio/OpenTelemetry packages and were intentionally left out.
- `Microsoft.SourceLink.GitHub` remains at `10.0.300`; NuGet reports that as latest.
- Docker SDK/runtime tags exist for `amd64`, `arm`, and `arm64`.

## Breaking changes

None expected.
