### PR TITLE
Optimize event and stack paging totals

### DIFF
--- a/docs/serialization-architecture.md
+++ b/docs/serialization-architecture.md
@@ -386,8 +386,8 @@ During deployment where old instances use Newtonsoft and new instances use STJ:
 ### Newtonsoft.Json (Transitive Only — NOT USED)
 
 ```
-Foundatio.Repositories.Elasticsearch v8.0.0-beta1
-  → Foundatio.Repositories v8.0.0-beta1
+Foundatio.Repositories.Elasticsearch v8.0.0-beta2
+  → Foundatio.Repositories v8.0.0-beta2
     → Foundatio.JsonNet v13.0.1
       → Newtonsoft.Json v13.0.4
 

--- a/src/Exceptionless.Core/Exceptionless.Core.csproj
+++ b/src/Exceptionless.Core/Exceptionless.Core.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Stripe.net" Version="52.0.0" />
     <PackageReference Include="System.DirectoryServices" Version="10.0.9" />
     <PackageReference Include="UAParser" Version="3.1.47" />
-    <PackageReference Include="Foundatio.Repositories.Elasticsearch" Version="8.0.0-beta1.11" Condition="'$(ReferenceFoundatioRepositoriesSource)' == '' OR '$(ReferenceFoundatioRepositoriesSource)' == 'false'" />
+    <PackageReference Include="Foundatio.Repositories.Elasticsearch" Version="8.0.0-beta1.search-after-pit-cursors.25" Condition="'$(ReferenceFoundatioRepositoriesSource)' == '' OR '$(ReferenceFoundatioRepositoriesSource)' == 'false'" />
     <ProjectReference Include="..\..\..\..\Foundatio\Foundatio.Repositories\src\Foundatio.Repositories.Elasticsearch\Foundatio.Repositories.Elasticsearch.csproj" Condition="'$(ReferenceFoundatioRepositoriesSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Exceptionless.Core/Exceptionless.Core.csproj
+++ b/src/Exceptionless.Core/Exceptionless.Core.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Stripe.net" Version="52.0.0" />
     <PackageReference Include="System.DirectoryServices" Version="10.0.9" />
     <PackageReference Include="UAParser" Version="3.1.47" />
-    <PackageReference Include="Foundatio.Repositories.Elasticsearch" Version="8.0.0-beta1.search-after-pit-cursors.25" Condition="'$(ReferenceFoundatioRepositoriesSource)' == '' OR '$(ReferenceFoundatioRepositoriesSource)' == 'false'" />
+    <PackageReference Include="Foundatio.Repositories.Elasticsearch" Version="8.0.0-beta2" Condition="'$(ReferenceFoundatioRepositoriesSource)' == '' OR '$(ReferenceFoundatioRepositoriesSource)' == 'false'" />
     <ProjectReference Include="..\..\..\..\Foundatio\Foundatio.Repositories\src\Foundatio.Repositories.Elasticsearch\Foundatio.Repositories.Elasticsearch.csproj" Condition="'$(ReferenceFoundatioRepositoriesSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
@@ -99,7 +99,7 @@ export interface GetEventsParams {
     after?: string;
     before?: string;
     filter?: string;
-    includeTotal?: boolean;
+    include?: 'total';
     limit?: number;
     mode?: GetEventsMode;
     offset?: string;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
@@ -99,6 +99,7 @@ export interface GetEventsParams {
     after?: string;
     before?: string;
     filter?: string;
+    includeTotal?: boolean;
     limit?: number;
     mode?: GetEventsMode;
     offset?: string;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
@@ -370,7 +370,7 @@ export function resolvePageCount(
         return Math.max(previousPageCount, currentPage + 1, totalPages ?? 0);
     }
 
-    return totalPages ?? (hasNextPage ? currentPage + 1 : currentPage);
+    return totalPages ?? (hasNextPage ? Math.max(previousPageCount, currentPage + 1) : currentPage);
 }
 
 export function resolvePaginationChange(previousPageInfo: PaginationState, currentPageInfo: PaginationState) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.test.ts
@@ -114,4 +114,12 @@ describe('resolvePageCount', () => {
 
         expect(result).toBe(424);
     });
+
+    it('keeps a known offset page count when a later response omits total but has a next page', () => {
+        const meta = { links: { next: { page: '3', rel: 'next', url: '/events?page=3' } } } as QueryMeta;
+
+        const result = resolvePageCount('offset', meta, 2, 50, 1060);
+
+        expect(result).toBe(1060);
+    });
 });

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -689,7 +689,10 @@
             return;
         }
 
-        const params = { ...eventsQueryParameters };
+        const params = {
+            ...eventsQueryParameters,
+            includeTotal: !eventsQueryParameters.after && !eventsQueryParameters.before
+        };
         delete params.page;
         clientResponse = await client.getJSON<EventSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organization.current}/events`, { params });
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -691,7 +691,7 @@
 
         const params = {
             ...eventsQueryParameters,
-            includeTotal: !eventsQueryParameters.after && !eventsQueryParameters.before
+            include: !eventsQueryParameters.after && !eventsQueryParameters.before ? 'total' : undefined
         };
         delete params.page;
         clientResponse = await client.getJSON<EventSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organization.current}/events`, { params });

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -657,7 +657,10 @@
         }
 
         clientResponse = await client.getJSON<EventSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organization.current}/events`, {
-            params: eventsQueryParameters as Record<string, unknown>
+            params: {
+                ...eventsQueryParameters,
+                includeTotal: !eventsQueryParameters.page || eventsQueryParameters.page <= 1
+            } as Record<string, unknown>
         });
 
         showBillingDialogOnUpgradeProblem(clientResponse.problem, organization.current, () => loadData());

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -659,7 +659,7 @@
         clientResponse = await client.getJSON<EventSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organization.current}/events`, {
             params: {
                 ...eventsQueryParameters,
-                includeTotal: !eventsQueryParameters.page || eventsQueryParameters.page <= 1
+                include: !eventsQueryParameters.page || eventsQueryParameters.page <= 1 ? 'total' : undefined
             } as Record<string, unknown>
         });
 

--- a/src/Exceptionless.Web/Controllers/Base/ExceptionlessApiController.cs
+++ b/src/Exceptionless.Web/Controllers/Base/ExceptionlessApiController.cs
@@ -259,6 +259,21 @@ public abstract class ExceptionlessApiController : Controller
         return new OkWithResourceLinks<TEntity>(content, hasMore, page, total, before, after);
     }
 
+    protected static bool ShouldIncludeTotal(string? include)
+    {
+        return ShouldInclude(include, "total");
+    }
+
+    protected static bool ShouldInclude(string? include, string value)
+    {
+        if (String.IsNullOrWhiteSpace(include))
+            return false;
+
+        return include
+            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .Contains(value, StringComparer.OrdinalIgnoreCase);
+    }
+
     protected string? GetResourceLink(string? url, string type)
     {
         return url is not null ? $"<{url}>; rel=\"{type}\"" : null;

--- a/src/Exceptionless.Web/Controllers/EventController.cs
+++ b/src/Exceptionless.Web/Controllers/EventController.cs
@@ -217,6 +217,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
+    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
     [HttpGet]
@@ -224,7 +225,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetAllAsync(string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetAllAsync(string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
     {
         var organizations = await GetSelectedOrganizationsAsync(_organizationRepository, _projectRepository, _stackRepository, filter);
         if (organizations.All(o => o.IsSuspended))
@@ -232,7 +233,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organizations.GetRetentionUtcCutoff(_appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(organizations) { IsUserOrganizationsFilter = true };
-        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after);
+        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after, includeTotal: includeTotal);
     }
 
     private async Task<ActionResult<CountResult>> CountInternalAsync(AppFilter sf, TimeInfo ti, string? filter = null, string? aggregations = null, string? mode = null)
@@ -271,7 +272,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
         return Ok(result);
     }
 
-    private async Task<ActionResult<ICollection<PersistentEvent>>> GetInternalAsync(AppFilter sf, TimeInfo ti, string? filter = null, string? sort = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool usesPremiumFeatures = false)
+    private async Task<ActionResult<ICollection<PersistentEvent>>> GetInternalAsync(AppFilter sf, TimeInfo ti, string? filter = null, string? sort = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool usesPremiumFeatures = false, bool includeTotal = true)
     {
         using var _ = _logger.BeginScope(new ExceptionlessState()
             .Property("Search Filter", new
@@ -309,7 +310,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
             switch (mode)
             {
                 case "summary":
-                    events = await GetEventsInternalAsync(sf, ti, filter, sort, page, limit, before, after);
+                    events = await GetEventsInternalAsync(sf, ti, filter, sort, page, limit, before, after, includeTotal);
                     return OkWithResourceLinks(events.Documents.Select(e =>
                     {
                         var summaryData = _formattingPluginManager.GetEventSummaryData(e);
@@ -321,7 +322,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
                             Type = e.Type,
                             Data = summaryData.Data
                         };
-                    }).ToList(), events.HasMore && !NextPageExceedsSkipLimit(page, limit), page, events.Total, events.Hits.FirstOrDefault()?.GetSortToken(_serializer), events.Hits.LastOrDefault()?.GetSortToken(_serializer));
+                    }).ToList(), events.HasMore && !NextPageExceedsSkipLimit(page, limit), page, includeTotal ? events.Total : null, events.Hits.FirstOrDefault()?.GetSortToken(_serializer), events.Hits.LastOrDefault()?.GetSortToken(_serializer));
                 case "stack_recent":
                 case "stack_frequent":
                 case "stack_new":
@@ -347,12 +348,16 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
                     if (mode == "stack_new")
                         filter = AddFirstOccurrenceFilter(ti.Range, filter);
 
+                    string aggregationExpression = includeTotal
+                        ? $"cardinality:stack_id terms:(stack_id~{GetSkip(resolvedPage + 1, limit) + 1} {stackAggregations})"
+                        : $"terms:(stack_id~{GetSkip(resolvedPage + 1, limit) + 1} {stackAggregations})";
+
                     var countResponse = await _repository.CountAsync(q => q
                         .SystemFilter(systemFilter)
                         .FilterExpression(filter)
                         .EnforceEventStackFilter()
-                        .AggregationsExpression($"terms:(stack_id~{GetSkip(resolvedPage + 1, limit) + 1} {stackAggregations})")
-                    );
+                        .AggregationsExpression(aggregationExpression),
+                        o => o.TrackTotalHits(false));
 
                     var stackTerms = countResponse.Aggregations.Terms<string>("terms_stack_id");
                     if (stackTerms is null || stackTerms.Buckets.Count == 0)
@@ -363,11 +368,12 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
                     var summaries = await GetStackSummariesAsync(stacks, stackTerms.Buckets, sf, ti);
 
-                    long total = (stackTerms.Data?.GetValueOrDefault("SumOtherDocCount") as long? ?? 0L) + stackTerms.Buckets.Count;
+                    double? totalStackCount = countResponse.Aggregations.Cardinality("cardinality_stack_id")?.Value;
+                    long? total = includeTotal && totalStackCount.HasValue ? Convert.ToInt64(totalStackCount.Value) : null;
                     return OkWithResourceLinks(summaries.Take(limit).ToList(), summaries.Count > limit && !NextPageExceedsSkipLimit(resolvedPage, limit), resolvedPage, total);
                 default:
-                    events = await GetEventsInternalAsync(sf, ti, filter, sort, page, limit, before, after);
-                    return OkWithResourceLinks(events.Documents.ToArray(), events.HasMore && !NextPageExceedsSkipLimit(page, limit), page, events.Total, events.Hits.FirstOrDefault()?.GetSortToken(_serializer), events.Hits.LastOrDefault()?.GetSortToken(_serializer));
+                    events = await GetEventsInternalAsync(sf, ti, filter, sort, page, limit, before, after, includeTotal);
+                    return OkWithResourceLinks(events.Documents.ToArray(), events.HasMore && !NextPageExceedsSkipLimit(page, limit), page, includeTotal ? events.Total : null, events.Hits.FirstOrDefault()?.GetSortToken(_serializer), events.Hits.LastOrDefault()?.GetSortToken(_serializer));
             }
         }
         catch (ApplicationException ex)
@@ -415,7 +421,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
         return sb.ToString();
     }
 
-    private Task<FindResults<PersistentEvent>> GetEventsInternalAsync(AppFilter sf, TimeInfo ti, string? filter, string? sort, int? page, int limit, string? before, string? after)
+    private Task<FindResults<PersistentEvent>> GetEventsInternalAsync(AppFilter sf, TimeInfo ti, string? filter, string? sort, int? page, int limit, string? before, string? after, bool includeTotal)
     {
         if (String.IsNullOrEmpty(sort))
             sort = $"-{EventIndex.Alias.Date}";
@@ -428,8 +434,8 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
                 .DateRange(ti.Range.UtcStart, ti.Range.UtcEnd, ti.Field)
                 .Index(ti.Range.UtcStart, ti.Range.UtcEnd),
             o => page.HasValue
-                ? o.PageNumber(page).PageLimit(limit)
-                : o.SearchBeforeToken(before, _serializer).SearchAfterToken(after, _serializer).PageLimit(limit));
+                ? o.PageNumber(page).PageLimit(limit).TrackTotalHits(includeTotal)
+                : o.SearchBeforeToken(before, _serializer).SearchAfterToken(after, _serializer).PageLimit(limit).TrackTotalHits(includeTotal));
     }
 
     /// <summary>
@@ -445,6 +451,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
+    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="404">The organization could not be found.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
@@ -453,7 +460,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByOrganizationAsync(string organizationId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByOrganizationAsync(string organizationId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
     {
         var organization = await GetOrganizationAsync(organizationId);
         if (organization is null)
@@ -464,7 +471,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organization.GetRetentionUtcCutoff(_appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(organization);
-        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after);
+        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after, includeTotal: includeTotal);
     }
 
     /// <summary>
@@ -480,6 +487,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
+    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="404">The project could not be found.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
@@ -488,7 +496,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByProjectAsync(string projectId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByProjectAsync(string projectId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
     {
         var project = await GetProjectAsync(projectId);
         if (project is null)
@@ -503,7 +511,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organization.GetRetentionUtcCutoff(project, _appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(project, organization);
-        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after);
+        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after, includeTotal: includeTotal);
     }
 
     /// <summary>
@@ -519,6 +527,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
+    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="404">The stack could not be found.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
@@ -527,7 +536,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByStackAsync(string stackId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByStackAsync(string stackId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
     {
         var stack = await GetStackAsync(stackId);
         if (stack is null)
@@ -542,7 +551,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organization.GetRetentionUtcCutoff(stack, _appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(stack, organization);
-        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after);
+        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after, includeTotal: includeTotal);
     }
 
     /// <summary>
@@ -555,6 +564,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
+    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
     [HttpGet("by-ref/{referenceId:identifier}")]
@@ -562,7 +572,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByReferenceIdAsync(string referenceId, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByReferenceIdAsync(string referenceId, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
     {
         var organizations = await GetSelectedOrganizationsAsync(_organizationRepository, _projectRepository, _stackRepository);
         if (organizations.All(o => o.IsSuspended))
@@ -570,7 +580,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(null, offset, organizations.GetRetentionUtcCutoff(_appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(organizations) { IsUserOrganizationsFilter = true };
-        return await GetInternalAsync(sf, ti, String.Concat("reference:", referenceId), null, mode, page, limit, before, after);
+        return await GetInternalAsync(sf, ti, String.Concat("reference:", referenceId), null, mode, page, limit, before, after, includeTotal: includeTotal);
     }
 
     /// <summary>
@@ -584,6 +594,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
+    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="404">The project could not be found.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
@@ -592,7 +603,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByReferenceIdAsync(string referenceId, string projectId, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByReferenceIdAsync(string referenceId, string projectId, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
     {
         var project = await GetProjectAsync(projectId);
         if (project is null)
@@ -607,7 +618,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(null, offset, organization.GetRetentionUtcCutoff(project, _appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(project, organization);
-        return await GetInternalAsync(sf, ti, String.Concat("reference:", referenceId), null, mode, page, limit, before, after);
+        return await GetInternalAsync(sf, ti, String.Concat("reference:", referenceId), null, mode, page, limit, before, after, includeTotal: includeTotal);
     }
 
     /// <summary>
@@ -623,6 +634,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
+    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
     [HttpGet("sessions/{sessionId:identifier}")]
@@ -630,7 +642,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetBySessionIdAsync(string sessionId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetBySessionIdAsync(string sessionId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
     {
         var organizations = await GetSelectedOrganizationsAsync(_organizationRepository, _projectRepository, _stackRepository, filter);
         if (organizations.All(o => o.IsSuspended))
@@ -638,7 +650,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organizations.GetRetentionUtcCutoff(_appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(organizations) { IsUserOrganizationsFilter = true };
-        return await GetInternalAsync(sf, ti, $"(reference:{sessionId} OR ref.session:{sessionId}) {filter}", sort, mode, page, limit, before, after, true);
+        return await GetInternalAsync(sf, ti, $"(reference:{sessionId} OR ref.session:{sessionId}) {filter}", sort, mode, page, limit, before, after, true, includeTotal);
     }
 
     /// <summary>
@@ -655,6 +667,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
+    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="404">The project could not be found.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
@@ -663,7 +676,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetBySessionIdAndProjectAsync(string sessionId, string projectId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetBySessionIdAndProjectAsync(string sessionId, string projectId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
     {
         var project = await GetProjectAsync(projectId);
         if (project is null)
@@ -678,7 +691,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organization.GetRetentionUtcCutoff(project, _appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(project, organization);
-        return await GetInternalAsync(sf, ti, $"(reference:{sessionId} OR ref.session:{sessionId}) {filter}", sort, mode, page, limit, before, after, true);
+        return await GetInternalAsync(sf, ti, $"(reference:{sessionId} OR ref.session:{sessionId}) {filter}", sort, mode, page, limit, before, after, true, includeTotal);
     }
 
     /// <summary>
@@ -693,13 +706,14 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
+    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
     /// <response code="400">Invalid filter.</response>
     [HttpGet("sessions")]
     [Authorize(Policy = AuthorizationRoles.UserPolicy)]
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetSessionsAsync(string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetSessionsAsync(string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
     {
         var organizations = await GetSelectedOrganizationsAsync(_organizationRepository, _projectRepository, _stackRepository, filter);
         if (organizations.All(o => o.IsSuspended))
@@ -707,7 +721,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organizations.GetRetentionUtcCutoff(_appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(organizations) { IsUserOrganizationsFilter = true };
-        return await GetInternalAsync(sf, ti, $"type:{Event.KnownTypes.Session} {filter}", sort, mode, page, limit, before, after, true);
+        return await GetInternalAsync(sf, ti, $"type:{Event.KnownTypes.Session} {filter}", sort, mode, page, limit, before, after, true, includeTotal);
     }
 
     /// <summary>
@@ -723,6 +737,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
+    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="404">The project could not be found.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
@@ -731,7 +746,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetSessionByOrganizationAsync(string organizationId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetSessionByOrganizationAsync(string organizationId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
     {
         var organization = await GetOrganizationAsync(organizationId);
         if (organization is null)
@@ -742,7 +757,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organization.GetRetentionUtcCutoff(_appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(organization);
-        return await GetInternalAsync(sf, ti, $"type:{Event.KnownTypes.Session} {filter}", sort, mode, page, limit, before, after, true);
+        return await GetInternalAsync(sf, ti, $"type:{Event.KnownTypes.Session} {filter}", sort, mode, page, limit, before, after, true, includeTotal);
     }
 
     /// <summary>
@@ -758,6 +773,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
+    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="404">The project could not be found.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
@@ -766,7 +782,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetSessionByProjectAsync(string projectId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetSessionByProjectAsync(string projectId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
     {
         var project = await GetProjectAsync(projectId);
         if (project is null)
@@ -781,7 +797,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organization.GetRetentionUtcCutoff(project, _appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(project, organization);
-        return await GetInternalAsync(sf, ti, $"type:{Event.KnownTypes.Session} {filter}", sort, mode, page, limit, before, after, true);
+        return await GetInternalAsync(sf, ti, $"type:{Event.KnownTypes.Session} {filter}", sort, mode, page, limit, before, after, true, includeTotal);
     }
 
     /// <summary>

--- a/src/Exceptionless.Web/Controllers/EventController.cs
+++ b/src/Exceptionless.Web/Controllers/EventController.cs
@@ -217,7 +217,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
-    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
+    /// <param name="include">Optional response metadata to include. Specify total to include the total result count in response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
     [HttpGet]
@@ -225,7 +225,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetAllAsync(string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetAllAsync(string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, string? include = null)
     {
         var organizations = await GetSelectedOrganizationsAsync(_organizationRepository, _projectRepository, _stackRepository, filter);
         if (organizations.All(o => o.IsSuspended))
@@ -233,7 +233,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organizations.GetRetentionUtcCutoff(_appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(organizations) { IsUserOrganizationsFilter = true };
-        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after, includeTotal: includeTotal);
+        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after, includeTotal: ShouldIncludeTotal(include));
     }
 
     private async Task<ActionResult<CountResult>> CountInternalAsync(AppFilter sf, TimeInfo ti, string? filter = null, string? aggregations = null, string? mode = null)
@@ -272,7 +272,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
         return Ok(result);
     }
 
-    private async Task<ActionResult<ICollection<PersistentEvent>>> GetInternalAsync(AppFilter sf, TimeInfo ti, string? filter = null, string? sort = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool usesPremiumFeatures = false, bool includeTotal = true)
+    private async Task<ActionResult<ICollection<PersistentEvent>>> GetInternalAsync(AppFilter sf, TimeInfo ti, string? filter = null, string? sort = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool usesPremiumFeatures = false, bool includeTotal = false)
     {
         using var _ = _logger.BeginScope(new ExceptionlessState()
             .Property("Search Filter", new
@@ -451,7 +451,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
-    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
+    /// <param name="include">Optional response metadata to include. Specify total to include the total result count in response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="404">The organization could not be found.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
@@ -460,7 +460,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByOrganizationAsync(string organizationId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByOrganizationAsync(string organizationId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, string? include = null)
     {
         var organization = await GetOrganizationAsync(organizationId);
         if (organization is null)
@@ -471,7 +471,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organization.GetRetentionUtcCutoff(_appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(organization);
-        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after, includeTotal: includeTotal);
+        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after, includeTotal: ShouldIncludeTotal(include));
     }
 
     /// <summary>
@@ -487,7 +487,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
-    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
+    /// <param name="include">Optional response metadata to include. Specify total to include the total result count in response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="404">The project could not be found.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
@@ -496,7 +496,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByProjectAsync(string projectId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByProjectAsync(string projectId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, string? include = null)
     {
         var project = await GetProjectAsync(projectId);
         if (project is null)
@@ -511,7 +511,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organization.GetRetentionUtcCutoff(project, _appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(project, organization);
-        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after, includeTotal: includeTotal);
+        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after, includeTotal: ShouldIncludeTotal(include));
     }
 
     /// <summary>
@@ -527,7 +527,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
-    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
+    /// <param name="include">Optional response metadata to include. Specify total to include the total result count in response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="404">The stack could not be found.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
@@ -536,7 +536,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByStackAsync(string stackId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByStackAsync(string stackId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, string? include = null)
     {
         var stack = await GetStackAsync(stackId);
         if (stack is null)
@@ -551,7 +551,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organization.GetRetentionUtcCutoff(stack, _appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(stack, organization);
-        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after, includeTotal: includeTotal);
+        return await GetInternalAsync(sf, ti, filter, sort, mode, page, limit, before, after, includeTotal: ShouldIncludeTotal(include));
     }
 
     /// <summary>
@@ -564,7 +564,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
-    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
+    /// <param name="include">Optional response metadata to include. Specify total to include the total result count in response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
     [HttpGet("by-ref/{referenceId:identifier}")]
@@ -572,7 +572,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByReferenceIdAsync(string referenceId, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByReferenceIdAsync(string referenceId, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, string? include = null)
     {
         var organizations = await GetSelectedOrganizationsAsync(_organizationRepository, _projectRepository, _stackRepository);
         if (organizations.All(o => o.IsSuspended))
@@ -580,7 +580,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(null, offset, organizations.GetRetentionUtcCutoff(_appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(organizations) { IsUserOrganizationsFilter = true };
-        return await GetInternalAsync(sf, ti, String.Concat("reference:", referenceId), null, mode, page, limit, before, after, includeTotal: includeTotal);
+        return await GetInternalAsync(sf, ti, String.Concat("reference:", referenceId), null, mode, page, limit, before, after, includeTotal: ShouldIncludeTotal(include));
     }
 
     /// <summary>
@@ -594,7 +594,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
-    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
+    /// <param name="include">Optional response metadata to include. Specify total to include the total result count in response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="404">The project could not be found.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
@@ -603,7 +603,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByReferenceIdAsync(string referenceId, string projectId, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetByReferenceIdAsync(string referenceId, string projectId, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, string? include = null)
     {
         var project = await GetProjectAsync(projectId);
         if (project is null)
@@ -618,7 +618,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(null, offset, organization.GetRetentionUtcCutoff(project, _appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(project, organization);
-        return await GetInternalAsync(sf, ti, String.Concat("reference:", referenceId), null, mode, page, limit, before, after, includeTotal: includeTotal);
+        return await GetInternalAsync(sf, ti, String.Concat("reference:", referenceId), null, mode, page, limit, before, after, includeTotal: ShouldIncludeTotal(include));
     }
 
     /// <summary>
@@ -634,7 +634,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
-    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
+    /// <param name="include">Optional response metadata to include. Specify total to include the total result count in response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
     [HttpGet("sessions/{sessionId:identifier}")]
@@ -642,7 +642,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetBySessionIdAsync(string sessionId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetBySessionIdAsync(string sessionId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, string? include = null)
     {
         var organizations = await GetSelectedOrganizationsAsync(_organizationRepository, _projectRepository, _stackRepository, filter);
         if (organizations.All(o => o.IsSuspended))
@@ -650,7 +650,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organizations.GetRetentionUtcCutoff(_appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(organizations) { IsUserOrganizationsFilter = true };
-        return await GetInternalAsync(sf, ti, $"(reference:{sessionId} OR ref.session:{sessionId}) {filter}", sort, mode, page, limit, before, after, true, includeTotal);
+        return await GetInternalAsync(sf, ti, $"(reference:{sessionId} OR ref.session:{sessionId}) {filter}", sort, mode, page, limit, before, after, true, ShouldIncludeTotal(include));
     }
 
     /// <summary>
@@ -667,7 +667,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
-    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
+    /// <param name="include">Optional response metadata to include. Specify total to include the total result count in response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="404">The project could not be found.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
@@ -676,7 +676,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetBySessionIdAndProjectAsync(string sessionId, string projectId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetBySessionIdAndProjectAsync(string sessionId, string projectId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, string? include = null)
     {
         var project = await GetProjectAsync(projectId);
         if (project is null)
@@ -691,7 +691,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organization.GetRetentionUtcCutoff(project, _appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(project, organization);
-        return await GetInternalAsync(sf, ti, $"(reference:{sessionId} OR ref.session:{sessionId}) {filter}", sort, mode, page, limit, before, after, true, includeTotal);
+        return await GetInternalAsync(sf, ti, $"(reference:{sessionId} OR ref.session:{sessionId}) {filter}", sort, mode, page, limit, before, after, true, ShouldIncludeTotal(include));
     }
 
     /// <summary>
@@ -706,14 +706,14 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
-    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
+    /// <param name="include">Optional response metadata to include. Specify total to include the total result count in response headers.</param>
     /// <response code="400">Invalid filter.</response>
     [HttpGet("sessions")]
     [Authorize(Policy = AuthorizationRoles.UserPolicy)]
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetSessionsAsync(string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetSessionsAsync(string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, string? include = null)
     {
         var organizations = await GetSelectedOrganizationsAsync(_organizationRepository, _projectRepository, _stackRepository, filter);
         if (organizations.All(o => o.IsSuspended))
@@ -721,7 +721,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organizations.GetRetentionUtcCutoff(_appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(organizations) { IsUserOrganizationsFilter = true };
-        return await GetInternalAsync(sf, ti, $"type:{Event.KnownTypes.Session} {filter}", sort, mode, page, limit, before, after, true, includeTotal);
+        return await GetInternalAsync(sf, ti, $"type:{Event.KnownTypes.Session} {filter}", sort, mode, page, limit, before, after, true, ShouldIncludeTotal(include));
     }
 
     /// <summary>
@@ -737,7 +737,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
-    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
+    /// <param name="include">Optional response metadata to include. Specify total to include the total result count in response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="404">The project could not be found.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
@@ -746,7 +746,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetSessionByOrganizationAsync(string organizationId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetSessionByOrganizationAsync(string organizationId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, string? include = null)
     {
         var organization = await GetOrganizationAsync(organizationId);
         if (organization is null)
@@ -757,7 +757,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organization.GetRetentionUtcCutoff(_appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(organization);
-        return await GetInternalAsync(sf, ti, $"type:{Event.KnownTypes.Session} {filter}", sort, mode, page, limit, before, after, true, includeTotal);
+        return await GetInternalAsync(sf, ti, $"type:{Event.KnownTypes.Session} {filter}", sort, mode, page, limit, before, after, true, ShouldIncludeTotal(include));
     }
 
     /// <summary>
@@ -773,7 +773,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     /// <param name="limit">A limit on the number of objects to be returned. Limit can range between 1 and 100 items.</param>
     /// <param name="before">The before parameter is a cursor used for pagination and defines your place in the list of results.</param>
     /// <param name="after">The after parameter is a cursor used for pagination and defines your place in the list of results.</param>
-    /// <param name="includeTotal">Whether to include the total result count in the response headers.</param>
+    /// <param name="include">Optional response metadata to include. Specify total to include the total result count in response headers.</param>
     /// <response code="400">Invalid filter.</response>
     /// <response code="404">The project could not be found.</response>
     /// <response code="426">Unable to view event occurrences for the suspended organization.</response>
@@ -782,7 +782,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
     [ProducesResponseType(typeof(ICollection<EventSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<StackSummaryModel>), 200)]
     [ProducesResponseType(typeof(ICollection<PersistentEvent>), 200)]
-    public async Task<ActionResult<ICollection<PersistentEvent>>> GetSessionByProjectAsync(string projectId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, bool includeTotal = true)
+    public async Task<ActionResult<ICollection<PersistentEvent>>> GetSessionByProjectAsync(string projectId, string? filter = null, string? sort = null, string? time = null, string? offset = null, string? mode = null, int? page = null, int limit = 10, string? before = null, string? after = null, string? include = null)
     {
         var project = await GetProjectAsync(projectId);
         if (project is null)
@@ -797,7 +797,7 @@ public class EventController : RepositoryApiController<IEventRepository, Persist
 
         var ti = GetTimeInfo(time, offset, organization.GetRetentionUtcCutoff(project, _appOptions.MaximumRetentionDays, _timeProvider));
         var sf = new AppFilter(project, organization);
-        return await GetInternalAsync(sf, ti, $"type:{Event.KnownTypes.Session} {filter}", sort, mode, page, limit, before, after, true, includeTotal);
+        return await GetInternalAsync(sf, ti, $"type:{Event.KnownTypes.Session} {filter}", sort, mode, page, limit, before, after, true, ShouldIncludeTotal(include));
     }
 
     /// <summary>

--- a/tests/Exceptionless.Tests/Controllers/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Controllers/Data/openapi.json
@@ -2144,12 +2144,11 @@
             }
           },
           {
-            "name": "includeTotal",
+            "name": "include",
             "in": "query",
-            "description": "Whether to include the total result count in the response headers.",
+            "description": "Optional response metadata to include. Specify total to include the total result count in response headers.",
             "schema": {
-              "type": "boolean",
-              "default": true
+              "type": "string"
             }
           }
         ],
@@ -2317,12 +2316,11 @@
             }
           },
           {
-            "name": "includeTotal",
+            "name": "include",
             "in": "query",
-            "description": "Whether to include the total result count in the response headers.",
+            "description": "Optional response metadata to include. Specify total to include the total result count in response headers.",
             "schema": {
-              "type": "boolean",
-              "default": true
+              "type": "string"
             }
           }
         ],
@@ -2445,12 +2443,11 @@
             }
           },
           {
-            "name": "includeTotal",
+            "name": "include",
             "in": "query",
-            "description": "Whether to include the total result count in the response headers.",
+            "description": "Optional response metadata to include. Specify total to include the total result count in response headers.",
             "schema": {
-              "type": "boolean",
-              "default": true
+              "type": "string"
             }
           }
         ],
@@ -2631,12 +2628,11 @@
             }
           },
           {
-            "name": "includeTotal",
+            "name": "include",
             "in": "query",
-            "description": "Whether to include the total result count in the response headers.",
+            "description": "Optional response metadata to include. Specify total to include the total result count in response headers.",
             "schema": {
-              "type": "boolean",
-              "default": true
+              "type": "string"
             }
           }
         ],
@@ -2735,12 +2731,11 @@
             }
           },
           {
-            "name": "includeTotal",
+            "name": "include",
             "in": "query",
-            "description": "Whether to include the total result count in the response headers.",
+            "description": "Optional response metadata to include. Specify total to include the total result count in response headers.",
             "schema": {
-              "type": "boolean",
-              "default": true
+              "type": "string"
             }
           }
         ],
@@ -2846,12 +2841,11 @@
             }
           },
           {
-            "name": "includeTotal",
+            "name": "include",
             "in": "query",
-            "description": "Whether to include the total result count in the response headers.",
+            "description": "Optional response metadata to include. Specify total to include the total result count in response headers.",
             "schema": {
-              "type": "boolean",
-              "default": true
+              "type": "string"
             }
           }
         ],
@@ -2974,12 +2968,11 @@
             }
           },
           {
-            "name": "includeTotal",
+            "name": "include",
             "in": "query",
-            "description": "Whether to include the total result count in the response headers.",
+            "description": "Optional response metadata to include. Specify total to include the total result count in response headers.",
             "schema": {
-              "type": "boolean",
-              "default": true
+              "type": "string"
             }
           }
         ],
@@ -3109,12 +3102,11 @@
             }
           },
           {
-            "name": "includeTotal",
+            "name": "include",
             "in": "query",
-            "description": "Whether to include the total result count in the response headers.",
+            "description": "Optional response metadata to include. Specify total to include the total result count in response headers.",
             "schema": {
-              "type": "boolean",
-              "default": true
+              "type": "string"
             }
           }
         ],
@@ -3227,12 +3219,11 @@
             }
           },
           {
-            "name": "includeTotal",
+            "name": "include",
             "in": "query",
-            "description": "Whether to include the total result count in the response headers.",
+            "description": "Optional response metadata to include. Specify total to include the total result count in response headers.",
             "schema": {
-              "type": "boolean",
-              "default": true
+              "type": "string"
             }
           }
         ],
@@ -3349,12 +3340,11 @@
             }
           },
           {
-            "name": "includeTotal",
+            "name": "include",
             "in": "query",
-            "description": "Whether to include the total result count in the response headers.",
+            "description": "Optional response metadata to include. Specify total to include the total result count in response headers.",
             "schema": {
-              "type": "boolean",
-              "default": true
+              "type": "string"
             }
           }
         ],
@@ -3477,12 +3467,11 @@
             }
           },
           {
-            "name": "includeTotal",
+            "name": "include",
             "in": "query",
-            "description": "Whether to include the total result count in the response headers.",
+            "description": "Optional response metadata to include. Specify total to include the total result count in response headers.",
             "schema": {
-              "type": "boolean",
-              "default": true
+              "type": "string"
             }
           }
         ],

--- a/tests/Exceptionless.Tests/Controllers/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Controllers/Data/openapi.json
@@ -673,7 +673,7 @@
           "Token"
         ],
         "summary": "Create for organization",
-        "description": "This is a helper action that makes it easier to create a token for a specific organization.\r\nYou may also specify a scope when creating a token. There are three valid scopes: client, user and admin.",
+        "description": "This is a helper action that makes it easier to create a token for a specific organization.\nYou may also specify a scope when creating a token. There are three valid scopes: client, user and admin.",
         "parameters": [
           {
             "name": "organizationId",
@@ -797,7 +797,7 @@
           "Token"
         ],
         "summary": "Create for project",
-        "description": "This is a helper action that makes it easier to create a token for a specific project.\r\nYou may also specify a scope when creating a token. There are three valid scopes: client, user and admin.",
+        "description": "This is a helper action that makes it easier to create a token for a specific project.\nYou may also specify a scope when creating a token. There are three valid scopes: client, user and admin.",
         "parameters": [
           {
             "name": "projectId",
@@ -1304,7 +1304,7 @@
           "Auth"
         ],
         "summary": "Login",
-        "description": "Log in with your email address and password to generate a token scoped with your users roles.\r\n\r\n```{ \"email\": \"noreply@exceptionless.io\", \"password\": \"exceptionless\" }```\r\n\r\nThis token can then be used to access the api. You can use this token in the header (bearer authentication)\r\nor append it onto the query string: ?access_token=MY_TOKEN\r\n\r\nPlease note that you can also use this token on the documentation site by placing it in the\r\nheaders api_key input box.",
+        "description": "Log in with your email address and password to generate a token scoped with your users roles.\n\n```{ \"email\": \"noreply@exceptionless.io\", \"password\": \"exceptionless\" }```\n\nThis token can then be used to access the api. You can use this token in the header (bearer authentication)\nor append it onto the query string: ?access_token=MY_TOKEN\n\nPlease note that you can also use this token on the documentation site by placing it in the\nheaders api_key input box.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2142,6 +2142,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "includeTotal",
+            "in": "query",
+            "description": "Whether to include the total result count in the response headers.",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
           }
         ],
         "responses": {
@@ -2171,7 +2180,7 @@
           "Event"
         ],
         "summary": "Submit event by POST",
