### PR TITLE
Fix predefined saved view synchronization

### DIFF
--- a/src/Exceptionless.Core/Bootstrapper.cs
+++ b/src/Exceptionless.Core/Bootstrapper.cs
@@ -87,6 +87,7 @@ public class Bootstrapper
         {
             var handlers = new WorkItemHandlers();
             handlers.Register<FixStackStatsWorkItem>(s.GetRequiredService<FixStackStatsWorkItemHandler>);
+            handlers.Register<ForcePredefinedSavedViewsWorkItem>(s.GetRequiredService<ForcePredefinedSavedViewsWorkItemHandler>);
             handlers.Register<OrganizationMaintenanceWorkItem>(s.GetRequiredService<OrganizationMaintenanceWorkItemHandler>);
             handlers.Register<OrganizationNotificationWorkItem>(s.GetRequiredService<OrganizationNotificationWorkItemHandler>);
             handlers.Register<ProjectMaintenanceWorkItem>(s.GetRequiredService<ProjectMaintenanceWorkItemHandler>);

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/ForcePredefinedSavedViewsWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/ForcePredefinedSavedViewsWorkItemHandler.cs
@@ -1,0 +1,177 @@
+using System.Text.RegularExpressions;
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Models.WorkItems;
+using Exceptionless.Core.Repositories;
+using Exceptionless.Core.Seed;
+using Foundatio.Jobs;
+using Foundatio.Lock;
+using Foundatio.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace Exceptionless.Core.Jobs.WorkItemHandlers;
+
+public class ForcePredefinedSavedViewsWorkItemHandler : WorkItemHandlerBase
+{
+    private const int OrganizationPageLimit = 100;
+    private const int SavedViewPageLimit = 1000;
+    private static readonly string[] ValidViewTypes = ["events", "stacks", "stream"];
+
+    private readonly IOrganizationRepository _organizationRepository;
+    private readonly ISavedViewRepository _savedViewRepository;
+    private readonly ILockProvider _lockProvider;
+
+    public ForcePredefinedSavedViewsWorkItemHandler(
+        IOrganizationRepository organizationRepository,
+        ISavedViewRepository savedViewRepository,
+        ILockProvider lockProvider,
+        ILoggerFactory loggerFactory) : base(loggerFactory)
+    {
+        _organizationRepository = organizationRepository;
+        _savedViewRepository = savedViewRepository;
+        _lockProvider = lockProvider;
+    }
+
+    public override Task<ILock?> GetWorkItemLockAsync(object workItem, CancellationToken cancellationToken = default)
+    {
+        return _lockProvider.TryAcquireAsync(nameof(ForcePredefinedSavedViewsWorkItemHandler), TimeSpan.FromHours(1), cancellationToken);
+    }
+
+    public override async Task HandleItemAsync(WorkItemContext context)
+    {
+        var workItem = context.GetData<ForcePredefinedSavedViewsWorkItem>()!;
+        var predefinedSavedViewsByKey = await GetPredefinedSavedViewsByKeyAsync();
+
+        Log.LogInformation(
+            "Starting predefined saved view force update. Definitions: {DefinitionCount} InitiatedByUserId: {UserId}",
+            predefinedSavedViewsByKey.Count,
+            workItem.UserId);
+
+        int organizationsUpdated = 0;
+        int savedViewsUpdated = 0;
+        var organizations = await _organizationRepository.GetAllAsync(o => o.SearchAfterPaging().PageLimit(OrganizationPageLimit));
+
+        do
+        {
+            foreach (var organization in organizations.Documents)
+            {
+                if (context.CancellationToken.IsCancellationRequested)
+                    break;
+
+                if (String.Equals(organization.Id, PredefinedSavedViewsDataSeed.SystemOrganizationId, StringComparison.Ordinal))
+                    continue;
+
+                int updatedForOrganization = await ForceUpdateOrganizationSavedViewsAsync(organization.Id, workItem.UserId, predefinedSavedViewsByKey);
+                if (updatedForOrganization > 0)
+                {
+                    organizationsUpdated++;
+                    savedViewsUpdated += updatedForOrganization;
+                }
+
+                await context.RenewLockAsync();
+            }
+        } while (!context.CancellationToken.IsCancellationRequested && await organizations.NextPageAsync());
+
+        Log.LogInformation(
+            "Completed predefined saved view force update. OrganizationsUpdated: {OrganizationsUpdated} SavedViewsUpdated: {SavedViewsUpdated} InitiatedByUserId: {UserId}",
+            organizationsUpdated,
+            savedViewsUpdated,
+            workItem.UserId);
+    }
+
+    private async Task<Dictionary<string, SavedView>> GetPredefinedSavedViewsByKeyAsync()
+    {
+        var savedViewsByKey = new Dictionary<string, SavedView>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (string viewType in ValidViewTypes)
+        {
+            var results = await _savedViewRepository.GetByViewAsync(PredefinedSavedViewsDataSeed.SystemOrganizationId, viewType, o => o.PageLimit(SavedViewPageLimit));
+            foreach (var savedView in results.Documents.Where(view => view.UserId is null && !String.IsNullOrWhiteSpace(view.PredefinedKey)))
+            {
+                if (!savedViewsByKey.TryAdd(savedView.PredefinedKey!, savedView))
+                    throw new InvalidOperationException($"Predefined saved view key '{savedView.PredefinedKey}' is duplicated.");
+            }
+        }
+
+        return savedViewsByKey;
+    }
+
+    private async Task<int> ForceUpdateOrganizationSavedViewsAsync(
+        string organizationId,
+        string userId,
+        IReadOnlyDictionary<string, SavedView> predefinedSavedViewsByKey)
+    {
+        int updatedSavedViews = 0;
+        bool lockAcquired = await _lockProvider.TryUsingAsync($"predefined-saved-views:{organizationId}", async () =>
+        {
+            updatedSavedViews = await ForceUpdateOrganizationSavedViewsWithLockAsync(organizationId, userId, predefinedSavedViewsByKey);
+        }, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(15));
+
+        if (!lockAcquired)
+            Log.LogWarning("Skipping force update for organization {OrganizationId} because the saved view synchronization lock could not be acquired", organizationId);
+
+        return updatedSavedViews;
+    }
+
+    private async Task<int> ForceUpdateOrganizationSavedViewsWithLockAsync(
+        string organizationId,
+        string userId,
+        IReadOnlyDictionary<string, SavedView> predefinedSavedViewsByKey)
+    {
+        var savedViewsToSave = new List<SavedView>();
+
+        foreach (string viewType in ValidViewTypes)
+        {
+            var results = await _savedViewRepository.GetByViewAsync(organizationId, viewType, o => o.PageLimit(SavedViewPageLimit));
+            var savedViews = results.Documents.ToList();
+
+            foreach (var savedView in savedViews)
+            {
+                if (savedView.UserId is not null
+                    || String.IsNullOrWhiteSpace(savedView.PredefinedKey)
+                    || !predefinedSavedViewsByKey.TryGetValue(savedView.PredefinedKey, out var predefinedSavedView))
+                {
+                    continue;
+                }
+
+                string slug = GetUniqueSlug(predefinedSavedView.Slug, savedViews, savedView.Id);
+                if (PredefinedSavedViewConfiguration.Apply(savedView, predefinedSavedView, predefinedSavedView.PredefinedKey!, slug))
+                {
+                    savedView.UpdatedByUserId = userId;
+                    savedViewsToSave.Add(savedView);
+                }
+            }
+        }
+
+        if (savedViewsToSave.Count > 0)
+            await _savedViewRepository.SaveAsync(savedViewsToSave, o => o.Cache());
+
+        return savedViewsToSave.Count;
+    }
+
+    private static string GetUniqueSlug(string slug, IReadOnlyCollection<SavedView> existingViews, string? excludingId)
+    {
+        string baseSlug = ToSlug(slug);
+        if (String.IsNullOrWhiteSpace(baseSlug))
+            baseSlug = "saved-view";
+
+        baseSlug = baseSlug.Length > 100 ? baseSlug[..100].Trim('-') : baseSlug;
+        string candidate = baseSlug;
+        int suffix = 2;
+
+        while (existingViews.Any(view => view.Id != excludingId && String.Equals(view.Slug, candidate, StringComparison.OrdinalIgnoreCase)))
+        {
+            string suffixText = $"-{suffix}";
+            int maxBaseLength = 100 - suffixText.Length;
+            candidate = $"{baseSlug[..Math.Min(baseSlug.Length, maxBaseLength)].Trim('-')}{suffixText}";
+            suffix++;
+        }
+
+        return candidate;
+    }
+
+    private static string ToSlug(string value)
+    {
+        string slug = Regex.Replace(value.Trim().ToLowerInvariant(), "[^a-z0-9]+", "-").Trim('-');
+        return Regex.Replace(slug, "-+", "-");
+    }
+}

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/ForcePredefinedSavedViewsWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/ForcePredefinedSavedViewsWorkItemHandler.cs
@@ -12,21 +12,17 @@ namespace Exceptionless.Core.Jobs.WorkItemHandlers;
 
 public class ForcePredefinedSavedViewsWorkItemHandler : WorkItemHandlerBase
 {
-    private const int OrganizationPageLimit = 100;
     private const int SavedViewPageLimit = 1000;
     private static readonly string[] ValidViewTypes = ["events", "stacks", "stream"];
 
-    private readonly IOrganizationRepository _organizationRepository;
     private readonly ISavedViewRepository _savedViewRepository;
     private readonly ILockProvider _lockProvider;
 
     public ForcePredefinedSavedViewsWorkItemHandler(
-        IOrganizationRepository organizationRepository,
         ISavedViewRepository savedViewRepository,
         ILockProvider lockProvider,
         ILoggerFactory loggerFactory) : base(loggerFactory)
     {
-        _organizationRepository = organizationRepository;
         _savedViewRepository = savedViewRepository;
         _lockProvider = lockProvider;
     }
@@ -48,19 +44,25 @@ public class ForcePredefinedSavedViewsWorkItemHandler : WorkItemHandlerBase
 
         int organizationsUpdated = 0;
         int savedViewsUpdated = 0;
-        var organizations = await _organizationRepository.GetAllAsync(o => o.SearchAfterPaging().PageLimit(OrganizationPageLimit));
+        var savedViews = await _savedViewRepository.GetPredefinedForForceUpdateAsync(
+            PredefinedSavedViewsDataSeed.SystemOrganizationId,
+            predefinedSavedViewsByKey.Keys.ToArray(),
+            o => o.SearchAfterPaging().PageLimit(SavedViewPageLimit));
 
         do
         {
-            foreach (var organization in organizations.Documents)
+            foreach (var savedViewsByOrganization in savedViews.Documents.GroupBy(savedView => savedView.OrganizationId))
             {
                 if (context.CancellationToken.IsCancellationRequested)
                     break;
 
-                if (String.Equals(organization.Id, PredefinedSavedViewsDataSeed.SystemOrganizationId, StringComparison.Ordinal))
-                    continue;
+                var updateResult = await UpdateOrganizationSavedViewsAsync(
+                    savedViewsByOrganization.Key,
+                    savedViewsByOrganization.Select(savedView => savedView.Id),
+                    workItem.UserId,
+                    predefinedSavedViewsByKey);
 
-                int updatedForOrganization = await ForceUpdateOrganizationSavedViewsAsync(organization.Id, workItem.UserId, predefinedSavedViewsByKey);
+                int updatedForOrganization = updateResult;
                 if (updatedForOrganization > 0)
                 {
                     organizationsUpdated++;
@@ -69,7 +71,7 @@ public class ForcePredefinedSavedViewsWorkItemHandler : WorkItemHandlerBase
 
                 await context.RenewLockAsync();
             }
-        } while (!context.CancellationToken.IsCancellationRequested && await organizations.NextPageAsync());
+        } while (!context.CancellationToken.IsCancellationRequested && await savedViews.NextPageAsync());
 
         Log.LogInformation(
             "Completed predefined saved view force update. OrganizationsUpdated: {OrganizationsUpdated} SavedViewsUpdated: {SavedViewsUpdated} InitiatedByUserId: {UserId}",
@@ -95,15 +97,16 @@ public class ForcePredefinedSavedViewsWorkItemHandler : WorkItemHandlerBase
         return savedViewsByKey;
     }
 
-    private async Task<int> ForceUpdateOrganizationSavedViewsAsync(
+    private async Task<int> UpdateOrganizationSavedViewsAsync(
         string organizationId,
+        IEnumerable<string> savedViewIds,
         string userId,
         IReadOnlyDictionary<string, SavedView> predefinedSavedViewsByKey)
     {
         int updatedSavedViews = 0;
         bool lockAcquired = await _lockProvider.TryUsingAsync($"predefined-saved-views:{organizationId}", async () =>
         {
-            updatedSavedViews = await ForceUpdateOrganizationSavedViewsWithLockAsync(organizationId, userId, predefinedSavedViewsByKey);
+            updatedSavedViews = await UpdateOrganizationSavedViewsWithLockAsync(organizationId, savedViewIds, userId, predefinedSavedViewsByKey);
         }, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(15));
 
         if (!lockAcquired)
@@ -112,19 +115,21 @@ public class ForcePredefinedSavedViewsWorkItemHandler : WorkItemHandlerBase
         return updatedSavedViews;
     }
 
-    private async Task<int> ForceUpdateOrganizationSavedViewsWithLockAsync(
+    private async Task<int> UpdateOrganizationSavedViewsWithLockAsync(
         string organizationId,
+        IEnumerable<string> savedViewIds,
         string userId,
         IReadOnlyDictionary<string, SavedView> predefinedSavedViewsByKey)
     {
         var savedViewsToSave = new List<SavedView>();
+        var savedViewIdsToUpdate = savedViewIds.ToHashSet(StringComparer.Ordinal);
+        var results = await _savedViewRepository.FindAsync(q => q.Organization(organizationId), o => o.PageLimit(SavedViewPageLimit));
+        var savedViewsByViewType = results.Documents.GroupBy(savedView => savedView.ViewType, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.OrdinalIgnoreCase);
 
-        foreach (string viewType in ValidViewTypes)
+        foreach (var savedViews in savedViewsByViewType.Values)
         {
-            var results = await _savedViewRepository.GetByViewAsync(organizationId, viewType, o => o.PageLimit(SavedViewPageLimit));
-            var savedViews = results.Documents.ToList();
-
-            foreach (var savedView in savedViews)
+            foreach (var savedView in savedViews.Where(savedView => savedViewIdsToUpdate.Contains(savedView.Id)))
             {
                 if (savedView.UserId is not null
                     || String.IsNullOrWhiteSpace(savedView.PredefinedKey)

--- a/src/Exceptionless.Core/Models/SavedView.cs
+++ b/src/Exceptionless.Core/Models/SavedView.cs
@@ -61,6 +61,10 @@ public partial record SavedView : IOwnedByOrganizationWithIdentity, IHaveDates
     [MaxLength(150)]
     public string? PredefinedKey { get; set; }
 
+    /// <summary>Content hash of the predefined configuration last applied to this view.</summary>
+    [MaxLength(64)]
+    public string? PredefinedContentHash { get; set; }
+
     /// <summary>Display name shown in the sidebar and picker.</summary>
     [Required]
     [MaxLength(100)]

--- a/src/Exceptionless.Core/Models/WorkItems/ForcePredefinedSavedViewsWorkItem.cs
+++ b/src/Exceptionless.Core/Models/WorkItems/ForcePredefinedSavedViewsWorkItem.cs
@@ -1,0 +1,10 @@
+using Foundatio.Queues;
+
+namespace Exceptionless.Core.Models.WorkItems;
+
+public record ForcePredefinedSavedViewsWorkItem : IHaveUniqueIdentifier
+{
+    public required string UserId { get; init; }
+
+    public string UniqueIdentifier => nameof(ForcePredefinedSavedViewsWorkItem);
+}

--- a/src/Exceptionless.Core/Models/WorkItems/ForcePredefinedSavedViewsWorkItem.cs
+++ b/src/Exceptionless.Core/Models/WorkItems/ForcePredefinedSavedViewsWorkItem.cs
@@ -6,5 +6,7 @@ public record ForcePredefinedSavedViewsWorkItem : IHaveUniqueIdentifier
 {
     public required string UserId { get; init; }
 
-    public string UniqueIdentifier => nameof(ForcePredefinedSavedViewsWorkItem);
+    public Guid RunId { get; init; } = Guid.NewGuid();
+
+    public string UniqueIdentifier => $"{nameof(ForcePredefinedSavedViewsWorkItem)}:{RunId:N}";
 }

--- a/src/Exceptionless.Core/Repositories/Configuration/Indexes/SavedViewIndex.cs
+++ b/src/Exceptionless.Core/Repositories/Configuration/Indexes/SavedViewIndex.cs
@@ -12,7 +12,7 @@ public sealed class SavedViewIndex : VersionedIndex<Models.SavedView>
 
     private readonly ExceptionlessElasticConfiguration _configuration;
 
-    public SavedViewIndex(ExceptionlessElasticConfiguration configuration) : base(configuration, configuration.Options.ScopePrefix + "saved-views", 1)
+    public SavedViewIndex(ExceptionlessElasticConfiguration configuration) : base(configuration, configuration.Options.ScopePrefix + "saved-views", 2)
     {
         _configuration = configuration;
     }
@@ -27,6 +27,7 @@ public sealed class SavedViewIndex : VersionedIndex<Models.SavedView>
                 .Keyword(e => e.UserId)
                 .Keyword(e => e.CreatedByUserId)
                 .Keyword(e => e.UpdatedByUserId)
+                .Keyword(e => e.PredefinedKey)
                 .Text(e => e.Name, t => t.Analyzer(KEYWORD_LOWERCASE_ANALYZER).AddKeywordField())
                 .Keyword(e => e.ViewType)
                 .IntegerNumber(e => e.Version));

--- a/src/Exceptionless.Core/Repositories/Configuration/Indexes/SavedViewIndex.cs
+++ b/src/Exceptionless.Core/Repositories/Configuration/Indexes/SavedViewIndex.cs
@@ -12,7 +12,7 @@ public sealed class SavedViewIndex : VersionedIndex<Models.SavedView>
 
     private readonly ExceptionlessElasticConfiguration _configuration;
 
-    public SavedViewIndex(ExceptionlessElasticConfiguration configuration) : base(configuration, configuration.Options.ScopePrefix + "saved-views", 2)
+    public SavedViewIndex(ExceptionlessElasticConfiguration configuration) : base(configuration, configuration.Options.ScopePrefix + "saved-views", 3)
     {
         _configuration = configuration;
     }
@@ -27,7 +27,7 @@ public sealed class SavedViewIndex : VersionedIndex<Models.SavedView>
                 .Keyword(e => e.UserId)
                 .Keyword(e => e.CreatedByUserId)
                 .Keyword(e => e.UpdatedByUserId)
-                .Keyword(e => e.PredefinedKey)
+                .Text(e => e.PredefinedKey, t => t.Analyzer(KEYWORD_LOWERCASE_ANALYZER))
                 .Text(e => e.Name, t => t.Analyzer(KEYWORD_LOWERCASE_ANALYZER).AddKeywordField())
                 .Keyword(e => e.ViewType)
                 .IntegerNumber(e => e.Version));

--- a/src/Exceptionless.Core/Repositories/Interfaces/ISavedViewRepository.cs
+++ b/src/Exceptionless.Core/Repositories/Interfaces/ISavedViewRepository.cs
@@ -9,6 +9,7 @@ public interface ISavedViewRepository : IRepositoryOwnedByOrganization<SavedView
     Task<FindResults<SavedView>> GetByViewAsync(string organizationId, string viewType, CommandOptionsDescriptor<SavedView>? options = null);
     Task<FindResults<SavedView>> GetByViewForUserAsync(string organizationId, string viewType, string userId, CommandOptionsDescriptor<SavedView>? options = null);
     Task<FindResults<SavedView>> GetByOrganizationForUserAsync(string organizationId, string userId, CommandOptionsDescriptor<SavedView>? options = null);
+    Task<FindResults<SavedView>> GetPredefinedForForceUpdateAsync(string systemOrganizationId, IReadOnlyCollection<string> predefinedKeys, CommandOptionsDescriptor<SavedView>? options = null);
     Task<long> CountByOrganizationIdAsync(string organizationId);
 
     /// <summary>Removes all private saved views belonging to a specific user within an organization.</summary>

--- a/src/Exceptionless.Core/Repositories/SavedViewRepository.cs
+++ b/src/Exceptionless.Core/Repositories/SavedViewRepository.cs
@@ -53,12 +53,18 @@ public class SavedViewRepository : RepositoryOwnedByOrganization<SavedView>, ISa
         if (predefinedKeys.Count == 0)
             return FindAsync(q => q.FieldEquals(e => e.Id, String.Empty), options);
 
-        return FindAsync(q => q
-            .FieldEmpty(e => e.UserId!)
-            .FieldNotEquals(e => e.OrganizationId, systemOrganizationId)
-            .FieldEquals(e => e.PredefinedKey!, predefinedKeys.ToArray())
-            .SortAscending(e => e.OrganizationId)
-            .SortAscending(e => e.Id), options);
+        return FindAsync(q =>
+        {
+            q.FieldEmpty(e => e.UserId!)
+                .FieldNotEquals(e => e.OrganizationId, systemOrganizationId)
+                .FieldOr(g =>
+                {
+                    foreach (string predefinedKey in predefinedKeys)
+                        g.FieldContains(e => e.PredefinedKey!, predefinedKey);
+                });
+
+            return q.SortAscending(e => e.OrganizationId).SortAscending(e => e.Id);
+        }, options);
     }
 
     public async Task<long> RemovePrivateByUserIdAsync(string organizationId, string userId)

--- a/src/Exceptionless.Core/Repositories/SavedViewRepository.cs
+++ b/src/Exceptionless.Core/Repositories/SavedViewRepository.cs
@@ -42,6 +42,25 @@ public class SavedViewRepository : RepositoryOwnedByOrganization<SavedView>, ISa
                 .FieldEquals(e => e.UserId!, userId)), options);
     }
 
+    public Task<FindResults<SavedView>> GetPredefinedForForceUpdateAsync(
+        string systemOrganizationId,
+        IReadOnlyCollection<string> predefinedKeys,
+        CommandOptionsDescriptor<SavedView>? options = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(systemOrganizationId);
+        ArgumentNullException.ThrowIfNull(predefinedKeys);
+
+        if (predefinedKeys.Count == 0)
+            return FindAsync(q => q.FieldEquals(e => e.Id, String.Empty), options);
+
+        return FindAsync(q => q
+            .FieldEmpty(e => e.UserId!)
+            .FieldNotEquals(e => e.OrganizationId, systemOrganizationId)
+            .FieldEquals(e => e.PredefinedKey!, predefinedKeys.ToArray())
+            .SortAscending(e => e.OrganizationId)
+            .SortAscending(e => e.Id), options);
+    }
+
     public async Task<long> RemovePrivateByUserIdAsync(string organizationId, string userId)
     {
         var results = await FindAsync(q => q

--- a/src/Exceptionless.Core/Seed/PredefinedSavedViewConfiguration.cs
+++ b/src/Exceptionless.Core/Seed/PredefinedSavedViewConfiguration.cs
@@ -1,0 +1,77 @@
+using Exceptionless.Core.Models;
+
+namespace Exceptionless.Core.Seed;
+
+public static class PredefinedSavedViewConfiguration
+{
+    public static bool Apply(SavedView destination, SavedView source, string key, string slug)
+    {
+        bool changed = false;
+        changed |= SetIfChanged(destination, null, static (view, value) => view.UserId = value, static view => view.UserId);
+        changed |= SetIfChanged(destination, key, static (view, value) => view.PredefinedKey = value, static view => view.PredefinedKey);
+        changed |= SetIfChanged(destination, source.Name, static (view, value) => view.Name = value, static view => view.Name);
+        changed |= SetIfChanged(destination, slug, static (view, value) => view.Slug = value, static view => view.Slug);
+        changed |= SetIfChanged(destination, source.ViewType, static (view, value) => view.ViewType = value, static view => view.ViewType);
+        changed |= SetIfChanged(destination, source.Filter, static (view, value) => view.Filter = value, static view => view.Filter);
+        changed |= SetIfChanged(destination, source.Time, static (view, value) => view.Time = value, static view => view.Time);
+        changed |= SetIfChanged(destination, source.Sort, static (view, value) => view.Sort = value, static view => view.Sort);
+        changed |= SetIfChanged(destination, source.FilterDefinitions, static (view, value) => view.FilterDefinitions = value, static view => view.FilterDefinitions);
+        changed |= SetDictionaryIfChanged(destination, source.Columns);
+        changed |= SetListIfChanged(destination, source.ColumnOrder);
+        changed |= SetIfChanged(destination, source.ShowStats, static (view, value) => view.ShowStats = value, static view => view.ShowStats);
+        changed |= SetIfChanged(destination, source.ShowChart, static (view, value) => view.ShowChart = value, static view => view.ShowChart);
+        changed |= SetIfChanged(destination, source.Version, static (view, value) => view.Version = value, static view => view.Version);
+        changed |= SetIfChanged(destination, PredefinedSavedViewContentHasher.GetContentHash(destination), static (view, value) => view.PredefinedContentHash = value, static view => view.PredefinedContentHash);
+
+        return changed;
+    }
+
+    private static bool SetDictionaryIfChanged(SavedView savedView, IReadOnlyDictionary<string, bool>? value)
+    {
+        if (DictionaryEquals(savedView.Columns, value))
+            return false;
+
+        savedView.Columns = value is null ? null : new Dictionary<string, bool>(value);
+        return true;
+    }
+
+    private static bool SetIfChanged<T>(SavedView savedView, T value, Action<SavedView, T> setter, Func<SavedView, T> getter)
+    {
+        if (EqualityComparer<T>.Default.Equals(getter(savedView), value))
+            return false;
+
+        setter(savedView, value);
+        return true;
+    }
+
+    private static bool SetListIfChanged(SavedView savedView, IReadOnlyCollection<string>? value)
+    {
+        if (CollectionEquals(savedView.ColumnOrder, value))
+            return false;
+
+        savedView.ColumnOrder = value is null ? null : [.. value];
+        return true;
+    }
+
+    private static bool CollectionEquals(IReadOnlyCollection<string>? left, IReadOnlyCollection<string>? right)
+    {
+        if (ReferenceEquals(left, right))
+            return true;
+
+        if (left is null || right is null || left.Count != right.Count)
+            return false;
+
+        return left.SequenceEqual(right, StringComparer.Ordinal);
+    }
+
+    private static bool DictionaryEquals(IReadOnlyDictionary<string, bool>? left, IReadOnlyDictionary<string, bool>? right)
+    {
+        if (ReferenceEquals(left, right))
+            return true;
+
+        if (left is null || right is null || left.Count != right.Count)
+            return false;
+
+        return left.All(kvp => right.TryGetValue(kvp.Key, out bool value) && value == kvp.Value);
+    }
+}

--- a/src/Exceptionless.Core/Seed/PredefinedSavedViewContentHasher.cs
+++ b/src/Exceptionless.Core/Seed/PredefinedSavedViewContentHasher.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using Exceptionless.Core.Extensions;
+using Exceptionless.Core.Models;
+
+namespace Exceptionless.Core.Seed;
+
+public static class PredefinedSavedViewContentHasher
+{
+    public static string GetContentHash(SavedView savedView)
+    {
+        ArgumentNullException.ThrowIfNull(savedView);
+
+        return GetContentHash(
+            savedView.Name,
+            savedView.Slug,
+            savedView.ViewType,
+            savedView.Filter,
+            savedView.Time,
+            savedView.Sort,
+            savedView.FilterDefinitions,
+            savedView.Columns,
+            savedView.ColumnOrder,
+            savedView.ShowStats,
+            savedView.ShowChart);
+    }
+
+    public static string GetDefinitionsContentHash(IEnumerable<PredefinedSavedViewDefinition> definitions)
+    {
+        ArgumentNullException.ThrowIfNull(definitions);
+
+        var content = definitions
+            .OrderBy(definition => definition.Key, StringComparer.Ordinal)
+            .Select(definition => new
+            {
+                definition.Key,
+                Hash = GetContentHash(
+                    definition.Name,
+                    definition.Slug,
+                    definition.ViewType,
+                    definition.Filter,
+                    definition.Time,
+                    definition.Sort,
+                    PredefinedSavedViewsDataSeed.GetRawJson(definition.FilterDefinitions),
+                    definition.Columns,
+                    definition.ColumnOrder,
+                    definition.ShowStats,
+                    definition.ShowChart)
+            });
+
+        return SerializeAndHash(content);
+    }
+
+    private static string GetContentHash(
+        string name,
+        string slug,
+        string viewType,
+        string? filter,
+        string? time,
+        string? sort,
+        string? filterDefinitions,
+        IReadOnlyDictionary<string, bool>? columns,
+        IReadOnlyCollection<string>? columnOrder,
+        bool? showStats,
+        bool? showChart)
+    {
+        var content = new
+        {
+            name,
+            slug,
+            viewType,
+            filter,
+            time,
+            sort,
+            filterDefinitions,
+            Columns = columns?.OrderBy(column => column.Key, StringComparer.Ordinal),
+            columnOrder,
+            showStats,
+            showChart
+        };
+
+        return SerializeAndHash(content);
+    }
+
+    private static string SerializeAndHash<T>(T content)
+    {
+        string json = JsonSerializer.Serialize(content);
+        return json.Replace(" ", String.Empty, StringComparison.Ordinal).ToSHA256();
+    }
+}

--- a/src/Exceptionless.Core/Seed/PredefinedSavedViewContentHasher.cs
+++ b/src/Exceptionless.Core/Seed/PredefinedSavedViewContentHasher.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Models;
 
@@ -71,7 +72,7 @@ public static class PredefinedSavedViewContentHasher
             filter,
             time,
             sort,
-            filterDefinitions,
+            filterDefinitions = CanonicalizeFilterDefinitions(filterDefinitions),
             Columns = columns?.OrderBy(column => column.Key, StringComparer.Ordinal),
             columnOrder,
             showStats,
@@ -84,6 +85,21 @@ public static class PredefinedSavedViewContentHasher
     private static string SerializeAndHash<T>(T content)
     {
         string json = JsonSerializer.Serialize(content);
-        return json.Replace(" ", String.Empty, StringComparison.Ordinal).ToSHA256();
+        return json.ToSHA256();
+    }
+
+    private static string? CanonicalizeFilterDefinitions(string? filterDefinitions)
+    {
+        if (String.IsNullOrWhiteSpace(filterDefinitions))
+            return filterDefinitions;
+
+        try
+        {
+            return JsonNode.Parse(filterDefinitions)?.ToJsonString() ?? filterDefinitions;
+        }
+        catch (JsonException)
+        {
+            return filterDefinitions;
+        }
     }
 }

--- a/src/Exceptionless.Core/Seed/PredefinedSavedViewsDataSeed.cs
+++ b/src/Exceptionless.Core/Seed/PredefinedSavedViewsDataSeed.cs
@@ -110,9 +110,53 @@ public class PredefinedSavedViewsDataSeed : IDataSeed
             changed = true;
         }
 
+        if (!String.Equals(existing.Time, definition.Time, StringComparison.Ordinal))
+        {
+            existing.Time = definition.Time;
+            changed = true;
+        }
+
         if (!String.Equals(existing.Sort, definition.Sort, StringComparison.Ordinal))
         {
             existing.Sort = definition.Sort;
+            changed = true;
+        }
+
+        string? filterDefinitions = GetRawJson(definition.FilterDefinitions);
+        if (!String.Equals(existing.FilterDefinitions, filterDefinitions, StringComparison.Ordinal))
+        {
+            existing.FilterDefinitions = filterDefinitions;
+            changed = true;
+        }
+
+        if (!DictionaryEquals(existing.Columns, definition.Columns))
+        {
+            existing.Columns = definition.Columns?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            changed = true;
+        }
+
+        if (!CollectionEquals(existing.ColumnOrder, definition.ColumnOrder))
+        {
+            existing.ColumnOrder = definition.ColumnOrder is null ? null : [.. definition.ColumnOrder];
+            changed = true;
+        }
+
+        if (existing.ShowStats != definition.ShowStats)
+        {
+            existing.ShowStats = definition.ShowStats;
+            changed = true;
+        }
+
+        if (existing.ShowChart != definition.ShowChart)
+        {
+            existing.ShowChart = definition.ShowChart;
+            changed = true;
+        }
+
+        string contentHash = PredefinedSavedViewContentHasher.GetContentHash(existing);
+        if (!String.Equals(existing.PredefinedContentHash, contentHash, StringComparison.Ordinal))
+        {
+            existing.PredefinedContentHash = contentHash;
             changed = true;
         }
 
@@ -134,7 +178,7 @@ public class PredefinedSavedViewsDataSeed : IDataSeed
 
     private static SavedView CreateSavedView(PredefinedSavedViewDefinition definition)
     {
-        return new SavedView
+        var savedView = new SavedView
         {
             OrganizationId = SystemOrganizationId,
             CreatedByUserId = SystemUserId,
@@ -152,6 +196,31 @@ public class PredefinedSavedViewsDataSeed : IDataSeed
             ShowChart = definition.ShowChart,
             Version = 1
         };
+
+        savedView.PredefinedContentHash = PredefinedSavedViewContentHasher.GetContentHash(savedView);
+        return savedView;
+    }
+
+    private static bool CollectionEquals(IReadOnlyCollection<string>? left, IReadOnlyCollection<string>? right)
+    {
+        if (ReferenceEquals(left, right))
+            return true;
+
+        if (left is null || right is null || left.Count != right.Count)
+            return false;
+
+        return left.SequenceEqual(right, StringComparer.Ordinal);
+    }
+
+    private static bool DictionaryEquals(IReadOnlyDictionary<string, bool>? left, IReadOnlyDictionary<string, bool>? right)
+    {
+        if (ReferenceEquals(left, right))
+            return true;
+
+        if (left is null || right is null || left.Count != right.Count)
+            return false;
+
+        return left.All(kvp => right.TryGetValue(kvp.Key, out bool value) && value == kvp.Value);
     }
 
     public static string? GetRawJson(JsonElement? value)

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
@@ -165,6 +165,19 @@ export function postOAuthApplicationMutation() {
     }));
 }
 
