### PR TITLE
Align production Redis PVC size

### DIFF
--- a/k8s/ex-prod-redis.yaml
+++ b/k8s/ex-prod-redis.yaml
@@ -31,7 +31,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 1Gi
+                storage: 8Gi
     - name: redis-sentinel
       serviceVersion: "8.4.0"
       replicas: 3


### PR DESCRIPTION
## What changed

- Updated the production Redis data PVC request from `1Gi` to `8Gi`.

## Why

The live Redis PVCs were expanded to 8Gi through KubeBlocks, but the committed manifest still requested 1Gi. KubeBlocks interpreted that drift as an unsupported volume shrink and stopped reconciliation, which prevented later Redis resource updates from reaching the InstanceSet and pods.

Matching the manifest to the live PVC size removes the invalid shrink request and allows normal reconciliation. This does not shrink, migrate, or recreate the existing volumes.

## Validation

- `git diff --check`
- Parsed `k8s/ex-prod-redis.yaml` successfully with PyYAML
- Confirmed the commit contains only the `1Gi` to `8Gi` storage request change

`kubectl apply --dry-run=client` was not available because the read-only Kubernetes wrapper blocks all `apply` operations, including client-side dry runs.

## Breaking changes

None.