-        "description": "      You can create an event by posting any uncompressed or compressed (gzip or deflate) string or json object. If we know how to handle it\r\n      we will create a new event. If none of the JSON properties match the event object then we will create a new event and place your JSON\r\n      object into the events data collection.\r\n\r\n      You can also post a multi-line string. We automatically split strings by the \\n character and create a new log event for every line.\r\n\r\n      Simple event:\r\n      ```{ \"message\": \"Exceptionless is amazing!\" }```\r\n\r\n      Simple log event with user identity:\r\n      ```{\r\n    \"type\": \"log\",\r\n    \"message\": \"Exceptionless is amazing!\",\r\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\r\n    \"@user\":{ \"identity\":\"123456789\", \"name\": \"Test User\" }\r\n}```\r\n\r\n      Multiple events from string content:\r\n      ```Exceptionless is amazing!\r\nExceptionless is really amazing!```\r\n\r\n      Simple error:\r\n      ```{\r\n    \"type\": \"error\",\r\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\r\n    \"@simple_error\": {\r\n        \"message\": \"Simple Exception\",\r\n        \"type\": \"System.Exception\",\r\n        \"stack_trace\": \"   at Client.Tests.ExceptionlessClientTests.CanSubmitSimpleException() in ExceptionlessClientTests.cs:line 77\"\r\n    }\r\n}```",
+        "description": "      You can create an event by posting any uncompressed or compressed (gzip or deflate) string or json object. If we know how to handle it\n      we will create a new event. If none of the JSON properties match the event object then we will create a new event and place your JSON\n      object into the events data collection.\n\n      You can also post a multi-line string. We automatically split strings by the \\n character and create a new log event for every line.\n\n      Simple event:\n      ```{ \"message\": \"Exceptionless is amazing!\" }```\n\n      Simple log event with user identity:\n      ```{\n    \"type\": \"log\",\n    \"message\": \"Exceptionless is amazing!\",\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\n    \"@user\":{ \"identity\":\"123456789\", \"name\": \"Test User\" }\n}```\n\n      Multiple events from string content:\n      ```Exceptionless is amazing!\nExceptionless is really amazing!```\n\n      Simple error:\n      ```{\n    \"type\": \"error\",\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\n    \"@simple_error\": {\n        \"message\": \"Simple Exception\",\n        \"type\": \"System.Exception\",\n        \"stack_trace\": \"   at Client.Tests.ExceptionlessClientTests.CanSubmitSimpleException() in ExceptionlessClientTests.cs:line 77\"\n    }\n}```",
         "parameters": [
           {
             "name": "userAgent",
@@ -2306,6 +2315,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "includeTotal",
+            "in": "query",
+            "description": "Whether to include the total result count in the response headers.",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
           }
         ],
         "responses": {
@@ -2425,6 +2443,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "includeTotal",
+            "in": "query",
+            "description": "Whether to include the total result count in the response headers.",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
           }
         ],
         "responses": {
@@ -2457,7 +2484,7 @@
           "Event"
         ],
         "summary": "Submit event by POST for a specific project",