+export function postForceUpdatePredefinedSavedViewsMutation() {
+    return createMutation<void, ProblemDetails, void>(() => ({
+        mutationFn: async () => {
+            const client = useFetchClient();
+            const response = await client.post('saved-views/predefined/force-update');
+
+            if (!response.ok) {
+                throw response.problem;
+            }
+        }
+    }));
+}
+
 export function putOAuthApplicationMutation() {
     const queryClient = useQueryClient();
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
@@ -145,6 +145,19 @@ export function getPredefinedSavedViewsMutation() {
     }));
 }
 
+export function postForceUpdatePredefinedSavedViewsMutation() {
+    return createMutation<void, ProblemDetails, void>(() => ({
+        mutationFn: async () => {
+            const client = useFetchClient();
+            const response = await client.post('saved-views/predefined/force-update');
+
+            if (!response.ok) {
+                throw response.problem;
+            }
+        }
+    }));
+}
+
 export function postOAuthApplicationMutation() {
     const queryClient = useQueryClient();
 
@@ -161,19 +174,6 @@ export function postOAuthApplicationMutation() {
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: queryKeys.oauthApplications });
-        }
-    }));
-}
-
-export function postForceUpdatePredefinedSavedViewsMutation() {
-    return createMutation<void, ProblemDetails, void>(() => ({
-        mutationFn: async () => {
-            const client = useFetchClient();
-            const response = await client.post('saved-views/predefined/force-update');
-
-            if (!response.ok) {
-                throw response.problem;
-            }
         }
     }));
 }

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/saved-views/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/saved-views/+page.svelte
@@ -1,10 +1,18 @@
 <script lang="ts">
     import CopyToClipboardButton from '$comp/copy-to-clipboard-button.svelte';
