### PR TITLE
Fix event filter refresh state

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
@@ -20,7 +20,7 @@
     import Braces from '@lucide/svelte/icons/braces';
     import ChevronLeft from '@lucide/svelte/icons/chevron-left';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
-    import Funnel from '@lucide/svelte/icons/funnel';
+    import EventsIcon from '@lucide/svelte/icons/calendar-days';
     import { onMount, tick } from 'svelte';
     import { toast } from 'svelte-sonner';
 
@@ -321,7 +321,7 @@
                     title="Show all events"
                     variant="outline"
                 >
-                    <Funnel class="size-4" />
+                    <EventsIcon class="size-4" />
                 </Button>
             {/if}
             {#if onNavigate && (navigation?.previousId || navigation?.nextId)}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
@@ -18,9 +18,9 @@
     import { getProjectQuery, updateProject } from '$features/projects/api.svelte';
     import StackCard from '$features/stacks/components/stack-card.svelte';
     import Braces from '@lucide/svelte/icons/braces';
+    import EventsIcon from '@lucide/svelte/icons/calendar-days';
     import ChevronLeft from '@lucide/svelte/icons/chevron-left';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
-    import EventsIcon from '@lucide/svelte/icons/calendar-days';
     import { onMount, tick } from 'svelte';
     import { toast } from 'svelte-sonner';
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/helpers.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/helpers.svelte.test.ts
@@ -71,6 +71,20 @@ describe('helpers.svelte', () => {
     });
 });
 
