### PR TITLE
Redact sensitive startup configuration

### DIFF
--- a/src/Exceptionless.Core/Bootstrapper.cs
+++ b/src/Exceptionless.Core/Bootstrapper.cs
@@ -44,8 +44,10 @@ using Foundatio.Repositories.Migrations;
 using Foundatio.Resilience;
 using Foundatio.Serializer;
 using Foundatio.Storage;
+using Foundatio.Utility;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using MaintainIndexesJob = Foundatio.Repositories.Elasticsearch.Jobs.MaintainIndexesJob;
 
@@ -251,6 +253,9 @@ public class Bootstrapper
 
     public static void LogConfiguration(IServiceProvider serviceProvider, AppOptions appOptions, ILogger logger)
     {
+        if (logger.IsEnabled(LogLevel.Information))
+            LogConfigurationSummary(serviceProvider, appOptions, logger);
+
         if (!logger.IsEnabled(LogLevel.Warning))
             return;
 
@@ -284,6 +289,225 @@ public class Bootstrapper
 
         if (!appOptions.AuthOptions.EnableAccountCreation)
             logger.LogWarning("Account Creation is NOT enabled on {MachineName}", Environment.MachineName);
+    }
+
+    private static void LogConfigurationSummary(IServiceProvider serviceProvider, AppOptions options, ILogger logger)
+    {
+        string environmentName = serviceProvider.GetService<IHostEnvironment>()?.EnvironmentName ?? options.AppMode.ToString();
+        string version = options.InformationalVersion ?? options.Version ?? "unknown";
+
+        logger.LogInformation(
+            "Startup configuration: environment {EnvironmentName}, scope {AppScope}, mode {AppMode}, version {Version}, base URL {BaseUrl}",
+            environmentName,
+            options.AppScope,
+            options.AppMode,
+            version,
+            GetSafeEndpoint(options.BaseURL));
+
+        logger.LogInformation(
+            "Startup infrastructure: Elasticsearch {ElasticsearchEndpoint} (migration {ElasticsearchMigrationEndpoint}, shards {ElasticsearchShards}, replicas {ElasticsearchReplicas}, index configuration {IndexConfiguration}, snapshot jobs {SnapshotJobs}); cache {CacheProvider} at {CacheEndpoint}; message bus {MessageBusProvider} at {MessageBusEndpoint} (topic {MessageBusTopic}); queue {QueueProvider} at {QueueEndpoint} (region {QueueRegion}); storage {StorageProvider} at {StorageEndpoint} (region {StorageRegion})",
+            GetSafeEndpoint(options.ElasticsearchOptions.ServerUrl),
+            GetSafeEndpoint(options.ElasticsearchOptions.ElasticsearchToMigrate?.ServerUrl),
+            options.ElasticsearchOptions.NumberOfShards,
+            options.ElasticsearchOptions.NumberOfReplicas,
+            GetStatus(!options.ElasticsearchOptions.DisableIndexConfiguration),
+            GetStatus(options.ElasticsearchOptions.EnableSnapshotJobs),
+            GetProvider(options.CacheOptions.Provider),
+            GetProviderEndpoint(options.CacheOptions.Data, options.CacheOptions.ConnectionString),
+            GetProvider(options.MessageBusOptions.Provider),
+            GetProviderEndpoint(options.MessageBusOptions.Data, options.MessageBusOptions.ConnectionString),
+            GetValueOrDefault(options.MessageBusOptions.Topic),
+            GetProvider(options.QueueOptions.Provider),
+            GetProviderEndpoint(options.QueueOptions.Data, options.QueueOptions.ConnectionString),
+            GetValueOrDefault(GetConnectionSetting(options.QueueOptions.Data, "region")),
+            GetProvider(options.StorageOptions.Provider),
+            GetProviderEndpoint(options.StorageOptions.Data, options.StorageOptions.ConnectionString),
+            GetValueOrDefault(GetConnectionSetting(options.StorageOptions.Data, "region")));
+
+        logger.LogInformation(
+            "Startup services: event submission {EventSubmission}; web sockets {WebSockets}; jobs in process {JobsInProcess}; repository notifications {RepositoryNotifications}; archive {Archive}; sample data {SampleData}; email {Email} at {SmtpEndpoint} ({SmtpEncryption}, daily summaries {DailySummary}); account creation {AccountCreation}; Active Directory {ActiveDirectory} at {ActiveDirectoryEndpoint}",
+            GetStatus(!options.EventSubmissionDisabled),
+            GetStatus(options.EnableWebSockets),
+            GetStatus(options.RunJobsInProcess),
+            GetStatus(options.EnableRepositoryNotifications),
+            GetStatus(options.EnableArchive),
+            GetStatus(options.EnableSampleData),
+            GetStatus(!String.IsNullOrWhiteSpace(options.EmailOptions.SmtpHost)),
+            GetHostAndPort(options.EmailOptions.SmtpHost, options.EmailOptions.SmtpPort),
+            options.EmailOptions.SmtpEncryption,
+            GetStatus(options.EmailOptions.EnableDailySummary),
+            GetStatus(options.AuthOptions.EnableAccountCreation),
+            GetStatus(options.AuthOptions.EnableActiveDirectoryAuth),
+            GetStandaloneConnectionEndpoint(options.AuthOptions.LdapConnectionString));
+
+        logger.LogInformation(
+            "Startup integrations: OAuth {OAuthProviders}; Intercom {Intercom}; Slack {Slack}; billing {Billing}; geocoding {Geocoding}; GeoIP {GeoIp}; internal Exceptionless logging {InternalLogging} at {ExceptionlessServerEndpoint}",
+            GetOAuthProviders(options.AuthOptions),
+            GetStatus(options.IntercomOptions.EnableIntercom),
+            GetStatus(options.SlackOptions.EnableSlack),
+            GetStatus(options.StripeOptions.EnableBilling),
+            GetStatus(!String.IsNullOrWhiteSpace(options.GoogleGeocodingApiKey)),
+            GetStatus(!String.IsNullOrWhiteSpace(options.MaxMindGeoIpKey)),
+            GetStatus(!String.IsNullOrWhiteSpace(options.ExceptionlessApiKey)),
+            GetSafeEndpoint(options.ExceptionlessServerUrl));
+
+        logger.LogInformation(
+            "Startup operations: retention {MaximumRetentionDays} days; maximum event post {MaximumEventPostSize} bytes; bulk batch {BulkBatchSize}; API throttle {ApiThrottleLimit}; bot throttle {BotThrottleLimit}; queue metrics polling {QueueMetricsPolling} every {QueueMetricsPollingInterval}; disabled pipeline actions {DisabledPipelineActionCount}; disabled plugins {DisabledPluginCount}",
+            options.MaximumRetentionDays,
+            options.MaximumEventPostSize,
+            options.BulkBatchSize,
+            options.ApiThrottleLimit,
+            options.BotThrottleLimit,
+            GetStatus(options.QueueOptions.MetricsPollingEnabled),
+            options.QueueOptions.MetricsPollingInterval,
+            options.DisabledPipelineActions.Count,
+            options.DisabledPlugins.Count);
+
+        logger.LogInformation(
+            "Startup source maps: auto-download {SourceMapAutoDownload}; request timeout {SourceMapRequestTimeout}; processing timeout {SourceMapProcessingTimeout}; per-project artifacts {MaximumArtifactsPerProject} / storage {MaximumStorageSizePerProject} bytes; free retention {FreeArtifactRetentionDays} days; paid retention {ArtifactRetentionDays} days; download concurrency {MaximumConcurrentDownloads} local / {MaximumConcurrentDownloadsGlobally} global",
+            GetStatus(options.SourceMapOptions.EnableAutoDownload),
+            options.SourceMapOptions.RequestTimeout,
+            options.SourceMapOptions.MaximumProcessingTime,
+            options.SourceMapOptions.MaximumArtifactsPerProject,
+            options.SourceMapOptions.MaximumStorageSizePerProject,
+            options.SourceMapOptions.FreeArtifactRetentionDays,
+            options.SourceMapOptions.ArtifactRetentionDays,
+            options.SourceMapOptions.MaximumConcurrentDownloads,
+            options.SourceMapOptions.MaximumConcurrentDownloadsGlobally);
+    }
+
+    private static string GetProvider(string? provider)
+        => String.IsNullOrWhiteSpace(provider) ? "disabled" : provider;
+
+    private static string GetStatus(bool enabled) => enabled ? "enabled" : "disabled";
+
+    private static string GetValueOrDefault(string? value)
+        => String.IsNullOrWhiteSpace(value) ? "not configured" : value;
+
+    private static string GetOAuthProviders(AuthOptions options)
+    {
+        List<string> providers = [];
+        if (!String.IsNullOrWhiteSpace(options.GoogleId))
+            providers.Add("Google");
+        if (!String.IsNullOrWhiteSpace(options.MicrosoftId))
+            providers.Add("Microsoft");
+        if (!String.IsNullOrWhiteSpace(options.FacebookId))
+            providers.Add("Facebook");
+        if (!String.IsNullOrWhiteSpace(options.GitHubId))
+            providers.Add("GitHub");
+
+        return providers.Count > 0 ? String.Join(", ", providers) : "disabled";
+    }
+
+    private static string GetProviderEndpoint(
+        IDictionary<string, string?>? data,
+        string? connectionString)
+    {
+        string? endpoint = GetConnectionSetting(
+            data,
+            "server",
+            "serviceurl",
+            "endpoint",
+            "host",
+            "hostname",
+            "blobendpoint",
+            "queueendpoint");
+        if (endpoint is not null)
+            return GetSafeEndpoint(endpoint);
+
+        if (String.IsNullOrWhiteSpace(connectionString))
+            return "not configured";
+
+        try
+        {
+            var parsed = connectionString.ParseConnectionString(defaultKey: "server");
+            endpoint = GetConnectionSetting(
+                parsed,
+                "server",
+                "serviceurl",
+                "endpoint",
+                "host",
+                "hostname",
+                "blobendpoint",
+                "queueendpoint");
+            if (endpoint is not null)
+                return GetSafeEndpoint(endpoint);
+        }
+        catch (ArgumentException) { }
+
+        return GetSafeEndpoint(connectionString);
+    }
+
+    private static string GetStandaloneConnectionEndpoint(string? connectionString)
+    {
+        if (String.IsNullOrWhiteSpace(connectionString))
+            return "not configured";
+
+        try
+        {
+            var parsed = connectionString.ParseConnectionString(defaultKey: "server");
+            string? endpoint = GetConnectionSetting(parsed, "server", "host", "hostname", "endpoint");
+            if (endpoint is not null)
+            {
+                string? port = GetConnectionSetting(parsed, "port");
+                return port is null ? GetSafeEndpoint(endpoint) : GetHostAndPort(GetSafeEndpoint(endpoint), Int32.TryParse(port, out int parsedPort) ? parsedPort : 0);
+            }
+        }
+        catch (ArgumentException) { }
+
+        return GetSafeEndpoint(connectionString);
+    }
+
+    private static string? GetConnectionSetting(
+        IDictionary<string, string?>? data,
+        params string[] keys)
+    {
+        if (data is null)
+            return null;
+
+        foreach (string key in keys)
+        {
+            if (data.TryGetValue(key, out string? value) && !String.IsNullOrWhiteSpace(value))
+                return value;
+        }
+
+        return null;
+    }
+
+    private static string GetSafeEndpoint(string? value)
+    {
+        if (String.IsNullOrWhiteSpace(value))
+            return "not configured";
+
+        string candidate = value.Trim().Trim('"', '\'');
+        if (!candidate.Contains("://", StringComparison.Ordinal))
+        {
+            int separatorIndex = candidate.IndexOfAny([',', ';']);
+            if (separatorIndex >= 0)
+                candidate = candidate[..separatorIndex].Trim();
+        }
+
+        if (Uri.TryCreate(candidate, UriKind.Absolute, out var uri) && !String.IsNullOrWhiteSpace(uri.Host))
+            return GetUriEndpoint(uri);
+
+        if (!candidate.Contains('=') && Uri.TryCreate($"tcp://{candidate}", UriKind.Absolute, out uri) && !String.IsNullOrWhiteSpace(uri.Host))
+            return GetHostAndPort(uri.Host, uri.IsDefaultPort ? 0 : uri.Port);
+
+        return "configured";
+    }
+
+    private static string GetUriEndpoint(Uri uri)
+    {
+        string host = uri.HostNameType == UriHostNameType.IPv6 ? $"[{uri.Host}]" : uri.IdnHost;
+        return uri.IsDefaultPort ? $"{uri.Scheme}://{host}" : $"{uri.Scheme}://{host}:{uri.Port}";
+    }
+
+    private static string GetHostAndPort(string? host, int port)
+    {
+        if (String.IsNullOrWhiteSpace(host))
+            return "not configured";
+
+        return port > 0 ? $"{host}:{port}" : host;
     }
 
     private static async Task CreateSampleDataAsync(IServiceProvider container)