-    import { Button } from '$comp/ui/button';
+    import * as AlertDialog from '$comp/ui/alert-dialog';
+    import { Button, buttonVariants } from '$comp/ui/button';
+    import * as Field from '$comp/ui/field';
+    import { Input } from '$comp/ui/input';
     import { Spinner } from '$comp/ui/spinner';
     import * as Tabs from '$comp/ui/tabs';
     import { Textarea } from '$comp/ui/textarea';
-    import { getOrgSavedViewsExportMutation, getPredefinedSavedViewsMutation, putPredefinedSavedViewsMutation } from '$features/admin/api.svelte';
+    import {
+        getOrgSavedViewsExportMutation,
+        getPredefinedSavedViewsMutation,
+        postForceUpdatePredefinedSavedViewsMutation,
+        putPredefinedSavedViewsMutation
+    } from '$features/admin/api.svelte';
     import { organization } from '$features/organizations/context.svelte';
     import { ProblemDetails } from '@exceptionless/fetchclient';
     import Save from '@lucide/svelte/icons/save';
@@ -13,12 +21,17 @@
 
     let predefinedJson = $state('');
     let predefinedTab = $state('config');
+    let savedPredefinedJson = $state('');
+    let forceUpdateOpen = $state(false);
+    let forceUpdateConfirmation = $state('');
     let toastId = $state<number | string>();
 
     const predefinedSavedViews = getPredefinedSavedViewsMutation();
     const organizationExport = getOrgSavedViewsExportMutation();
     const savePredefined = putPredefinedSavedViewsMutation();