-        "description": "      You can create an event by posting any uncompressed or compressed (gzip or deflate) string or json object. If we know how to handle it\r\n      we will create a new event. If none of the JSON properties match the event object then we will create a new event and place your JSON\r\n      object into the events data collection.\r\n\r\n      You can also post a multi-line string. We automatically split strings by the \\n character and create a new log event for every line.\r\n\r\n      Simple event:\r\n      ```{ \"message\": \"Exceptionless is amazing!\" }```\r\n\r\n      Simple log event with user identity:\r\n      ```{\r\n    \"type\": \"log\",\r\n    \"message\": \"Exceptionless is amazing!\",\r\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\r\n    \"@user\":{ \"identity\":\"123456789\", \"name\": \"Test User\" }\r\n}```\r\n\r\n      Multiple events from string content:\r\n      ```Exceptionless is amazing!\r\nExceptionless is really amazing!```\r\n\r\n      Simple error:\r\n      ```{\r\n    \"type\": \"error\",\r\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\r\n    \"@simple_error\": {\r\n        \"message\": \"Simple Exception\",\r\n        \"type\": \"System.Exception\",\r\n        \"stack_trace\": \"   at Client.Tests.ExceptionlessClientTests.CanSubmitSimpleException() in ExceptionlessClientTests.cs:line 77\"\r\n    }\r\n}```",
+        "description": "      You can create an event by posting any uncompressed or compressed (gzip or deflate) string or json object. If we know how to handle it\n      we will create a new event. If none of the JSON properties match the event object then we will create a new event and place your JSON\n      object into the events data collection.\n\n      You can also post a multi-line string. We automatically split strings by the \\n character and create a new log event for every line.\n\n      Simple event:\n      ```{ \"message\": \"Exceptionless is amazing!\" }```\n\n      Simple log event with user identity:\n      ```{\n    \"type\": \"log\",\n    \"message\": \"Exceptionless is amazing!\",\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\n    \"@user\":{ \"identity\":\"123456789\", \"name\": \"Test User\" }\n}```\n\n      Multiple events from string content:\n      ```Exceptionless is amazing!\nExceptionless is really amazing!```\n\n      Simple error:\n      ```{\n    \"type\": \"error\",\n    \"date\":\"2030-01-01T12:00:00.0000000-05:00\",\n    \"@simple_error\": {\n        \"message\": \"Simple Exception\",\n        \"type\": \"System.Exception\",\n        \"stack_trace\": \"   at Client.Tests.ExceptionlessClientTests.CanSubmitSimpleException() in ExceptionlessClientTests.cs:line 77\"\n    }\n}```",
         "parameters": [
           {
             "name": "projectId",
@@ -2602,6 +2629,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "includeTotal",
+            "in": "query",
+            "description": "Whether to include the total result count in the response headers.",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
           }
         ],
         "responses": {
@@ -2696,6 +2732,15 @@
             "description": "The after parameter is a cursor used for pagination and defines your place in the list of results.",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "includeTotal",
+            "in": "query",
+            "description": "Whether to include the total result count in the response headers.",
+            "schema": {
+              "type": "boolean",
+              "default": true
             }
           }
         ],