--- a/src/Exceptionless.Core/Bootstrapper.cs
+++ b/src/Exceptionless.Core/Bootstrapper.cs
@@ -305,75 +305,29 @@ public class Bootstrapper
             GetSafeEndpoint(options.BaseURL));
 
         logger.LogInformation(
-            "Startup infrastructure: Elasticsearch {ElasticsearchEndpoint} (migration {ElasticsearchMigrationEndpoint}, shards {ElasticsearchShards}, replicas {ElasticsearchReplicas}, index configuration {IndexConfiguration}, snapshot jobs {SnapshotJobs}); cache {CacheProvider} at {CacheEndpoint}; message bus {MessageBusProvider} at {MessageBusEndpoint} (topic {MessageBusTopic}); queue {QueueProvider} at {QueueEndpoint} (region {QueueRegion}); storage {StorageProvider} at {StorageEndpoint} (region {StorageRegion})",
+            "Startup infrastructure: Elasticsearch at {ElasticsearchEndpoint}; cache {CacheProvider} at {CacheEndpoint}; message bus {MessageBusProvider} at {MessageBusEndpoint}; queue {QueueProvider} at {QueueEndpoint}; storage {StorageProvider} at {StorageEndpoint}",
             GetSafeEndpoint(options.ElasticsearchOptions.ServerUrl),
-            GetSafeEndpoint(options.ElasticsearchOptions.ElasticsearchToMigrate?.ServerUrl),
-            options.ElasticsearchOptions.NumberOfShards,
-            options.ElasticsearchOptions.NumberOfReplicas,
-            GetStatus(!options.ElasticsearchOptions.DisableIndexConfiguration),
-            GetStatus(options.ElasticsearchOptions.EnableSnapshotJobs),
             GetProvider(options.CacheOptions.Provider),
             GetProviderEndpoint(options.CacheOptions.Data, options.CacheOptions.ConnectionString),
             GetProvider(options.MessageBusOptions.Provider),
             GetProviderEndpoint(options.MessageBusOptions.Data, options.MessageBusOptions.ConnectionString),
-            GetValueOrDefault(options.MessageBusOptions.Topic),
             GetProvider(options.QueueOptions.Provider),
             GetProviderEndpoint(options.QueueOptions.Data, options.QueueOptions.ConnectionString),
-            GetValueOrDefault(GetConnectionSetting(options.QueueOptions.Data, "region")),
             GetProvider(options.StorageOptions.Provider),
-            GetProviderEndpoint(options.StorageOptions.Data, options.StorageOptions.ConnectionString),
-            GetValueOrDefault(GetConnectionSetting(options.StorageOptions.Data, "region")));
+            GetProviderEndpoint(options.StorageOptions.Data, options.StorageOptions.ConnectionString));
 
         logger.LogInformation(
-            "Startup services: event submission {EventSubmission}; web sockets {WebSockets}; jobs in process {JobsInProcess}; repository notifications {RepositoryNotifications}; archive {Archive}; sample data {SampleData}; email {Email} at {SmtpEndpoint} ({SmtpEncryption}, daily summaries {DailySummary}); account creation {AccountCreation}; Active Directory {ActiveDirectory} at {ActiveDirectoryEndpoint}",
+            "Startup services: event submission {EventSubmission}; WebSockets {WebSockets}; jobs in process {JobsInProcess}; email {Email}; account creation {AccountCreation}; index configuration {IndexConfiguration}",
             GetStatus(!options.EventSubmissionDisabled),
             GetStatus(options.EnableWebSockets),
             GetStatus(options.RunJobsInProcess),
-            GetStatus(options.EnableRepositoryNotifications),
-            GetStatus(options.EnableArchive),
-            GetStatus(options.EnableSampleData),
             GetStatus(!String.IsNullOrWhiteSpace(options.EmailOptions.SmtpHost)),
-            GetHostAndPort(options.EmailOptions.SmtpHost, options.EmailOptions.SmtpPort),
-            options.EmailOptions.SmtpEncryption,
-            GetStatus(options.EmailOptions.EnableDailySummary),
             GetStatus(options.AuthOptions.EnableAccountCreation),
-            GetStatus(options.AuthOptions.EnableActiveDirectoryAuth),
-            GetStandaloneConnectionEndpoint(options.AuthOptions.LdapConnectionString));
+            GetStatus(!options.ElasticsearchOptions.DisableIndexConfiguration));
 
         logger.LogInformation(
-            "Startup integrations: OAuth {OAuthProviders}; Intercom {Intercom}; Slack {Slack}; billing {Billing}; geocoding {Geocoding}; GeoIP {GeoIp}; internal Exceptionless logging {InternalLogging} at {ExceptionlessServerEndpoint}",
-            GetOAuthProviders(options.AuthOptions),
-            GetStatus(options.IntercomOptions.EnableIntercom),
-            GetStatus(options.SlackOptions.EnableSlack),
-            GetStatus(options.StripeOptions.EnableBilling),
-            GetStatus(!String.IsNullOrWhiteSpace(options.GoogleGeocodingApiKey)),
-            GetStatus(!String.IsNullOrWhiteSpace(options.MaxMindGeoIpKey)),
-            GetStatus(!String.IsNullOrWhiteSpace(options.ExceptionlessApiKey)),
-            GetSafeEndpoint(options.ExceptionlessServerUrl));
-
-        logger.LogInformation(
-            "Startup operations: retention {MaximumRetentionDays} days; maximum event post {MaximumEventPostSize} bytes; bulk batch {BulkBatchSize}; API throttle {ApiThrottleLimit}; bot throttle {BotThrottleLimit}; queue metrics polling {QueueMetricsPolling} every {QueueMetricsPollingInterval}; disabled pipeline actions {DisabledPipelineActionCount}; disabled plugins {DisabledPluginCount}",
-            options.MaximumRetentionDays,
-            options.MaximumEventPostSize,
-            options.BulkBatchSize,
-            options.ApiThrottleLimit,
-            options.BotThrottleLimit,
-            GetStatus(options.QueueOptions.MetricsPollingEnabled),
-            options.QueueOptions.MetricsPollingInterval,
-            options.DisabledPipelineActions.Count,
-            options.DisabledPlugins.Count);
-
-        logger.LogInformation(
-            "Startup source maps: auto-download {SourceMapAutoDownload}; request timeout {SourceMapRequestTimeout}; processing timeout {SourceMapProcessingTimeout}; per-project artifacts {MaximumArtifactsPerProject} / storage {MaximumStorageSizePerProject} bytes; free retention {FreeArtifactRetentionDays} days; paid retention {ArtifactRetentionDays} days; download concurrency {MaximumConcurrentDownloads} local / {MaximumConcurrentDownloadsGlobally} global",
-            GetStatus(options.SourceMapOptions.EnableAutoDownload),
-            options.SourceMapOptions.RequestTimeout,
-            options.SourceMapOptions.MaximumProcessingTime,
-            options.SourceMapOptions.MaximumArtifactsPerProject,
-            options.SourceMapOptions.MaximumStorageSizePerProject,
-            options.SourceMapOptions.FreeArtifactRetentionDays,
-            options.SourceMapOptions.ArtifactRetentionDays,
-            options.SourceMapOptions.MaximumConcurrentDownloads,
-            options.SourceMapOptions.MaximumConcurrentDownloadsGlobally);
+            "Startup optional integrations/auth providers: {EnabledIntegrations}",
+            GetEnabledIntegrations(options));
     }
 
     private static string GetProvider(string? provider)
@@ -381,22 +335,33 @@ public class Bootstrapper
 
     private static string GetStatus(bool enabled) => enabled ? "enabled" : "disabled";
 
-    private static string GetValueOrDefault(string? value)
-        => String.IsNullOrWhiteSpace(value) ? "not configured" : value;
-
-    private static string GetOAuthProviders(AuthOptions options)
+    private static string GetEnabledIntegrations(AppOptions options)
     {
-        List<string> providers = [];
-        if (!String.IsNullOrWhiteSpace(options.GoogleId))
-            providers.Add("Google");
-        if (!String.IsNullOrWhiteSpace(options.MicrosoftId))
-            providers.Add("Microsoft");
-        if (!String.IsNullOrWhiteSpace(options.FacebookId))
-            providers.Add("Facebook");
-        if (!String.IsNullOrWhiteSpace(options.GitHubId))
-            providers.Add("GitHub");
+        List<string> integrations = [];
+        if (!String.IsNullOrWhiteSpace(options.AuthOptions.GoogleId))
+            integrations.Add("Google OAuth");
+        if (!String.IsNullOrWhiteSpace(options.AuthOptions.MicrosoftId))
+            integrations.Add("Microsoft OAuth");
+        if (!String.IsNullOrWhiteSpace(options.AuthOptions.FacebookId))
+            integrations.Add("Facebook OAuth");
+        if (!String.IsNullOrWhiteSpace(options.AuthOptions.GitHubId))
+            integrations.Add("GitHub OAuth");
+        if (options.AuthOptions.EnableActiveDirectoryAuth)
+            integrations.Add("Active Directory");
+        if (options.IntercomOptions.EnableIntercom)
+            integrations.Add("Intercom");
+        if (options.SlackOptions.EnableSlack)
+            integrations.Add("Slack");
+        if (options.StripeOptions.EnableBilling)
+            integrations.Add("billing");
+        if (!String.IsNullOrWhiteSpace(options.GoogleGeocodingApiKey))
+            integrations.Add("geocoding");
+        if (!String.IsNullOrWhiteSpace(options.MaxMindGeoIpKey))
+            integrations.Add("GeoIP");
+        if (!String.IsNullOrWhiteSpace(options.ExceptionlessApiKey))
+            integrations.Add("internal Exceptionless logging");
 
-        return providers.Count > 0 ? String.Join(", ", providers) : "disabled";
+        return integrations.Count > 0 ? String.Join(", ", integrations) : "none";
     }
 
     private static string GetProviderEndpoint(
@@ -432,26 +397,6 @@ public class Bootstrapper
                 "queueendpoint");
             if (endpoint is not null)
                 return GetSafeEndpoint(endpoint);