+    const forceUpdatePredefined = postForceUpdatePredefinedSavedViewsMutation();
     const organizationId = $derived(organization.current ?? '');
+    const hasUnsavedPredefinedChanges = $derived(predefinedTab === 'config' && predefinedJson !== savedPredefinedJson);
 
     function getErrorMessage(error: unknown, fallback: string) {
         return error instanceof ProblemDetails ? error.title : fallback;
@@ -29,6 +42,7 @@
 
         try {
             predefinedJson = await predefinedSavedViews.mutateAsync();
+            savedPredefinedJson = predefinedJson;
         } catch (error: unknown) {
             toastId = toast.error(`An error occurred while loading predefined saved views: ${getErrorMessage(error, 'Please try again.')}`);
         }
@@ -53,6 +67,7 @@
 
         try {
             predefinedJson = await savePredefined.mutateAsync(predefinedJson);
+            savedPredefinedJson = predefinedJson;
             toastId = toast.success('Predefined saved views updated successfully.');
         } catch (error: unknown) {
             toastId = toast.error(`An error occurred while saving predefined saved views: ${getErrorMessage(error, 'Please try again.')}`);
@@ -65,6 +80,25 @@
             void loadPredefinedSavedViews();
         } else {
             void loadOrganizationViews();
+        }
+    }
+
+    $effect(() => {
+        if (!forceUpdateOpen) {
+            forceUpdateConfirmation = '';
+        }
+    });
+
+    async function handleForceUpdatePredefined() {
+        toast.dismiss(toastId);
+
+        try {
+            await forceUpdatePredefined.mutateAsync();
+            forceUpdateOpen = false;
+            forceUpdateConfirmation = '';
+            toastId = toast.success('Force update of matching organization saved views was queued.');
+        } catch (error: unknown) {
+            toastId = toast.error(`An error occurred while queuing the force update: ${getErrorMessage(error, 'Please try again.')}`);
         }
     }
 