@@ -2798,6 +2843,15 @@
             "description": "The after parameter is a cursor used for pagination and defines your place in the list of results.",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "includeTotal",
+            "in": "query",
+            "description": "Whether to include the total result count in the response headers.",
+            "schema": {
+              "type": "boolean",
+              "default": true
             }
           }
         ],
@@ -2917,6 +2971,15 @@
             "description": "The after parameter is a cursor used for pagination and defines your place in the list of results.",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "includeTotal",
+            "in": "query",
+            "description": "Whether to include the total result count in the response headers.",
+            "schema": {
+              "type": "boolean",
+              "default": true
             }
           }
         ],
@@ -3044,6 +3107,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "includeTotal",
+            "in": "query",
+            "description": "Whether to include the total result count in the response headers.",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
           }
         ],
         "responses": {
@@ -3152,6 +3224,15 @@
             "description": "The after parameter is a cursor used for pagination and defines your place in the list of results.",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "includeTotal",
+            "in": "query",
+            "description": "Whether to include the total result count in the response headers.",
+            "schema": {
+              "type": "boolean",
+              "default": true
             }
           }
         ],
@@ -3265,6 +3346,15 @@
             "description": "The after parameter is a cursor used for pagination and defines your place in the list of results.",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "includeTotal",
+            "in": "query",
+            "description": "Whether to include the total result count in the response headers.",
+            "schema": {
+              "type": "boolean",
+              "default": true
             }
           }
         ],
