### PR TITLE
Limit test AppHost logs to warnings

### DIFF
--- a/tests/Exceptionless.Tests/AppWebHostFactory.cs
+++ b/tests/Exceptionless.Tests/AppWebHostFactory.cs
@@ -39,7 +39,9 @@ public class AppWebHostFactory : WebApplicationFactory<Startup>, IAsyncLifetime
 
     private static async Task<DistributedApplication> StartSharedAppHostAsync()
     {
-        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.Exceptionless_AppHost>(["services-only"], CancellationToken.None);
+        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.Exceptionless_AppHost>(
+            ["services-only", "--Logging:LogLevel:Default=Warning"],
+            CancellationToken.None);
         var app = await appHost.BuildAsync(CancellationToken.None);
         await app.StartAsync(CancellationToken.None);
 


### PR DESCRIPTION
## What changed

- Limited the Aspire AppHost launched by integration tests to `Warning` and above logging.
- Kept normal AppHost runtime logging unchanged for local `aspire run` usage.

## Why

Failing integration test runs were dumping captured AppHost resource stdout, especially Elasticsearch `Information` logs, which made the useful failure output hard to find.

## Verification

- `dotnet build tests\Exceptionless.Tests\Exceptionless.Tests.csproj --no-restore --configuration Release`
- `dotnet test tests\Exceptionless.Tests\Exceptionless.Tests.csproj --no-restore --no-build --configuration Release -- --filter-class Exceptionless.Tests.Controllers.StatusControllerTests`

## Breaking changes

None.