### PR TITLE
Update GitHub Script action to Node 24

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Resolve preview pull request
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             if (context.eventName === "repository_dispatch") {

--- a/.github/workflows/preview-command.yml
+++ b/.github/workflows/preview-command.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Prepare Preview
         id: preview
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const owner = context.repo.owner;
@@ -136,7 +136,7 @@ jobs:
 
       - name: Dispatch Preview
         if: ${{ steps.preview.outputs.pr-number != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ steps.preview.outputs.pr-number }}
           HEAD_REF: ${{ steps.preview.outputs.head-ref }}


### PR DESCRIPTION
## Summary
- Update `actions/github-script` from v7 to v8 in preview workflow steps.
- Remove the Node.js 20 deprecation warning by using the Node 24 action runtime.
- Audited other workflow actions; JavaScript actions already declare Node 24 and the coverage summary action is Docker-based.

## Verification
- Parsed all `.github/workflows` YAML files with `ConvertFrom-Yaml`.
- Ran `git diff --check`.
- Confirmed no remaining `actions/github-script@v7`, `node20`, or `Node.js 20` references in workflows.

## Breaking Changes
- None.