### PR TITLE
Fix event cursor pagination links

### DIFF
--- a/src/Exceptionless.Web/Utility/Results/OkWithHeadersContentResult.cs
+++ b/src/Exceptionless.Web/Utility/Results/OkWithHeadersContentResult.cs
@@ -41,7 +41,7 @@ public class OkWithResourceLinks<TEntity> : OkWithHeadersContentResult<ICollecti
     {
         var links = Page.HasValue
             ? GetPagedLinks(new Uri(context.HttpContext.Request.GetDisplayUrl()), Page.Value, HasMore)
-            : GetBeforeAndAfterLinks(new Uri(context.HttpContext.Request.GetDisplayUrl()), Before, After);
+            : GetBeforeAndAfterLinks(new Uri(context.HttpContext.Request.GetDisplayUrl()), Before, After, HasMore);
         if (links.Count > 0)
             Headers[HeaderNames.Link] = links.ToArray();
 
@@ -74,7 +74,7 @@ public class OkWithResourceLinks<TEntity> : OkWithHeadersContentResult<ICollecti
         return links;
     }
 
-    public static List<string> GetBeforeAndAfterLinks(Uri url, string? before, string? after)
+    public static List<string> GetBeforeAndAfterLinks(Uri url, string? before, string? after, bool hasMore)
     {
         var previousParameters = HttpUtility.ParseQueryString(url.Query);
         previousParameters.Remove("before");
@@ -88,7 +88,7 @@ public class OkWithResourceLinks<TEntity> : OkWithHeadersContentResult<ICollecti
         var links = new List<string>(2);
         if (!String.IsNullOrEmpty(before))
             links.Add($"<{baseUrl}?{previousParameters.ToQueryString()}>; rel=\"previous\"");
-        if (!String.IsNullOrEmpty(after))
+        if (hasMore && !String.IsNullOrEmpty(after))
             links.Add($"<{baseUrl}?{nextParameters.ToQueryString()}>; rel=\"next\"");
 
         return links;

--- a/tests/Exceptionless.Tests/Controllers/EventControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/EventControllerTests.cs
@@ -1610,8 +1610,62 @@ public partial class EventControllerTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task CanEventsWithStablePagingAsync()
+    public async Task GetEvents_WithPartialLastCursorPage_DoesNotReturnNextLinkAsync()
     {
+        // Arrange
+        await CreateDataAsync(d =>
+        {
+            d.Event().TestProject().Type(Event.KnownTypes.Log);
+            d.Event().TestProject().Type(Event.KnownTypes.Log);
+            d.Event().TestProject().Type(Event.KnownTypes.Log);
+        });
+
+        // Act
+        var response = await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("events")
+            .QueryString("limit", "2")
+            .QueryString("include", "total")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.Equal("3", response.Headers.GetValues(Headers.ResultCount).Single());
+
+        var links = ParseLinkHeaderValue(response.Headers.GetValues(HeaderNames.Link).ToArray());
+        Assert.True(links.TryGetValue("next", out var nextLink));
+
+        string? after = GetQueryStringValue(nextLink, "after");
+        Assert.NotNull(after);
+
+        var result = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<PersistentEvent>>(TestCancellationToken);
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+
+        // Act
+        response = await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("events")
+            .QueryString("limit", "2")
+            .QueryString("after", after)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        links = ParseLinkHeaderValue(response.Headers.GetValues(HeaderNames.Link).ToArray());
+        Assert.Single(links);
+        Assert.True(links.ContainsKey("previous"));
+        Assert.False(links.ContainsKey("next"));
+
+        result = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<PersistentEvent>>(TestCancellationToken);
+        Assert.NotNull(result);
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task GetEvents_WithStableCursorPaging_ReturnsExpectedDirectionalLinksAsync()
+    {
+        // Arrange
         await CreateDataAsync(d =>
         {
             d.Event().TestProject().Type(Event.KnownTypes.Log);
@@ -1623,6 +1677,7 @@ public partial class EventControllerTests : IntegrationTestsBase
         Log.SetLogLevel<StackRepository>(LogLevel.Trace);
         Log.SetLogLevel<EventStackFilterQueryBuilder>(LogLevel.Trace);
 
+        // Act
         var response = await SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPath("events")
@@ -1631,6 +1686,7 @@ public partial class EventControllerTests : IntegrationTestsBase
             .StatusCodeShouldBeOk()
         );
 
+        // Assert
         Assert.Equal("3", response.Headers.GetValues(Headers.ResultCount).Single());
 
         var links = ParseLinkHeaderValue(response.Headers.GetValues(HeaderNames.Link).ToArray());
@@ -1647,7 +1703,7 @@ public partial class EventControllerTests : IntegrationTestsBase
         Assert.NotNull(result);
         string firstEventId = result.Single().Id;
 
-        // Go to second page
+        // Act
         response = await SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPath("events")
@@ -1657,6 +1713,7 @@ public partial class EventControllerTests : IntegrationTestsBase
             .StatusCodeShouldBeOk()
         );
 
+        // Assert
         Assert.Equal("3", response.Headers.GetValues(Headers.ResultCount).Single());
         links = ParseLinkHeaderValue(response.Headers.GetValues(HeaderNames.Link).ToArray());
         Assert.Equal(2, links.Count);
@@ -1673,7 +1730,7 @@ public partial class EventControllerTests : IntegrationTestsBase
         string secondEventId = result.Single().Id;
         Assert.NotEqual(firstEventId, secondEventId);
 
-        // Go to last page
+        // Act
         response = await SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPath("events")
@@ -1683,23 +1740,21 @@ public partial class EventControllerTests : IntegrationTestsBase
             .StatusCodeShouldBeOk()
         );
 
+        // Assert
         Assert.Equal("3", response.Headers.GetValues(Headers.ResultCount).Single());
         links = ParseLinkHeaderValue(response.Headers.GetValues(HeaderNames.Link).ToArray());
-        Assert.Equal(2, links.Count);
+        Assert.Single(links);
 
         before = GetQueryStringValue(links["previous"], "before");
         Assert.NotNull(before);
-
-        after = GetQueryStringValue(links["next"], "after");
-        Assert.NotNull(after);
-        Assert.Equal(before, after);
+        Assert.False(links.ContainsKey("next"));
 
         result = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<PersistentEvent>>(TestCancellationToken);
         Assert.NotNull(result);
         string thirdEventId = result.Single().Id;
         Assert.NotEqual(secondEventId, thirdEventId);
 
-        // go to previous page
+        // Act
         response = await SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPath("events")
@@ -1709,6 +1764,7 @@ public partial class EventControllerTests : IntegrationTestsBase
             .StatusCodeShouldBeOk()
         );
 
+        // Assert
         Assert.Equal("3", response.Headers.GetValues(Headers.ResultCount).Single());
         links = ParseLinkHeaderValue(response.Headers.GetValues(HeaderNames.Link).ToArray());
         Assert.Equal(2, links.Count);

--- a/tests/Exceptionless.Tests/Miscellaneous/EfficientPagingTests.cs
+++ b/tests/Exceptionless.Tests/Miscellaneous/EfficientPagingTests.cs
@@ -12,15 +12,19 @@ public class EfficientPagingTests : TestWithServices
     [InlineData("http://localhost?after=1", "1", null, true, false)]
     [InlineData("http://localhost?after=1", "1", "2", true, true)]
     [InlineData("http://localhost?before=11", null, "1", false, true)]
-    public void CanBeforeAndAfterLinks(string url, string? before, string? after, bool expectPrevious, bool expectNext)
+    public void GetBeforeAndAfterLinks_WithCursorTokens_ReturnsExpectedDirectionalLinks(string url, string? before, string? after, bool expectPrevious, bool expectNext)
     {
-        var links = OkWithResourceLinks<string>.GetBeforeAndAfterLinks(new Uri(url), before, after); ;
+        // Arrange
         byte expectedLinkCount = 0;
         if (expectPrevious)
             expectedLinkCount++;
         if (expectNext)
             expectedLinkCount++;
 
+        // Act
+        var links = OkWithResourceLinks<string>.GetBeforeAndAfterLinks(new Uri(url), before, after, true);
+
+        // Assert
         foreach (string link in links)
             _logger.LogInformation(link);
 
@@ -31,21 +35,39 @@ public class EfficientPagingTests : TestWithServices
             Assert.Contains(links, l => l.Contains("next") && l.Contains("after"));
     }
 
+    [Fact]
+    public void GetBeforeAndAfterLinks_WithoutMoreResults_DoesNotIncludeNextLink()
+    {
+        // Arrange
+        var url = new Uri("http://localhost?after=1");
+
+        // Act
+        var links = OkWithResourceLinks<string>.GetBeforeAndAfterLinks(url, "1", "2", false);
+
+        // Assert
+        Assert.Single(links);
+        Assert.Contains(links, l => l.Contains("previous") && l.Contains("before"));
+        Assert.DoesNotContain(links, l => l.Contains("next"));
+    }
+
     [Theory]
     [InlineData("http://localhost", 0, false, false, false)]
     [InlineData("http://localhost", 1, false, false, false)]
     [InlineData("http://localhost", 2, false, true, false)]
     [InlineData("http://localhost", 2, true, true, true)]
-    public void CanPageLinks(string url, int pageNumber, bool hasMore, bool expectPrevious, bool expectNext)
+    public void GetPagedLinks_WithPageNumber_ReturnsExpectedDirectionalLinks(string url, int pageNumber, bool hasMore, bool expectPrevious, bool expectNext)
     {
-        var links = OkWithResourceLinks<string>.GetPagedLinks(new Uri(url), pageNumber, hasMore);
-
+        // Arrange
         int expectedLinkCount = 0;
         if (expectPrevious)
             expectedLinkCount++;
         if (expectNext)
             expectedLinkCount++;
 
+        // Act
+        var links = OkWithResourceLinks<string>.GetPagedLinks(new Uri(url), pageNumber, hasMore);
+
+        // Assert
         foreach (string link in links)
             _logger.LogInformation(link);
 


### PR DESCRIPTION
## Summary
- Stop cursor-paged responses from emitting `rel="next"` when the repository says there are no more results.
- Add regression coverage for partial final cursor pages and link helper generation.

## Root Cause
- `EventController` passed the last row sort token into `OkWithResourceLinks` for every non-empty cursor page.
- `OkWithResourceLinks` generated a next link solely from a non-empty `after` token, ignoring `HasMore`, so a partial final page advertised a phantom cursor.

## Validation
- `dotnet test -- --filter-class Exceptionless.Tests.Miscellaneous.EfficientPagingTests`
- `dotnet test -- --filter-class Exceptionless.Tests.Controllers.EventControllerTests`
- Local Aspire UI: `/next/event/all?limit=10` showed `Page 1 of 2`, then `Page 2 of 2` with 4 rows and Next disabled.

## Breaking Changes
None.