+describe('TagFilter', () => {
+    it('quotes tag values with spaces', () => {
+        const filters = [new TagFilter(['First Chance'] as never[])];
+
+        expect(toFilter(filters)).toBe('tag:"First Chance"');
+    });
+
+    it('quotes multiple tag values with spaces', () => {
+        const filters = [new TagFilter(['First Chance', 'Second Chance'] as never[])];
+
+        expect(toFilter(filters)).toBe('(tag:"First Chance" OR tag:"Second Chance")');
+    });
+});
+
 describe('applyTimeFilter', () => {
     it('removes an existing date filter when time is explicitly empty', () => {
         // Arrange

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/models.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/models.svelte.ts
@@ -381,10 +381,10 @@ export class TagFilter implements IFilter {
         }
 
         if (this.value.length == 1) {
-            return `tag:${this.value[0]}`;
+            return `tag:${quoteIfSpecialCharacters(this.value[0])}`;
         }
 
-        return `(${this.value.map((val) => `tag:${val}`).join(' OR ')})`;
+        return `(${this.value.map((val) => `tag:${quoteIfSpecialCharacters(val)}`).join(' OR ')})`;
     }
 }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/session-event-duration.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/session-event-duration.svelte
@@ -16,6 +16,10 @@
     const durationValue = $derived(getSessionStartDuration(event));
 </script>
 
-<Live live={isActive} liveTitle="Online" notLiveTitle="Ended" /><Duration value={durationValue} />{#if !isActive}
-    <span class="text-muted-foreground"> (ended <TimeAgo value={event.data!.sessionend} />)</span>
-{/if}
+<div class="flex items-center gap-1.5">
+    <Live live={isActive} liveTitle="Online" notLiveTitle="Ended" />
+    <Duration value={durationValue} />
+    {#if !isActive}
+        <span class="text-muted-foreground">(ended <TimeAgo value={event.data!.sessionend} />)</span>
+    {/if}
+</div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
@@ -14,7 +14,7 @@
     import Summary from '$features/events/components/summary/summary.svelte';
     import { getSessionId } from '$features/events/utils/index';
     import { organization } from '$features/organizations/context.svelte';
-    import Funnel from '@lucide/svelte/icons/funnel';
+    import EventsIcon from '@lucide/svelte/icons/calendar-days';
     import InfoIcon from '@lucide/svelte/icons/info';
 
     import SessionEventDuration from '../session-event-duration.svelte';
@@ -37,7 +37,7 @@
             return undefined;
         }
 
-        const query = new URLSearchParams({ filter: filter.toFilter(), time: '' });
+        const query = new URLSearchParams({ filter: filter.toFilter(), time: 'all' });
         return `${eventsPath}?${query.toString()}`;
     });
 
@@ -149,7 +149,7 @@
             title="Open events filtered to this session"
             variant="outline"
         >
-            <Funnel class="size-4" />
+            <EventsIcon class="size-4" />
         </Button>
     </div>
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
@@ -7,6 +7,7 @@
     import Percentage from '$comp/formatters/percentage.svelte';
     import TimeAgo from '$comp/formatters/time-ago.svelte';
     import Muted from '$comp/typography/muted.svelte';
+    import { Button } from '$comp/ui/button';
     import * as ButtonGroup from '$comp/ui/button-group';
     import * as Card from '$comp/ui/card';
     import { Skeleton } from '$comp/ui/skeleton';
@@ -23,6 +24,7 @@
     import LastOccurrence from '@lucide/svelte/icons/arrow-right-circle';
     import Calendar from '@lucide/svelte/icons/calendar';
     import Clock from '@lucide/svelte/icons/clock';
+    import EventsIcon from '@lucide/svelte/icons/calendar-days';
     import Filter from '@lucide/svelte/icons/filter';
     import Info from '@lucide/svelte/icons/info';
     import Users from '@lucide/svelte/icons/users';
@@ -161,18 +163,35 @@
                             <Calendar aria-hidden="true" class={metricIconClass} />
                             <Card.Title class={metricTitleClass}>Total Events</Card.Title>
                         </div>
-                        <Tooltip.Root>
-                            <Tooltip.Trigger
-                                class="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded-sm outline-none focus-visible:ring-2"
-                                aria-label="About total events"
+                        <div class="flex shrink-0 items-center gap-1">
+                            <Button
+                                aria-label="Open events for this stack"
+                                onclick={() => filterChanged(new StringFilter('stack', stack.id))}
+                                size="icon-xs"
+                                title="Open events for this stack"
+                                variant="ghost"
                             >
-                                <Info aria-hidden="true" class="size-3.5" />
-                            </Tooltip.Trigger>
-                            <Tooltip.Content sideOffset={6}><Number value={totalOccurrences} /> All Time</Tooltip.Content>
-                        </Tooltip.Root>
+                                <EventsIcon aria-hidden="true" class="size-3.5" />
+                            </Button>
+                            <Tooltip.Root>
+                                <Tooltip.Trigger
+                                    class="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded-sm outline-none focus-visible:ring-2"
+                                    aria-label="About total events"
+                                >
+                                    <Info aria-hidden="true" class="size-3.5" />
+                                </Tooltip.Trigger>
+                                <Tooltip.Content sideOffset={6}><Number value={totalOccurrences} /> All Time</Tooltip.Content>
+                            </Tooltip.Root>
+                        </div>
                     </Card.Header>
                     <Card.Content class="px-3">
-                        <button class={metricValueClass} onclick={() => filterChanged(new StringFilter('stack', stack.id))} type="button">
+                        <button
+                            aria-label="Open events for this stack"
+                            class={metricValueClass}
+                            onclick={() => filterChanged(new StringFilter('stack', stack.id))}
+                            title="Open events for this stack"
+                            type="button"
+                        >
                             <Number value={totalOccurrences} />
                         </button>
                     </Card.Content>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
@@ -23,8 +23,8 @@
     import FirstOccurrence from '@lucide/svelte/icons/arrow-left-circle';
     import LastOccurrence from '@lucide/svelte/icons/arrow-right-circle';
     import Calendar from '@lucide/svelte/icons/calendar';
-    import Clock from '@lucide/svelte/icons/clock';
     import EventsIcon from '@lucide/svelte/icons/calendar-days';
+    import Clock from '@lucide/svelte/icons/clock';
     import Filter from '@lucide/svelte/icons/filter';
     import Info from '@lucide/svelte/icons/info';
     import Users from '@lucide/svelte/icons/users';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -266,6 +266,7 @@
         view: VIEW
     });
     const pageTitle = $derived(savedViewsState.activeSavedView?.name ?? 'Events');
