### PR TITLE
Handle stale MCP OAuth refresh tokens

### DIFF
--- a/src/Exceptionless.Core/Configuration/OAuthServerOptions.cs
+++ b/src/Exceptionless.Core/Configuration/OAuthServerOptions.cs
@@ -7,6 +7,7 @@ public class OAuthServerOptions
     public TimeSpan AuthorizationCodeLifetime { get; internal set; } = TimeSpan.FromMinutes(5);
     public TimeSpan AccessTokenLifetime { get; internal set; } = TimeSpan.FromHours(1);
     public TimeSpan RefreshTokenLifetime { get; internal set; } = TimeSpan.FromDays(30);
+    public TimeSpan RefreshTokenReuseGracePeriod { get; internal set; } = TimeSpan.FromHours(1);
     public bool EnableClientIdMetadataDocuments { get; internal set; } = true;
     public int DynamicClientRegistrationIpLimit { get; internal set; } = 20;
     public TimeSpan ClientMetadataDocumentCacheLifetime { get; internal set; } = TimeSpan.FromHours(1);
@@ -19,6 +20,7 @@ public class OAuthServerOptions
         options.AuthorizationCodeLifetime = TimeSpan.FromMinutes(config.GetValue("OAuthServer:AuthorizationCodeLifetimeMinutes", 5));
         options.AccessTokenLifetime = TimeSpan.FromMinutes(config.GetValue("OAuthServer:AccessTokenLifetimeMinutes", 60));
         options.RefreshTokenLifetime = TimeSpan.FromDays(config.GetValue("OAuthServer:RefreshTokenLifetimeDays", 30));
+        options.RefreshTokenReuseGracePeriod = TimeSpan.FromMinutes(Math.Max(0, config.GetValue("OAuthServer:RefreshTokenReuseGracePeriodMinutes", 60)));
         options.EnableClientIdMetadataDocuments = config.GetValue("OAuthServer:EnableClientIdMetadataDocuments", true);
         options.DynamicClientRegistrationIpLimit = config.GetValue("OAuthServer:DynamicClientRegistrationIpLimit", 20);
         options.ClientMetadataDocumentCacheLifetime = TimeSpan.FromMinutes(config.GetValue("OAuthServer:ClientMetadataDocumentCacheLifetimeMinutes", 60));

--- a/src/Exceptionless.Core/Models/OAuthToken.cs
+++ b/src/Exceptionless.Core/Models/OAuthToken.cs
@@ -35,6 +35,7 @@ public class OAuthToken : IIdentity, IHaveDates, IValidatableObject
 
     public DateTime? ExpiresUtc { get; set; }
     public DateTime? RefreshExpiresUtc { get; set; }
+    public DateTime? RefreshTokenUsedUtc { get; set; }
     public HashSet<string> OrganizationIds { get; set; } = new(StringComparer.Ordinal);
     public HashSet<string> Scopes { get; set; } = new(StringComparer.Ordinal);
     public bool IsDisabled { get; set; }

--- a/src/Exceptionless.Core/Repositories/Configuration/Indexes/OAuthTokenIndex.cs
+++ b/src/Exceptionless.Core/Repositories/Configuration/Indexes/OAuthTokenIndex.cs
@@ -32,6 +32,7 @@ public sealed class OAuthTokenIndex : VersionedIndex<OAuthToken>
                 .Keyword(e => e.CreatedBy)
                 .Date(e => e.ExpiresUtc)
                 .Date(e => e.RefreshExpiresUtc)
+                .Date(e => e.RefreshTokenUsedUtc)
                 .Boolean(e => e.IsDisabled)
                 .Boolean(e => e.IsSuspended));
     }

