### PR TITLE
Fix production synthetic monitoring

### DIFF
--- a/.github/workflows/production-synthetic-monitoring.yml
+++ b/.github/workflows/production-synthetic-monitoring.yml
@@ -77,7 +77,7 @@ jobs:
               "Production Synthetic Monitoring failed.",
               "",
               `- Run: ${runUrl}`,
-              `- Run ID: production-${context.runId}-${context.runAttempt}`,
+              `- Run ID: production-${context.runId}-${process.env.GITHUB_RUN_ATTEMPT}`,
               "- E2E URL: https://app.exceptionless.io",
               "",
               "Review the Playwright report and test-results artifacts attached to the workflow run."

--- a/src/Exceptionless.Web/ClientApp/e2e/support/exceptionless-journey.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/support/exceptionless-journey.ts
@@ -118,7 +118,7 @@ export class ExceptionlessE2EJourney {
             this.projectId = getIdFromUrl(this.page, /\/project\/([^/]+)\/configure/);
         }
 
-        await expect(this.page.getByText('Choose your project type.')).toBeVisible();
+        await expect(this.page.getByRole('button', { name: 'Please select a project type' })).toBeVisible();
 
         await selectProjectType(this.page, 'Bash Shell');
         await expect(this.page.getByText('Execute the following in your shell.')).toBeVisible();
@@ -222,7 +222,7 @@ export class ExceptionlessE2EJourney {
         await this.page.waitForURL(/\/next\/project\/[^/]+\/configure/, { timeout: 30_000 });
         this.projectId = getIdFromUrl(this.page, /\/project\/([^/]+)\/configure/);
         this.organizationId = await this.getOrganizationIdByName();
-        await expect(this.page.getByText('Choose your project type.')).toBeVisible();
+        await expect(this.page.getByRole('button', { name: 'Please select a project type' })).toBeVisible();
     }
 
     async submitRepresentativeEvent(): Promise<void> {


### PR DESCRIPTION
## Summary

- make the production onboarding synthetic check locate the project-type selector by its accessible role and name instead of mutable instructional copy
- include the correct GitHub Actions run attempt in failure alert issue metadata

## Root cause

Production Synthetic Monitoring runs the current `main` test suite against the deployed production version. The project setup copy changed from `Select your project type.` to `Choose your project type.` on `main` after production `8.6.2` was deployed, so the exact-copy assertion failed even though signup, organization creation, project creation, and the configure page all worked.

## Verification

- `npm run validate`
- `git diff --check`
- inspected the failing run's Playwright results and DOM snapshot to confirm the project-type selector is present in production

## Breaking changes

None.

Fixes #2371