+    const isSavedViewRoutePending = $derived(!!page.params.slug && !savedViewsState.activeSavedView);
 
     $effect(() => {
         document.title = `${pageTitle} - Exceptionless`;
@@ -449,15 +450,7 @@
 
         const newFilterParam = filterParam === baseExpressionFilterParam ? null : filterParam || (savedViewFilters && baseExpressionFilterParam ? '' : null);
         const newTimeParam = time === baseTime ? null : time ? serializeTimeQueryParam(time) : ALL_TIME_QUERY_VALUE;
-
-        updateFilterCache(filterCacheKey(filter), updatedFilters);
-        if (shouldClearPagination) {
-            clearPaginationQueryParams();
-        }
-
-        // Only skip the watch when the URL will actually change from our update.
-        // If the URL doesn't change, the watch won't fire and the flag would stay stale.
-        if (
+        const urlQueryWillChange =
             newFilterParam !== queryParams.filter ||
             newTimeParam !== queryParams.time ||
             queryFilterParams.bot !== queryParams.bot ||
@@ -470,8 +463,19 @@
             queryFilterParams.status !== queryParams.status ||
             queryFilterParams.tag !== queryParams.tag ||
             queryFilterParams.type !== queryParams.type ||
-            queryFilterParams.version !== queryParams.version
-        ) {
+            queryFilterParams.version !== queryParams.version;
+        const effectiveQueryWillChange = (filter || null) !== getEffectiveFilter() || time !== getQueryTime();
+        const shouldClearPaginationForFilter = shouldClearPagination && effectiveQueryWillChange;
+        const paginationWillChange = shouldClearPaginationForFilter && (queryParams.after != null || queryParams.before != null || queryParams.page != null);
+
+        updateFilterCache(filterCacheKey(filter), updatedFilters);
+        if (shouldClearPaginationForFilter) {
+            clearPaginationQueryParams();
+        }
+
+        // Only skip the watch when the URL will actually change from our update.
+        // If the URL doesn't change, the watch won't fire and the flag would stay stale.
+        if (paginationWillChange || urlQueryWillChange) {
             isInternalFilterUpdate = true;
         }
 
@@ -685,7 +689,7 @@
     }
 
     async function loadData() {
-        if (!organization.current) {
+        if (!organization.current || isSavedViewRoutePending) {
             return;
         }
 
@@ -735,6 +739,7 @@
     });
 
     const chartDataQuery = getOrganizationCountQuery({
+        enabled: () => !isSavedViewRoutePending,
         params: {
             get aggregations() {
                 return `date:(date${DEFAULT_OFFSET ? `^${DEFAULT_OFFSET}` : ''} cardinality:stack sum:count~1) cardinality:stack terms:(first @include:true) sum:count~1`;
@@ -859,7 +864,7 @@
         {#if showStats}
             <EventsStatsDashboard
                 eventsPerHour={stats.eventsPerHour}
-                isLoading={chartDataQuery.isLoading && !chartDataQuery.isSuccess}
+                isLoading={isSavedViewRoutePending || (chartDataQuery.isLoading && !chartDataQuery.isSuccess)}
                 newStacks={stats.newStacks}
                 totalEvents={stats.totalEvents}
                 totalStacks={stats.totalStacks}
@@ -867,10 +872,10 @@
         {/if}
 
         {#if showChart}
-            <EventsDashboardChart data={chartData()} isLoading={chartDataQuery.isLoading && !chartDataQuery.isSuccess} {onRangeSelect} />
+            <EventsDashboardChart data={chartData()} isLoading={isSavedViewRoutePending || (chartDataQuery.isLoading && !chartDataQuery.isSuccess)} {onRangeSelect} />
         {/if}
 
-        <EventsDataTable bind:limit={eventsQueryParameters.limit!} isLoading={clientStatus.isLoading} {rowClick} {rowHref} {table}>
+        <EventsDataTable bind:limit={eventsQueryParameters.limit!} isLoading={isSavedViewRoutePending || clientStatus.isLoading} {rowClick} {rowHref} {table}>
             {#snippet footerChildren()}
                 <div class="h-9 min-w-35">
                     {#if table.getSelectedRowModel().flatRows.length}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -872,7 +872,11 @@
         {/if}
 
         {#if showChart}
-            <EventsDashboardChart data={chartData()} isLoading={isSavedViewRoutePending || (chartDataQuery.isLoading && !chartDataQuery.isSuccess)} {onRangeSelect} />
+            <EventsDashboardChart
+                data={chartData()}
+                isLoading={isSavedViewRoutePending || (chartDataQuery.isLoading && !chartDataQuery.isSuccess)}
+                {onRangeSelect}
+            />
         {/if}
 
         <EventsDataTable bind:limit={eventsQueryParameters.limit!} isLoading={isSavedViewRoutePending || clientStatus.isLoading} {rowClick} {rowHref} {table}>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -253,6 +253,7 @@
         view: VIEW
     });
     const pageTitle = $derived(savedViewsState.activeSavedView?.name ?? 'Stacks');
+    const isSavedViewRoutePending = $derived(!!page.params.slug && !savedViewsState.activeSavedView);
 
     $effect(() => {
         document.title = `${pageTitle} - Exceptionless`;
@@ -437,15 +438,7 @@
 
         const newFilterParam = filterParam === baseExpressionFilterParam ? null : filterParam || (savedViewFilters && baseExpressionFilterParam ? '' : null);
         const newTimeParam = time === baseTime ? null : time ? serializeTimeQueryParam(time) : ALL_TIME_QUERY_VALUE;
-
-        updateFilterCache(filterCacheKey(filter), updatedFilters);
-        if (shouldClearPagination) {
-            clearPaginationQueryParams();
-        }
-
-        // Only skip the watch when the URL will actually change from our update.
-        // If the URL doesn't change, the watch won't fire and the flag would stay stale.
-        if (
+        const urlQueryWillChange =
             newFilterParam !== queryParams.filter ||
             newTimeParam !== queryParams.time ||
             queryFilterParams.bot !== queryParams.bot ||
@@ -458,8 +451,19 @@
             queryFilterParams.status !== queryParams.status ||
             queryFilterParams.tag !== queryParams.tag ||
             queryFilterParams.type !== queryParams.type ||
-            queryFilterParams.version !== queryParams.version
-        ) {
+            queryFilterParams.version !== queryParams.version;
+        const effectiveQueryWillChange = (filter || null) !== getEffectiveFilter() || time !== getQueryTime();
+        const shouldClearPaginationForFilter = shouldClearPagination && effectiveQueryWillChange;
+        const paginationWillChange = shouldClearPaginationForFilter && queryParams.page != null;
+
+        updateFilterCache(filterCacheKey(filter), updatedFilters);
+        if (shouldClearPaginationForFilter) {
+            clearPaginationQueryParams();
+        }
+
+        // Only skip the watch when the URL will actually change from our update.
+        // If the URL doesn't change, the watch won't fire and the flag would stay stale.
+        if (paginationWillChange || urlQueryWillChange) {
             isInternalFilterUpdate = true;
         }
 
@@ -652,7 +656,7 @@
     }
 
     async function loadData() {
-        if (!organization.current) {
+        if (!organization.current || isSavedViewRoutePending) {
             return;
         }
 
@@ -693,6 +697,7 @@
     });
 
     const chartDataQuery = getOrganizationCountQuery({
+        enabled: () => !isSavedViewRoutePending,
         params: {
             get aggregations() {
                 return `date:(date${DEFAULT_OFFSET ? `^${DEFAULT_OFFSET}` : ''} cardinality:stack sum:count~1) cardinality:stack terms:(first @include:true) sum:count~1`;
@@ -806,7 +811,7 @@
         {#if showStats}
             <EventsStatsDashboard
                 eventsPerHour={stats.eventsPerHour}
-                isLoading={chartDataQuery.isLoading && !chartDataQuery.isSuccess}
+                isLoading={isSavedViewRoutePending || (chartDataQuery.isLoading && !chartDataQuery.isSuccess)}
                 newStacks={stats.newStacks}
                 totalEvents={stats.totalEvents}
                 totalStacks={stats.totalStacks}
@@ -814,10 +819,10 @@
         {/if}
 
         {#if showChart}
-            <EventsDashboardChart data={chartData()} isLoading={clientStatus.isLoading || chartDataQuery.isLoading} {onRangeSelect} />
+            <EventsDashboardChart data={chartData()} isLoading={isSavedViewRoutePending || clientStatus.isLoading || chartDataQuery.isLoading} {onRangeSelect} />
         {/if}
 
-        <EventsDataTable bind:limit={eventsQueryParameters.limit!} isLoading={clientStatus.isLoading} {rowClick} {rowHref} {table}>
+        <EventsDataTable bind:limit={eventsQueryParameters.limit!} isLoading={isSavedViewRoutePending || clientStatus.isLoading} {rowClick} {rowHref} {table}>
             {#snippet footerChildren()}
                 <div class="h-9 min-w-35">
                     <TableStacksBulkActionsDropdownMenu {table} />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -819,7 +819,11 @@
         {/if}
 
         {#if showChart}
-            <EventsDashboardChart data={chartData()} isLoading={isSavedViewRoutePending || clientStatus.isLoading || chartDataQuery.isLoading} {onRangeSelect} />
+            <EventsDashboardChart
+                data={chartData()}
+                isLoading={isSavedViewRoutePending || clientStatus.isLoading || chartDataQuery.isLoading}
+                {onRangeSelect}
+            />
         {/if}
 
         <EventsDataTable bind:limit={eventsQueryParameters.limit!} isLoading={isSavedViewRoutePending || clientStatus.isLoading} {rowClick} {rowHref} {table}>


### PR DESCRIPTION
## Summary

- Preserve filter UI state and pagination when URL-only filter serialization or event auto-refreshes occur.
- Delay saved-view list/count loading until saved-view filters hydrate so refreshes do not flash default data first.
- Fix tag filters with spaces, session event all-time navigation, Events icons, duration spacing, and the Total Events action affordance.

## Root Cause

Filter updates always cleared pagination when any query-string write happened, even if the effective API filter/time did not change. Saved-view pages could also start loading with default filters before the saved-view filters were available, then correct themselves after hydration.

## Verification

- `npx vitest run src/lib/features/events/components/filters/helpers.svelte.test.ts "src/routes/(app)/redirect-to-events.svelte.test.ts"`
- `npm run check`
- Local browser verification against the Svelte app: page 2 raw-filter auto-refresh stayed on page 2 with the filter open, tag `First Chance` matched, Session Events links used `time=all`, saved-view refreshes did not show invalid rows first, and last-page refresh stayed on the last page.