### PR TITLE
Relax .NET SDK patch requirement

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "10.0.301",
+        "version": "10.0.100",
         "rollForward": "latestMinor",
         "allowPrerelease": false
     },


### PR DESCRIPTION
## Summary
- Lower the pinned .NET SDK baseline in global.json from 10.0.301 to 10.0.100.
- Keep rollForward=latestMinor so newer compatible SDKs are still selected when installed.

## Testing
- dotnet --version -> 10.0.300
- dotnet build tests\\Exceptionless.Tests\\Exceptionless.Tests.csproj -v:minimal -m:1