-        }
-        catch (ArgumentException) { }
-
-        return GetSafeEndpoint(connectionString);
-    }
-
-    private static string GetStandaloneConnectionEndpoint(string? connectionString)
-    {
-        if (String.IsNullOrWhiteSpace(connectionString))
-            return "not configured";
-
-        try
-        {
-            var parsed = connectionString.ParseConnectionString(defaultKey: "server");
-            string? endpoint = GetConnectionSetting(parsed, "server", "host", "hostname", "endpoint");
-            if (endpoint is not null)
-            {
-                string? port = GetConnectionSetting(parsed, "port");
-                return port is null ? GetSafeEndpoint(endpoint) : GetHostAndPort(GetSafeEndpoint(endpoint), Int32.TryParse(port, out int parsedPort) ? parsedPort : 0);
-            }
         }
         catch (ArgumentException) { }
 

--- a/src/Exceptionless.Insulation/Security/SensitiveDataLogging.cs
+++ b/src/Exceptionless.Insulation/Security/SensitiveDataLogging.cs
@@ -1,30 +1,543 @@
+using System.Collections.Frozen;
+using System.Diagnostics.CodeAnalysis;
 using Exceptionless.Core;
 using Exceptionless.Core.Configuration;
+using Foundatio.Utility;
 using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using StackExchange.Redis;
 
 namespace Exceptionless.Insulation.Security;
 
 /// <summary>
-/// Prevents configuration option objects from being destructured into logs.
-/// Option objects contain credentials and API keys, so they must be treated as scalars.
+/// Replaces configuration option objects with safe, structured copies before they reach log sinks.
 /// </summary>
 public static class SensitiveDataLogging
 {
+    private const string RedactedValue = "[REDACTED]";
+
+    private static readonly FrozenSet<string> _secretConnectionStringKeys = new[]
+    {
+        "password",
+        "pwd",
+        "secret",
+        "secretkey",
+        "accesskeysecret",
+        "accountkey",
+        "sharedaccesskey",
+        "sharedaccesssignature",
+        "signature",
+        "sig",
+        "token",
+        "accesstoken",
+        "access_token",
+        "apikey",
+        "api_key",
+        "clientsecret",
+        "client_secret",
+        "connectiontoken",
+        "sas",
+        "x-amz-signature"
+    }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+    private delegate LogEventPropertyValue Transform(
+        object value,
+        ILogEventPropertyValueFactory propertyValueFactory);
+
+    private static readonly FrozenDictionary<Type, Transform> _transformers =
+        new Dictionary<Type, Transform>
+        {
+            [typeof(AppOptions)] = static (value, factory) => CreateSafeAppOptions((AppOptions)value, factory),
+            [typeof(AuthOptions)] = static (value, factory) => CreateSafeAuthOptions((AuthOptions)value, factory),
+            [typeof(CacheOptions)] = static (value, factory) => CreateSafeCacheOptions((CacheOptions)value, factory),
+            [typeof(ElasticsearchOptions)] = static (value, factory) => CreateSafeElasticsearchOptions((ElasticsearchOptions)value, factory),
+            [typeof(EmailOptions)] = static (value, factory) => CreateSafeEmailOptions((EmailOptions)value, factory),
+            [typeof(IntercomOptions)] = static (value, factory) => CreateSafeIntercomOptions((IntercomOptions)value, factory),
+            [typeof(MessageBusOptions)] = static (value, factory) => CreateSafeMessageBusOptions((MessageBusOptions)value, factory),
+            [typeof(MetricOptions)] = static (value, factory) => CreateSafeMetricOptions((MetricOptions)value, factory),
+            [typeof(QueueOptions)] = static (value, factory) => CreateSafeQueueOptions((QueueOptions)value, factory),
+            [typeof(StorageOptions)] = static (value, factory) => CreateSafeStorageOptions((StorageOptions)value, factory),
+            [typeof(StripeOptions)] = static (value, factory) => CreateSafeStripeOptions((StripeOptions)value, factory),
+            [typeof(SlackOptions)] = static (value, factory) => CreateSafeSlackOptions((SlackOptions)value, factory),
+            [typeof(OAuthServerOptions)] = static (value, factory) => CreateSafeOAuthServerOptions((OAuthServerOptions)value, factory),
+            [typeof(SourceMapOptions)] = static (value, factory) => CreateSafeSourceMapOptions((SourceMapOptions)value, factory)
+        }.ToFrozenDictionary();
+
+    private static readonly SensitiveOptionsDestructuringPolicy _policy = new();
+
     public static LoggerConfiguration ApplySensitiveDataLogging(this LoggerConfiguration configuration)
     {
-        return configuration
-            .Destructure.AsScalar<AppOptions>()
-            .Destructure.AsScalar<AuthOptions>()
-            .Destructure.AsScalar<CacheOptions>()
-            .Destructure.AsScalar<ElasticsearchOptions>()
-            .Destructure.AsScalar<EmailOptions>()
-            .Destructure.AsScalar<IntercomOptions>()
-            .Destructure.AsScalar<MessageBusOptions>()
-            .Destructure.AsScalar<QueueOptions>()
-            .Destructure.AsScalar<StorageOptions>()
-            .Destructure.AsScalar<StripeOptions>()
-            .Destructure.AsScalar<SlackOptions>()
-            .Destructure.AsScalar<OAuthServerOptions>()
-            .Destructure.AsScalar<SourceMapOptions>();
+        return configuration.Destructure.With(_policy);
+    }
+
+    private static StructureValue CreateSafeAppOptions(AppOptions options, ILogEventPropertyValueFactory factory)
+    {
+        var result = new SafeStructureBuilder(nameof(AppOptions), factory, 41);
+        result.Add(nameof(options.BaseURL), options.BaseURL);
+        result.Add(nameof(options.InternalProjectId), options.InternalProjectId);
+        result.Add(nameof(options.ExceptionlessApiKey), RedactedValue);
+        result.Add(nameof(options.ExceptionlessServerUrl), options.ExceptionlessServerUrl);
+        result.Add(nameof(options.AppMode), options.AppMode);
+        result.Add(nameof(options.AppScope), options.AppScope);
+        result.Add(nameof(options.RunJobsInProcess), options.RunJobsInProcess);
+        result.Add(nameof(options.JobsIterationLimit), options.JobsIterationLimit);
+        result.Add(nameof(options.BotThrottleLimit), options.BotThrottleLimit);
+        result.Add(nameof(options.ApiThrottleLimit), options.ApiThrottleLimit);
+        result.Add(nameof(options.EnableArchive), options.EnableArchive);
+        result.Add(nameof(options.EnableSampleData), options.EnableSampleData);
+        result.Add(nameof(options.EventSubmissionDisabled), options.EventSubmissionDisabled);
+        result.Add(nameof(options.DisabledPipelineActions), options.DisabledPipelineActions?.ToArray());
+        result.Add(nameof(options.DisabledPlugins), options.DisabledPlugins?.ToArray());
+        result.Add(nameof(options.MaximumEventPostSize), options.MaximumEventPostSize);
+        result.Add(nameof(options.MaximumRetentionDays), options.MaximumRetentionDays);
+        result.Add(nameof(options.EnableRepositoryNotifications), options.EnableRepositoryNotifications);
+        result.Add(nameof(options.EnableWebSockets), options.EnableWebSockets);
+        result.Add(nameof(options.Version), options.Version);
+        result.Add(nameof(options.InformationalVersion), options.InformationalVersion);
+        result.Add(nameof(options.NotificationMessage), options.NotificationMessage);
+        result.Add(nameof(options.GoogleGeocodingApiKey), RedactedValue);
+        result.Add(nameof(options.MaxMindGeoIpKey), RedactedValue);
+        result.Add(nameof(options.BulkBatchSize), options.BulkBatchSize);
+        result.Add(
+            nameof(options.CacheOptions),
+            options.CacheOptions is null ? null : CreateSafeCacheOptions(options.CacheOptions, factory));
+        result.Add(
+            nameof(options.MessageBusOptions),
+            options.MessageBusOptions is null ? null : CreateSafeMessageBusOptions(options.MessageBusOptions, factory));
+        result.Add(
+            nameof(options.QueueOptions),
+            options.QueueOptions is null ? null : CreateSafeQueueOptions(options.QueueOptions, factory));
+        result.Add(
+            nameof(options.StorageOptions),
+            options.StorageOptions is null ? null : CreateSafeStorageOptions(options.StorageOptions, factory));
+        result.Add(
+            nameof(options.EmailOptions),
+            options.EmailOptions is null ? null : CreateSafeEmailOptions(options.EmailOptions, factory));
+        result.Add(
+            nameof(options.ElasticsearchOptions),
+            options.ElasticsearchOptions is null ? null : CreateSafeElasticsearchOptions(options.ElasticsearchOptions, factory));
+        result.Add(
+            nameof(options.IntercomOptions),
+            options.IntercomOptions is null ? null : CreateSafeIntercomOptions(options.IntercomOptions, factory));
+        result.Add(
+            nameof(options.SlackOptions),
+            options.SlackOptions is null ? null : CreateSafeSlackOptions(options.SlackOptions, factory));
+        result.Add(
+            nameof(options.StripeOptions),
+            options.StripeOptions is null ? null : CreateSafeStripeOptions(options.StripeOptions, factory));
+        result.Add(
+            nameof(options.AuthOptions),
+            options.AuthOptions is null ? null : CreateSafeAuthOptions(options.AuthOptions, factory));
+        result.Add(
+            nameof(options.OAuthServerOptions),
+            options.OAuthServerOptions is null ? null : CreateSafeOAuthServerOptions(options.OAuthServerOptions, factory));
+        result.Add(
+            nameof(options.SourceMapOptions),
+            options.SourceMapOptions is null ? null : CreateSafeSourceMapOptions(options.SourceMapOptions, factory));
+        return result.Build();
+    }
+
+    private static StructureValue CreateSafeAuthOptions(AuthOptions options, ILogEventPropertyValueFactory factory)
+    {
+        var result = new SafeStructureBuilder(nameof(AuthOptions), factory, 11);
+        result.Add(nameof(options.EnableAccountCreation), options.EnableAccountCreation);
+        result.Add(nameof(options.EnableActiveDirectoryAuth), options.EnableActiveDirectoryAuth);
+        result.Add(nameof(options.MicrosoftId), options.MicrosoftId);
+        result.Add(nameof(options.MicrosoftSecret), RedactedValue);
+        result.Add(nameof(options.FacebookId), options.FacebookId);
+        result.Add(nameof(options.FacebookSecret), RedactedValue);
+        result.Add(nameof(options.GitHubId), options.GitHubId);
+        result.Add(nameof(options.GitHubSecret), RedactedValue);
+        result.Add(nameof(options.GoogleId), options.GoogleId);
+        result.Add(nameof(options.GoogleSecret), RedactedValue);
+        result.Add(nameof(options.LdapConnectionString), SanitizeStandaloneConnectionString(options.LdapConnectionString));
+        return result.Build();
+    }
+
+    private static StructureValue CreateSafeCacheOptions(CacheOptions options, ILogEventPropertyValueFactory factory)
+    {
+        var result = new SafeStructureBuilder(nameof(CacheOptions), factory, 5);
+        result.Add(nameof(options.ConnectionString), SanitizeConnectionString(options.ConnectionString, options.Provider));
+        result.Add(nameof(options.Provider), options.Provider);
+        result.Add(nameof(options.Data), SanitizeConnectionData(options.Data, options.Provider));
+        result.Add(nameof(options.Scope), options.Scope);
+        result.Add(nameof(options.ScopePrefix), options.ScopePrefix);
+        return result.Build();
+    }
+
+    private static StructureValue CreateSafeElasticsearchOptions(ElasticsearchOptions options, ILogEventPropertyValueFactory factory)
+    {
+        var result = new SafeStructureBuilder(nameof(ElasticsearchOptions), factory, 15);
+        result.Add(nameof(options.ServerUrl), SanitizeUri(options.ServerUrl));
+        result.Add(nameof(options.NumberOfShards), options.NumberOfShards);
+        result.Add(nameof(options.NumberOfReplicas), options.NumberOfReplicas);
+        result.Add(nameof(options.FieldsLimit), options.FieldsLimit);
+        result.Add(nameof(options.EnableMapperSizePlugin), options.EnableMapperSizePlugin);
+        result.Add(nameof(options.Scope), options.Scope);
+        result.Add(nameof(options.ScopePrefix), options.ScopePrefix);
+        result.Add(nameof(options.EnableSnapshotJobs), options.EnableSnapshotJobs);
+        result.Add(nameof(options.DisableIndexConfiguration), options.DisableIndexConfiguration);
+        result.Add(nameof(options.Password), RedactedValue);
+        result.Add(nameof(options.UserName), options.UserName);
+        result.Add(nameof(options.ReindexCutOffDate), options.ReindexCutOffDate);
+        result.Add(
+            nameof(options.ElasticsearchToMigrate),
+            options.ElasticsearchToMigrate is null
+                ? null
+                : CreateSafeElasticsearchOptions(options.ElasticsearchToMigrate, factory));
+        return result.Build();
+    }
+
+    private static StructureValue CreateSafeEmailOptions(EmailOptions options, ILogEventPropertyValueFactory factory)
+    {
+        var result = new SafeStructureBuilder(nameof(EmailOptions), factory, 11);
+        result.Add(nameof(options.EnableDailySummary), options.EnableDailySummary);
+        result.Add(nameof(options.TestEmailAddress), options.TestEmailAddress);
+        result.Add(nameof(options.ContactEmailAddress), options.ContactEmailAddress);
+        result.Add(nameof(options.AllowedOutboundAddresses), options.AllowedOutboundAddresses?.ToArray());
+        result.Add(nameof(options.SmtpFrom), options.SmtpFrom);
+        result.Add(nameof(options.SmtpHost), options.SmtpHost);
+        result.Add(nameof(options.SmtpPort), options.SmtpPort);
+        result.Add(nameof(options.SmtpEncryption), options.SmtpEncryption);
+        result.Add(nameof(options.SmtpUser), options.SmtpUser);
+        result.Add(nameof(options.SmtpPassword), RedactedValue);
+        return result.Build();
+    }
+
+    private static StructureValue CreateSafeIntercomOptions(IntercomOptions options, ILogEventPropertyValueFactory factory)
+    {
+        var result = new SafeStructureBuilder(nameof(IntercomOptions), factory, 3);
+        result.Add(nameof(options.EnableIntercom), options.EnableIntercom);
+        result.Add(nameof(options.IntercomId), options.IntercomId);
+        result.Add(nameof(options.IntercomSecret), RedactedValue);
+        return result.Build();
+    }
+
+    private static StructureValue CreateSafeMessageBusOptions(MessageBusOptions options, ILogEventPropertyValueFactory factory)
+    {
+        var result = new SafeStructureBuilder(nameof(MessageBusOptions), factory, 6);
+        result.Add(nameof(options.ConnectionString), SanitizeConnectionString(options.ConnectionString, options.Provider));
+        result.Add(nameof(options.Provider), options.Provider);
+        result.Add(nameof(options.Data), SanitizeConnectionData(options.Data, options.Provider));
+        result.Add(nameof(options.Scope), options.Scope);
+        result.Add(nameof(options.ScopePrefix), options.ScopePrefix);
+        result.Add(nameof(options.Topic), options.Topic);
+        return result.Build();
+    }
+
+    private static StructureValue CreateSafeMetricOptions(MetricOptions options, ILogEventPropertyValueFactory factory)
+    {
+        var result = new SafeStructureBuilder(nameof(MetricOptions), factory, 3);
+        result.Add(nameof(options.ConnectionString), SanitizeConnectionString(options.ConnectionString, options.Provider));
+        result.Add(nameof(options.Provider), options.Provider);
+        result.Add(nameof(options.Data), SanitizeConnectionData(options.Data, options.Provider));
+        return result.Build();
+    }
+
+    private static StructureValue CreateSafeOAuthServerOptions(OAuthServerOptions options, ILogEventPropertyValueFactory factory)
+    {
+        var result = new SafeStructureBuilder(nameof(OAuthServerOptions), factory, 8);
+        result.Add(nameof(options.AuthorizationCodeLifetime), options.AuthorizationCodeLifetime);
+        result.Add(nameof(options.AccessTokenLifetime), options.AccessTokenLifetime);
+        result.Add(nameof(options.RefreshTokenLifetime), options.RefreshTokenLifetime);
+        result.Add(nameof(options.EnableClientIdMetadataDocuments), options.EnableClientIdMetadataDocuments);
+        result.Add(nameof(options.DynamicClientRegistrationIpLimit), options.DynamicClientRegistrationIpLimit);
+        result.Add(nameof(options.ClientMetadataDocumentCacheLifetime), options.ClientMetadataDocumentCacheLifetime);
+        result.Add(nameof(options.ClientMetadataDocumentRequestTimeout), options.ClientMetadataDocumentRequestTimeout);
+        result.Add(nameof(options.ClientMetadataDocumentMaxBytes), options.ClientMetadataDocumentMaxBytes);
+        return result.Build();
+    }
+
+    private static StructureValue CreateSafeQueueOptions(QueueOptions options, ILogEventPropertyValueFactory factory)
+    {
+        var result = new SafeStructureBuilder(nameof(QueueOptions), factory, 7);
+        result.Add(nameof(options.ConnectionString), SanitizeConnectionString(options.ConnectionString, options.Provider));
+        result.Add(nameof(options.Provider), options.Provider);
+        result.Add(nameof(options.Data), SanitizeConnectionData(options.Data, options.Provider));
+        result.Add(nameof(options.Scope), options.Scope);
+        result.Add(nameof(options.ScopePrefix), options.ScopePrefix);
+        result.Add(nameof(options.MetricsPollingEnabled), options.MetricsPollingEnabled);
+        result.Add(nameof(options.MetricsPollingInterval), options.MetricsPollingInterval);
+        return result.Build();
+    }
+
+    private static StructureValue CreateSafeSlackOptions(SlackOptions options, ILogEventPropertyValueFactory factory)
+    {
+        var result = new SafeStructureBuilder(nameof(SlackOptions), factory, 3);
+        result.Add(nameof(options.SlackId), options.SlackId);
+        result.Add(nameof(options.SlackSecret), RedactedValue);
+        result.Add(nameof(options.EnableSlack), options.EnableSlack);
+        return result.Build();
+    }
+
+    private static StructureValue CreateSafeSourceMapOptions(SourceMapOptions options, ILogEventPropertyValueFactory factory)
+    {
+        var result = new SafeStructureBuilder(nameof(SourceMapOptions), factory, 41);
+        result.Add(nameof(options.EnableAutoDownload), options.EnableAutoDownload);
+        result.Add(nameof(options.RequestTimeoutMilliseconds), options.RequestTimeoutMilliseconds);
+        result.Add(nameof(options.MaximumGeneratedFileSize), options.MaximumGeneratedFileSize);
+        result.Add(nameof(options.MaximumSourceMapSize), options.MaximumSourceMapSize);
+        result.Add(nameof(options.MaximumArtifactsPerProject), options.MaximumArtifactsPerProject);
+        result.Add(nameof(options.MaximumStorageSizePerProject), options.MaximumStorageSizePerProject);
+        result.Add(nameof(options.MaximumArtifactsPerFreeProject), options.MaximumArtifactsPerFreeProject);
+        result.Add(nameof(options.MaximumStorageSizePerFreeProject), options.MaximumStorageSizePerFreeProject);
+        result.Add(nameof(options.MaximumMappingSegments), options.MaximumMappingSegments);
+        result.Add(nameof(options.MaximumRedirects), options.MaximumRedirects);
+        result.Add(nameof(options.MaximumConcurrentDownloads), options.MaximumConcurrentDownloads);
+        result.Add(nameof(options.MaximumConcurrentDownloadsGlobally), options.MaximumConcurrentDownloadsGlobally);
+        result.Add(nameof(options.AutoDownloadRateLimitPeriodMinutes), options.AutoDownloadRateLimitPeriodMinutes);
+        result.Add(nameof(options.MaximumAutoDiscoveriesPerFreeClientKey), options.MaximumAutoDiscoveriesPerFreeClientKey);
+        result.Add(nameof(options.MaximumAutoDiscoveriesPerClientKey), options.MaximumAutoDiscoveriesPerClientKey);
+        result.Add(nameof(options.MaximumAutoDiscoveriesPerFreeProject), options.MaximumAutoDiscoveriesPerFreeProject);
+        result.Add(nameof(options.MaximumAutoDiscoveriesPerProject), options.MaximumAutoDiscoveriesPerProject);
+        result.Add(nameof(options.MaximumAutoDiscoveriesPerFreeOrganization), options.MaximumAutoDiscoveriesPerFreeOrganization);
+        result.Add(nameof(options.MaximumAutoDiscoveriesPerOrganization), options.MaximumAutoDiscoveriesPerOrganization);
+        result.Add(nameof(options.MaximumAutoDownloadRequestsPerDestination), options.MaximumAutoDownloadRequestsPerDestination);
+        result.Add(nameof(options.MaximumAutoDownloadConnectionsPerIpAddress), options.MaximumAutoDownloadConnectionsPerIpAddress);
+        result.Add(nameof(options.MaximumAutoDownloadRequestsGlobally), options.MaximumAutoDownloadRequestsGlobally);
+        result.Add(nameof(options.MaximumAutoRefreshRequestsPerDestination), options.MaximumAutoRefreshRequestsPerDestination);
+        result.Add(nameof(options.MaximumAutoRefreshRequestsGlobally), options.MaximumAutoRefreshRequestsGlobally);
+        result.Add(nameof(options.MaximumFramesPerError), options.MaximumFramesPerError);
+        result.Add(nameof(options.MaximumProcessingTimeMilliseconds), options.MaximumProcessingTimeMilliseconds);
+        result.Add(nameof(options.AutoDownloadRefreshIntervalMinutes), options.AutoDownloadRefreshIntervalMinutes);
+        result.Add(nameof(options.ParsedSourceMapCacheLifetimeMinutes), options.ParsedSourceMapCacheLifetimeMinutes);
+        result.Add(nameof(options.MaximumParsedSourceMapCacheSize), options.MaximumParsedSourceMapCacheSize);
+        result.Add(nameof(options.UsageTrackingDebounceMinutes), options.UsageTrackingDebounceMinutes);
+        result.Add(nameof(options.FreeArtifactRetentionDays), options.FreeArtifactRetentionDays);
+        result.Add(nameof(options.ArtifactRetentionDays), options.ArtifactRetentionDays);
+        result.Add(nameof(options.RequestTimeout), options.RequestTimeout);
+        result.Add(nameof(options.MaximumProcessingTime), options.MaximumProcessingTime);
+        result.Add(nameof(options.AutoDownloadRefreshInterval), options.AutoDownloadRefreshInterval);
+        result.Add(nameof(options.ParsedSourceMapCacheLifetime), options.ParsedSourceMapCacheLifetime);
+        result.Add(nameof(options.AutoDownloadRateLimitPeriod), options.AutoDownloadRateLimitPeriod);
+        result.Add(nameof(options.UsageTrackingDebounce), options.UsageTrackingDebounce);
+        result.Add(nameof(options.FreeArtifactRetention), options.FreeArtifactRetention);
+        result.Add(nameof(options.ArtifactRetention), options.ArtifactRetention);
+        return result.Build();
+    }
+
+    private static StructureValue CreateSafeStorageOptions(StorageOptions options, ILogEventPropertyValueFactory factory)
+    {
+        var result = new SafeStructureBuilder(nameof(StorageOptions), factory, 5);
+        result.Add(nameof(options.ConnectionString), SanitizeConnectionString(options.ConnectionString, options.Provider));
+        result.Add(nameof(options.Provider), options.Provider);
+        result.Add(nameof(options.Data), SanitizeConnectionData(options.Data, options.Provider));
+        result.Add(nameof(options.Scope), options.Scope);
+        result.Add(nameof(options.ScopePrefix), options.ScopePrefix);
+        return result.Build();
+    }
+
+    private static StructureValue CreateSafeStripeOptions(StripeOptions options, ILogEventPropertyValueFactory factory)
+    {
+        var result = new SafeStructureBuilder(nameof(StripeOptions), factory, 4);
+        result.Add(nameof(options.EnableBilling), options.EnableBilling);
+        result.Add(nameof(options.StripeApiKey), RedactedValue);
+        result.Add(nameof(options.StripePublishableApiKey), options.StripePublishableApiKey);
+        result.Add(nameof(options.StripeWebHookSigningSecret), RedactedValue);
+        return result.Build();
+    }
+
+    private static Dictionary<string, string?>? SanitizeConnectionData(
+        IDictionary<string, string?>? data,
+        string? provider)
+    {
+        if (data is null)
+            return null;
+
+        var safeData = new Dictionary<string, string?>(data.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in data)
+            safeData[pair.Key] = SanitizeConnectionValue(pair.Key, pair.Value, provider);
+
+        return safeData;
+    }
+
+    private static string? SanitizeConnectionString(string? connectionString, string? provider)
+    {
+        if (String.IsNullOrEmpty(connectionString))
+            return connectionString;
+
+        if (String.Equals(provider, "redis", StringComparison.OrdinalIgnoreCase)
+            && TrySanitizeRedisConnectionString(connectionString, out string? safeRedisConnectionString))
+        {
+            return safeRedisConnectionString;
+        }
+
+        try
+        {
+            var data = connectionString.ParseConnectionString(defaultKey: "server");
+            return SanitizeConnectionData(data, provider)?.BuildConnectionString();
+        }
+        catch (ArgumentException)
+        {
+            string? safeUri = SanitizeUri(connectionString);
+            if (!String.Equals(safeUri, connectionString, StringComparison.Ordinal))
+                return safeUri;
+
+            return RedactCommaSeparatedSecrets(connectionString);
+        }
+    }
+
+    private static string? SanitizeStandaloneConnectionString(string? connectionString)
+    {
+        if (String.IsNullOrEmpty(connectionString))
+            return connectionString;
+
+        string? safeUri = SanitizeUri(connectionString);
+        if (!String.Equals(safeUri, connectionString, StringComparison.Ordinal))
+            return safeUri;
+
+        try
+        {
+            var data = connectionString.ParseConnectionString();
+            return SanitizeConnectionData(data, provider: null)?.BuildConnectionString();
+        }
+        catch (ArgumentException)
+        {
+            return RedactCommaSeparatedSecrets(connectionString);
+        }
+    }
+
+    private static string? SanitizeConnectionValue(string key, string? value, string? provider)
+    {
+        if (_secretConnectionStringKeys.Contains(key))
+            return RedactedValue;
+
+        if (String.IsNullOrEmpty(value))
+            return value;
+
+        if (String.Equals(provider, "redis", StringComparison.OrdinalIgnoreCase)
+            && String.Equals(key, "server", StringComparison.OrdinalIgnoreCase)
+            && TrySanitizeRedisConnectionString(value, out string? safeRedisConnectionString))
+        {
+            return safeRedisConnectionString;
+        }
+
+        return SanitizeUri(value);
+    }
+
+    private static bool TrySanitizeRedisConnectionString(string connectionString, out string? safeConnectionString)
+    {
+        try
+        {
+            var redisOptions = ConfigurationOptions.Parse(connectionString);
+            safeConnectionString = redisOptions
+                .ToString(includePassword: false)
+                .Replace("password=*****", $"password={RedactedValue}", StringComparison.OrdinalIgnoreCase);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            safeConnectionString = null;
+            return false;
+        }
+    }
+
+    private static string? SanitizeUri(string? value)
+    {
+        if (String.IsNullOrEmpty(value)
+            || !value.Contains("://", StringComparison.Ordinal)
+            || !Uri.TryCreate(value, UriKind.Absolute, out var uri))
+        {
+            return value;
+        }
+
+        var builder = new UriBuilder(uri);
+        bool changed = false;
+
+        if (!String.IsNullOrEmpty(builder.Password))
+        {
+            builder.Password = RedactedValue;
+            changed = true;
+        }
+
+        if (!String.IsNullOrEmpty(builder.Query))
+        {
+            string[] segments = builder.Query.TrimStart('?').Split('&');
+            for (int index = 0; index < segments.Length; index++)
+            {
+                int separatorIndex = segments[index].IndexOf('=');
+                string encodedKey = separatorIndex >= 0 ? segments[index][..separatorIndex] : segments[index];
+                string key = Uri.UnescapeDataString(encodedKey.Replace("+", " ", StringComparison.Ordinal));
+
+                if (!_secretConnectionStringKeys.Contains(key))
+                    continue;
+
+                segments[index] = $"{encodedKey}={Uri.EscapeDataString(RedactedValue)}";
+                changed = true;
+            }
+
+            if (changed)
+                builder.Query = String.Join('&', segments);
+        }
+
+        return changed ? builder.Uri.AbsoluteUri : value;
+    }
+
+    private static string RedactCommaSeparatedSecrets(string value)
+    {
+        string[] segments = value.Split(',');
+        bool changed = false;
+
+        for (int index = 0; index < segments.Length; index++)
+        {
+            int separatorIndex = segments[index].IndexOf('=');
+            if (separatorIndex < 0)
+                continue;
+
+            string key = segments[index][..separatorIndex].Trim();
+            if (!_secretConnectionStringKeys.Contains(key))
+                continue;
+
+            segments[index] = $"{segments[index][..(separatorIndex + 1)]}{RedactedValue}";
+            changed = true;
+        }
+
+        return changed ? String.Join(',', segments) : value;
+    }
+
+    private sealed class SensitiveOptionsDestructuringPolicy : IDestructuringPolicy
+    {
+        public bool TryDestructure(
+            object value,
+            ILogEventPropertyValueFactory propertyValueFactory,
+            [NotNullWhen(true)]
+            out LogEventPropertyValue? result)
+        {
+            if (!_transformers.TryGetValue(value.GetType(), out var transform))
+            {
+                result = null;
+                return false;
+            }
+
+            result = transform(value, propertyValueFactory);
+            return true;
+        }
+    }
+
+    private sealed class SafeStructureBuilder
+    {
+        private readonly ILogEventPropertyValueFactory _factory;
+        private readonly List<LogEventProperty> _properties;
+        private readonly string _typeTag;
+
+        public SafeStructureBuilder(
+            string typeTag,
+            ILogEventPropertyValueFactory factory,
+            int propertyCapacity)
+        {
+            _typeTag = typeTag;
+            _factory = factory;
+            _properties = new List<LogEventProperty>(propertyCapacity);
+        }
+
+        public void Add(string name, object? value)
+        {
+            _properties.Add(new LogEventProperty(
+                name,
+                value as LogEventPropertyValue ?? _factory.CreatePropertyValue(value, destructureObjects: true)));
+        }
+
+        public StructureValue Build() => new(_properties, _typeTag);
     }
 }

--- a/src/Exceptionless.Insulation/Security/SensitiveDataLogging.cs
+++ b/src/Exceptionless.Insulation/Security/SensitiveDataLogging.cs
@@ -1,0 +1,30 @@
+using Exceptionless.Core;
+using Exceptionless.Core.Configuration;
+using Serilog;
+
+namespace Exceptionless.Insulation.Security;
+
+/// <summary>
+/// Prevents configuration option objects from being destructured into logs.
+/// Option objects contain credentials and API keys, so they must be treated as scalars.
+/// </summary>
+public static class SensitiveDataLogging
+{
+    public static LoggerConfiguration ApplySensitiveDataLogging(this LoggerConfiguration configuration)
+    {
+        return configuration
+            .Destructure.AsScalar<AppOptions>()
+            .Destructure.AsScalar<AuthOptions>()
+            .Destructure.AsScalar<CacheOptions>()
+            .Destructure.AsScalar<ElasticsearchOptions>()
+            .Destructure.AsScalar<EmailOptions>()
+            .Destructure.AsScalar<IntercomOptions>()
+            .Destructure.AsScalar<MessageBusOptions>()
+            .Destructure.AsScalar<QueueOptions>()
+            .Destructure.AsScalar<StorageOptions>()
+            .Destructure.AsScalar<StripeOptions>()
+            .Destructure.AsScalar<SlackOptions>()
+            .Destructure.AsScalar<OAuthServerOptions>()
+            .Destructure.AsScalar<SourceMapOptions>();
+    }
+}

--- a/src/Exceptionless.Job/Program.cs
+++ b/src/Exceptionless.Job/Program.cs
@@ -5,6 +5,7 @@ using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Jobs;
 using Exceptionless.Core.Jobs.Elastic;
 using Exceptionless.Insulation.Configuration;
+using Exceptionless.Insulation.Security;
 using Foundatio.Extensions.Hosting.Jobs;
 using Foundatio.Extensions.Hosting.Startup;
 using Foundatio.Jobs;
@@ -56,6 +57,7 @@ public class Program
 
         Log.Logger = new LoggerConfiguration()
             .ReadFrom.Configuration(config)
+            .ApplySensitiveDataLogging()
             .CreateBootstrapLogger()
             .ForContext<Program>();
 
@@ -73,6 +75,7 @@ public class Program
             .UseSerilog((ctx, sp, c) =>
             {
                 c.ReadFrom.Configuration(ctx.Configuration);
+                c.ApplySensitiveDataLogging();
                 c.ReadFrom.Services(sp);
                 c.Enrich.WithMachineName();
 

--- a/src/Exceptionless.Web/Program.cs
+++ b/src/Exceptionless.Web/Program.cs
@@ -7,6 +7,7 @@ using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Serialization;
 using Exceptionless.Core.Validation;
 using Exceptionless.Insulation.Configuration;
+using Exceptionless.Insulation.Security;
 using Exceptionless.Web.Api;
 using Exceptionless.Web.Api.Results;
 using Exceptionless.Web.Extensions;
@@ -81,6 +82,7 @@ public partial class Program
             var configuration = (IConfigurationRoot)builder.Configuration;
             Log.Logger = new LoggerConfiguration()
                 .ReadFrom.Configuration(configuration)
+                .ApplySensitiveDataLogging()
                 .CreateBootstrapLogger()
                 .ForContext<Program>();
 
@@ -99,6 +101,7 @@ public partial class Program
                 .UseSerilog((ctx, sp, c) =>
                 {
                     c.ReadFrom.Configuration(ctx.Configuration);
+                    c.ApplySensitiveDataLogging();
                     c.ReadFrom.Services(sp);
                     c.Enrich.WithMachineName();
 

--- a/tests/Exceptionless.Tests/BootstrapperTests.cs
+++ b/tests/Exceptionless.Tests/BootstrapperTests.cs
@@ -1,0 +1,260 @@
+using Exceptionless.Core;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Exceptionless.Tests;
+
+public class BootstrapperTests
+{
+    [Fact]
+    public void LogConfiguration_ConfiguredServices_LogsCuratedSafeSummary()
+    {
+        var options = CreateConfiguredOptions();
+        var logger = new CollectingLogger(LogLevel.Information);
+        using var serviceProvider = CreateServiceProvider("Integration");
+
+        Bootstrapper.LogConfiguration(serviceProvider, options, logger);
+
+        string[] informationMessages = logger.Entries
+            .Where(entry => entry.Level == LogLevel.Information)
+            .Select(entry => entry.Message)
+            .ToArray();
+
+        Assert.Equal(
+        [
+            "Startup configuration: environment Integration, scope tenant-a, mode Staging, version 1.2.3+build.4, base URL https://app.example.test:8443",
+            "Startup infrastructure: Elasticsearch https://elastic.example.test:9200 (migration https://elastic-migrate.example.test:9243, shards 3, replicas 2, index configuration enabled, snapshot jobs enabled); cache redis at cache.example.test:6380; message bus rabbitmq at amqps://rabbit.example.test:5671 (topic tenant-a-messages); queue sqs at https://queue.example.test (region us-east-2); storage azurestorage at https://visibleaccount.blob.core.windows.net (region us-central-1)",
+            "Startup services: event submission enabled; web sockets enabled; jobs in process enabled; repository notifications enabled; archive enabled; sample data disabled; email enabled at smtp.example.test:465 (SSL, daily summaries enabled); account creation enabled; Active Directory enabled at ldap.example.test:389",
+            "Startup integrations: OAuth Google, Microsoft, GitHub; Intercom enabled; Slack enabled; billing enabled; geocoding enabled; GeoIP enabled; internal Exceptionless logging enabled at https://collector.example.test",
+            "Startup operations: retention 365 days; maximum event post 250000 bytes; bulk batch 750; API throttle 5000; bot throttle 30; queue metrics polling enabled every 00:00:07; disabled pipeline actions 1; disabled plugins 2",
+            "Startup source maps: auto-download enabled; request timeout 00:00:04; processing timeout 00:00:06; per-project artifacts 200 / storage 524288000 bytes; free retention 10 days; paid retention 60 days; download concurrency 3 local / 12 global"
+        ],
+        informationMessages);
+
+        string output = String.Join(Environment.NewLine, logger.Entries.Select(entry => entry.Message));
+        Assert.Contains("cache.example.test:6380", output, StringComparison.Ordinal);
+        Assert.Contains("rabbit.example.test:5671", output, StringComparison.Ordinal);
+        Assert.Contains("us-east-2", output, StringComparison.Ordinal);
+        Assert.Contains("smtp.example.test:465", output, StringComparison.Ordinal);
+        Assert.Contains("elastic.example.test:9200", output, StringComparison.Ordinal);
+        Assert.Contains("retention 365 days", output, StringComparison.Ordinal);
+
+        foreach (string secret in GetCanarySecrets())
+            Assert.DoesNotContain(secret, output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LogConfiguration_DisabledServices_LogsDisabledSummaryAndPreservesWarnings()
+    {
+        var options = CreateOptions(
+        [
+            new("BaseURL", "http://localhost:5000"),
+            new("AppMode", "Production"),
+            new("AppScope", "disabled-test"),
+            new("EnableWebSockets", "false"),
+            new("EnableAccountCreation", "false"),
+            new("EventSubmissionDisabled", "true"),
+            new("SourceMaps:EnableAutoDownload", "false")
+        ]);
+        var logger = new CollectingLogger(LogLevel.Information);
+        using var serviceProvider = CreateServiceProvider("Production");
+
+        Bootstrapper.LogConfiguration(serviceProvider, options, logger);
+
+        string output = String.Join(Environment.NewLine, logger.Entries.Select(entry => entry.Message));
+        Assert.Contains("cache disabled at not configured", output, StringComparison.Ordinal);
+        Assert.Contains("message bus disabled at not configured", output, StringComparison.Ordinal);
+        Assert.Contains("queue disabled at not configured", output, StringComparison.Ordinal);
+        Assert.Contains("storage disabled at not configured", output, StringComparison.Ordinal);
+        Assert.Contains("event submission disabled", output, StringComparison.Ordinal);
+        Assert.Contains("web sockets disabled", output, StringComparison.Ordinal);
+        Assert.Contains("email disabled at not configured", output, StringComparison.Ordinal);
+        Assert.Contains("account creation disabled", output, StringComparison.Ordinal);
+        Assert.Contains("OAuth disabled", output, StringComparison.Ordinal);
+        Assert.Contains("auto-download disabled", output, StringComparison.Ordinal);
+
+        string[] warnings = logger.Entries
+            .Where(entry => entry.Level == LogLevel.Warning)
+            .Select(entry => entry.Message)
+            .ToArray();
+        Assert.Contains(warnings, message => message.StartsWith("Distributed cache is NOT enabled", StringComparison.Ordinal));
+        Assert.Contains(warnings, message => message.StartsWith("Distributed message bus is NOT enabled", StringComparison.Ordinal));
+        Assert.Contains(warnings, message => message.StartsWith("Distributed queue is NOT enabled", StringComparison.Ordinal));
+        Assert.Contains(warnings, message => message.StartsWith("Distributed storage is NOT enabled", StringComparison.Ordinal));
+        Assert.Contains(warnings, message => message.StartsWith("Web Sockets is NOT enabled", StringComparison.Ordinal));
+        Assert.Contains(warnings, message => message.StartsWith("Emails will NOT be sent", StringComparison.Ordinal));
+        Assert.Contains(warnings, message => message.StartsWith("Event Submission is NOT enabled", StringComparison.Ordinal));
+        Assert.Contains(warnings, message => message.StartsWith("Account Creation is NOT enabled", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void LogConfiguration_InformationDisabled_DoesNotLogSummaryAndPreservesWarnings()
+    {
+        var options = CreateOptions(
+        [
+            new("BaseURL", "http://localhost:5000"),
+            new("EnableWebSockets", "false")
+        ]);
+        var logger = new CollectingLogger(LogLevel.Warning);
+        using var serviceProvider = CreateServiceProvider("Production");
+
+        Bootstrapper.LogConfiguration(serviceProvider, options, logger);
+
+        Assert.DoesNotContain(logger.Entries, entry => entry.Level == LogLevel.Information);
+        Assert.Contains(
+            logger.Entries,
+            entry => entry.Level == LogLevel.Warning
+                && entry.Message.StartsWith("Web Sockets is NOT enabled", StringComparison.Ordinal));
+    }
+
+    private static AppOptions CreateConfiguredOptions()
+    {
+        var options = CreateOptions(
+        [
+            new("BaseURL", "https://base-user:base-password-secret-canary@app.example.test:8443/path?token=query-token-secret-canary"),
+            new("ExceptionlessApiKey", "exceptionless-api-key-secret-canary"),
+            new("ExceptionlessServerUrl", "https://collector-user:collector-password-secret-canary@collector.example.test/path?api_key=collector-query-secret-canary"),
+            new("AppMode", "Staging"),
+            new("AppScope", "tenant-a"),
+            new("RunJobsInProcess", "true"),
+            new("JobsIterationLimit", "42"),
+            new("BotThrottleLimit", "30"),
+            new("ApiThrottleLimit", "5000"),
+            new("EnableArchive", "true"),
+            new("EnableSampleData", "false"),
+            new("MaximumEventPostSize", "250000"),
+            new("MaximumRetentionDays", "365"),
+            new("BulkBatchSize", "750"),
+            new("EnableRepositoryNotifications", "true"),
+            new("EnableWebSockets", "true"),
+            new("DisabledPipelineActions", "CanaryPipelineAction"),
+            new("DisabledPlugins", "CanaryPlugin1,CanaryPlugin2"),
+            new("GoogleGeocodingApiKey", "google-api-key-secret-canary"),
+            new("MaxMindGeoIpKey", "maxmind-key-secret-canary"),
+            new("EnableDailySummary", "true"),
+            new("EnableAccountCreation", "true"),
+            new("EnableActiveDirectoryAuth", "true"),
+            new("ConnectionStrings:Cache", "provider=redis;server=\"cache.example.test:6380,password=cache-password-secret-canary,abortConnect=false\""),
+            new("ConnectionStrings:MessageBus", "provider=rabbitmq;server=\"amqps://rabbit-user:rabbit-password-secret-canary@rabbit.example.test:5671/vhost\""),
+            new("ConnectionStrings:Queue", "provider=sqs;serviceurl=\"https://queue-user:queue-password-secret-canary@queue.example.test/v1?token=queue-token-secret-canary\";region=us-east-2;accesskey=queue-access-key-secret-canary;secretkey=queue-secret-key-secret-canary"),
+            new("ConnectionStrings:Storage", "provider=azurestorage;BlobEndpoint=\"https://storage-user:storage-password-secret-canary@visibleaccount.blob.core.windows.net/container?sig=storage-signature-secret-canary\";AccountName=visibleaccount;AccountKey=storage-account-key-secret-canary;region=us-central-1"),
+            new("ConnectionStrings:Elasticsearch", "server=\"https://elastic-user:elastic-password-secret-canary@elastic.example.test:9200/path?token=elastic-token-secret-canary\";shards=3;replicas=2"),
+            new("ConnectionStrings:ElasticsearchToMigrate", "server=\"https://migrate-user:migrate-password-secret-canary@elastic-migrate.example.test:9243\""),
+            new("ConnectionStrings:Email", "smtps://smtp-user:smtp-password-secret-canary@smtp.example.test:465"),
+            new("ConnectionStrings:LDAP", "server=ldap.example.test;port=389;username=ldap-user;password=ldap-password-secret-canary"),
+            new("ConnectionStrings:OAuth", "GoogleId=google-id;GoogleSecret=google-secret-canary;MicrosoftId=microsoft-id;MicrosoftSecret=microsoft-secret-canary;GitHubId=github-id;GitHubSecret=github-secret-canary;IntercomId=intercom-id;IntercomSecret=intercom-secret-canary;SlackId=slack-id;SlackSecret=slack-secret-canary"),
+            new("StripeApiKey", "stripe-api-key-secret-canary"),
+            new("StripePublishableApiKey", "stripe-publishable-key"),
+            new("StripeWebHookSigningSecret", "stripe-signing-secret-canary"),
+            new("EnableSnapshotJobs", "true"),
+            new("QueueMetricsPollingEnabled", "true"),
+            new("SourceMaps:EnableAutoDownload", "true"),
+            new("SourceMaps:RequestTimeoutMilliseconds", "4000"),
+            new("SourceMaps:MaximumProcessingTimeMilliseconds", "6000"),
+            new("SourceMaps:MaximumArtifactsPerProject", "200"),
+            new("SourceMaps:MaximumStorageSizePerProject", "524288000"),
+            new("SourceMaps:FreeArtifactRetentionDays", "10"),
+            new("SourceMaps:ArtifactRetentionDays", "60"),
+            new("SourceMaps:MaximumConcurrentDownloads", "3"),
+            new("SourceMaps:MaximumConcurrentDownloadsGlobally", "12")
+        ]);
+
+        options.Version = "1.2.3";
+        options.InformationalVersion = "1.2.3+build.4";
+        options.QueueOptions.MetricsPollingEnabled = true;
+        options.QueueOptions.MetricsPollingInterval = TimeSpan.FromSeconds(7);
+        return options;
+    }
+
+    private static AppOptions CreateOptions(IEnumerable<KeyValuePair<string, string?>> values)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+        return AppOptions.ReadFromConfiguration(configuration);
+    }
+
+    private static ServiceProvider CreateServiceProvider(string environmentName)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IHostEnvironment>(new TestHostEnvironment
+        {
+            EnvironmentName = environmentName
+        });
+        return services.BuildServiceProvider();
+    }
+
+    private static string[] GetCanarySecrets()
+    {
+        return
+        [
+            "base-user",
+            "base-password-secret-canary",
+            "query-token-secret-canary",
+            "exceptionless-api-key-secret-canary",
+            "collector-user",
+            "collector-password-secret-canary",
+            "collector-query-secret-canary",
+            "cache-password-secret-canary",
+            "rabbit-user",
+            "rabbit-password-secret-canary",
+            "queue-user",
+            "queue-password-secret-canary",
+            "queue-token-secret-canary",
+            "queue-access-key-secret-canary",
+            "queue-secret-key-secret-canary",
+            "storage-user",
+            "storage-password-secret-canary",
+            "storage-signature-secret-canary",
+            "storage-account-key-secret-canary",
+            "elastic-user",
+            "elastic-password-secret-canary",
+            "elastic-token-secret-canary",
+            "migrate-user",
+            "migrate-password-secret-canary",
+            "smtp-user",
+            "smtp-password-secret-canary",
+            "ldap-user",
+            "ldap-password-secret-canary",
+            "google-secret-canary",
+            "microsoft-secret-canary",
+            "github-secret-canary",
+            "intercom-secret-canary",
+            "slack-secret-canary",
+            "stripe-api-key-secret-canary",
+            "stripe-signing-secret-canary"
+        ];
+    }
+
+    private sealed class CollectingLogger(LogLevel minimumLevel) : ILogger
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= minimumLevel;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (IsEnabled(logLevel))
+                Entries.Add(new LogEntry(logLevel, formatter(state, exception)));
+        }
+    }
+
+    private sealed record LogEntry(LogLevel Level, string Message);
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = "Exceptionless.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/tests/Exceptionless.Tests/BootstrapperTests.cs
+++ b/tests/Exceptionless.Tests/BootstrapperTests.cs
@@ -25,21 +25,17 @@ public class BootstrapperTests
         Assert.Equal(
         [
             "Startup configuration: environment Integration, scope tenant-a, mode Staging, version 1.2.3+build.4, base URL https://app.example.test:8443",
-            "Startup infrastructure: Elasticsearch https://elastic.example.test:9200 (migration https://elastic-migrate.example.test:9243, shards 3, replicas 2, index configuration enabled, snapshot jobs enabled); cache redis at cache.example.test:6380; message bus rabbitmq at amqps://rabbit.example.test:5671 (topic tenant-a-messages); queue sqs at https://queue.example.test (region us-east-2); storage azurestorage at https://visibleaccount.blob.core.windows.net (region us-central-1)",
-            "Startup services: event submission enabled; web sockets enabled; jobs in process enabled; repository notifications enabled; archive enabled; sample data disabled; email enabled at smtp.example.test:465 (SSL, daily summaries enabled); account creation enabled; Active Directory enabled at ldap.example.test:389",
-            "Startup integrations: OAuth Google, Microsoft, GitHub; Intercom enabled; Slack enabled; billing enabled; geocoding enabled; GeoIP enabled; internal Exceptionless logging enabled at https://collector.example.test",
-            "Startup operations: retention 365 days; maximum event post 250000 bytes; bulk batch 750; API throttle 5000; bot throttle 30; queue metrics polling enabled every 00:00:07; disabled pipeline actions 1; disabled plugins 2",
-            "Startup source maps: auto-download enabled; request timeout 00:00:04; processing timeout 00:00:06; per-project artifacts 200 / storage 524288000 bytes; free retention 10 days; paid retention 60 days; download concurrency 3 local / 12 global"
+            "Startup infrastructure: Elasticsearch at https://elastic.example.test:9200; cache redis at cache.example.test:6380; message bus rabbitmq at amqps://rabbit.example.test:5671; queue sqs at https://queue.example.test; storage azurestorage at https://visibleaccount.blob.core.windows.net",
+            "Startup services: event submission enabled; WebSockets enabled; jobs in process enabled; email enabled; account creation enabled; index configuration enabled",
+            "Startup optional integrations/auth providers: Google OAuth, Microsoft OAuth, GitHub OAuth, Active Directory, Intercom, Slack, billing, geocoding, GeoIP, internal Exceptionless logging"
         ],
         informationMessages);
 
         string output = String.Join(Environment.NewLine, logger.Entries.Select(entry => entry.Message));
         Assert.Contains("cache.example.test:6380", output, StringComparison.Ordinal);
         Assert.Contains("rabbit.example.test:5671", output, StringComparison.Ordinal);
-        Assert.Contains("us-east-2", output, StringComparison.Ordinal);
-        Assert.Contains("smtp.example.test:465", output, StringComparison.Ordinal);
         Assert.Contains("elastic.example.test:9200", output, StringComparison.Ordinal);
-        Assert.Contains("retention 365 days", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("source map", output, StringComparison.OrdinalIgnoreCase);
 
         foreach (string secret in GetCanarySecrets())
             Assert.DoesNotContain(secret, output, StringComparison.Ordinal);
@@ -69,11 +65,11 @@ public class BootstrapperTests
         Assert.Contains("queue disabled at not configured", output, StringComparison.Ordinal);
         Assert.Contains("storage disabled at not configured", output, StringComparison.Ordinal);
         Assert.Contains("event submission disabled", output, StringComparison.Ordinal);
-        Assert.Contains("web sockets disabled", output, StringComparison.Ordinal);
-        Assert.Contains("email disabled at not configured", output, StringComparison.Ordinal);
+        Assert.Contains("WebSockets disabled", output, StringComparison.Ordinal);
+        Assert.Contains("email disabled", output, StringComparison.Ordinal);
         Assert.Contains("account creation disabled", output, StringComparison.Ordinal);
-        Assert.Contains("OAuth disabled", output, StringComparison.Ordinal);
-        Assert.Contains("auto-download disabled", output, StringComparison.Ordinal);
+        Assert.Contains("Startup optional integrations/auth providers: none", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("source map", output, StringComparison.OrdinalIgnoreCase);
 
         string[] warnings = logger.Entries
             .Where(entry => entry.Level == LogLevel.Warning)

--- a/tests/Exceptionless.Tests/Logging/SensitiveDataLoggingTests.cs
+++ b/tests/Exceptionless.Tests/Logging/SensitiveDataLoggingTests.cs
@@ -1,0 +1,50 @@
+using Exceptionless.Core;
+using Exceptionless.Core.Configuration;
+using Exceptionless.Insulation.Security;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Xunit;
+
+namespace Exceptionless.Tests.Logging;
+
+public class SensitiveDataLoggingTests
+{
+    [Fact]
+    public void ApplySensitiveDataLogging_DoesNotDestructureConfigurationObjects()
+    {
+        var sink = new CollectingSink();
+        using var logger = new LoggerConfiguration()
+            .ApplySensitiveDataLogging()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        logger.Information("Loaded configuration {@Options}", new AppOptions());
+
+        var rendered = sink.Events.Single().Properties["Options"].ToString();
+        Assert.DoesNotContain("InternalProjectId", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("ExceptionlessApiKey", rendered, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ApplySensitiveDataLogging_DoesNotDestructureNestedSensitiveOptions()
+    {
+        var sink = new CollectingSink();
+        using var logger = new LoggerConfiguration()
+            .ApplySensitiveDataLogging()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        logger.Information("Loaded configuration {@Options}", new EmailOptions());
+
+        var rendered = sink.Events.Single().Properties["Options"].ToString();
+        Assert.DoesNotContain("SmtpPassword", rendered, StringComparison.Ordinal);
+    }
+
+    private sealed class CollectingSink : ILogEventSink
+    {
+        public List<LogEvent> Events { get; } = [];
+
+        public void Emit(LogEvent logEvent) => Events.Add(logEvent);
+    }
+}

--- a/tests/Exceptionless.Tests/Logging/SensitiveDataLoggingTests.cs
+++ b/tests/Exceptionless.Tests/Logging/SensitiveDataLoggingTests.cs
@@ -11,33 +11,39 @@ namespace Exceptionless.Tests.Logging;
 public class SensitiveDataLoggingTests
 {
     [Fact]
-    public void ApplySensitiveDataLogging_DoesNotDestructureConfigurationObjects()
+    public void ApplySensitiveDataLogging_AppOptions_DoesNotDestructureSensitiveProperties()
     {
+        // Arrange
         var sink = new CollectingSink();
         using var logger = new LoggerConfiguration()
             .ApplySensitiveDataLogging()
             .WriteTo.Sink(sink)
             .CreateLogger();
 
+        // Act
         logger.Information("Loaded configuration {@Options}", new AppOptions());
-
         var rendered = sink.Events.Single().Properties["Options"].ToString();
+
+        // Assert
         Assert.DoesNotContain("InternalProjectId", rendered, StringComparison.Ordinal);
         Assert.DoesNotContain("ExceptionlessApiKey", rendered, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void ApplySensitiveDataLogging_DoesNotDestructureNestedSensitiveOptions()
+    public void ApplySensitiveDataLogging_EmailOptions_DoesNotDestructureSensitiveProperties()
     {
+        // Arrange
         var sink = new CollectingSink();
         using var logger = new LoggerConfiguration()
             .ApplySensitiveDataLogging()
             .WriteTo.Sink(sink)
             .CreateLogger();
 
+        // Act
         logger.Information("Loaded configuration {@Options}", new EmailOptions());
-
         var rendered = sink.Events.Single().Properties["Options"].ToString();
+
+        // Assert
         Assert.DoesNotContain("SmtpPassword", rendered, StringComparison.Ordinal);
     }
 

--- a/tests/Exceptionless.Tests/Logging/SensitiveDataLoggingTests.cs
+++ b/tests/Exceptionless.Tests/Logging/SensitiveDataLoggingTests.cs
@@ -1,9 +1,14 @@
+using System.Reflection;
+using Exceptionless;
 using Exceptionless.Core;
 using Exceptionless.Core.Configuration;
 using Exceptionless.Insulation.Security;
+using Exceptionless.Models;
+using Exceptionless.Serializer;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
+using Serilog.Sinks.Exceptionless;
 using Xunit;
 
 namespace Exceptionless.Tests.Logging;
@@ -11,40 +16,415 @@ namespace Exceptionless.Tests.Logging;
 public class SensitiveDataLoggingTests
 {
     [Fact]
-    public void ApplySensitiveDataLogging_AppOptions_DoesNotDestructureSensitiveProperties()
+    public void ApplySensitiveDataLogging_AppOptions_PreservesSafeValuesAndRedactsNestedSecrets()
     {
-        // Arrange
         var sink = new CollectingSink();
         using var logger = new LoggerConfiguration()
             .ApplySensitiveDataLogging()
             .WriteTo.Sink(sink)
             .CreateLogger();
 
-        // Act
-        logger.Information("Loaded configuration {@Options}", new AppOptions());
-        var rendered = sink.Events.Single().Properties["Options"].ToString();
+        var options = CreateAppOptions();
 
-        // Assert
-        Assert.DoesNotContain("InternalProjectId", rendered, StringComparison.Ordinal);
-        Assert.DoesNotContain("ExceptionlessApiKey", rendered, StringComparison.Ordinal);
+        logger.Information("Loaded configuration {@Options}", options);
+
+        var structure = Assert.IsType<StructureValue>(sink.Events.Single().Properties["Options"]);
+        string rendered = structure.ToString();
+        Assert.Contains("AppOptions", rendered, StringComparison.Ordinal);
+        Assert.Contains("https://app.example.test", rendered, StringComparison.Ordinal);
+        Assert.Contains("internal-project-id", rendered, StringComparison.Ordinal);
+        Assert.Contains("smtp.example.test", rendered, StringComparison.Ordinal);
+        Assert.Contains("smtp-user", rendered, StringComparison.Ordinal);
+        Assert.Contains("VisiblePipelineAction", rendered, StringComparison.Ordinal);
+        Assert.Contains("VisiblePlugin", rendered, StringComparison.Ordinal);
+        Assert.Contains("redis.example.test:6379", rendered, StringComparison.Ordinal);
+        Assert.Contains("abortConnect=False", rendered, StringComparison.Ordinal);
+        Assert.Contains("elastic.example.test:9200", rendered, StringComparison.Ordinal);
+        Assert.Contains("elastic-migrate.example.test:9200", rendered, StringComparison.Ordinal);
+        Assert.Contains("rabbit.example.test", rendered, StringComparison.Ordinal);
+        Assert.Contains("rabbit-user", rendered, StringComparison.Ordinal);
+        Assert.Contains("AKIA_VISIBLE_ACCESS_KEY", rendered, StringComparison.Ordinal);
+        Assert.Contains("us-east-2", rendered, StringComparison.Ordinal);
+        Assert.Contains("visibleaccount", rendered, StringComparison.Ordinal);
+        Assert.Contains("core.windows.net", rendered, StringComparison.Ordinal);
+        Assert.Contains("pk_publishable-visible", rendered, StringComparison.Ordinal);
+        Assert.Contains("[REDACTED]", rendered, StringComparison.Ordinal);
+
+        foreach (string secret in GetAppOptionCanarySecrets())
+            Assert.DoesNotContain(secret, rendered, StringComparison.Ordinal);
+
+        object[] originalOptionObjects =
+        [
+            options,
+            options.CacheOptions,
+            options.MessageBusOptions,
+            options.QueueOptions,
+            options.StorageOptions,
+            options.EmailOptions,
+            options.ElasticsearchOptions,
+            options.ElasticsearchOptions.ElasticsearchToMigrate!,
+            options.IntercomOptions,
+            options.SlackOptions,
+            options.StripeOptions,
+            options.AuthOptions,
+            options.OAuthServerOptions,
+            options.SourceMapOptions
+        ];
+        Assert.DoesNotContain(
+            EnumerateScalarValues(structure),
+            value => originalOptionObjects.Any(original => ReferenceEquals(value, original)));
     }
 
     [Fact]
-    public void ApplySensitiveDataLogging_EmailOptions_DoesNotDestructureSensitiveProperties()
+    public void ApplySensitiveDataLogging_SensitiveOptionTypes_IncludeEveryPublicProperty()
     {
-        // Arrange
+        object[] options =
+        [
+            new AppOptions(),
+            new AuthOptions(),
+            new CacheOptions(),
+            new ElasticsearchOptions(),
+            new EmailOptions(),
+            new IntercomOptions(),
+            new MessageBusOptions(),
+            new MetricOptions(),
+            new QueueOptions(),
+            new StorageOptions(),
+            new StripeOptions(),
+            new SlackOptions(),
+            new OAuthServerOptions(),
+            new SourceMapOptions()
+        ];
+
         var sink = new CollectingSink();
         using var logger = new LoggerConfiguration()
             .ApplySensitiveDataLogging()
             .WriteTo.Sink(sink)
             .CreateLogger();
 
-        // Act
-        logger.Information("Loaded configuration {@Options}", new EmailOptions());
-        var rendered = sink.Events.Single().Properties["Options"].ToString();
+        foreach (object option in options)
+            logger.Information("Loaded configuration {@Options}", option);
 
-        // Assert
-        Assert.DoesNotContain("SmtpPassword", rendered, StringComparison.Ordinal);
+        Assert.Equal(options.Length, sink.Events.Count);
+        for (int index = 0; index < options.Length; index++)
+        {
+            string[] expectedProperties = options[index]
+                .GetType()
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(property => property.GetMethod?.IsPrivate is false && property.GetIndexParameters().Length == 0)
+                .Select(property => property.Name)
+                .Order()
+                .ToArray();
+            var propertyValue = sink.Events[index].Properties["Options"];
+            if (propertyValue is not StructureValue)
+                Assert.Fail($"{options[index].GetType().Name} was captured as {propertyValue.GetType().Name}.");
+
+            var structure = (StructureValue)propertyValue;
+            string[] actualProperties = structure.Properties
+                .Select(property => property.Name)
+                .Order()
+                .ToArray();
+
+            Assert.Equal(expectedProperties, actualProperties);
+        }
+    }
+
+    [Fact]
+    public void ApplySensitiveDataLogging_MetricOptions_PreservesSafeConnectionStringComponents()
+    {
+        var sink = new CollectingSink();
+        using var logger = new LoggerConfiguration()
+            .ApplySensitiveDataLogging()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        var options = CreateMetricOptions();
+
+        logger.Information("Loaded configuration {@Options}", options);
+
+        var structure = Assert.IsType<StructureValue>(sink.Events.Single().Properties["Options"]);
+        string rendered = structure.ToString();
+        Assert.Contains("MetricOptions", rendered, StringComparison.Ordinal);
+        Assert.Contains("statsd", rendered, StringComparison.Ordinal);
+        Assert.Contains("metrics.example.test", rendered, StringComparison.Ordinal);
+        Assert.Contains("8125", rendered, StringComparison.Ordinal);
+        Assert.Contains("[REDACTED]", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("metric-password-secret-canary", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain(EnumerateScalarValues(structure), value => ReferenceEquals(value, options));
+    }
+
+    [Fact]
+    public void ApplySensitiveDataLogging_ExceptionlessSink_SerializedPayloadPreservesSafeValuesAndOmitsCanarySecrets()
+    {
+        Event? submittedEvent = null;
+        var appOptions = CreateAppOptions();
+        var metricOptions = CreateMetricOptions();
+
+        using var client = new ExceptionlessClient(configuration =>
+        {
+            configuration.ApiKey = "00000000000000000000000000000000";
+            configuration.UseInMemoryStorage();
+        });
+        client.SubmittingEvent += (_, args) =>
+        {
+            submittedEvent = args.Event;
+            args.Cancel = true;
+        };
+
+        using (var logger = new LoggerConfiguration()
+            .ApplySensitiveDataLogging()
+            .WriteTo.Sink(new ExceptionlessSink(client: client))
+            .CreateLogger())
+        {
+            logger.Information(
+                "Loaded configuration {@AppOptions} {@MetricOptions}",
+                appOptions,
+                metricOptions);
+        }
+
+        Assert.NotNull(submittedEvent);
+        string payload = new DefaultJsonSerializer().Serialize(submittedEvent);
+
+        Assert.Contains("https://app.example.test", payload, StringComparison.Ordinal);
+        Assert.Contains("internal-project-id", payload, StringComparison.Ordinal);
+        Assert.Contains("smtp.example.test", payload, StringComparison.Ordinal);
+        Assert.Contains("VisiblePipelineAction", payload, StringComparison.Ordinal);
+        Assert.Contains("VisiblePlugin", payload, StringComparison.Ordinal);
+        Assert.Contains("redis.example.test", payload, StringComparison.Ordinal);
+        Assert.Contains("elastic.example.test", payload, StringComparison.Ordinal);
+        Assert.Contains("elastic-migrate.example.test", payload, StringComparison.Ordinal);
+        Assert.Contains("rabbit.example.test", payload, StringComparison.Ordinal);
+        Assert.Contains("rabbit-user", payload, StringComparison.Ordinal);
+        Assert.Contains("AKIA_VISIBLE_ACCESS_KEY", payload, StringComparison.Ordinal);
+        Assert.Contains("us-east-2", payload, StringComparison.Ordinal);
+        Assert.Contains("visibleaccount", payload, StringComparison.Ordinal);
+        Assert.Contains("core.windows.net", payload, StringComparison.Ordinal);
+        Assert.Contains("pk_publishable-visible", payload, StringComparison.Ordinal);
+        Assert.Contains("metrics.example.test", payload, StringComparison.Ordinal);
+        Assert.Contains("8125", payload, StringComparison.Ordinal);
+        Assert.Contains("[REDACTED]", payload, StringComparison.Ordinal);
+
+        foreach (string secret in GetAppOptionCanarySecrets().Append("metric-password-secret-canary"))
+            Assert.DoesNotContain(secret, payload, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ApplySensitiveDataLogging_OrdinaryNonSensitiveObject_DoesNotTraverse()
+    {
+        var sink = new CollectingSink();
+        using var logger = new LoggerConfiguration()
+            .ApplySensitiveDataLogging()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        var value = new TraversalTrackingValue();
+
+        logger.Information("Loaded value {Value}", value);
+
+        Assert.Equal(0, value.ValueAccessCount);
+        var scalar = Assert.IsType<ScalarValue>(sink.Events.Single().Properties["Value"]);
+        Assert.IsType<string>(scalar.Value);
+        Assert.NotSame(value, scalar.Value);
+    }
+
+    private static AppOptions CreateAppOptions()
+    {
+        return new AppOptions
+        {
+            BaseURL = "https://app.example.test",
+            InternalProjectId = "internal-project-id",
+            ExceptionlessApiKey = "exceptionless-api-key-secret-canary",
+            ExceptionlessServerUrl = "https://collector.example.test",
+            AppMode = AppMode.Staging,
+            AppScope = "visible-scope",
+            RunJobsInProcess = true,
+            JobsIterationLimit = 42,
+            BotThrottleLimit = 43,
+            ApiThrottleLimit = 44,
+            EnableArchive = true,
+            EnableSampleData = false,
+            EventSubmissionDisabled = false,
+            DisabledPipelineActions = ["VisiblePipelineAction"],
+            DisabledPlugins = ["VisiblePlugin"],
+            MaximumEventPostSize = 200_000,
+            MaximumRetentionDays = 180,
+            EnableRepositoryNotifications = true,
+            EnableWebSockets = true,
+            Version = "1.2.3",
+            InformationalVersion = "1.2.3+visible",
+            NotificationMessage = "visible notification",
+            GoogleGeocodingApiKey = "google-api-key-secret-canary",
+            MaxMindGeoIpKey = "maxmind-key-secret-canary",
+            BulkBatchSize = 1_000,
+            CacheOptions = new CacheOptions
+            {
+                Provider = "redis",
+                ConnectionString = "redis.example.test:6379,password=redis-password-secret-canary,abortConnect=false",
+                Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["provider"] = "redis",
+                    ["server"] = "redis.example.test:6379,password=redis-data-password-secret-canary,abortConnect=false"
+                },
+                Scope = "visible-scope",
+                ScopePrefix = "visible-scope-"
+            },
+            EmailOptions = new EmailOptions
+            {
+                EnableDailySummary = true,
+                AllowedOutboundAddresses = ["example.test"],
+                SmtpHost = "smtp.example.test",
+                SmtpPort = 587,
+                SmtpEncryption = SmtpEncryption.StartTLS,
+                SmtpUser = "smtp-user",
+                SmtpPassword = "smtp-password-secret-canary"
+            },
+            ElasticsearchOptions = new ElasticsearchOptions
+            {
+                ServerUrl = "https://elastic-user:elastic-uri-password-secret-canary@elastic.example.test:9200",
+                UserName = "elastic-user",
+                Password = "elastic-password-secret-canary",
+                NumberOfShards = 3,
+                ElasticsearchToMigrate = new ElasticsearchOptions
+                {
+                    ServerUrl = "https://migrate-user:elastic-migrate-uri-password-secret-canary@elastic-migrate.example.test:9200",
+                    UserName = "migrate-user",
+                    Password = "elastic-migrate-password-secret-canary"
+                }
+            },
+            StripeOptions = new StripeOptions
+            {
+                StripeApiKey = "stripe-api-key-secret-canary",
+                StripePublishableApiKey = "pk_publishable-visible",
+                StripeWebHookSigningSecret = "stripe-signing-secret-canary"
+            },
+            AuthOptions = new AuthOptions
+            {
+                EnableAccountCreation = true,
+                MicrosoftId = "microsoft-id-visible",
+                MicrosoftSecret = "microsoft-secret-canary",
+                LdapConnectionString = "server=ldap.example.test;password=ldap-password-secret-canary"
+            },
+            IntercomOptions = new IntercomOptions
+            {
+                IntercomId = "intercom-id-visible",
+                IntercomSecret = "intercom-secret-canary"
+            },
+            SlackOptions = new SlackOptions
+            {
+                SlackId = "slack-id-visible",
+                SlackSecret = "slack-secret-canary"
+            },
+            MessageBusOptions = new MessageBusOptions
+            {
+                Provider = "rabbitmq",
+                ConnectionString = "server=amqp://rabbit-user:rabbit-password-secret-canary@rabbit.example.test:5672/vhost",
+                Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["provider"] = "rabbitmq",
+                    ["server"] = "amqp://rabbit-user:rabbit-data-password-secret-canary@rabbit.example.test:5672/vhost"
+                },
+                Scope = "visible-scope",
+                ScopePrefix = "visible-scope-",
+                Topic = "visible-topic"
+            },
+            QueueOptions = new QueueOptions
+            {
+                Provider = "sqs",
+                ConnectionString = "accesskey=AKIA_VISIBLE_ACCESS_KEY;secretkey=aws-secret-key-secret-canary;region=us-east-2",
+                Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["provider"] = "sqs",
+                    ["accesskey"] = "AKIA_VISIBLE_ACCESS_KEY",
+                    ["secretkey"] = "aws-data-secret-key-secret-canary",
+                    ["region"] = "us-east-2"
+                },
+                Scope = "visible-scope",
+                ScopePrefix = "visible-scope-"
+            },
+            StorageOptions = new StorageOptions
+            {
+                Provider = "azurestorage",
+                ConnectionString = "DefaultEndpointsProtocol=https;AccountName=visibleaccount;AccountKey=azure-account-key-secret-canary;EndpointSuffix=core.windows.net",
+                Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["provider"] = "azurestorage",
+                    ["DefaultEndpointsProtocol"] = "https",
+                    ["AccountName"] = "visibleaccount",
+                    ["AccountKey"] = "azure-data-account-key-secret-canary",
+                    ["EndpointSuffix"] = "core.windows.net"
+                },
+                Scope = "visible-scope",
+                ScopePrefix = "visible-scope-"
+            },
+            OAuthServerOptions = new OAuthServerOptions(),
+            SourceMapOptions = new SourceMapOptions()
+        };
+    }
+
+    private static MetricOptions CreateMetricOptions()
+    {
+        return new MetricOptions
+        {
+            Provider = "statsd",
+            ConnectionString = "server=metrics.example.test;port=8125;password=metric-password-secret-canary",
+            Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["provider"] = "statsd",
+                ["server"] = "metrics.example.test",
+                ["port"] = "8125",
+                ["password"] = "metric-password-secret-canary"
+            }
+        };
+    }
+
+    private static string[] GetAppOptionCanarySecrets()
+    {
+        return
+        [
+            "exceptionless-api-key-secret-canary",
+            "google-api-key-secret-canary",
+            "maxmind-key-secret-canary",
+            "redis-password-secret-canary",
+            "redis-data-password-secret-canary",
+            "smtp-password-secret-canary",
+            "elastic-uri-password-secret-canary",
+            "elastic-password-secret-canary",
+            "elastic-migrate-uri-password-secret-canary",
+            "elastic-migrate-password-secret-canary",
+            "rabbit-password-secret-canary",
+            "rabbit-data-password-secret-canary",
+            "aws-secret-key-secret-canary",
+            "aws-data-secret-key-secret-canary",
+            "azure-account-key-secret-canary",
+            "azure-data-account-key-secret-canary",
+            "stripe-api-key-secret-canary",
+            "stripe-signing-secret-canary",
+            "microsoft-secret-canary",
+            "ldap-password-secret-canary",
+            "intercom-secret-canary",
+            "slack-secret-canary"
+        ];
+    }
+
+    private static IEnumerable<object?> EnumerateScalarValues(LogEventPropertyValue value)
+    {
+        switch (value)
+        {
+            case ScalarValue scalar:
+                yield return scalar.Value;
+                break;
+            case StructureValue structure:
+                foreach (var child in structure.Properties.SelectMany(property => EnumerateScalarValues(property.Value)))
+                    yield return child;
+                break;
+            case SequenceValue sequence:
+                foreach (var child in sequence.Elements.SelectMany(EnumerateScalarValues))
+                    yield return child;
+                break;
+            case DictionaryValue dictionary:
+                foreach (var child in dictionary.Elements.SelectMany(pair => EnumerateScalarValues(pair.Value)))
+                    yield return child;
+                break;
+        }
     }
 
     private sealed class CollectingSink : ILogEventSink
@@ -52,5 +432,19 @@ public class SensitiveDataLoggingTests
         public List<LogEvent> Events { get; } = [];
 
         public void Emit(LogEvent logEvent) => Events.Add(logEvent);
+    }
+
+    private sealed class TraversalTrackingValue
+    {
+        public int ValueAccessCount { get; private set; }
+
+        public string Value
+        {
+            get
+            {
+                ValueAccessCount++;
+                return "visible";
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Prevents `AppOptions` and all nested configuration option objects from being destructured into startup logs.
- Applies the protection to both the web and job bootstrap loggers and their fully configured Serilog pipelines.
- Adds regression tests covering top-level and nested sensitive configuration objects.

## Why
Startup logging previously allowed configuration objects to be rendered with destructuring, which could expose passwords, connection strings, API keys, OAuth secrets, and webhook signing secrets in application logs.

## Verification
- `dotnet test --project tests/Exceptionless.Tests/Exceptionless.Tests.csproj -- --filter-class Exceptionless.Tests.Logging.SensitiveDataLoggingTests`
- `dotnet build --no-restore`

## Breaking changes
None.