@@ -89,7 +123,16 @@
 
     <Textarea bind:value={predefinedJson} class="font-mono text-xs max-h-[60vh] min-h-96 overflow-auto" rows={24} spellcheck={false} />
 
-    <div class="flex justify-end">
+    <div class="flex flex-col justify-end gap-2 sm:flex-row">
+        <Button
+            variant="destructive"
+            disabled={forceUpdatePredefined.isPending || savePredefined.isPending || hasUnsavedPredefinedChanges}
+            onclick={() => {
+                forceUpdateOpen = true;
+            }}
+        >
+            Force Update
+        </Button>
         <Button
             disabled={savePredefined.isPending || !predefinedJson.trim()}
             onclick={() => {
@@ -106,3 +149,33 @@
         </Button>
     </div>
 </div>
+
+<AlertDialog.Root bind:open={forceUpdateOpen}>
+    <AlertDialog.Content>
+        <AlertDialog.Header>
+            <AlertDialog.Title>Force Update Matching Organization Saved Views</AlertDialog.Title>
+            <AlertDialog.Description>
+                This queues a background job that overwrites every organization-wide saved view whose predefined key matches a saved system definition. It discards
+                customizations to those views. Private, unmatched, and missing views are not changed. Unsaved JSON edits are not included.
+            </AlertDialog.Description>
+        </AlertDialog.Header>
+
+        <div class="py-4">
+            <Field.Field>
+                <Field.Label for="force-update-confirmation">Type FORCE to confirm</Field.Label>
+                <Input id="force-update-confirmation" bind:value={forceUpdateConfirmation} autocomplete="off" placeholder="FORCE" />
+            </Field.Field>
+        </div>
+
+        <AlertDialog.Footer>
+            <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+            <AlertDialog.Action
+                class={buttonVariants({ variant: 'destructive' })}
+                disabled={forceUpdatePredefined.isPending || forceUpdateConfirmation !== 'FORCE'}
+                onclick={handleForceUpdatePredefined}
+            >
+                {forceUpdatePredefined.isPending ? 'Queuing...' : 'Force Update'}
+            </AlertDialog.Action>
+        </AlertDialog.Footer>
+    </AlertDialog.Content>
+</AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/saved-views/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/saved-views/+page.svelte
@@ -155,8 +155,8 @@
         <AlertDialog.Header>
             <AlertDialog.Title>Force Update Matching Organization Saved Views</AlertDialog.Title>
             <AlertDialog.Description>
-                This queues a background job that overwrites every organization-wide saved view whose predefined key matches a saved system definition. It discards
-                customizations to those views. Private, unmatched, and missing views are not changed. Unsaved JSON edits are not included.
+                This queues a background job that overwrites every organization-wide saved view whose predefined key matches a saved system definition. It
+                discards customizations to those views. Private, unmatched, and missing views are not changed. Unsaved JSON edits are not included.
             </AlertDialog.Description>
         </AlertDialog.Header>
 

--- a/src/Exceptionless.Web/Controllers/SavedViewController.cs
+++ b/src/Exceptionless.Web/Controllers/SavedViewController.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using Exceptionless.Core.Authorization;
 using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Models;
+using Exceptionless.Core.Models.WorkItems;
 using Exceptionless.Core.Queries.Validation;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Seed;
@@ -11,7 +12,9 @@ using Exceptionless.Web.Controllers;
 using Exceptionless.Web.Mapping;
 using Exceptionless.Web.Models;
 using Exceptionless.Web.Utility;
+using Foundatio.Jobs;
 using Foundatio.Lock;
+using Foundatio.Queues;
 using Foundatio.Repositories;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -24,16 +27,18 @@ namespace Exceptionless.App.Controllers.API;
 public partial class SavedViewController : RepositoryApiController<ISavedViewRepository, SavedView, ViewSavedView, NewSavedView, UpdateSavedView>
 {
     private const int MaxViewsPerOrganization = 100;
+    private const string PredefinedSavedViewsContentHashDataKey = "@@PredefinedSavedViewsContentHash";
     private const string PredefinedSavedViewsDataKey = "@@PredefinedSavedViewsVersion";
-    private const int PredefinedSavedViewsVersion = 1;
 
     private readonly IOrganizationRepository _organizationRepository;
     private readonly ILockProvider _lockProvider;
+    private readonly IQueue<WorkItemData> _workItemQueue;
 
     public SavedViewController(
         ISavedViewRepository repository,
         IOrganizationRepository organizationRepository,
         ILockProvider lockProvider,
+        IQueue<WorkItemData> workItemQueue,
         ApiMapper mapper,
         IAppQueryValidator validator,
         TimeProvider timeProvider,
@@ -41,6 +46,7 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
     {
         _organizationRepository = organizationRepository;
         _lockProvider = lockProvider;
+        _workItemQueue = workItemQueue;
     }
 
     protected override SavedView MapToModel(NewSavedView newModel)
@@ -156,7 +162,7 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
         if (!IsInOrganization(organizationId))
             return NotFound();
 
-        var savedViews = await UpsertPredefinedSavedViewsAsync(organizationId);
+        var savedViews = await UpsertPredefinedSavedViewsAsync(organizationId, true);
         return Ok(MapToViewModels(savedViews));
     }
 
@@ -236,10 +242,40 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
         })
             .ToList();
 
+        foreach (var savedView in savedViews)
+            savedView.PredefinedContentHash = PredefinedSavedViewContentHasher.GetContentHash(savedView);
+
         if (savedViews.Count > 0)
             await _repository.AddAsync(savedViews, o => o.Cache().ImmediateConsistency());
 
         return Ok(await GetPredefinedSavedViewsAsync());
+    }
+
+    /// <summary>
+    /// Force update organization saved views that match a predefined saved view key
+    /// </summary>
+    /// <response code="202">The predefined saved view force update was queued.</response>
+    /// <response code="422">The predefined saved view definitions contain duplicate keys.</response>
+    [HttpPost("predefined/force-update")]
+    [Authorize(Policy = AuthorizationRoles.GlobalAdminPolicy)]
+    [ProducesResponseType<WorkInProgressResult>(StatusCodes.Status202Accepted)]
+    public async Task<ActionResult<WorkInProgressResult>> PostForceUpdatePredefinedAsync()
+    {
+        var definitions = await GetPredefinedSavedViewsAsync();
+        if (definitions.Count == 0)
+        {
+            ModelState.AddModelError(nameof(definitions), "At least one predefined saved view is required before forcing an update.");
+            return ValidationProblem(ModelState);
+        }
+
+        if (definitions.GroupBy(definition => definition.Key, StringComparer.OrdinalIgnoreCase).Any(group => group.Count() > 1))
+        {
+            ModelState.AddModelError(nameof(definitions), "Predefined saved view keys must be unique before forcing an update.");
+            return ValidationProblem(ModelState);
+        }
+
+        string workItemId = await _workItemQueue.EnqueueAsync(new ForcePredefinedSavedViewsWorkItem { UserId = CurrentUser.Id });
+        return WorkInProgress([workItemId]);
     }
 
     /// <summary>
@@ -490,13 +526,29 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
     private async Task EnsurePredefinedSavedViewsCreatedAsync(string organizationId)
     {
         var organization = await _organizationRepository.GetByIdAsync(organizationId);
-        if (organization is null || HasCreatedPredefinedSavedViews(organization))
+        if (organization is null)
             return;
 
-        await UpsertPredefinedSavedViewsAsync(organizationId, true);
+        var definitions = await GetPredefinedSavedViewsAsync();
+        string definitionsContentHash = PredefinedSavedViewContentHasher.GetDefinitionsContentHash(definitions);
+        if (HasSynchronizedPredefinedSavedViews(organization, definitionsContentHash))
+            return;
+
+        await UpsertPredefinedSavedViewsAsync(organizationId, definitions, definitionsContentHash);
     }
 
-    private async Task<IReadOnlyCollection<SavedView>> UpsertPredefinedSavedViewsAsync(string organizationId, bool onlyIfNeverCreated = false)
+    private async Task<IReadOnlyCollection<SavedView>> UpsertPredefinedSavedViewsAsync(string organizationId, bool forceCreateMissing = false)
+    {
+        var definitions = await GetPredefinedSavedViewsAsync();
+        string definitionsContentHash = PredefinedSavedViewContentHasher.GetDefinitionsContentHash(definitions);
+        return await UpsertPredefinedSavedViewsAsync(organizationId, definitions, definitionsContentHash, forceCreateMissing);
+    }
+
+    private async Task<IReadOnlyCollection<SavedView>> UpsertPredefinedSavedViewsAsync(
+        string organizationId,
+        IReadOnlyCollection<PredefinedSavedViewDefinition> definitions,
+        string definitionsContentHash,
+        bool forceCreateMissing = false)
     {
         List<SavedView> savedViews = [];
 
@@ -506,30 +558,33 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
             if (organization is null)
                 return;
 
-            if (onlyIfNeverCreated && HasCreatedPredefinedSavedViews(organization))
+            if (!forceCreateMissing && HasSynchronizedPredefinedSavedViews(organization, definitionsContentHash))
             {
-                savedViews = await GetExistingPredefinedSavedViewsForOrganizationAsync(organizationId);
+                savedViews = await GetExistingPredefinedSavedViewsForOrganizationAsync(organizationId, definitions);
                 return;
             }
 
-            savedViews = await UpsertPredefinedSavedViewsForOrganizationAsync(organizationId);
+            bool createMissing = forceCreateMissing || !HasCreatedPredefinedSavedViews(organization);
+            savedViews = await UpsertPredefinedSavedViewsForOrganizationAsync(organizationId, definitions, createMissing);
             organization.Data ??= new DataDictionary();
-            organization.Data[PredefinedSavedViewsDataKey] = PredefinedSavedViewsVersion.ToString();
+            organization.Data[PredefinedSavedViewsContentHashDataKey] = definitionsContentHash;
             await _organizationRepository.SaveAsync(organization, o => o.Cache().ImmediateConsistency());
         }, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(15));
 
         if (!lockAcquired)
