### PR TITLE
Fix idle-resume visibility listener churn

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-shell.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-shell.svelte.test.ts
@@ -1,11 +1,13 @@
 import type { BootOptions } from 'svelte-intercom';
 
 import { fireEvent, render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import IntercomShellTestHarness from './intercom-shell.test-harness.svelte';
 
 const intercomShowMessages = vi.hoisted(() => vi.fn());
+const intercomUpdate = vi.hoisted(() => vi.fn());
 
 vi.mock('$features/auth/index.svelte', () => ({
     accessToken: { current: 'token_123' }
@@ -33,12 +35,13 @@ vi.mock('@intercom/messenger-js-sdk', () => ({
     startSurvey: vi.fn(),
     startTour: vi.fn(),
     trackEvent: vi.fn(),
-    update: vi.fn()
+    update: intercomUpdate
 }));
 
 describe('IntercomShell', () => {
     beforeEach(() => {
         intercomShowMessages.mockReset();
+        intercomUpdate.mockReset();
         vi.restoreAllMocks();
     });
 
@@ -71,5 +74,39 @@ describe('IntercomShell', () => {
         expect(mountCount).toBe(1);
         expect(openWindow).toHaveBeenCalledTimes(1);
         expect(intercomShowMessages).toHaveBeenCalledTimes(1);
+    });
+
+    it('remains stable across repeated tab visibility changes', async () => {
+        // Arrange
+        let hidden = false;
+        const addEventListener = vi.spyOn(document, 'addEventListener');
+        vi.spyOn(document, 'hidden', 'get').mockImplementation(() => hidden);
+        const { rerender } = render(IntercomShellTestHarness, {
+            props: {
+                appId: 'app_123',
+                bootOptions: { intercomUserJwt: 'token_0', userId: 'user_123' } as BootOptions
+            }
+        });
+        await tick();
+
+        // Act
+        for (let index = 0; index < 100; index++) {
+            hidden = true;
+            document.dispatchEvent(new Event('visibilitychange'));
+            await tick();
+
+            await rerender({
+                appId: 'app_123',
+                bootOptions: { intercomUserJwt: `token_${index + 1}`, userId: 'user_123' } as BootOptions
+            });
+
+            hidden = false;
+            document.dispatchEvent(new Event('visibilitychange'));
+            await tick();
+        }
+
+        // Assert
+        expect(intercomUpdate).toHaveBeenCalled();
+        expect(addEventListener.mock.calls.filter(([eventName]) => eventName === 'visibilitychange')).toHaveLength(1);
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/document-visibility.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/document-visibility.svelte.ts
@@ -2,30 +2,16 @@ import { useEventListener } from 'runed';
 
 export class DocumentVisibility {
     get visible(): boolean {
-        if ($effect.tracking() && this.#effectRegistered === 0) {
-            // If we are in an effect and this effect has not been registered yet
-            // we match the current value, register the listener and return match
-            $effect(() => {
-                this.#effectRegistered++;
-
-                useEventListener(
-                    () => document,
-                    'visibilitychange',
-                    () => (this.#visible = !document.hidden)
-                );
-
-                return () => {
-                    this.#effectRegistered--;
-                    // if we deregister the event it means it's not used in any component
-                    // and we want to go back to use the value from `this.#mediaQueryList.matches`
-                    this.#visible = undefined;
-                };
-            });
-        }
-
-        return this.#visible ?? !document.hidden;
+        return this.#visible;
     }
-    #effectRegistered = 0;
 
-    #visible = $state<boolean | undefined>(!document.hidden);
+    #visible = $state(!document.hidden);
+
+    constructor() {
+        useEventListener(
+            () => document,
+            'visibilitychange',
+            () => (this.#visible = !document.hidden)
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- register document visibility tracking once for each `DocumentVisibility` lifecycle instead of creating child effects from the `visible` getter
- keep visibility state reactive for the WebSocket and Intercom consumers
- add an Intercom regression test covering repeated hidden/resume cycles and token refreshes

## Root cause

Reading `DocumentVisibility.visible` from reactive effects dynamically created another child effect and event listener. When visibility or Intercom boot options changed, those child effects were torn down and recreated. The regression test reproduced 502 `visibilitychange` registrations across 100 hidden/resume cycles; the updated implementation keeps one registration. This listener/effect churn could eventually trip Svelte's `effect_update_depth_exceeded` guard and leave the page unresponsive after resuming an idle tab.

## Validation

- `npm run validate`
- `npm run test:unit -- --run` — 299 tests passed
- focused Intercom/WebSocket tests — 31 tests passed
- `npm run build`
- local frontend and proxied API health checks returned HTTP 200

## Breaking changes

None.