### PR TITLE
Fix legacy stack saved view comparison

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -106,6 +106,25 @@ export function hasSavedColumnVisibility(columns: null | Record<string, boolean>
     return columns != null;
 }
 
+export function savedViewColumnsEqual(
+    a: ColumnVisibilityState | undefined,
+    b: null | Record<string, boolean> | undefined,
+    defaultColumnVisibility: ColumnVisibilityState = {}
+): boolean {
+    const normalize = (value: ColumnVisibilityState | null | undefined) => ({ ...defaultColumnVisibility, ...(value ?? {}) });
+    const aEntries = Object.entries(normalize(a)).sort(([k1], [k2]) => k1.localeCompare(k2));
+    const bEntries = Object.entries(normalize(b)).sort(([k1], [k2]) => k1.localeCompare(k2));
+
+    if (aEntries.length !== bEntries.length) {
+        return false;
+    }
+
+    return aEntries.every(([k, v], i) => {
+        const bEntry = bEntries[i];
+        return bEntry !== undefined && bEntry[0] === k && bEntry[1] === v;
+    });
+}
+
 export function setSortQueryParam(queryParams: SavedViewQueryParams, value: null | string): void {
     if (supportsSortQueryParam(queryParams)) {
         queryParams.sort = value;
@@ -256,7 +275,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         if (
             options.getColumnVisibility &&
             hasSavedColumnVisibility(view.columns) &&
-            !columnsEqual(options.getColumnVisibility(), view.columns, options.defaultColumnVisibility)
+            !savedViewColumnsEqual(options.getColumnVisibility(), view.columns, options.defaultColumnVisibility)
         ) {
             return true;
         }
@@ -362,25 +381,6 @@ function columnOrderEqual(a: ColumnOrderState | undefined, b: null | string[] | 
     }
 
     return aOrder.every((columnId, index) => columnId === bOrder[index]);
-}
-
-function columnsEqual(
-    a: ColumnVisibilityState | undefined,
-    b: null | Record<string, boolean> | undefined,
-    defaultColumnVisibility: ColumnVisibilityState = {}
-): boolean {
-    const normalize = (value: ColumnVisibilityState | null | undefined) => ({ ...defaultColumnVisibility, ...(value ?? {}) });
-    const aEntries = Object.entries(normalize(a)).sort(([k1], [k2]) => k1.localeCompare(k2));
-    const bEntries = Object.entries(normalize(b)).sort(([k1], [k2]) => k1.localeCompare(k2));
-
-    if (aEntries.length !== bEntries.length) {
-        return false;
-    }
-
-    return aEntries.every(([k, v], i) => {
-        const bEntry = bEntries[i];
-        return bEntry !== undefined && bEntry[0] === k && bEntry[1] === v;
-    });
 }
 
 function normalizeFilterDefinitions(value: null | string | undefined): string {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -14,6 +14,7 @@ import {
     hasMissingSavedViewSlug,
     hasSavedColumnOrder,
     hasSavedColumnVisibility,
+    savedViewColumnsEqual,
     type SavedViewQueryParams,
     setSortQueryParam,
     setTimeQueryParam,
@@ -209,6 +210,32 @@ describe('useSavedViews', () => {
             // Act & Assert
             expect(hasSavedColumnVisibility({})).toBe(true);
             expect(hasSavedColumnVisibility({ events: false })).toBe(true);
+        });
+
+        it('treats legacy visibility missing default-hidden columns as unchanged', () => {
+            // Arrange
+            const current = { project: false, summary: true, tags: false };
+            const legacySaved = { summary: true };
+            const defaults = { project: false, tags: false };
+
+            // Act
+            const result = savedViewColumnsEqual(current, legacySaved, defaults);
+
+            // Assert
+            expect(result).toBe(true);
+        });
+
+        it('detects a changed column after applying default visibility', () => {
+            // Arrange
+            const current = { project: true, summary: true, tags: false };
+            const legacySaved = { summary: true };
+            const defaults = { project: false, tags: false };
+
+            // Act
+            const result = savedViewColumnsEqual(current, legacySaved, defaults);
+
+            // Assert
+            expect(result).toBe(false);
         });
 
         it('does not compare column order when a saved view omits or clears column order', () => {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -234,6 +234,7 @@
     let showChart = $state(true);
     const savedViewsState = useSavedViews({
         baseHref: resolve('/(app)/stack'),
+        defaultColumnVisibility: defaultStackColumnVisibility,
         defaultFilter: DEFAULT_FILTER,
         defaultTime: DEFAULT_TIME_RANGE,
         filterCacheKey,


### PR DESCRIPTION
## Summary

- pass stack column visibility defaults into saved-view comparison
- normalize legacy saved column settings against the current default-hidden Project and Tags columns
- add regression coverage for unchanged legacy records and real column customizations

## Why

Follow-up to the post-merge review feedback on #2396: stack saved views created before Project and Tags columns existed omit those keys. The table hydrates both defaults as `false`, but the saved-view comparison previously did not receive the same defaults, so legacy views appeared modified immediately and Reset to Saved could not clear that state.

Review thread: https://github.com/exceptionless/Exceptionless/pull/2396#discussion_r3651097695

## Verification

- `npx vitest run src/lib/features/saved-views/use-saved-views.test.ts` (39 passed)
- `npm run validate`

## Breaking changes

None.