@@ -3384,6 +3474,15 @@
             "description": "The after parameter is a cursor used for pagination and defines your place in the list of results.",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "includeTotal",
+            "in": "query",
+            "description": "Whether to include the total result count in the response headers.",
+            "schema": {
+              "type": "boolean",
+              "default": true
             }
           }
         ],
@@ -3790,7 +3889,7 @@
           "Event"
         ],
         "summary": "Submit event by GET",
-        "description": "You can submit an event using an HTTP GET and query string parameters. Any unknown query string parameters will be added to the extended data of the event.\r\n\r\nFeature usage named build with a duration of 10:\r\n```/events/submit?access_token=YOUR_API_KEY&amp;type=usage&amp;source=build&amp;value=10```\r\n\r\nLog with message, geo and extended data\r\n```/events/submit?access_token=YOUR_API_KEY&amp;type=log&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
+        "description": "You can submit an event using an HTTP GET and query string parameters. Any unknown query string parameters will be added to the extended data of the event.\n\nFeature usage named build with a duration of 10:\n```/events/submit?access_token=YOUR_API_KEY&amp;type=usage&amp;source=build&amp;value=10```\n\nLog with message, geo and extended data\n```/events/submit?access_token=YOUR_API_KEY&amp;type=log&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
         "parameters": [
           {
             "name": "type",
@@ -3924,7 +4023,7 @@
           "Event"
         ],
         "summary": "Submit event type by GET",
-        "description": "You can submit an event using an HTTP GET and query string parameters.\r\n\r\nFeature usage event named build with a value of 10:\r\n```/events/submit/usage?access_token=YOUR_API_KEY&amp;source=build&amp;value=10```\r\n\r\nLog event with message, geo and extended data\r\n```/events/submit/log?access_token=YOUR_API_KEY&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
+        "description": "You can submit an event using an HTTP GET and query string parameters.\n\nFeature usage event named build with a value of 10:\n```/events/submit/usage?access_token=YOUR_API_KEY&amp;source=build&amp;value=10```\n\nLog event with message, geo and extended data\n```/events/submit/log?access_token=YOUR_API_KEY&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
         "parameters": [
           {
             "name": "type",
@@ -4060,7 +4159,7 @@
           "Event"
         ],
         "summary": "Submit event type by GET for a specific project",
-        "description": "You can submit an event using an HTTP GET and query string parameters.\r\n\r\nFeature usage named build with a duration of 10:\r\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=usage&amp;source=build&amp;value=10```\r\n\r\nLog with message, geo and extended data\r\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=log&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
+        "description": "You can submit an event using an HTTP GET and query string parameters.\n\nFeature usage named build with a duration of 10:\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=usage&amp;source=build&amp;value=10```\n\nLog with message, geo and extended data\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=log&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
         "parameters": [
           {
             "name": "projectId",
@@ -4196,7 +4295,7 @@
           "Event"
         ],
         "summary": "Submit event type by GET for a specific project",
-        "description": "You can submit an event using an HTTP GET and query string parameters.\r\n\r\nFeature usage named build with a duration of 10:\r\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=usage&amp;source=build&amp;value=10```\r\n\r\nLog with message, geo and extended data\r\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=log&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
+        "description": "You can submit an event using an HTTP GET and query string parameters.\n\nFeature usage named build with a duration of 10:\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=usage&amp;source=build&amp;value=10```\n\nLog with message, geo and extended data\n```/projects/{projectId}/events/submit?access_token=YOUR_API_KEY&amp;type=log&amp;message=Hello World&amp;source=server01&amp;geo=32.85,-96.9613&amp;randomproperty=true```",
         "parameters": [
           {
             "name": "projectId",
@@ -5058,7 +5157,7 @@
           "Organization"
         ],
         "summary": "Change plan",
-        "description": "Upgrades or downgrades the organization's plan.\r\nAccepts parameters via JSON body (preferred) or query string (legacy).",
+        "description": "Upgrades or downgrades the organization's plan.\nAccepts parameters via JSON body (preferred) or query string (legacy).",
         "parameters": [
           {
             "name": "id",
@@ -8689,7 +8788,7 @@
               "null",
               "string"
             ],
-            "description": "The event type (ie. error, log message, feature usage). Check KnownTypes for standard event types.\r\nNullable in transit; the pipeline infers a default before save. Validated as required on repository save."
+            "description": "The event type (ie. error, log message, feature usage). Check KnownTypes for standard event types.\nNullable in transit; the pipeline infers a default before save. Validated as required on repository save."
           },
           "source": {
             "maxLength": 2000,


### PR DESCRIPTION
## Summary

- Adds an `include=total` query option to event list endpoints so cursor paging can opt into total metadata only when needed.
- Updates event and stack pages to request totals only when they are useful for stable initial pagination metadata.
- Replaces stack total calculation based on `sum_other_doc_count` with an optional `stack_id` cardinality aggregation, and preserves known table page counts when later offset responses omit totals.
- Updates the Foundatio.Repositories.Elasticsearch package to `8.0.0-beta2` without using PIT.

## Root Cause

Event paging was asking Elasticsearch for exact totals on every before/after request and still returning `X-Result-Count` on cursor hops. Stack paging was also deriving a stack total from terms aggregation spillover document counts, which is not a stable distinct stack count.

## Validation

- `dotnet restore src/Exceptionless.Web/Exceptionless.Web.csproj`
- `dotnet build src/Exceptionless.Web/Exceptionless.Web.csproj -p:UseSharedCompilation=false -p:BuildInParallel=false --no-restore`
- `dotnet build tests/Exceptionless.Tests/Exceptionless.Tests.csproj -p:UseSharedCompilation=false -p:BuildInParallel=false --no-restore`
- `UPDATE_SNAPSHOTS=true dotnet test tests/Exceptionless.Tests/Exceptionless.Tests.csproj -- --filter-class Exceptionless.Tests.Controllers.OpenApiControllerTests`
- `dotnet test tests/Exceptionless.Tests/Exceptionless.Tests.csproj -- --filter-class Exceptionless.Tests.Controllers.OpenApiControllerTests`
- `npm run check`
- `npm run test:unit -- src/lib/features/shared/table.test.ts`
- `git diff --check`
- `UPDATE_SNAPSHOTS=true dotnet test tests/Exceptionless.Tests/Exceptionless.Tests.csproj -- --filter-class Exceptionless.Tests.Controllers.OpenApiControllerTests`
- `dotnet test tests/Exceptionless.Tests/Exceptionless.Tests.csproj -- --filter-class Exceptionless.Tests.Controllers.OpenApiControllerTests`
- `dotnet build src/Exceptionless.Web/Exceptionless.Web.csproj -p:UseSharedCompilation=false -p:BuildInParallel=false --no-restore`
- `npm run check`

## Notes

- PIT is intentionally not used because there is not a reliable cleanup path and it is not required for this change.
- Missing `include` does not include total metadata; clients must pass `include=total` when they need `X-Result-Count`.
- Aspire was started locally and reported the API and Svelte app healthy on dynamic ports.