--- a/src/Exceptionless.Core/Services/OAuthService.cs
+++ b/src/Exceptionless.Core/Services/OAuthService.cs
@@ -443,7 +443,8 @@ public class OAuthService(OAuthServerOptions options, ICacheClient cacheClient, 
         if (token is null || !String.Equals(token.ClientId, request.ClientId, StringComparison.Ordinal))
             return OAuthTokenIssueResult.Invalid("invalid_grant", "Refresh token is invalid.");
 
-        if (token.IsDisabled || token.IsSuspended)
+        var utcNow = timeProvider.GetUtcNow().UtcDateTime;
+        if (token.IsSuspended || (token.IsDisabled && !CanReuseRefreshToken(token, utcNow)))
         {
             await RevokeOAuthGrantFamilyAsync(token);
             return OAuthTokenIssueResult.Invalid("invalid_grant", "Refresh token is invalid.");
@@ -452,7 +453,7 @@ public class OAuthService(OAuthServerOptions options, ICacheClient cacheClient, 
         if (token.OrganizationIds.Count == 0)
             return OAuthTokenIssueResult.Invalid("invalid_grant", "Refresh token is invalid.");
 
-        if (token.RefreshExpiresUtc.HasValue && token.RefreshExpiresUtc.Value < timeProvider.GetUtcNow().UtcDateTime)
+        if (token.RefreshExpiresUtc.HasValue && token.RefreshExpiresUtc.Value < utcNow)
             return OAuthTokenIssueResult.Invalid("invalid_grant", "Refresh token is expired.");
 
         var scopeValidation = ValidateRefreshScopes(token, client);
@@ -476,7 +477,9 @@ public class OAuthService(OAuthServerOptions options, ICacheClient cacheClient, 
             return OAuthTokenIssueResult.Invalid("invalid_grant", "Refresh token is invalid.");
         }
 
-        await DisableTokenAsync(token, clearRefresh: false);
+        if (!token.IsDisabled)
+            await SpendRefreshTokenAsync(token, utcNow);
+
         return OAuthTokenIssueResult.Success(await CreateTokenAsync(token.UserId, token.ClientId, token.Resource, scopeValidation.Scopes, activeOrganizationIds, token.GrantId));
     }
 
@@ -552,12 +555,27 @@ public class OAuthService(OAuthServerOptions options, ICacheClient cacheClient, 
         return RefreshScopeValidationResult.Valid(refreshedScopes);
     }
 
-    private Task DisableTokenAsync(OAuthToken token, bool clearRefresh = true)
+    private bool CanReuseRefreshToken(OAuthToken token, DateTime utcNow)
+    {
+        return options.RefreshTokenReuseGracePeriod > TimeSpan.Zero
+            && token.RefreshTokenUsedUtc.HasValue
+            && token.RefreshTokenUsedUtc.Value <= utcNow
+            && utcNow - token.RefreshTokenUsedUtc.Value <= options.RefreshTokenReuseGracePeriod;
+    }
+
+    private Task SpendRefreshTokenAsync(OAuthToken token, DateTime utcNow)
     {
         token.IsDisabled = true;
-        if (clearRefresh)
-            token.RefreshTokenHash = null;
+        token.RefreshTokenUsedUtc = utcNow;
+        token.UpdatedUtc = utcNow;
+        return oauthTokenRepository.SaveAsync(token, o => o.ImmediateConsistency());
+    }
 
+    private Task DisableTokenAsync(OAuthToken token)
+    {
+        token.IsDisabled = true;
+        token.RefreshTokenHash = null;
+        token.RefreshTokenUsedUtc = null;
         token.UpdatedUtc = timeProvider.GetUtcNow().UtcDateTime;
         return oauthTokenRepository.SaveAsync(token, o => o.ImmediateConsistency());
     }

--- a/tests/Exceptionless.Tests/Api/Endpoints/OAuthEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/OAuthEndpointTests.cs
@@ -955,31 +955,113 @@ public sealed class OAuthEndpointTests : IntegrationTestsBase
         Assert.NotNull(spentToken);
         Assert.True(spentToken.IsDisabled);
         Assert.Equal(OAuthService.CreateTokenHash(token.RefreshToken), spentToken.RefreshTokenHash);
+        Assert.NotNull(spentToken.RefreshTokenUsedUtc);
 
         var refreshedStoredToken = await GetStoredOAuthTokenAsync(refreshedToken.AccessToken);
         Assert.NotNull(refreshedStoredToken);
         Assert.False(refreshedStoredToken.IsDisabled);
         Assert.Equal(OAuthService.CreateTokenHash(refreshedToken.RefreshToken), refreshedStoredToken.RefreshTokenHash);
         Assert.Equal(spentToken.GrantId, refreshedStoredToken.GrantId);
+    }
 
-        using var reusedRefreshRequestContent = new FormUrlEncodedContent(new Dictionary<string, string?>
-        {
-            ["grant_type"] = OAuthGrantTypes.RefreshToken,
-            ["client_id"] = ClientId,
-            ["refresh_token"] = token.RefreshToken
-        });
-        var reusedRefreshResponse = await client.PostAsync("oauth/token", reusedRefreshRequestContent, TestContext.Current.CancellationToken);
+    [Fact]
+    public async Task TokenAsync_RecentlyUsedRefreshToken_IssuesNewToken()
+    {
+        var token = await IssueTokenAsync();
+        Assert.NotNull(token.RefreshToken);
+        using var client = CreateHttpClient();
+
+        using var firstRefreshContent = CreateRefreshTokenContent(token.RefreshToken);
+        var firstRefreshResponse = await client.PostAsync("oauth/token", firstRefreshContent, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, firstRefreshResponse.StatusCode);
+        var firstRefreshedToken = await DeserializeResponseAsync<OAuthTokenResponse>(firstRefreshResponse);
+        Assert.NotNull(firstRefreshedToken);
+
+        using var reusedRefreshContent = CreateRefreshTokenContent(token.RefreshToken);
+        var reusedRefreshResponse = await client.PostAsync("oauth/token", reusedRefreshContent, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, reusedRefreshResponse.StatusCode);
+        var secondRefreshedToken = await DeserializeResponseAsync<OAuthTokenResponse>(reusedRefreshResponse);
+        Assert.NotNull(secondRefreshedToken);
+        Assert.NotEqual(firstRefreshedToken.AccessToken, secondRefreshedToken.AccessToken);
+        Assert.NotEqual(firstRefreshedToken.RefreshToken, secondRefreshedToken.RefreshToken);
+
+        var spentToken = await GetStoredOAuthTokenAsync(token.AccessToken);
+        var firstRefreshedStoredToken = await GetStoredOAuthTokenAsync(firstRefreshedToken.AccessToken);
+        var secondRefreshedStoredToken = await GetStoredOAuthTokenAsync(secondRefreshedToken.AccessToken);
+        Assert.NotNull(spentToken);
+        Assert.NotNull(firstRefreshedStoredToken);
+        Assert.NotNull(secondRefreshedStoredToken);
+        Assert.True(spentToken.IsDisabled);
+        Assert.False(firstRefreshedStoredToken.IsDisabled);
+        Assert.False(secondRefreshedStoredToken.IsDisabled);
+        Assert.Equal(spentToken.GrantId, firstRefreshedStoredToken.GrantId);
+        Assert.Equal(spentToken.GrantId, secondRefreshedStoredToken.GrantId);
+    }
+
+    [Fact]
+    public async Task TokenAsync_MultipleGenerationOldRefreshTokenWithinGracePeriod_IssuesNewToken()
+    {
+        var token = await IssueTokenAsync();
+        Assert.NotNull(token.RefreshToken);
+        using var client = CreateHttpClient();
+
+        using var firstRefreshContent = CreateRefreshTokenContent(token.RefreshToken);
+        var firstRefreshResponse = await client.PostAsync("oauth/token", firstRefreshContent, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, firstRefreshResponse.StatusCode);
+        var firstRefreshedToken = await DeserializeResponseAsync<OAuthTokenResponse>(firstRefreshResponse);
+        Assert.NotNull(firstRefreshedToken);
+        Assert.NotNull(firstRefreshedToken.RefreshToken);
+
+        using var secondRefreshContent = CreateRefreshTokenContent(firstRefreshedToken.RefreshToken);
+        var secondRefreshResponse = await client.PostAsync("oauth/token", secondRefreshContent, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, secondRefreshResponse.StatusCode);
+
+        using var staleRefreshContent = CreateRefreshTokenContent(token.RefreshToken);
+        var staleRefreshResponse = await client.PostAsync("oauth/token", staleRefreshContent, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, staleRefreshResponse.StatusCode);
+        var staleRefreshedToken = await DeserializeResponseAsync<OAuthTokenResponse>(staleRefreshResponse);
+        Assert.NotNull(staleRefreshedToken);
+        Assert.NotNull(staleRefreshedToken.RefreshToken);
+    }
+
+    [Fact]
+    public async Task TokenAsync_RefreshTokenReusedOutsideGracePeriod_RevokesGrantFamily()
+    {
+        var token = await IssueTokenAsync();
+        Assert.NotNull(token.RefreshToken);
+        using var client = CreateHttpClient();
+
+        using var firstRefreshContent = CreateRefreshTokenContent(token.RefreshToken);
+        var firstRefreshResponse = await client.PostAsync("oauth/token", firstRefreshContent, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, firstRefreshResponse.StatusCode);
+
+        TimeProvider.Advance(TimeSpan.FromHours(1).Add(TimeSpan.FromMinutes(1)));
+
+        using var reusedRefreshContent = CreateRefreshTokenContent(token.RefreshToken);
+        var reusedRefreshResponse = await client.PostAsync("oauth/token", reusedRefreshContent, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.BadRequest, reusedRefreshResponse.StatusCode);
+        await AssertGrantFamilyRevokedAsync(token.AccessToken);
+    }
 
-        spentToken = await GetStoredOAuthTokenAsync(token.AccessToken);
-        refreshedStoredToken = await GetStoredOAuthTokenAsync(refreshedToken.AccessToken);
-        Assert.NotNull(spentToken);
-        Assert.NotNull(refreshedStoredToken);
-        Assert.True(spentToken.IsDisabled);
-        Assert.True(refreshedStoredToken.IsDisabled);
-        Assert.Null(spentToken.RefreshTokenHash);
-        Assert.Null(refreshedStoredToken.RefreshTokenHash);
+    [Fact]
+    public async Task TokenAsync_LegacySpentRefreshTokenWithoutUsedTimestamp_RevokesGrantFamily()
+    {
+        var token = await IssueTokenAsync();
+        Assert.NotNull(token.RefreshToken);
+        var storedToken = await GetStoredOAuthTokenAsync(token.AccessToken);
+        Assert.NotNull(storedToken);
+        storedToken.IsDisabled = true;
+        storedToken.RefreshTokenUsedUtc = null;
+        await _oauthTokenRepository.SaveAsync(storedToken, o => o.ImmediateConsistency());
+        using var client = CreateHttpClient();
+
+        using var refreshContent = CreateRefreshTokenContent(token.RefreshToken);
+        var refreshResponse = await client.PostAsync("oauth/token", refreshContent, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, refreshResponse.StatusCode);
+        await AssertGrantFamilyRevokedAsync(token.AccessToken);
     }
 
     [Fact]
@@ -1123,7 +1205,7 @@ public sealed class OAuthEndpointTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task TokenAsync_ConcurrentRefreshTokenUse_AllowsOnlyOneRefresh()
+    public async Task TokenAsync_ConcurrentRefreshTokenUse_AllowsBothRefreshesWithinGracePeriod()
     {
         var token = await IssueTokenAsync();
         Assert.NotNull(token.RefreshToken);
@@ -1145,8 +1227,7 @@ public sealed class OAuthEndpointTests : IntegrationTestsBase
             client.PostAsync("oauth/token", firstRefreshContent, TestContext.Current.CancellationToken),
             client.PostAsync("oauth/token", secondRefreshContent, TestContext.Current.CancellationToken));
 
-        Assert.Contains(responses, r => r.StatusCode == HttpStatusCode.OK);
-        Assert.Contains(responses, r => r.StatusCode == HttpStatusCode.BadRequest);
+        Assert.All(responses, r => Assert.Equal(HttpStatusCode.OK, r.StatusCode));
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Serializer/Models/OAuthTokenSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/OAuthTokenSerializerTests.cs
@@ -28,6 +28,7 @@ public class OAuthTokenSerializerTests : TestWithServices
             AccessTokenHash = OAuthService.CreateTokenHash("serializer-access-token"),
             RefreshTokenHash = OAuthService.CreateTokenHash("serializer-refresh-token"),
             RefreshExpiresUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            RefreshTokenUsedUtc = new DateTime(2025, 12, 1, 0, 0, 0, DateTimeKind.Utc),
             OrganizationIds = ["550000000000000000000001", "550000000000000000000002"],
             Scopes = [AuthorizationRoles.ProjectsRead],
             CreatedBy = "660000000000000000000001",
@@ -45,6 +46,7 @@ public class OAuthTokenSerializerTests : TestWithServices
         Assert.Equal(OAuthService.CreateTokenHash("serializer-access-token"), result.AccessTokenHash);
         Assert.Equal(OAuthService.CreateTokenHash("serializer-refresh-token"), result.RefreshTokenHash);
         Assert.Equal(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), result.RefreshExpiresUtc);
