### PR TITLE
Fix saved view deletion

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -54,6 +54,21 @@ export interface UseSavedViewsReturn {
     savedViews: SavedView[];
 }
 
+export function clearSavedViewQueryParams(queryParams: SavedViewQueryParams): void {
+    queryParams.filter = null;
+
+    if (supportsFiltersQueryParam(queryParams)) {
+        queryParams.filters = null;
+    }
+
+    setSortQueryParam(queryParams, null);
+    setTimeQueryParam(queryParams, null);
+
+    if (supportsSavedQueryParam(queryParams)) {
+        queryParams.saved = null;
+    }
+}
+
 export function filterDefinitionsEqual(a: null | string | undefined, b: null | string | undefined): boolean {
     return normalizeFilterDefinitions(a) === normalizeFilterDefinitions(b);
 }
@@ -100,21 +115,6 @@ export function setSortQueryParam(queryParams: SavedViewQueryParams, value: null
 export function setTimeQueryParam(queryParams: SavedViewQueryParams, value: null | string): void {
     if (supportsTimeQueryParam(queryParams)) {
         queryParams.time = value;
-    }
-}
-
-export function clearSavedViewQueryParams(queryParams: SavedViewQueryParams): void {
-    queryParams.filter = null;
-
-    if (supportsFiltersQueryParam(queryParams)) {
-        queryParams.filters = null;
-    }
-
-    setSortQueryParam(queryParams, null);
-    setTimeQueryParam(queryParams, null);
-
-    if (supportsSavedQueryParam(queryParams)) {
-        queryParams.saved = null;
     }
 }
 
@@ -404,12 +404,12 @@ function sortFilterDefinitions(filters: IFilter[]): IFilter[] {
     return [...filters].sort((a, b) => a.key.localeCompare(b.key));
 }
 
-function supportsSavedQueryParam(queryParams: SavedViewQueryParams): queryParams is SavedViewQueryParams & { saved: null | string | undefined } {
-    return Object.prototype.hasOwnProperty.call(queryParams, 'saved');
-}
-
 function supportsFiltersQueryParam(queryParams: SavedViewQueryParams): queryParams is SavedViewQueryParams & { filters: null | string | undefined } {
     return Object.prototype.hasOwnProperty.call(queryParams, 'filters');
+}
+
+function supportsSavedQueryParam(queryParams: SavedViewQueryParams): queryParams is SavedViewQueryParams & { saved: null | string | undefined } {
+    return Object.prototype.hasOwnProperty.call(queryParams, 'saved');
 }
 
 function updateSavedViewFilterCache(options: UseSavedViewsOptions, view: SavedView, filters: IFilter[]): void {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -103,6 +103,21 @@ export function setTimeQueryParam(queryParams: SavedViewQueryParams, value: null
     }
 }
 
+export function clearSavedViewQueryParams(queryParams: SavedViewQueryParams): void {
+    queryParams.filter = null;
+
+    if (supportsFiltersQueryParam(queryParams)) {
+        queryParams.filters = null;
+    }
+
+    setSortQueryParam(queryParams, null);
+    setTimeQueryParam(queryParams, null);
+
+    if (supportsSavedQueryParam(queryParams)) {
+        queryParams.saved = null;
+    }
+}
+
 export function supportsSortQueryParam(queryParams: SavedViewQueryParams): queryParams is SavedViewQueryParams & { sort: null | string | undefined } {
     return Object.prototype.hasOwnProperty.call(queryParams, 'sort');
 }
@@ -303,16 +318,9 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     }
 
     function handleClearSavedView() {
-        options.queryParams.filter = null;
-        options.queryParams.filters = null;
-        setSortQueryParam(options.queryParams, null);
-        setTimeQueryParam(options.queryParams, null);
+        clearSavedViewQueryParams(options.queryParams);
         applyColumnState(undefined);
         applyDisplayState(undefined);
-
-        if (supportsSavedQueryParam(options.queryParams)) {
-            options.queryParams.saved = undefined;
-        }
 
         if (options.baseHref) {
             goto(options.baseHref);
@@ -398,6 +406,10 @@ function sortFilterDefinitions(filters: IFilter[]): IFilter[] {
 
 function supportsSavedQueryParam(queryParams: SavedViewQueryParams): queryParams is SavedViewQueryParams & { saved: null | string | undefined } {
     return Object.prototype.hasOwnProperty.call(queryParams, 'saved');
+}
+
+function supportsFiltersQueryParam(queryParams: SavedViewQueryParams): queryParams is SavedViewQueryParams & { filters: null | string | undefined } {
+    return Object.prototype.hasOwnProperty.call(queryParams, 'filters');
 }
 
 function updateSavedViewFilterCache(options: UseSavedViewsOptions, view: SavedView, filters: IFilter[]): void {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -6,6 +6,7 @@ import type { SavedView } from './models';
 
 import { invalidateSavedViewQueries, queryKeys, removeSavedViewFromCaches, SAVED_VIEW_REFRESH_DELAY_MS, syncSavedViewCaches } from './api.svelte';
 import {
+    clearSavedViewQueryParams,
     filterDefinitionsEqual,
     getComparableSavedViewFilter,
     getComparableSavedViewTime,
@@ -296,6 +297,57 @@ describe('useSavedViews', () => {
 
             // Assert
             expect(queryParams.time).toBeNull();
+        });
+    });
+
+    describe('saved parameter clearing', () => {
+        it('clears saved view selection to null instead of undefined', () => {
+            // Arrange
+            const queryParams: SavedViewQueryParams = {
+                filter: 'type:error',
+                filters: 'type:error',
+                saved: 'view-1',
+                sort: '-date',
+                time: '[now-7d TO now]'
+            };
+
+            // Act
+            clearSavedViewQueryParams(queryParams);
+
+            // Assert
+            expect(queryParams).toEqual({
+                filter: null,
+                filters: null,
+                saved: null,
+                sort: null,
+                time: null
+            });
+        });
+
+        it('does not write query parameters unsupported by the route', () => {
+            // Arrange
+            const target: SavedViewQueryParams = {
+                filter: 'type:error',
+                time: '[now-7d TO now]'
+            };
+            const queryParams = new Proxy(target, {
+                set(obj, prop, value) {
+                    if (prop === 'filters' || prop === 'saved' || prop === 'sort') {
+                        throw new Error(`unexpected ${String(prop)} assignment: ${String(value)}`);
+                    }
+
+                    return Reflect.set(obj, prop, value);
+                }
+            }) as SavedViewQueryParams;
+
+            // Act & Assert
+            expect(() => {
+                clearSavedViewQueryParams(queryParams);
+            }).not.toThrow();
+            expect(queryParams).toEqual({
+                filter: null,
+                time: null
+            });
         });
     });
 


### PR DESCRIPTION
## Summary
- Clear saved-view query params through a helper that respects the current route's supported params.
- Avoid assigning unsupported `filters`, `saved`, or `sort` keys while clearing the active saved view.
- Add unit coverage for both full saved-view query state and route-limited query state.

## Why
Deleting an active saved view first clears the selected view state. Stack/event routes do not define every optional saved-view query key in `kit-query-params`, so assigning unsupported keys caused the clear path to throw before the delete flow could finish, leaving the confirmation dialog open.

## Validation
- `npm run test:unit -- src/lib/features/saved-views/use-saved-views.test.ts --run`
- Local Aspire browser repro: created and deleted a disposable saved stack view; the confirmation dialog closed, navigation returned to `/next/stack`, and the API returned 404 for the deleted saved view.

## Breaking changes
None.