### PR TITLE
Collect Redis metrics in SigNoz

### DIFF
--- a/k8s/ex-prod-redis.yaml
+++ b/k8s/ex-prod-redis.yaml
@@ -11,6 +11,10 @@ spec:
     - name: redis
       serviceVersion: "8.4.0"
       disableExporter: false
+      annotations:
+        signoz.io/scrape: "true"
+        signoz.io/port: "9121"
+        signoz.io/path: "/metrics"
       replicas: 2
       systemAccounts:
         - name: default


### PR DESCRIPTION
## What changed

- Added SigNoz scrape annotations to the production Redis component.
- Directs the existing SigNoz pod discovery configuration to scrape the KubeBlocks Redis exporter on port 9121.

## Why

KubeBlocks already runs a Redis metrics exporter because `disableExporter` is false, but the production Redis pods were not annotated for the existing SigNoz collector. As a result, Redis memory, eviction, availability, and replication metrics were not being ingested for alerting.

Keeping the scrape metadata beside the exporter setting makes the Redis manifest self-contained and avoids a custom discovery rule in the shared SigNoz collector configuration.

## Impact

Applying the production Redis manifest allows SigNoz to discover both current Redis pods and future replacement or scaled pods. This is a metadata-only configuration change; no Redis resource, storage, or runtime configuration is changed.

## Validation

- Rebased onto `main` after PR #2406 merged
- `git diff --check`
- Parsed the manifest and asserted all three scrape annotations with PyYAML
- Confirmed the Redis PVC request remains `8Gi`
- Confirmed the installed KubeBlocks v1 API supports component annotations

## Breaking changes

None.