+        Assert.Equal(new DateTime(2025, 12, 1, 0, 0, 0, DateTimeKind.Utc), result.RefreshTokenUsedUtc);
         Assert.Contains("550000000000000000000001", result.OrganizationIds);
         Assert.Contains("550000000000000000000002", result.OrganizationIds);
         Assert.Contains(AuthorizationRoles.ProjectsRead, result.Scopes);


### PR DESCRIPTION
## Summary

- allow recently rotated OAuth refresh tokens to be reused during a configurable 60-minute grace period
- persist the original rotation time so the grace window stays bounded across repeated and multi-generation stale refreshes
- preserve grant-family revocation for suspended tokens, legacy spent tokens without a rotation timestamp, and reuse after the grace period
- add focused concurrency, stale-generation, legacy-record, expiry, and serialization coverage

## Why

Codex can retain stale MCP OAuth refresh-token generations across active sessions or processes. Exceptionless previously treated the first stale refresh as replay and revoked the entire grant family, turning a recoverable client race into persistent `invalid_grant` failures on MCP startup.

This keeps refresh-token rotation in place while adding a bounded compatibility window for legitimate client races. Set `OAuthServer:RefreshTokenReuseGracePeriodMinutes` to `0` to retain strict single-use behavior.

## Verification

- `dotnet build tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-restore --verbosity minimal`
- OAuth endpoint tests: 63 passed
- OAuth token serialization tests: 1 passed

## Breaking changes

None.