### PR TITLE
Configure production contact recipient

### DIFF
--- a/k8s/ex-prod-values.yaml
+++ b/k8s/ex-prod-values.yaml
@@ -30,6 +30,7 @@ jobs:
 config:
   EX_EnableSnapshotJobs: "true"
   EX_SmtpFrom: "Exceptionless <noreply@exceptionless.io>"
+  EX_ContactEmailAddress: "support@exceptionless.com"
   EX_TestEmailAddress: "test@exceptionless.io"
   EX_EnableArchive: "false"
   EX_Serilog__MinimumLevel__Default: "Warning"


### PR DESCRIPTION
## Summary
- Adds the production contact form recipient setting for /api/v2/contact.
- Uses support@exceptionless.com as the recipient for website contact submissions.

## Why
The static website contact form reaches the API, but production currently returns 503 because ContactEmailAddress is not configured.

## Verification
- git diff --check
- Confirmed k8s/ex-prod-values.yaml contains EX_ContactEmailAddress.

## Breaking changes
None.