-            return await GetExistingPredefinedSavedViewsForOrganizationAsync(organizationId);
+            return await GetExistingPredefinedSavedViewsForOrganizationAsync(organizationId, definitions);
 
         return savedViews;
     }
 
-    private async Task<List<SavedView>> UpsertPredefinedSavedViewsForOrganizationAsync(string organizationId)
+    private async Task<List<SavedView>> UpsertPredefinedSavedViewsForOrganizationAsync(
+        string organizationId,
+        IReadOnlyCollection<PredefinedSavedViewDefinition> definitions,
+        bool createMissing)
     {
         var savedViewsByView = new Dictionary<string, List<SavedView>>(StringComparer.OrdinalIgnoreCase);
         var upserted = new List<SavedView>();
 
-        var definitions = await GetPredefinedSavedViewsAsync();
         foreach (var definition in definitions)
         {
             if (!savedViewsByView.TryGetValue(definition.ViewType, out var existingViews))
@@ -544,6 +599,9 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
 
             if (existing is null)
             {
+                if (!createMissing)
+                    continue;
+
                 var savedView = CreatePredefinedSavedView(organizationId, definition, slug);
                 await _repository.AddAsync(savedView, o => o.Cache().ImmediateConsistency());
                 existingViews.Add(savedView);
@@ -551,7 +609,7 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
                 continue;
             }
 
-            if (ApplyPredefinedSavedView(existing, definition, slug))
+            if (CanApplyPredefinedSavedView(existing) && ApplyPredefinedSavedView(existing, definition, slug))
             {
                 existing.UpdatedByUserId = CurrentUser.Id;
                 await _repository.SaveAsync(existing, o => o.Cache().ImmediateConsistency());
@@ -563,12 +621,14 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
         return upserted;
     }
 
-    private async Task<List<SavedView>> GetExistingPredefinedSavedViewsForOrganizationAsync(string organizationId)
+    private async Task<List<SavedView>> GetExistingPredefinedSavedViewsForOrganizationAsync(
+        string organizationId,
+        IReadOnlyCollection<PredefinedSavedViewDefinition>? definitions = null)
     {
         var savedViewsByView = new Dictionary<string, List<SavedView>>(StringComparer.OrdinalIgnoreCase);
         var existingPredefinedViews = new List<SavedView>();
 
-        var definitions = await GetPredefinedSavedViewsAsync();
+        definitions ??= await GetPredefinedSavedViewsAsync();
         foreach (var definition in definitions)
         {
             if (!savedViewsByView.TryGetValue(definition.ViewType, out var existingViews))
@@ -594,15 +654,25 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
 
     private static bool HasCreatedPredefinedSavedViews(Organization organization)
     {
-        if (organization.Data is null || !organization.Data.TryGetValue(PredefinedSavedViewsDataKey, out object? versionValue))
+        if (organization.Data is null)
             return false;
 
-        return Int32.TryParse(versionValue?.ToString(), out int version) && version >= PredefinedSavedViewsVersion;
+        return organization.Data.ContainsKey(PredefinedSavedViewsContentHashDataKey)
+            || organization.Data.TryGetValue(PredefinedSavedViewsDataKey, out object? versionValue)
+                && Int32.TryParse(versionValue?.ToString(), out int version)
+                && version > 0;
+    }
+
+    private static bool HasSynchronizedPredefinedSavedViews(Organization organization, string definitionsContentHash)
+    {
+        return organization.Data is not null
+            && organization.Data.TryGetValue(PredefinedSavedViewsContentHashDataKey, out object? contentHash)
+            && String.Equals(contentHash?.ToString(), definitionsContentHash, StringComparison.Ordinal);
     }
 
     private SavedView CreatePredefinedSavedView(string organizationId, PredefinedSavedViewDefinition definition, string slug)
     {
-        return new SavedView
+        var savedView = new SavedView
         {
             OrganizationId = organizationId,
             CreatedByUserId = CurrentUser.Id,
@@ -620,6 +690,9 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
             ShowChart = definition.ShowChart,
             Version = 1
         };
+
+        savedView.PredefinedContentHash = PredefinedSavedViewContentHasher.GetContentHash(savedView);
+        return savedView;
     }
 
     private static bool ApplyPredefinedSavedView(SavedView savedView, PredefinedSavedViewDefinition definition, string slug)
@@ -637,8 +710,21 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
         changed |= SetIfChanged(savedView, definition.ShowStats, static (view, value) => view.ShowStats = value, static view => view.ShowStats);
         changed |= SetIfChanged(savedView, definition.ShowChart, static (view, value) => view.ShowChart = value, static view => view.ShowChart);
         changed |= SetIfChanged(savedView, 1, static (view, value) => view.Version = value, static view => view.Version);
+        changed |= SetIfChanged(savedView, PredefinedSavedViewContentHasher.GetContentHash(savedView), static (view, value) => view.PredefinedContentHash = value, static view => view.PredefinedContentHash);
 
         return changed;
+    }
+
+    private static bool CanApplyPredefinedSavedView(SavedView savedView)
+    {
+        if (String.IsNullOrWhiteSpace(savedView.PredefinedContentHash))
+            // Pre-hash views have no baseline to compare. Preserve legacy views that were explicitly updated.
+            return savedView.UpdatedByUserId is null;
+
+        return String.Equals(
+            savedView.PredefinedContentHash,
+            PredefinedSavedViewContentHasher.GetContentHash(savedView),
+            StringComparison.Ordinal);
     }
 
     private async Task<SavedView> UpsertSystemPredefinedSavedViewAsync(SavedView source)
@@ -677,19 +763,7 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
 
     private static void ApplySavedViewConfiguration(SavedView destination, SavedView source, string key, string slug)
     {
-        destination.UserId = null;
-        destination.PredefinedKey = key;
-        destination.Name = source.Name;
-        destination.Slug = slug;
-        destination.ViewType = source.ViewType;
-        destination.Filter = source.Filter;
-        destination.Time = source.Time;
-        destination.Sort = source.Sort;
-        destination.FilterDefinitions = source.FilterDefinitions;
-        destination.Columns = Copy(source.Columns);
-        destination.ColumnOrder = source.ColumnOrder is null ? null : [.. source.ColumnOrder];
-        destination.ShowStats = source.ShowStats;
-        destination.ShowChart = source.ShowChart;
+        PredefinedSavedViewConfiguration.Apply(destination, source, key, slug);
     }
 
     private async Task<IReadOnlyCollection<PredefinedSavedViewDefinition>> GetPredefinedSavedViewsAsync()

--- a/src/Exceptionless.Web/Controllers/SavedViewController.cs
+++ b/src/Exceptionless.Web/Controllers/SavedViewController.cs
@@ -565,10 +565,15 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
             }
 
             bool createMissing = forceCreateMissing || !HasCreatedPredefinedSavedViews(organization);
-            savedViews = await UpsertPredefinedSavedViewsForOrganizationAsync(organizationId, definitions, createMissing);
-            organization.Data ??= new DataDictionary();
-            organization.Data[PredefinedSavedViewsContentHashDataKey] = definitionsContentHash;
-            await _organizationRepository.SaveAsync(organization, o => o.Cache().ImmediateConsistency());
+            var upsertResult = await UpsertPredefinedSavedViewsForOrganizationAsync(organizationId, definitions, createMissing);
+            savedViews = upsertResult.SavedViews;
+
+            if (!upsertResult.HasSkippedCustomizations)
+            {
+                organization.Data ??= new DataDictionary();
+                organization.Data[PredefinedSavedViewsContentHashDataKey] = definitionsContentHash;
+                await _organizationRepository.SaveAsync(organization, o => o.Cache().ImmediateConsistency());
+            }
         }, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(15));
 
         if (!lockAcquired)
@@ -577,13 +582,14 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
         return savedViews;
     }
 
-    private async Task<List<SavedView>> UpsertPredefinedSavedViewsForOrganizationAsync(
+    private async Task<(List<SavedView> SavedViews, bool HasSkippedCustomizations)> UpsertPredefinedSavedViewsForOrganizationAsync(
         string organizationId,
         IReadOnlyCollection<PredefinedSavedViewDefinition> definitions,
         bool createMissing)
     {
         var savedViewsByView = new Dictionary<string, List<SavedView>>(StringComparer.OrdinalIgnoreCase);
         var upserted = new List<SavedView>();
+        bool hasSkippedCustomizations = false;
 
         foreach (var definition in definitions)
         {
@@ -609,7 +615,11 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
                 continue;
             }
 
-            if (CanApplyPredefinedSavedView(existing) && ApplyPredefinedSavedView(existing, definition, slug))
+            if (!CanApplyPredefinedSavedView(existing))
+            {
+                hasSkippedCustomizations = true;
+            }
+            else if (ApplyPredefinedSavedView(existing, definition, slug))
             {
                 existing.UpdatedByUserId = CurrentUser.Id;
                 await _repository.SaveAsync(existing, o => o.Cache().ImmediateConsistency());
@@ -618,7 +628,7 @@ public partial class SavedViewController : RepositoryApiController<ISavedViewRep
             upserted.Add(existing);
         }
 
-        return upserted;
+        return (upserted, hasSkippedCustomizations);
     }
 
     private async Task<List<SavedView>> GetExistingPredefinedSavedViewsForOrganizationAsync(

--- a/tests/Exceptionless.Tests/Controllers/Data/controller-manifest.json
+++ b/tests/Exceptionless.Tests/Controllers/Data/controller-manifest.json
@@ -2432,6 +2432,22 @@
   },
   {
     "Controller": "SavedViewController",
+    "Action": "PostForceUpdatePredefinedAsync",
+    "HttpMethod": "POST",
+    "Route": "/api/v2/saved-views/predefined/force-update",
+    "Authorization": [
+      "Authorize(Policy=GlobalAdminPolicy)",
+      "Authorize(Policy=UserPolicy)"
+    ],
+    "Consumes": [],
+    "Produces": [
+      "application/json",
+      "application/problem\u002Bjson"
+    ],
+    "ExcludeFromDescription": false
+  },
+  {
+    "Controller": "SavedViewController",
     "Action": "GetAsync",
     "HttpMethod": "GET",
     "Route": "/api/v2/saved-views/{id:objectid}",

--- a/tests/Exceptionless.Tests/Controllers/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Controllers/Data/openapi.json
@@ -503,6 +503,29 @@
         }
       }
     },
+    "/api/v2/saved-views/predefined/force-update": {
+      "post": {
+        "tags": [
+          "SavedView"
+        ],
+        "summary": "Force update organization saved views that match a predefined saved view key",
+        "responses": {
+          "202": {
+            "description": "The predefined saved view force update was queued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkInProgressResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The predefined saved view definitions contain duplicate keys."
+          }
+        }
+      }
+    },
     "/api/v2/saved-views/{id}/predefined": {
       "post": {
         "tags": [

--- a/tests/Exceptionless.Tests/Controllers/SavedViewControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/SavedViewControllerTests.cs
@@ -7,8 +7,10 @@ using Exceptionless.Core.Services;
 using Exceptionless.Core.Utility;
 using Exceptionless.Tests.Extensions;
 using Exceptionless.Tests.Utility;
+using Exceptionless.Web.Controllers;
 using Exceptionless.Web.Models;
 using FluentRest;
+using Foundatio.Jobs;
 using Foundatio.Repositories;
 using Xunit;
 
@@ -138,6 +140,92 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
         return SendRequestAsync(r => r
             .AsTestOrganizationUser()
             .AppendPaths("saved-views", "predefined")
+            .StatusCodeShouldBeForbidden()
+        );
+    }
+
+    [Fact]
+    public async Task PostForceUpdatePredefinedAsync_GlobalAdmin_OverwritesMatchingOrganizationSavedViews()
+    {
+        // Arrange
+        var predefinedViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views", "predefined")
+            .StatusCodeShouldBeOk()
+        );
+
+        Assert.NotNull(predefinedViews);
+        var logs = predefinedViews.First(view => IsPredefinedSavedView(view, "events", "Logs"));
+        var savedLogs = await _savedViewRepository.GetByIdAsync(logs.Id);
+        Assert.NotNull(savedLogs);
+        savedLogs.PredefinedKey = "EVENTS:LOGS";
+        savedLogs.Filter = "type:error";
+        savedLogs.Slug = "custom-logs";
+        await _savedViewRepository.SaveAsync(savedLogs, o => o.ImmediateConsistency());
+
+        var testUser = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_ORG_USER_EMAIL);
+        Assert.NotNull(testUser);
+        var privateLogs = await _savedViewRepository.AddAsync(new SavedView
+        {
+            OrganizationId = SampleDataService.TEST_ORG_ID,
+            UserId = testUser.Id,
+            CreatedByUserId = testUser.Id,
+            PredefinedKey = "events:logs",
+            Name = "Private Logs",
+            Slug = "private-logs",
+            ViewType = "events",
+            Filter = "type:error"
+        }, o => o.ImmediateConsistency());
+
+        var legacyLogs = await _savedViewRepository.AddAsync(new SavedView
+        {
+            OrganizationId = SampleDataService.TEST_ORG_ID,
+            CreatedByUserId = testUser.Id,
+            Name = "Legacy Logs",
+            Slug = "legacy-logs",
+            ViewType = "events",
+            Filter = "type:error"
+        }, o => o.ImmediateConsistency());
+
+        await RefreshDataAsync();
+
+        // Act
+        var workItems = await SendRequestAsAsync<WorkInProgressResult>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPaths("saved-views", "predefined", "force-update")
+            .StatusCodeShouldBeAccepted()
+        );
+
+        Assert.NotNull(workItems);
+        Assert.NotEmpty(workItems.Workers);
+        await GetService<WorkItemJob>().RunUntilEmptyAsync(TestCancellationToken);
+        await RefreshDataAsync();
+
+        // Assert
+        var updatedLogs = await _savedViewRepository.GetByIdAsync(logs.Id);
+        Assert.NotNull(updatedLogs);
+        Assert.Equal("type:log (status:open OR status:regressed)", updatedLogs.Filter);
+        Assert.Equal("logs", updatedLogs.Slug);
+        Assert.Equal(PredefinedSavedViewContentHasher.GetContentHash(updatedLogs), updatedLogs.PredefinedContentHash);
+
+        var unchangedPrivateLogs = await _savedViewRepository.GetByIdAsync(privateLogs.Id);
+        Assert.NotNull(unchangedPrivateLogs);
+        Assert.Equal("type:error", unchangedPrivateLogs.Filter);
+
+        var unchangedLegacyLogs = await _savedViewRepository.GetByIdAsync(legacyLogs.Id);
+        Assert.NotNull(unchangedLegacyLogs);
+        Assert.Equal("type:error", unchangedLegacyLogs.Filter);
+    }
+
+    [Fact]
+    public Task PostForceUpdatePredefinedAsync_User_ReturnsForbidden()
+    {
+        return SendRequestAsync(r => r
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPaths("saved-views", "predefined", "force-update")
             .StatusCodeShouldBeForbidden()
         );
     }
@@ -672,7 +760,7 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task PostPredefinedAsync_ExistingViews_UpdatesByNameAndViewTypeAndPreservesCustomViews()
+    public async Task PostPredefinedAsync_ExistingModifiedPredefinedView_PreservesCustomConfiguration()
     {
         // Arrange
         var predefinedViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
@@ -720,10 +808,93 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
         var updatedLogs = updatedPredefinedViews.FirstOrDefault(view => IsPredefinedSavedView(view, "events", "Logs"));
         Assert.NotNull(updatedLogs);
         Assert.Equal(logs.Id, updatedLogs.Id);
-        Assert.Equal("type:log (status:open OR status:regressed)", updatedLogs.Filter);
-        Assert.Equal("logs", updatedLogs.Slug);
+        Assert.Equal("type:error", updatedLogs.Filter);
+        Assert.Equal("legacy-logs", updatedLogs.Slug);
 
         Assert.NotNull(await _savedViewRepository.GetByIdAsync(customView.Id));
+    }
+
+    [Fact]
+    public async Task GetByOrganizationAsync_PredefinedDefinitionChanges_UpdatesUnmodifiedView()
+    {
+        // Arrange
+        var initialViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views")
+            .StatusCodeShouldBeOk()
+        );
+
+        Assert.NotNull(initialViews);
+        var logs = initialViews.First(view => IsPredefinedSavedView(view, "events", "Logs"));
+        var systemLogs = (await GetSystemPredefinedSavedViewsAsync()).First(view => String.Equals(view.PredefinedKey, "events:logs", StringComparison.Ordinal));
+        systemLogs.Filter = "type:log level:warn";
+        systemLogs.PredefinedContentHash = PredefinedSavedViewContentHasher.GetContentHash(systemLogs);
+        await _savedViewRepository.SaveAsync(systemLogs, o => o.ImmediateConsistency());
+        await RefreshDataAsync();
+
+        // Act
+        var updatedViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(updatedViews);
+        var updatedLogs = updatedViews.First(view => view.Id == logs.Id);
+        Assert.Equal("type:log level:warn", updatedLogs.Filter);
+
+        var savedLogs = await _savedViewRepository.GetByIdAsync(logs.Id);
+        Assert.NotNull(savedLogs);
+        Assert.Equal(PredefinedSavedViewContentHasher.GetContentHash(savedLogs), savedLogs.PredefinedContentHash);
+    }
+
+    [Fact]
+    public async Task GetByOrganizationAsync_PredefinedDefinitionChanges_UpdatesViewRevertedToBaseline()
+    {
+        // Arrange
+        var initialViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views")
+            .StatusCodeShouldBeOk()
+        );
+
+        Assert.NotNull(initialViews);
+        var logs = initialViews.First(view => IsPredefinedSavedView(view, "events", "Logs"));
+
+        await SendRequestAsync(r => r
+            .Patch()
+            .AsTestOrganizationUser()
+            .AppendPaths("saved-views", logs.Id)
+            .Content(new UpdateSavedView { Filter = "type:error" })
+            .StatusCodeShouldBeOk()
+        );
+
+        await SendRequestAsync(r => r
+            .Patch()
+            .AsTestOrganizationUser()
+            .AppendPaths("saved-views", logs.Id)
+            .Content(new UpdateSavedView { Filter = "type:log (status:open OR status:regressed)" })
+            .StatusCodeShouldBeOk()
+        );
+
+        var systemLogs = (await GetSystemPredefinedSavedViewsAsync()).First(view => String.Equals(view.PredefinedKey, "events:logs", StringComparison.Ordinal));
+        systemLogs.Filter = "type:log level:warn";
+        systemLogs.PredefinedContentHash = PredefinedSavedViewContentHasher.GetContentHash(systemLogs);
+        await _savedViewRepository.SaveAsync(systemLogs, o => o.ImmediateConsistency());
+        await RefreshDataAsync();
+
+        // Act
+        var updatedViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(updatedViews);
+        var updatedLogs = updatedViews.First(view => view.Id == logs.Id);
+        Assert.Equal("type:log level:warn", updatedLogs.Filter);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Controllers/SavedViewControllerTests.cs
+++ b/tests/Exceptionless.Tests/Controllers/SavedViewControllerTests.cs
@@ -898,6 +898,63 @@ public sealed class SavedViewControllerTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task GetByOrganizationAsync_PredefinedDefinitionChanges_UpdatesViewRevertedAfterSkippedSync()
+    {
+        // Arrange
+        var initialViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views")
+            .StatusCodeShouldBeOk()
+        );
+
+        Assert.NotNull(initialViews);
+        var logs = initialViews.First(view => IsPredefinedSavedView(view, "events", "Logs"));
+
+        await SendRequestAsync(r => r
+            .Patch()
+            .AsTestOrganizationUser()
+            .AppendPaths("saved-views", logs.Id)
+            .Content(new UpdateSavedView { Filter = "type:error" })
+            .StatusCodeShouldBeOk()
+        );
+
+        var systemLogs = (await GetSystemPredefinedSavedViewsAsync()).First(view => String.Equals(view.PredefinedKey, "events:logs", StringComparison.Ordinal));
+        systemLogs.Filter = "type:log level:warn";
+        systemLogs.PredefinedContentHash = PredefinedSavedViewContentHasher.GetContentHash(systemLogs);
+        await _savedViewRepository.SaveAsync(systemLogs, o => o.ImmediateConsistency());
+        await RefreshDataAsync();
+
+        var customizedViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views")
+            .StatusCodeShouldBeOk()
+        );
+
+        Assert.NotNull(customizedViews);
+        Assert.Equal("type:error", customizedViews.First(view => view.Id == logs.Id).Filter);
+
+        await SendRequestAsync(r => r
+            .Patch()
+            .AsTestOrganizationUser()
+            .AppendPaths("saved-views", logs.Id)
+            .Content(new UpdateSavedView { Filter = "type:log (status:open OR status:regressed)" })
+            .StatusCodeShouldBeOk()
+        );
+        await RefreshDataAsync();
+
+        // Act
+        var updatedViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views")
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(updatedViews);
+        Assert.Equal("type:log level:warn", updatedViews.First(view => view.Id == logs.Id).Filter);
+    }
+
+    [Fact]
     public Task PostPredefinedAsync_CrossOrganization_ReturnsNotFound()
     {
         return SendRequestAsync(r => r

--- a/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/ForcePredefinedSavedViewsWorkItemTests.cs
+++ b/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/ForcePredefinedSavedViewsWorkItemTests.cs
@@ -1,0 +1,26 @@
+using Exceptionless.Core.Models.WorkItems;
+using Xunit;
+
+namespace Exceptionless.Tests.Jobs.WorkItemHandlers;
+
+public class ForcePredefinedSavedViewsWorkItemTests
+{
+    [Fact]
+    public void UniqueIdentifier_WhenForceUpdatesUseDifferentRunIds_IsDifferent()
+    {
+        // Arrange
+        var first = new ForcePredefinedSavedViewsWorkItem
+        {
+            UserId = "user-id",
+            RunId = Guid.Parse("11111111-1111-1111-1111-111111111111")
+        };
+        var second = new ForcePredefinedSavedViewsWorkItem
+        {
+            UserId = "user-id",
+            RunId = Guid.Parse("22222222-2222-2222-2222-222222222222")
+        };
+
+        // Act & Assert
+        Assert.NotEqual(first.UniqueIdentifier, second.UniqueIdentifier);
+    }
+}

--- a/tests/Exceptionless.Tests/Seed/PredefinedSavedViewContentHasherTests.cs
+++ b/tests/Exceptionless.Tests/Seed/PredefinedSavedViewContentHasherTests.cs
@@ -1,0 +1,45 @@
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Seed;
+using Xunit;
+
+namespace Exceptionless.Tests.Seed;
+
+public sealed class PredefinedSavedViewContentHasherTests
+{
+    [Fact]
+    public void GetContentHash_ConfigurationDiffersOnlyBySpacesAndDictionaryInsertionOrder_ReturnsSameHash()
+    {
+        // Arrange
+        var original = new SavedView
+        {
+            Name = "Logs",
+            Slug = "logs",
+            ViewType = "events",
+            Filter = "type:log (status:open OR status:regressed)",
+            FilterDefinitions = """[{"type":"status","value":"open"}]""",
+            Columns = new Dictionary<string, bool>
+            {
+                ["date"] = true,
+                ["summary"] = false
+            },
+            ColumnOrder = ["summary", "date"]
+        };
+        var reformatted = original with
+        {
+            Filter = "type:log(status:openORstatus:regressed)",
+            FilterDefinitions = """[{"type":"status", "value":"open"}]""",
+            Columns = new Dictionary<string, bool>
+            {
+                ["summary"] = false,
+                ["date"] = true
+            }
+        };
+
+        // Act
+        string originalHash = PredefinedSavedViewContentHasher.GetContentHash(original);
+        string reformattedHash = PredefinedSavedViewContentHasher.GetContentHash(reformatted);
+
+        // Assert
+        Assert.Equal(originalHash, reformattedHash);
+    }
+}

--- a/tests/Exceptionless.Tests/Seed/PredefinedSavedViewContentHasherTests.cs
+++ b/tests/Exceptionless.Tests/Seed/PredefinedSavedViewContentHasherTests.cs
@@ -7,7 +7,7 @@ namespace Exceptionless.Tests.Seed;
 public sealed class PredefinedSavedViewContentHasherTests
 {
     [Fact]
-    public void GetContentHash_ConfigurationDiffersOnlyBySpacesAndDictionaryInsertionOrder_ReturnsSameHash()
+    public void GetContentHash_FilterDefinitionsDifferOnlyByFormattingAndDictionaryInsertionOrder_ReturnsSameHash()
     {
         // Arrange
         var original = new SavedView
@@ -26,7 +26,7 @@ public sealed class PredefinedSavedViewContentHasherTests
         };
         var reformatted = original with
         {
-            Filter = "type:log(status:openORstatus:regressed)",
+            Filter = "type:log (status:open OR status:regressed)",
             FilterDefinitions = """[{"type":"status", "value":"open"}]""",
             Columns = new Dictionary<string, bool>
             {
@@ -41,5 +41,25 @@ public sealed class PredefinedSavedViewContentHasherTests
 
         // Assert
         Assert.Equal(originalHash, reformattedHash);
+    }
+
+    [Fact]
+    public void GetContentHash_StringFieldDiffersOnlyBySpaces_ReturnsDifferentHash()
+    {
+        // Arrange
+        var withSpaces = new SavedView
+        {
+            Name = "Open Issues",
+            Slug = "open-issues",
+            ViewType = "events"
+        };
+        var withoutSpaces = withSpaces with { Name = "OpenIssues" };
+
+        // Act
+        string withSpacesHash = PredefinedSavedViewContentHasher.GetContentHash(withSpaces);
+        string withoutSpacesHash = PredefinedSavedViewContentHasher.GetContentHash(withoutSpaces);
+
+        // Assert
+        Assert.NotEqual(withSpacesHash, withoutSpacesHash);
     }
 }

--- a/tests/Exceptionless.Tests/Serializer/Models/SavedViewSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/SavedViewSerializerTests.cs
@@ -24,6 +24,7 @@ public class SavedViewSerializerTests : TestWithServices
             UserId = "660000000000000000000001",
             CreatedByUserId = "660000000000000000000001",
             UpdatedByUserId = "660000000000000000000002",
+            PredefinedContentHash = "95d71d134b0f8f62c6a70de8ec9819f7a0a0e450577764e9c1c13c863ccbe6ba",
             Filter = "(status:open OR status:regressed)",
             FilterDefinitions = """[{"field":"status","operator":"in","values":["open","regressed"]}]""",
             Columns = new Dictionary<string, bool>
@@ -51,6 +52,7 @@ public class SavedViewSerializerTests : TestWithServices
         Assert.Equal("660000000000000000000001", result.UserId);
         Assert.Equal("660000000000000000000001", result.CreatedByUserId);
         Assert.Equal("660000000000000000000002", result.UpdatedByUserId);
+        Assert.Equal("95d71d134b0f8f62c6a70de8ec9819f7a0a0e450577764e9c1c13c863ccbe6ba", result.PredefinedContentHash);
         Assert.Equal("(status:open OR status:regressed)", result.Filter);
         Assert.Equal("Open Issues", result.Name);
         Assert.Equal("[now-7d TO now]", result.Time);

--- a/tests/http/saved-views.http
+++ b/tests/http/saved-views.http
@@ -38,6 +38,10 @@ Authorization: Bearer {{token}}
 GET {{apiUrl}}/saved-views/predefined
 Authorization: Bearer {{token}}
 
+### Force update matching organization saved views from the saved predefined definitions
+POST {{apiUrl}}/saved-views/predefined/force-update
+Authorization: Bearer {{token}}
+
 ### Create organization-wide saved view
 # @name newSavedView
 POST {{apiUrl}}/organizations/{{organizationId}}/saved-views


### PR DESCRIPTION
## Summary

- Store a normalized baseline hash for predefined saved views and safely sync unchanged or reverted organization views after system definitions change.
- Add a global-admin, confirmation-gated background force update for existing organization-wide saved views with matching predefined keys.

## Why

Organizations created before a predefined-view update were not receiving safe updates. Customized views must remain protected, while the queued force update provides an explicit recovery path.

## Impact

Adds a protected force-update endpoint and Svelte system-page action. No breaking API changes.

## Validation

- `dotnet build tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-restore -v:minimal`
- `dotnet test --project tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-build --no-restore -- --filter-class Exceptionless.Tests.Controllers.SavedViewControllerTests` (98 passed)
- `dotnet test --project tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-build --no-restore -- --filter-class Exceptionless.Tests.Controllers.OpenApiControllerTests` (3 passed)
- `npm run check` in `src/Exceptionless.Web/ClientApp`
