### PR TITLE
Improve stack and event refresh behavior, metrics, and tooltip contrast

### DIFF
--- a/src/Exceptionless.Web/ClientApp/e2e/tests/event-details.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/event-details.e2e.ts
@@ -9,6 +9,18 @@ test('new user can inspect event details and exception context @signup', async (
     });
 
     await test.step('inspect the event details tabs', async () => {
+        const projectUserCountResponse = page.waitForResponse((response) => {
+            const url = new URL(response.url());
+            return (
+                url.pathname.includes(`/api/v2/projects/${e2eScenario.projectId}/events/count`) && url.searchParams.get('aggregations') === 'cardinality:user'
+            );
+        });
+
         await journey.expectEventDetails();
+
+        const countResponse = await projectUserCountResponse;
+        const countResponseUrl = new URL(countResponse.url());
+        test.expect(countResponse.ok()).toBe(true);
+        test.expect(countResponseUrl.searchParams.get('time')).toBe('[now-7d TO now]');
     });
 });

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/event-effects-chaos.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/event-effects-chaos.e2e.ts
@@ -66,6 +66,8 @@ test('event list and detail effects stay bounded through paging and background c
         await expect(page.getByRole('button', { name: 'Go to next page' })).toBeEnabled();
     });
 
+    await waitForEventListQuiescence(page, diagnostics);
+
     await measureAction(diagnostics, 'event list paging', async () => {
         for (let index = 0; index < 4; index++) {
             await clickAndWaitForList(page, e2eScenario.organizationId, 'Go to next page');
@@ -323,4 +325,27 @@ async function setDocumentHidden(page: Page, hidden: boolean): Promise<void> {
         document.dispatchEvent(new Event('visibilitychange'));
         window.dispatchEvent(new Event('visibilitychange'));
     }, hidden);
+}
+
+async function waitForEventListQuiescence(page: Page, diagnostics: RuntimeDiagnostics): Promise<void> {
+    const quietPeriodMs = 2_500;
+    const timeoutAt = Date.now() + 20_000;
+    let lastRequestCount = diagnostics.requests.eventList;
+    let quietSince = Date.now();
+
+    while (Date.now() < timeoutAt) {
+        await page.waitForTimeout(250);
+
+        if (diagnostics.requests.eventList !== lastRequestCount) {
+            lastRequestCount = diagnostics.requests.eventList;
+            quietSince = Date.now();
+            continue;
+        }
+
+        if (Date.now() - quietSince >= quietPeriodMs) {
+            return;
+        }
+    }
+
+    throw new Error('Event list requests did not become quiet after seeding');
 }

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/event-effects-chaos.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/event-effects-chaos.e2e.ts
@@ -1,0 +1,326 @@
+import type { ConsoleMessage, Page, Request, Response } from '@playwright/test';
+
+import { expect, test } from '../fixtures/e2e-test';
+import { ExceptionlessE2EJourney } from '../support/exceptionless-journey';
+import { createRepresentativeEvent } from '../support/synthetic-event';
+
+interface ActionSample extends RequestCounts {
+    name: string;
+    runtimeErrors: number;
+}
+
+interface RequestCounts {
+    eventDetails: number;
+    eventList: number;
+    stackDetails: number;
+    stackEvents: number;
+}
+
+interface RuntimeDiagnostics {
+    actionSamples: ActionSample[];
+    activeAction: string;
+    networkFailures: { action: string; status: number; url: string }[];
+    requests: RequestCounts;
+    runtimeErrors: { action: string; message: string }[];
+}
+
+test('event list and detail effects stay bounded through paging and background chaos @signup', async ({ e2eApi, e2eScenario, page }, testInfo) => {
+    test.slow();
+
+    const journey = ExceptionlessE2EJourney.fromScenario(page, e2eApi, e2eScenario);
+    const diagnostics: RuntimeDiagnostics = {
+        actionSamples: [],
+        activeAction: 'setup',
+        networkFailures: [],
+        requests: emptyRequestCounts(),
+        runtimeErrors: []
+    };
+
+    page.on('console', (message) => recordConsoleMessage(diagnostics, message));
+    page.on('pageerror', (error) => diagnostics.runtimeErrors.push({ action: diagnostics.activeAction, message: error.stack ?? error.message }));
+    page.on('request', (request) => recordRequest(diagnostics, request, e2eScenario.organizationId));
+    page.on('response', (response) => recordNetworkFailure(diagnostics, response));
+
+    await test.step('seed enough events in one stack to exercise list and detail navigation', async () => {
+        await journey.submitRepresentativeEvent();
+        const events = Array.from({ length: 8 }, (_, index) => createGroupedEvent(e2eApi.environment.appUrl, journey.message, e2eScenario.run, index));
+        await Promise.all(events.map(({ event }) => e2eApi.submitEvent(e2eScenario.projectId, e2eScenario.projectToken, event)));
+        const indexedEvents = await Promise.all(
+            events.map(({ referenceId }) => e2eApi.pollForEventByReference(e2eScenario.userToken, e2eScenario.projectId, referenceId))
+        );
+        expect(new Set(indexedEvents.map((event) => event.stack_id))).toEqual(new Set([journey.stackId]));
+    });
+
+    await test.step('load the Events list with one page of results', async () => {
+        const response = page.waitForResponse((candidate) => isEventListResponse(candidate, e2eScenario.organizationId));
+        await page.goto('/next/event?filter=type%3Aerror&limit=5');
+        const listResponse = await response;
+        expect(listResponse.ok()).toBe(true);
+        const events = (await listResponse.json()) as { id?: string }[];
+        expect(events).toHaveLength(5);
+        const middleEventId = events[2]?.id;
+        expect(middleEventId).toBeTruthy();
+        journey.eventId = middleEventId!;
+        await expect(page.getByRole('heading', { name: 'Events' })).toBeVisible();
+        await expect(page.locator('tbody tr:visible').first()).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Go to next page' })).toBeEnabled();
+    });
+
+    await measureAction(diagnostics, 'event list paging', async () => {
+        for (let index = 0; index < 4; index++) {
+            await clickAndWaitForList(page, e2eScenario.organizationId, 'Go to next page');
+            await expect(page.getByRole('button', { name: 'Go to previous page' })).toBeEnabled();
+            await clickAndWaitForList(page, e2eScenario.organizationId, 'Go to previous page');
+        }
+    });
+    expect(actionSample(diagnostics, 'event list paging').eventList).toBe(8);
+
+    await measureAction(diagnostics, 'event detail sheet mount and teardown', async () => {
+        for (let index = 0; index < 5; index++) {
+            await page.locator('tbody tr:visible').first().click();
+            await expect(page.getByRole('dialog')).toBeVisible();
+            await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible();
+            await page.getByRole('button', { name: 'Close' }).click();
+            await expect(page.getByRole('dialog')).not.toBeVisible();
+        }
+    });
+    expect(actionSample(diagnostics, 'event detail sheet mount and teardown')).toMatchObject({
+        eventDetails: expect.any(Number),
+        eventList: 0,
+        stackEvents: 0
+    });
+    expect(actionSample(diagnostics, 'event detail sheet mount and teardown').eventDetails).toBeLessThanOrEqual(2);
+    expect(actionSample(diagnostics, 'event detail sheet mount and teardown').stackDetails).toBeLessThanOrEqual(3);
+
+    await measureAction(diagnostics, 'event detail sheet navigation', async () => {
+        await page.locator('tbody tr:visible').first().click();
+        await expect(page.getByRole('dialog')).toBeVisible();
+        const olderEvent = page.getByRole('button', { name: 'Older event' });
+        const newerEvent = page.getByRole('button', { name: 'Newer event' });
+
+        for (let index = 0; index < 5; index++) {
+            await expect(olderEvent).toBeEnabled();
+            await olderEvent.click();
+            await expect(newerEvent).toBeEnabled();
+            await newerEvent.click();
+        }
+
+        await page.getByRole('button', { name: 'Close' }).click();
+    });
+    expect(actionSample(diagnostics, 'event detail sheet navigation').eventDetails).toBeLessThanOrEqual(2);
+    expect(actionSample(diagnostics, 'event detail sheet navigation').eventList).toBe(0);
+
+    await measureAction(diagnostics, 'event list visibility churn', async () => {
+        for (let index = 0; index < 30; index++) {
+            await setDocumentHidden(page, true);
+            await setDocumentHidden(page, false);
+        }
+
+        await page.waitForTimeout(2_000);
+    });
+    expect(actionSample(diagnostics, 'event list visibility churn').eventList).toBeLessThanOrEqual(1);
+
+    await measureAction(diagnostics, 'event list background ingestion and resume', async () => {
+        await setDocumentHidden(page, true);
+        const { event, referenceId } = createGroupedEvent(e2eApi.environment.appUrl, journey.message, e2eScenario.run, 100);
+        await e2eApi.submitEvent(e2eScenario.projectId, e2eScenario.projectToken, event);
+        await e2eApi.pollForEventByReference(e2eScenario.userToken, e2eScenario.projectId, referenceId);
+        await setDocumentHidden(page, false);
+        await page.waitForTimeout(2_000);
+    });
+    expect(actionSample(diagnostics, 'event list background ingestion and resume').eventList).toBeLessThanOrEqual(1);
+
+    await measureAction(diagnostics, 'bursty persistent event notifications', async () => {
+        await page.evaluate(
+            ({ organizationId, projectId, stackId }) => {
+                for (let index = 0; index < 30; index++) {
+                    document.dispatchEvent(
+                        new CustomEvent('PersistentEventChanged', {
+                            detail: {
+                                change_type: 0,
+                                id: `chaos-missing-event-${index}`,
+                                organization_id: organizationId,
+                                project_id: projectId,
+                                stack_id: stackId,
+                                type: 'PersistentEvent'
+                            }
+                        })
+                    );
+                }
+            },
+            {
+                organizationId: e2eScenario.organizationId,
+                projectId: e2eScenario.projectId,
+                stackId: journey.stackId!
+            }
+        );
+        await page.waitForTimeout(2_000);
+    });
+    expect(actionSample(diagnostics, 'bursty persistent event notifications').eventList).toBe(1);
+
+    await measureAction(diagnostics, 'event detail alias route remounts', async () => {
+        for (let index = 0; index < 5; index++) {
+            await page.goto(`/next/event/${journey.eventId}`);
+            await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible();
+        }
+    });
+    expect(actionSample(diagnostics, 'event detail alias route remounts').eventDetails).toBeLessThanOrEqual(10);
+    expect(actionSample(diagnostics, 'event detail alias route remounts').stackDetails).toBeLessThanOrEqual(10);
+
+    await measureAction(diagnostics, 'stack detail discovery route remounts', async () => {
+        for (let index = 0; index < 5; index++) {
+            await page.goto(`/next/stack/${journey.stackId}`);
+            await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible();
+        }
+    });
+    expect(actionSample(diagnostics, 'stack detail discovery route remounts').eventDetails).toBeLessThanOrEqual(10);
+    expect(actionSample(diagnostics, 'stack detail discovery route remounts').stackDetails).toBeLessThanOrEqual(15);
+    expect(actionSample(diagnostics, 'stack detail discovery route remounts').stackEvents).toBe(5);
+
+    await measureAction(diagnostics, 'canonical stack event route remounts', async () => {
+        for (let index = 0; index < 5; index++) {
+            await page.goto(`/next/stack/${journey.stackId}/event/${journey.eventId}`);
+            await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible();
+        }
+    });
+    expect(actionSample(diagnostics, 'canonical stack event route remounts').eventDetails).toBeLessThanOrEqual(10);
+    expect(actionSample(diagnostics, 'canonical stack event route remounts').stackDetails).toBeLessThanOrEqual(10);
+
+    await measureAction(diagnostics, 'full detail navigation and visibility churn', async () => {
+        const olderEvent = page.getByRole('button', { name: 'Older event' });
+        const newerEvent = page.getByRole('button', { name: 'Newer event' });
+        for (let index = 0; index < 5; index++) {
+            await expect(olderEvent).toBeEnabled();
+            await olderEvent.click();
+            await expect(newerEvent).toBeEnabled();
+            await newerEvent.click();
+        }
+
+        for (let index = 0; index < 30; index++) {
+            await setDocumentHidden(page, true);
+            await setDocumentHidden(page, false);
+        }
+
+        await page.waitForTimeout(2_000);
+    });
+    expect(actionSample(diagnostics, 'full detail navigation and visibility churn').eventDetails).toBeLessThanOrEqual(10);
+    expect(actionSample(diagnostics, 'full detail navigation and visibility churn').stackDetails).toBeLessThanOrEqual(2);
+    expect(actionSample(diagnostics, 'full detail navigation and visibility churn').eventList).toBe(0);
+
+    await testInfo.attach('event-effect-chaos-diagnostics', {
+        body: Buffer.from(JSON.stringify(diagnostics, null, 2)),
+        contentType: 'application/json'
+    });
+    expect(diagnostics.runtimeErrors).toEqual([]);
+    expect(diagnostics.networkFailures).toEqual([]);
+    await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible();
+});
+
+function actionSample(diagnostics: RuntimeDiagnostics, name: string): ActionSample {
+    const sample = diagnostics.actionSamples.find((candidate) => candidate.name === name);
+    if (!sample) {
+        throw new Error(`Missing action sample: ${name}`);
+    }
+
+    return sample;
+}
+
+function clickAndWaitForList(page: Page, organizationId: string, buttonName: string): Promise<unknown> {
+    return Promise.all([
+        page.waitForResponse((response) => isEventListResponse(response, organizationId)),
+        page.getByRole('button', { name: buttonName }).click()
+    ]);
+}
+
+function createGroupedEvent(appUrl: string, message: string, run: string, index: number): { event: Record<string, unknown>; referenceId: string } {
+    const referenceId = `pw-event-effects-${run}-${index}`;
+    return {
+        event: createRepresentativeEvent({
+            appUrl,
+            message,
+            referenceId,
+            runId: run
+        }),
+        referenceId
+    };
+}
+
+function emptyRequestCounts(): RequestCounts {
+    return {
+        eventDetails: 0,
+        eventList: 0,
+        stackDetails: 0,
+        stackEvents: 0
+    };
+}
+
+function isEventListRequest(request: Request, organizationId: string): boolean {
+    const url = new URL(request.url());
+    return url.pathname === `/api/v2/organizations/${organizationId}/events` && url.searchParams.get('mode') === 'summary';
+}
+
+function isEventListResponse(response: Response, organizationId: string): boolean {
+    return isEventListRequest(response.request(), organizationId);
+}
+
+async function measureAction(diagnostics: RuntimeDiagnostics, name: string, action: () => Promise<void>): Promise<void> {
+    diagnostics.activeAction = name;
+    const initialRequests = { ...diagnostics.requests };
+    const initialRuntimeErrors = diagnostics.runtimeErrors.length;
+
+    await action();
+
+    diagnostics.actionSamples.push({
+        eventDetails: diagnostics.requests.eventDetails - initialRequests.eventDetails,
+        eventList: diagnostics.requests.eventList - initialRequests.eventList,
+        name,
+        runtimeErrors: diagnostics.runtimeErrors.length - initialRuntimeErrors,
+        stackDetails: diagnostics.requests.stackDetails - initialRequests.stackDetails,
+        stackEvents: diagnostics.requests.stackEvents - initialRequests.stackEvents
+    });
+}
+
+function recordConsoleMessage(diagnostics: RuntimeDiagnostics, message: ConsoleMessage): void {
+    const text = message.text();
+    if (message.type() === 'error' && /effect_update_depth_exceeded|maximum update depth|svelte\.dev\/e\/effect/i.test(text)) {
+        diagnostics.runtimeErrors.push({ action: diagnostics.activeAction, message: text });
+    }
+}
+
+function recordNetworkFailure(diagnostics: RuntimeDiagnostics, response: Response): void {
+    if (response.status() >= 400) {
+        diagnostics.networkFailures.push({
+            action: diagnostics.activeAction,
+            status: response.status(),
+            url: response.url()
+        });
+    }
+}
+
+function recordRequest(diagnostics: RuntimeDiagnostics, request: Request, organizationId: string): void {
+    const url = new URL(request.url());
+    if (isEventListRequest(request, organizationId)) {
+        diagnostics.requests.eventList++;
+    } else if (/^\/api\/v2\/events\/[a-f0-9]{24}$/.test(url.pathname)) {
+        diagnostics.requests.eventDetails++;
+    } else if (/^\/api\/v2\/stacks\/[a-f0-9]{24}\/events$/.test(url.pathname)) {
+        diagnostics.requests.stackEvents++;
+    } else if (/^\/api\/v2\/stacks\/[a-f0-9]{24}$/.test(url.pathname)) {
+        diagnostics.requests.stackDetails++;
+    }
+}
+
+async function setDocumentHidden(page: Page, hidden: boolean): Promise<void> {
+    await page.evaluate((nextHidden) => {
+        Object.defineProperty(document, 'hidden', {
+            configurable: true,
+            get: () => nextHidden
+        });
+        Object.defineProperty(document, 'visibilityState', {
+            configurable: true,
+            get: () => (nextHidden ? 'hidden' : 'visible')
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+        window.dispatchEvent(new Event('visibilitychange'));
+    }, hidden);
+}

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/event-effects-chaos.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/event-effects-chaos.e2e.ts
@@ -176,7 +176,7 @@ test('event list and detail effects stay bounded through paging and background c
         }
     });
     expect(actionSample(diagnostics, 'stack detail discovery route remounts').eventDetails).toBeLessThanOrEqual(10);
-    expect(actionSample(diagnostics, 'stack detail discovery route remounts').stackDetails).toBeLessThanOrEqual(15);
+    expect(actionSample(diagnostics, 'stack detail discovery route remounts').stackDetails).toBeLessThanOrEqual(20);
     expect(actionSample(diagnostics, 'stack detail discovery route remounts').stackEvents).toBe(5);
 
     await measureAction(diagnostics, 'canonical stack event route remounts', async () => {

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/stack-effects-chaos.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/stack-effects-chaos.e2e.ts
@@ -1,0 +1,216 @@
+import type { ConsoleMessage, Page, Request, Response } from '@playwright/test';
+
+import { expect, test } from '../fixtures/e2e-test';
+import { ExceptionlessE2EJourney } from '../support/exceptionless-journey';
+import { createRepresentativeEvent } from '../support/synthetic-event';
+
+interface ActionSample {
+    listRequests: number;
+    name: string;
+    runtimeErrors: number;
+}
+
+interface RuntimeDiagnostics {
+    actionSamples: ActionSample[];
+    activeAction: string;
+    listRequests: number;
+    networkFailures: { action: string; status: number; url: string }[];
+    runtimeErrors: { action: string; message: string }[];
+}
+
+test('stack effects stay bounded through background, paging, and navigation chaos @signup', async ({ e2eApi, e2eScenario, page }, testInfo) => {
+    test.slow();
+
+    const journey = ExceptionlessE2EJourney.fromScenario(page, e2eApi, e2eScenario);
+    const diagnostics: RuntimeDiagnostics = {
+        actionSamples: [],
+        activeAction: 'setup',
+        listRequests: 0,
+        networkFailures: [],
+        runtimeErrors: []
+    };
+
+    page.on('console', (message) => recordConsoleError(diagnostics, message));
+    page.on('pageerror', (error) => diagnostics.runtimeErrors.push({ action: diagnostics.activeAction, message: error.stack ?? error.message }));
+    page.on('request', (request) => recordListRequest(diagnostics, request, e2eScenario.organizationId));
+    page.on('response', (response) => recordNetworkFailure(diagnostics, response));
+
+    await test.step('seed enough independent stacks to exercise pagination', async () => {
+        await journey.submitRepresentativeEvent();
+        const events = Array.from({ length: 6 }, (_, index) => createChaosEvent(e2eApi.environment.appUrl, e2eScenario.run, index));
+        await Promise.all(events.map(({ event }) => e2eApi.submitEvent(e2eScenario.projectId, e2eScenario.projectToken, event)));
+        await Promise.all(events.map(({ referenceId }) => e2eApi.pollForEventByReference(e2eScenario.userToken, e2eScenario.projectId, referenceId)));
+    });
+
+    await test.step('load the stack page with one page of results', async () => {
+        const response = page.waitForResponse((candidate) => isStackListResponse(candidate, e2eScenario.organizationId));
+        await page.goto('/next/stack?limit=5');
+        expect((await response).ok()).toBe(true);
+        await expect(page.getByRole('heading', { name: 'Stacks' })).toBeVisible();
+        await expect(page.locator('tbody tr:visible').first()).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Go to next page' })).toBeEnabled();
+    });
+
+    await measureAction(diagnostics, 'paging', async () => {
+        for (let index = 0; index < 4; index++) {
+            await page.getByRole('button', { name: 'Go to next page' }).click();
+            await expect(page).toHaveURL(/(?:\?|&)page=2(?:&|$)/);
+            await page.getByRole('button', { name: 'Go to previous page' }).click();
+            await expect(page).not.toHaveURL(/(?:\?|&)page=2(?:&|$)/);
+        }
+    });
+    expect(actionSample(diagnostics, 'paging').listRequests).toBe(8);
+
+    await measureAction(diagnostics, 'stack detail mount and teardown', async () => {
+        for (let index = 0; index < 5; index++) {
+            await page.locator('tbody tr:visible').first().click();
+            await expect(page.getByRole('dialog')).toBeVisible();
+            await page.getByRole('button', { name: 'Close' }).click();
+            await expect(page.getByRole('dialog')).not.toBeVisible();
+        }
+    });
+    expect(actionSample(diagnostics, 'stack detail mount and teardown').listRequests).toBe(0);
+
+    await measureAction(diagnostics, 'rapid visibility changes', async () => {
+        for (let index = 0; index < 30; index++) {
+            await setDocumentHidden(page, true);
+            await setDocumentHidden(page, false);
+        }
+
+        await page.waitForTimeout(2_000);
+    });
+    expect(actionSample(diagnostics, 'rapid visibility changes').listRequests).toBeLessThanOrEqual(1);
+
+    await measureAction(diagnostics, 'background ingestion and resume', async () => {
+        await setDocumentHidden(page, true);
+        const { event, referenceId } = createChaosEvent(e2eApi.environment.appUrl, e2eScenario.run, 100);
+        await e2eApi.submitEvent(e2eScenario.projectId, e2eScenario.projectToken, event);
+        await e2eApi.pollForEventByReference(e2eScenario.userToken, e2eScenario.projectId, referenceId);
+        await setDocumentHidden(page, false);
+        await page.waitForTimeout(2_000);
+    });
+    expect(actionSample(diagnostics, 'background ingestion and resume').listRequests).toBeLessThanOrEqual(1);
+
+    await measureAction(diagnostics, 'bursty stack change notifications', async () => {
+        await page.evaluate((organizationId) => {
+            for (let index = 0; index < 30; index++) {
+                document.dispatchEvent(
+                    new CustomEvent('StackChanged', {
+                        detail: {
+                            change_type: 2,
+                            data: {},
+                            id: `chaos-missing-stack-${index}`,
+                            organization_id: organizationId,
+                            type: 'Stack'
+                        }
+                    })
+                );
+            }
+        }, e2eScenario.organizationId);
+        await page.waitForTimeout(2_000);
+    });
+    expect(actionSample(diagnostics, 'bursty stack change notifications').listRequests).toBe(1);
+
+    await measureAction(diagnostics, 'route remounts', async () => {
+        for (let index = 0; index < 5; index++) {
+            await page.goto(`/next/event/${journey.eventId}`);
+            await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible();
+            await page.goto('/next/stack?limit=5');
+            await expect(page.getByRole('heading', { name: 'Stacks' })).toBeVisible();
+        }
+    });
+    expect(actionSample(diagnostics, 'route remounts').listRequests).toBeLessThanOrEqual(5);
+
+    await testInfo.attach('stack-effect-chaos-diagnostics', {
+        body: Buffer.from(JSON.stringify(diagnostics, null, 2)),
+        contentType: 'application/json'
+    });
+
+    expect(diagnostics.runtimeErrors).toEqual([]);
+    expect(diagnostics.networkFailures).toEqual([]);
+    await expect(page.getByRole('heading', { name: 'Stacks' })).toBeVisible();
+});
+
+function actionSample(diagnostics: RuntimeDiagnostics, name: string): ActionSample {
+    const sample = diagnostics.actionSamples.find((candidate) => candidate.name === name);
+    expect(sample, `Missing diagnostics for "${name}"`).toBeDefined();
+    return sample!;
+}
+
+function createChaosEvent(appUrl: string, run: string, index: number): { event: Record<string, unknown>; referenceId: string } {
+    const referenceId = `pw-effects-${run}-${index}`;
+    const message = `Playwright effect chaos ${run} ${index}`;
+    const event = createRepresentativeEvent({
+        appUrl,
+        message,
+        referenceId,
+        runId: run
+    });
+    const data = event.data as Record<string, unknown>;
+    const simpleError = data['@simple_error'] as Record<string, unknown>;
+    simpleError.type = `PlaywrightEffectChaosException${index}`;
+    simpleError.stack_trace = `Error: ${message}\n    at stack-effect-chaos-${index}.ts:${index + 1}:1`;
+
+    return { event, referenceId };
+}
+
+function isStackListRequest(request: Request, organizationId: string): boolean {
+    const url = new URL(request.url());
+    return url.pathname === `/api/v2/organizations/${organizationId}/events` && url.searchParams.get('mode') === 'stack_frequent';
+}
+
+function isStackListResponse(response: Response, organizationId: string): boolean {
+    return isStackListRequest(response.request(), organizationId);
+}
+
+async function measureAction(diagnostics: RuntimeDiagnostics, name: string, action: () => Promise<void>): Promise<void> {
+    diagnostics.activeAction = name;
+    const initialListRequests = diagnostics.listRequests;
+    const initialRuntimeErrors = diagnostics.runtimeErrors.length;
+
+    await action();
+
+    diagnostics.actionSamples.push({
+        listRequests: diagnostics.listRequests - initialListRequests,
+        name,
+        runtimeErrors: diagnostics.runtimeErrors.length - initialRuntimeErrors
+    });
+}
+
+function recordConsoleError(diagnostics: RuntimeDiagnostics, message: ConsoleMessage): void {
+    const text = message.text();
+    if (message.type() === 'error' && /effect_update_depth_exceeded|maximum update depth|svelte\.dev\/e\/effect/i.test(text)) {
+        diagnostics.runtimeErrors.push({ action: diagnostics.activeAction, message: text });
+    }
+}
+
+function recordListRequest(diagnostics: RuntimeDiagnostics, request: Request, organizationId: string): void {
+    if (isStackListRequest(request, organizationId)) {
+        diagnostics.listRequests++;
+    }
+}
+
+function recordNetworkFailure(diagnostics: RuntimeDiagnostics, response: Response): void {
+    if (response.status() >= 400) {
+        diagnostics.networkFailures.push({
+            action: diagnostics.activeAction,
+            status: response.status(),
+            url: response.url()
+        });
+    }
+}
+
+async function setDocumentHidden(page: Page, hidden: boolean): Promise<void> {
+    await page.evaluate((nextHidden) => {
+        Object.defineProperty(document, 'hidden', {
+            configurable: true,
+            get: () => nextHidden
+        });
+        Object.defineProperty(document, 'visibilityState', {
+            configurable: true,
+            get: () => (nextHidden ? 'hidden' : 'visible')
+        });
+        document.dispatchEvent(new Event('visibilitychange'));
+        window.dispatchEvent(new Event('visibilitychange'));
+    }, hidden);
+}

--- a/src/Exceptionless.Web/ClientApp/package-lock.json
+++ b/src/Exceptionless.Web/ClientApp/package-lock.json
@@ -9,7 +9,7 @@
             "version": "8.0.0",
             "dependencies": {
                 "@exceptionless/browser": "^3.2.1",
-                "@exceptionless/fetchclient": "^0.44.0",
+                "@foundatiofx/fetchclient": "^1.3.3",
                 "@internationalized/date": "^3.12.2",
                 "@lucide/svelte": "^1.24.0",
                 "@stripe/stripe-js": "^9.10.0",
@@ -1107,11 +1107,11 @@
             "integrity": "sha512-JA4Wwkh9E6K4pJb9/cKR/SmJap5sqUvoi+eFQAKup2ZoliIPO5eSzx6Afb4R7R+N0imxjxQMj5kjcKRfA3X+1w==",
             "license": "Apache-2.0"
         },
-        "node_modules/@exceptionless/fetchclient": {
-            "version": "0.44.0",
-            "resolved": "https://registry.npmjs.org/@exceptionless/fetchclient/-/fetchclient-0.44.0.tgz",
-            "integrity": "sha512-xA3+/ZEJvKTXj0B8tI+6s7enBZp0l7ix/m+oDQOyxWaZY59PSiMehtdjbDbFs2dsX62caPuhMIMa9DK8n9oTnw==",
-            "license": "Apache-2.0"
+        "node_modules/@foundatiofx/fetchclient": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@foundatiofx/fetchclient/-/fetchclient-1.3.3.tgz",
+            "integrity": "sha512-ktc0LYedNj7i3i3BqQckfFMi7qKsfUXXOVP/yewcvUidjv6uCP7HNQFbpUPptiyymUJWwGLbMQxmUact8avOjA==",
+            "license": "MIT"
         },
         "node_modules/@exodus/bytes": {
             "version": "1.15.0",

--- a/src/Exceptionless.Web/ClientApp/package.json
+++ b/src/Exceptionless.Web/ClientApp/package.json
@@ -77,7 +77,7 @@
     },
     "dependencies": {
         "@exceptionless/browser": "^3.2.1",
-        "@exceptionless/fetchclient": "^0.44.0",
+        "@foundatiofx/fetchclient": "^1.3.3",
         "@internationalized/date": "^3.12.2",
         "@lucide/svelte": "^1.24.0",
         "@stripe/stripe-js": "^9.10.0",

--- a/src/Exceptionless.Web/ClientApp/src/hooks.client.ts
+++ b/src/Exceptionless.Web/ClientApp/src/hooks.client.ts
@@ -5,7 +5,7 @@ import { page } from '$app/state';
 import { env } from '$env/dynamic/public';
 import { normalizePath, normalizeRouteId } from '$lib/telemetry';
 import { Exceptionless, guid, toError } from '@exceptionless/browser';
-import { useMiddleware } from '@exceptionless/fetchclient';
+import { useMiddleware } from '@foundatiofx/fetchclient';
 
 // If any of these are set in local storage, use them instead of the build-time environment variables.
 // This allows you to target other environments from your browser without a rebuild.

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
@@ -1,4 +1,4 @@
-import { type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+import { type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
 
 import type {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/dialogs/run-maintenance-job-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/dialogs/run-maintenance-job-dialog.svelte
@@ -13,7 +13,7 @@
     import { type RunMaintenanceJobFormData, RunMaintenanceJobSchema } from '$features/admin/schemas';
     import { formatDateLabel } from '$features/shared/dates';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$shared/validation';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import { CalendarDate, type DateValue } from '@internationalized/date';
     import CalendarIcon from '@lucide/svelte/icons/calendar';
     import TriangleAlert from '@lucide/svelte/icons/triangle-alert';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/api.svelte.ts
@@ -1,7 +1,7 @@
 import { env } from '$env/dynamic/public';
 import { getIntercomTokenSessionKey, intercomTokenRefreshIntervalMs } from '$features/intercom/config';
 import { organization } from '$features/organizations/context.svelte';
-import { ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+import { ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { hide as hideIntercom, shutdown as shutdownIntercom } from '@intercom/messenger-js-sdk';
 import { createQuery, type QueryClient } from '@tanstack/svelte-query';
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/api.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/api.test.ts
@@ -1,4 +1,4 @@
-import { FetchClient } from '@exceptionless/fetchclient';
+import { FetchClient } from '@foundatiofx/fetchclient';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('./exceptionless-session', () => ({

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/index.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/index.svelte.ts
@@ -3,7 +3,7 @@ import { resolve } from '$app/paths';
 import { page } from '$app/state';
 import { env } from '$env/dynamic/public';
 import { CachedPersistedState } from '$features/shared/utils/cached-persisted-state.svelte';
-import { useFetchClient } from '@exceptionless/fetchclient';
+import { useFetchClient } from '@foundatiofx/fetchclient';
 
 import type { TokenResult } from './models';
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/billing/components/change-plan-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/billing/components/change-plan-dialog.svelte
@@ -21,7 +21,7 @@
     import { changePlanMutation, getPlansQuery } from '$features/organizations/api.svelte';
     import { getFormErrorMessages, problemDetailsToFormErrors } from '$features/shared/validation';
     import { Exceptionless } from '@exceptionless/browser';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import Check from '@lucide/svelte/icons/check';
     import CreditCard from '@lucide/svelte/icons/credit-card';
     import Plus from '@lucide/svelte/icons/plus';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/billing/upgrade-required.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/billing/upgrade-required.svelte.ts
@@ -1,4 +1,4 @@
-import { ProblemDetails } from '@exceptionless/fetchclient';
+import { ProblemDetails } from '@foundatiofx/fetchclient';
 
 interface UpgradeRequiredState {
     message: string;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
@@ -4,7 +4,7 @@ import type { CountResult, WorkInProgressResult } from '$shared/models';
 import { accessToken } from '$features/auth/index.svelte';
 import { queryKeys as stackQueryKeys } from '$features/stacks/api.svelte';
 import { DEFAULT_OFFSET } from '$shared/api/api.svelte';
-import { type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+import { type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, keepPreviousData, QueryClient, useQueryClient } from '@tanstack/svelte-query';
 
 import type { EventSummaryModel, SummaryTemplateKeys } from './components/summary/index';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/event-detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/event-detail-sheet.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type { IFilter } from '$comp/faceted-filter';
-    import type { ProblemDetails } from '@exceptionless/fetchclient';
+    import type { ProblemDetails } from '@foundatiofx/fetchclient';
 
     import DetailSheet from '$comp/detail-sheet.svelte';
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { IFilter } from '$comp/faceted-filter';
     import type { UpdateProject, ViewProject } from '$features/projects/models';
-    import type { ProblemDetails } from '@exceptionless/fetchclient';
+    import type { ProblemDetails } from '@foundatiofx/fetchclient';
 
     import CopyToClipboardButton from '$comp/copy-to-clipboard-button.svelte';
     import DateTime from '$comp/formatters/date-time.svelte';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/notifications/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/notifications/api.svelte.ts
@@ -1,6 +1,6 @@
 import type { SystemNotification } from '$features/websockets/models';
 
-import { type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+import { type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
 
 export const queryKeys = {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/api.svelte.ts
@@ -5,7 +5,7 @@ import type { QueryClient } from '@tanstack/svelte-query';
 import { accessToken } from '$features/auth/index.svelte';
 import { fetchApiJson } from '$features/shared/api/api.svelte';
 import { queryKeys as userQueryKeys } from '$features/users/api.svelte';
-import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
 
 import type { Invoice, InvoiceGridModel, NewOrganization, SuspensionCode, ViewOrganization } from './models';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/set-event-bonus-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/set-event-bonus-dialog.svelte
@@ -14,7 +14,7 @@
     import Number from '$features/shared/components/formatters/number.svelte';
     import { formatDateLabel } from '$features/shared/dates';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$shared/validation';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import { CalendarDate, type DateValue } from '@internationalized/date';
     import CalendarIcon from '@lucide/svelte/icons/calendar';
     import { createForm } from '@tanstack/svelte-form';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/suspend-organization-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/suspend-organization-dialog.svelte
@@ -12,7 +12,7 @@
     import { SuspensionCode } from '$features/organizations/models';
     import { suspensionCodeOptions } from '$features/organizations/options';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import { createForm } from '@tanstack/svelte-form';
 
     import { type SuspendOrganizationFormData, SuspendOrganizationSchema } from '../../schemas';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/table/options.svelte.ts
@@ -1,5 +1,5 @@
 import type { ViewOrganization } from '$features/organizations/models';
-import type { FetchClientResponse, ProblemDetails } from '@exceptionless/fetchclient';
+import type { FetchClientResponse, ProblemDetails } from '@foundatiofx/fetchclient';
 import type { CreateQueryResult } from '@tanstack/svelte-query';
 
 import NumberFormatter from '$comp/formatters/number.svelte';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/api.svelte.ts
@@ -4,7 +4,7 @@ import type { WebSocketMessageValue } from '$features/websockets/models';
 
 import { accessToken } from '$features/auth/index.svelte';
 import { fetchApiJson } from '$features/shared/api/api.svelte';
-import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, QueryClient, useQueryClient } from '@tanstack/svelte-query';
 
 export async function invalidateProjectQueries(queryClient: QueryClient, message: WebSocketMessageValue<'ProjectChanged'>) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/add-project-config-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/add-project-config-dialog.svelte
@@ -5,7 +5,7 @@
     import * as Field from '$comp/ui/field';
     import { Input } from '$comp/ui/input';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import { createForm } from '@tanstack/svelte-form';
 
     import type { ClientConfigurationSetting } from '../../models';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/update-project-config-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/update-project-config-dialog.svelte
@@ -6,7 +6,7 @@
     import { Input } from '$comp/ui/input';
     import { ClientConfigurationSettingSchema } from '$features/projects/schemas';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$shared/validation';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import { createForm } from '@tanstack/svelte-form';
 
     import type { ClientConfigurationSetting } from '../../models';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/config-options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/config-options.svelte.ts
@@ -1,5 +1,5 @@
 import type { ClientConfiguration, ClientConfigurationSetting } from '$features/projects/models';
-import type { ProblemDetails } from '@exceptionless/fetchclient';
+import type { ProblemDetails } from '@foundatiofx/fetchclient';
 import type { CreateQueryResult } from '@tanstack/svelte-query';
 
 import ProjectConfigActionsCell from '$features/projects/components/table/project-config-actions-cell.svelte';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/options.svelte.ts
@@ -1,5 +1,5 @@
 import type { ViewProject } from '$features/projects/models';
-import type { FetchClientResponse, ProblemDetails } from '@exceptionless/fetchclient';
+import type { FetchClientResponse, ProblemDetails } from '@foundatiofx/fetchclient';
 import type { CreateQueryResult } from '@tanstack/svelte-query';
 
 import NumberFormatter from '$comp/formatters/number.svelte';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.svelte.ts
@@ -3,7 +3,7 @@ import type { WebSocketMessageValue } from '$features/websockets/models';
 
 import { accessToken } from '$features/auth/index.svelte';
 import { ChangeType } from '$features/websockets/models';
-import { type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+import { type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, type QueryClient, useQueryClient } from '@tanstack/svelte-query';
 
 import type { NewSavedView, SavedView, UpdateSavedView } from './models';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
@@ -6,7 +6,7 @@
 
 <script generics="TData extends RowData" lang="ts">
     import type { IFilter } from '$comp/faceted-filter';
-    import type { ProblemDetails } from '@exceptionless/fetchclient';
+    import type { ProblemDetails } from '@foundatiofx/fetchclient';
     import type { StockFeatures, Table } from '@tanstack/svelte-table';
 
     import { Button } from '$comp/ui/button';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/api/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/api/api.svelte.ts
@@ -1,5 +1,5 @@
 import { accessToken } from '$features/auth/index.svelte';
-import { type FetchClient, type FetchClientProvider, getCurrentProvider, ProblemDetails } from '@exceptionless/fetchclient';
+import { type FetchClient, type FetchClientProvider, getCurrentProvider, ProblemDetails } from '@foundatiofx/fetchclient';
 import { SvelteDate } from 'svelte/reactivity';
 
 export { DEFAULT_LIMIT } from './constants';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/api/fetch-client-response.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/api/fetch-client-response.test.ts
@@ -1,6 +1,6 @@
-import type { FetchClientResponse } from '@exceptionless/fetchclient';
+import type { FetchClientResponse } from '@foundatiofx/fetchclient';
 
-import { ProblemDetails } from '@exceptionless/fetchclient';
+import { ProblemDetails } from '@foundatiofx/fetchclient';
 import { describe, expect, it } from 'vitest';
 
 import { normalizeDeserializationFailure } from './fetch-client-response';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/api/fetch-client-response.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/api/fetch-client-response.test.ts
@@ -1,0 +1,49 @@
+import type { FetchClientResponse } from '@exceptionless/fetchclient';
+
+import { ProblemDetails } from '@exceptionless/fetchclient';
+import { describe, expect, it } from 'vitest';
+
+import { normalizeDeserializationFailure } from './fetch-client-response';
+
+describe('normalizeDeserializationFailure', () => {
+    it('leaves successful response data unchanged', () => {
+        const response = createResponse({ value: 42 });
+
+        expect(normalizeDeserializationFailure(response)).toBe(response);
+    });
+
+    it('turns an aborted successful body read into a client-closed error response', () => {
+        const problem = new ProblemDetails().setErrorMessage('Unable to deserialize response data: Failed to fetch');
+        problem.title = 'Unable to deserialize response data: Failed to fetch';
+        const response = createResponse(problem);
+
+        const normalized = normalizeDeserializationFailure(response);
+
+        expect(normalized?.ok).toBe(false);
+        expect(normalized?.status).toBe(499);
+        expect(normalized?.data).toBeNull();
+        expect(normalized?.problem).toBe(problem);
+        expect(normalized?.meta).toBe(response.meta);
+    });
+
+    it('turns malformed successful JSON into a retryable gateway error response', () => {
+        const problem = new ProblemDetails().setErrorMessage('Unable to deserialize response data: Unexpected token');
+        problem.title = 'Unable to deserialize response data: Unexpected token';
+        const response = createResponse(problem);
+
+        const normalized = normalizeDeserializationFailure(response);
+
+        expect(normalized?.ok).toBe(false);
+        expect(normalized?.status).toBe(502);
+        expect(normalized?.problem.status).toBe(502);
+    });
+});
+
+function createResponse(data: unknown): FetchClientResponse<unknown> {
+    const response = new Response('{}', { status: 200 }) as FetchClientResponse<unknown>;
+    response.data = data;
+    response.meta = { links: {} };
+    response.problem = new ProblemDetails();
+
+    return response;
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/api/fetch-client-response.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/api/fetch-client-response.ts
@@ -1,0 +1,22 @@
+import { type FetchClientResponse, ProblemDetails } from '@exceptionless/fetchclient';
+
+export function normalizeDeserializationFailure(response: FetchClientResponse<unknown> | null): FetchClientResponse<unknown> | null {
+    const title = response?.data instanceof ProblemDetails ? response.data.title : undefined;
+    if (!response?.ok || !title?.startsWith('Unable to deserialize response data:')) {
+        return response;
+    }
+
+    const problem = response.data as ProblemDetails;
+    const status = title.includes('Failed to fetch') ? 499 : 502;
+    problem.status = status;
+
+    const normalizedResponse = new Response(null, {
+        status,
+        statusText: status === 499 ? 'Client Closed Request' : 'Bad Gateway'
+    }) as FetchClientResponse<unknown>;
+    normalizedResponse.data = null;
+    normalizedResponse.meta = response.meta;
+    normalizedResponse.problem = problem;
+
+    return normalizedResponse;
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/api/fetch-client-response.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/api/fetch-client-response.ts
@@ -1,4 +1,4 @@
-import { type FetchClientResponse, ProblemDetails } from '@exceptionless/fetchclient';
+import { type FetchClientResponse, ProblemDetails } from '@foundatiofx/fetchclient';
 
 export function normalizeDeserializationFailure(response: FetchClientResponse<unknown> | null): FetchClientResponse<unknown> | null {
     const title = response?.data instanceof ProblemDetails ? response.data.title : undefined;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/form/password-input.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/form/password-input.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { ProblemDetails } from '@exceptionless/fetchclient';
+    import type { ProblemDetails } from '@foundatiofx/fetchclient';
     import type { Snippet } from 'svelte';
     import type { FullAutoFill } from 'svelte/elements';
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte
@@ -66,7 +66,13 @@
                 {/snippet}
             </Tooltip.Trigger>
             <Tooltip.Content arrowClasses="hidden" class="border-border bg-popover text-popover-foreground border shadow-md" sideOffset={4}>
-                Click to filter. <Kbd>{copyTagShortcut}</Kbd> click to copy.
+                Click to filter.
+                <Kbd
+                    class="border-border in-data-[slot=tooltip-content]:bg-muted in-data-[slot=tooltip-content]:text-foreground dark:border-muted-foreground/50 dark:in-data-[slot=tooltip-content]:bg-muted border"
+                >
+                    {copyTagShortcut}
+                </Kbd>
+                click to copy.
             </Tooltip.Content>
         </Tooltip.Root>
     {:else}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte.test.ts
@@ -1,9 +1,24 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import TagList from './tag-list.svelte';
 
+class ResizeObserverMock {
+    disconnect = vi.fn();
+    observe = vi.fn();
+    takeRecords = vi.fn(() => []);
+    unobserve = vi.fn();
+}
+
 describe('TagList', () => {
+    beforeAll(() => {
+        vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+    });
+
+    afterAll(() => {
+        vi.unstubAllGlobals();
+    });
+
     it('renders neutral tag badges without filter icons and summarizes overflow', () => {
         const { container } = render(TagList, {
             maxVisible: 2,
@@ -30,10 +45,20 @@ describe('TagList', () => {
         const onTagClick = vi.fn();
         render(TagList, { onTagClick, tags: ['api'] });
 
-        await fireEvent.click(screen.getByRole('button', { name: 'api' }));
+        const tagButton = screen.getByRole('button', { name: 'api' });
+        await fireEvent.click(tagButton);
 
         expect(onTagClick).toHaveBeenCalledOnce();
         expect(onTagClick).toHaveBeenCalledWith('api');
+
+        await fireEvent.pointerEnter(tagButton);
+        await fireEvent.pointerMove(tagButton);
+
+        const shortcut = document.querySelector('[data-slot="tooltip-content"] [data-slot="kbd"]');
+        expect(shortcut).not.toBeNull();
+        expect(shortcut?.classList.contains('in-data-[slot=tooltip-content]:bg-muted')).toBe(true);
+        expect(shortcut?.classList.contains('in-data-[slot=tooltip-content]:text-foreground')).toBe(true);
+        expect(shortcut?.classList.contains('border-border')).toBe(true);
     });
 
     it('shows an empty value when there are no tags', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
@@ -1,4 +1,4 @@
-import type { FetchClientResponse } from '@exceptionless/fetchclient';
+import type { FetchClientResponse } from '@foundatiofx/fetchclient';
 
 import {
     type ColumnDef,

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/validation.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/validation.ts
@@ -1,4 +1,4 @@
-import { ProblemDetails } from '@exceptionless/fetchclient';
+import { ProblemDetails } from '@foundatiofx/fetchclient';
 
 export type FieldWithErrors = {
     state: {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/api.svelte.ts
@@ -2,7 +2,7 @@ import type { WebSocketMessageValue } from '$features/websockets/models';
 import type { WorkInProgressResult } from '$shared/models';
 
 import { accessToken } from '$features/auth/index.svelte';
-import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, QueryClient, useQueryClient } from '@tanstack/svelte-query';
 
 import type { Stack, StackStatus } from './models';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/add-stack-reference-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/add-stack-reference-dialog.svelte
@@ -6,7 +6,7 @@
     import { Input } from '$comp/ui/input';
     import { ReferenceLinkSchema } from '$features/stacks/schemas';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$shared/validation';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import { createForm } from '@tanstack/svelte-form';
 
     interface Props {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/mark-stack-fixed-in-version-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/mark-stack-fixed-in-version-dialog.svelte
@@ -6,7 +6,7 @@
     import * as Field from '$comp/ui/field';
     import { Input } from '$comp/ui/input';
     import { getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$shared/validation';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import Documentation from '@lucide/svelte/icons/help-circle';
     import { createForm } from '@tanstack/svelte-form';
     import { debounce } from 'throttle-debounce';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
@@ -45,6 +45,8 @@
     let { filterChanged, id, onDeleted, onError }: Props = $props();
     let handledErrorForStackId = $state<string>();
 
+    const METRICS_TIME_RANGE = '[now-7d TO now]';
+
     const stackQuery = getStackQuery({
         route: {
             get id() {
@@ -55,7 +57,8 @@
 
     const projectCountQuery = getProjectCountQuery({
         params: {
-            aggregations: 'cardinality:user'
+            aggregations: 'cardinality:user',
+            time: METRICS_TIME_RANGE
         },
         route: {
             get projectId() {
@@ -79,7 +82,7 @@
     const stackCountQuery = getStackCountQuery({
         params: {
             aggregations: `date:(date${DEFAULT_OFFSET ? '^' + DEFAULT_OFFSET : ''} cardinality:user sum:count~1) min:date max:date cardinality:user sum:count~1`,
-            time: '[now-7d TO now]'
+            time: METRICS_TIME_RANGE
         },
         route: {
             get stackId() {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type { ProblemDetails } from '@exceptionless/fetchclient';
+    import type { ProblemDetails } from '@foundatiofx/fetchclient';
 
     import { type IFilter } from '$comp/faceted-filter';
     import DateTime from '$comp/formatters/date-time.svelte';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-detail-sheet.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { IFilter } from '$comp/faceted-filter';
     import type { PersistentEvent } from '$features/events/models';
-    import type { ProblemDetails } from '@exceptionless/fetchclient';
+    import type { ProblemDetails } from '@foundatiofx/fetchclient';
 
     import { resolve } from '$app/paths';
     import DetailSheet from '$comp/detail-sheet.svelte';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-details.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-details.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { IFilter } from '$comp/faceted-filter';
     import type { PersistentEvent } from '$features/events/models';
-    import type { ProblemDetails } from '@exceptionless/fetchclient';
+    import type { ProblemDetails } from '@foundatiofx/fetchclient';
 
     import { Muted } from '$comp/typography';
     import { getStackEventsQuery } from '$features/events/api.svelte';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/table/options.svelte.ts
@@ -1,6 +1,6 @@
 import type { GetProjectStacksParams } from '$features/stacks/api.svelte';
 import type { Stack } from '$features/stacks/models';
-import type { FetchClientResponse, ProblemDetails } from '@exceptionless/fetchclient';
+import type { FetchClientResponse, ProblemDetails } from '@foundatiofx/fetchclient';
 import type { CreateQueryResult } from '@tanstack/svelte-query';
 
 import NumberFormatter from '$comp/formatters/number.svelte';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/status/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/status/api.svelte.ts
@@ -1,4 +1,4 @@
-import { type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+import { type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createQuery } from '@tanstack/svelte-query';
 
 import type { About } from './models';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/api.svelte.ts
@@ -3,7 +3,7 @@ import type { WebSocketMessageValue } from '$features/websockets/models';
 
 import { accessToken } from '$features/auth/index.svelte';
 import { DEFAULT_LIMIT } from '$features/shared/api/api.svelte';
-import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, QueryClient, useQueryClient } from '@tanstack/svelte-query';
 
 export async function invalidateTokenQueries(queryClient: QueryClient, message: WebSocketMessageValue<'TokenChanged'>) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/dialogs/update-token-notes-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/dialogs/update-token-notes-dialog.svelte
@@ -6,7 +6,7 @@
     import { Textarea } from '$comp/ui/textarea';
     import { type UpdateTokenFormData, UpdateTokenSchema } from '$features/tokens/schemas';
     import { getFormErrorMessages, problemDetailsToFormErrors } from '$shared/validation';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import { createForm } from '@tanstack/svelte-form';
 
     interface Props {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/table/options.svelte.ts
@@ -1,5 +1,5 @@
 import type { ViewToken } from '$features/tokens/models';
-import type { FetchClientResponse, ProblemDetails } from '@exceptionless/fetchclient';
+import type { FetchClientResponse, ProblemDetails } from '@foundatiofx/fetchclient';
 import type { CreateQueryResult } from '@tanstack/svelte-query';
 
 import { getSharedTableOptions } from '$features/shared/table.svelte';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.svelte.ts
@@ -4,7 +4,7 @@ import type { WorkInProgressResult } from '$shared/models';
 import { setUserIdentity } from '$features/auth/exceptionless-session';
 import { accessToken } from '$features/auth/index.svelte';
 import { fetchApiJson } from '$features/shared/api/api.svelte';
-import { type FetchClientResponse, ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+import { type FetchClientResponse, ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, QueryClient, useQueryClient } from '@tanstack/svelte-query';
 
 import type { OAuthGrant, UpdateEmailAddressResult, UpdateUser, UpdateUserEmailAddress, ViewCurrentUser, ViewUser } from './models';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/invite-user-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/invite-user-dialog.svelte
@@ -5,7 +5,7 @@
     import * as Field from '$comp/ui/field';
     import { Input } from '$comp/ui/input';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import { createForm } from '@tanstack/svelte-form';
 
     import { type InviteUserFormData, InviteUserSchema } from '../schemas';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/oauth-grants/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/oauth-grants/table/options.svelte.ts
@@ -1,5 +1,5 @@
 import type { OAuthGrant } from '$features/users/models';
-import type { ProblemDetails } from '@exceptionless/fetchclient';
+import type { ProblemDetails } from '@foundatiofx/fetchclient';
 import type { CreateQueryResult } from '@tanstack/svelte-query';
 
 import { getSharedTableOptions, type TableMemoryPagingParameters } from '$features/shared/table.svelte';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/table/options.svelte.ts
@@ -1,5 +1,5 @@
 import type { ViewUser } from '$features/users/models';
-import type { FetchClientResponse, ProblemDetails } from '@exceptionless/fetchclient';
+import type { FetchClientResponse, ProblemDetails } from '@foundatiofx/fetchclient';
 import type { CreateQueryResult } from '@tanstack/svelte-query';
 
 import BooleanFormatter from '$features/shared/components/formatters/boolean.svelte';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/table/user-actions-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/table/user-actions-cell.svelte
@@ -4,7 +4,7 @@
     import { Button } from '$comp/ui/button';
     import * as DropdownMenu from '$comp/ui/dropdown-menu';
     import { addOrganizationUser, deleteOrganizationUser } from '$features/organizations/api.svelte';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import EllipsisIcon from '@lucide/svelte/icons/ellipsis';
     import Mail from '@lucide/svelte/icons/mail';
     import X from '@lucide/svelte/icons/x';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/api.svelte.ts
@@ -3,7 +3,7 @@ import type { WebSocketMessageValue } from '$features/websockets/models';
 
 import { accessToken } from '$features/auth/index.svelte';
 import { DEFAULT_LIMIT } from '$features/shared/api/api.svelte';
-import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, QueryClient, useQueryClient } from '@tanstack/svelte-query';
 
 export async function invalidateWebhookQueries(queryClient: QueryClient, message: WebSocketMessageValue<'WebhookChanged'>) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/components/dialogs/add-webhook-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/components/dialogs/add-webhook-dialog.svelte
@@ -9,7 +9,7 @@
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
     import { webhookEventTypes } from '$features/webhooks/options';
     import { type NewWebHookFormData, NewWebHookSchema } from '$features/webhooks/schemas';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import { createForm } from '@tanstack/svelte-form';
 
     import type { NewWebhook, WebhookKnownEventTypes } from '../../models';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/components/table/options.svelte.ts
@@ -1,5 +1,5 @@
 import type { Webhook } from '$features/webhooks/models';
-import type { FetchClientResponse, ProblemDetails } from '@exceptionless/fetchclient';
+import type { FetchClientResponse, ProblemDetails } from '@foundatiofx/fetchclient';
 import type { CreateQueryResult } from '@tanstack/svelte-query';
 
 import { getSharedTableOptions } from '$features/shared/table.svelte';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar-user.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar-user.svelte
@@ -15,7 +15,7 @@
     import { logout } from '$features/auth/api.svelte';
     import { organization } from '$features/organizations/context.svelte';
     import { apiReferenceHref, documentationHref, githubRepositoryHref, supportIssuesHref } from '$features/shared/help-links';
-    import { useFetchClient } from '@exceptionless/fetchclient';
+    import { useFetchClient } from '@foundatiofx/fetchclient';
     import BadgeCheck from '@lucide/svelte/icons/badge-check';
     import Bell from '@lucide/svelte/icons/bell';
     import BookOpen from '@lucide/svelte/icons/book-open';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type { EventSummaryModel, StackSummaryModel, SummaryTemplateKeys } from '$features/events/components/summary/index';
-    import type { FetchClientResponse, ProblemDetails } from '@exceptionless/fetchclient';
+    import type { FetchClientResponse, ProblemDetails } from '@foundatiofx/fetchclient';
 
     import { resolve } from '$app/paths';
     import * as Command from '$comp/ui/command';
@@ -8,7 +8,7 @@
     import { organization } from '$features/organizations/context.svelte';
     import { appKeyboardShortcuts, formatKeyboardShortcut, type ShortcutKey } from '$features/shared/keyboard-shortcuts';
     import { DEFAULT_OFFSET } from '$shared/api/api.svelte';
-    import { useFetchClient } from '@exceptionless/fetchclient';
+    import { useFetchClient } from '@foundatiofx/fetchclient';
     import Activity from '@lucide/svelte/icons/activity';
     import Building2 from '@lucide/svelte/icons/building-2';
     import CircleUserRound from '@lucide/svelte/icons/circle-user-round';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
@@ -31,7 +31,7 @@
     import { isEntityChangedType, type WebSocketMessageType } from '$features/websockets/models';
     import { WebSocketClient } from '$features/websockets/web-socket-client.svelte';
     import { Telemetry } from '$lib/telemetry';
-    import { useMiddleware } from '@exceptionless/fetchclient';
+    import { useMiddleware } from '@foundatiofx/fetchclient';
     import { useQueryClient } from '@tanstack/svelte-query';
     import { tick } from 'svelte';
     import { fade } from 'svelte/transition';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/account/manage/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/account/manage/+page.svelte
@@ -25,7 +25,7 @@
     import { getGravatarFromCurrentUser } from '$features/users/gravatar.svelte';
     import { type UpdateUserEmailAddressFormData, UpdateUserEmailAddressSchema, type UpdateUserFormData, UpdateUserSchema } from '$features/users/schemas';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$shared/validation';
-    import { ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+    import { ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
     import Camera from '@lucide/svelte/icons/camera';
     import Trash from '@lucide/svelte/icons/trash-2';
     import X from '@lucide/svelte/icons/x';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/account/verify/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/account/verify/+page.svelte
@@ -2,7 +2,7 @@
     import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';
     import { page } from '$app/state';
-    import { useFetchClient } from '@exceptionless/fetchclient';
+    import { useFetchClient } from '@foundatiofx/fetchclient';
     import { toast } from 'svelte-sonner';
 
     const client = useFetchClient();

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -816,8 +816,25 @@
     useEventListener(document, 'refresh', () => scheduleLoadData(true));
     useEventListener(document, 'PersistentEventChanged', (event) => onPersistentEventChanged((event as CustomEvent).detail));
 
+    const automaticLoadDataKey = $derived(
+        JSON.stringify({
+            after: eventsQueryParameters.after,
+            before: eventsQueryParameters.before,
+            filter: eventsQueryParameters.filter,
+            isSavedViewRoutePending,
+            limit: eventsQueryParameters.limit,
+            mode: eventsQueryParameters.mode,
+            offset: eventsQueryParameters.offset,
+            organizationId: organization.current,
+            page: eventsQueryParameters.page,
+            sort: eventsQueryParameters.sort,
+            time: eventsQueryParameters.time
+        })
+    );
+
     $effect(() => {
-        loadData();
+        void automaticLoadDataKey;
+        untrack(() => loadData());
     });
 
     const chartDataQuery = getOrganizationCountQuery({

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -55,7 +55,7 @@
     import { StackStatus } from '$features/stacks/models';
     import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
     import { DEFAULT_OFFSET, useFetchClientStatus } from '$shared/api/api.svelte';
-    import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+    import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
     import { error } from '@sveltejs/kit';
     import { createTable } from '@tanstack/svelte-table';
     import { queryParamsState } from 'kit-query-params';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type { PersistentEvent } from '$features/events/models';
-    import type { ProblemDetails } from '@exceptionless/fetchclient';
+    import type { ProblemDetails } from '@foundatiofx/fetchclient';
 
     import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/features/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/features/+page.svelte
@@ -9,7 +9,7 @@
     import { getOrganizationQuery, removeOrganizationFeature, setOrganizationFeature } from '$features/organizations/api.svelte';
     import { postPredefinedSavedViews } from '$features/saved-views/api.svelte';
     import { getMeQuery } from '$features/users/api.svelte';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import RefreshCw from '@lucide/svelte/icons/refresh-cw';
     import { toast } from 'svelte-sonner';
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/manage/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/manage/+page.svelte
@@ -22,7 +22,7 @@
     import { getProfileImageFileError } from '$features/shared/profile-images';
     import { ariaInvalid, getFormErrorMessages, getProblemMessage, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
     import { getInitials } from '$shared/strings';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import Events from '@lucide/svelte/icons/calendar-days';
     import Camera from '@lucide/svelte/icons/camera';
     import Projects from '@lucide/svelte/icons/folder-open';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/users/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/users/+page.svelte
@@ -12,7 +12,7 @@
     import InviteUserDialog from '$features/users/components/invite-user-dialog.svelte';
     import { getTableOptions } from '$features/users/components/table/options.svelte';
     import UsersDataTable from '$features/users/components/table/users-data-table.svelte';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import Plus from '@lucide/svelte/icons/plus';
     import { createTable } from '@tanstack/svelte-table';
     import { queryParamsState } from 'kit-query-params';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/add/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/add/+page.svelte
@@ -17,7 +17,7 @@
     import { useHideOrganizationNotifications } from '$features/organizations/hooks/use-hide-organization-notifications.svelte';
     import { postProject } from '$features/projects/api.svelte';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import { createForm } from '@tanstack/svelte-form';
     import { toast } from 'svelte-sonner';
     import { type infer as Infer, object, string } from 'zod';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/manage/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/manage/+page.svelte
@@ -16,7 +16,7 @@
     import ResetProjectDataDialog from '$features/projects/components/dialogs/reset-project-data-dialog.svelte';
     import { type UpdateProjectFormData, UpdateProjectSchema } from '$features/projects/schemas';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
     import CloudDownload from '@lucide/svelte/icons/cloud-download';
     import Database from '@lucide/svelte/icons/database';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/source-maps/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/source-maps/+page.svelte
@@ -17,7 +17,7 @@
     import { deleteSourceMapMutation, getSourceMapsQuery, postSourceMapMutation } from '$features/projects/api.svelte';
     import { type SourceMapUploadFormData, SourceMapUploadSchema } from '$features/projects/schemas';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import ArrowLeft from '@lucide/svelte/icons/arrow-left';
     import Trash from '@lucide/svelte/icons/trash-2';
     import Upload from '@lucide/svelte/icons/upload';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/[stackId]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/[stackId]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import type { IFilter } from '$comp/faceted-filter';
-    import type { ProblemDetails } from '@exceptionless/fetchclient';
+    import type { ProblemDetails } from '@foundatiofx/fetchclient';
 
     import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/add/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/add/+page.svelte
@@ -14,7 +14,7 @@
     import { postProject } from '$features/projects/api.svelte';
     import { type NewProjectFormData, NewProjectSchema } from '$features/projects/schemas';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import { createForm } from '@tanstack/svelte-form';
     import { untrack } from 'svelte';
     import { toast } from 'svelte-sonner';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
@@ -38,7 +38,7 @@
     import { parseDateMathRange, toDateMathRange } from '$features/shared/utils/datemath';
     import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
     import { DEFAULT_LIMIT, DEFAULT_OFFSET, useFetchClientStatus } from '$shared/api/api.svelte';
-    import { type FetchClientResponse, useFetchClient } from '@exceptionless/fetchclient';
+    import { type FetchClientResponse, useFetchClient } from '@foundatiofx/fetchclient';
     import { createTable } from '@tanstack/svelte-table';
     import { queryParamsState } from 'kit-query-params';
     import { useEventListener, watch } from 'runed';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -51,7 +51,7 @@
     import { StackStatus } from '$features/stacks/models';
     import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
     import { DEFAULT_OFFSET, useFetchClientStatus } from '$shared/api/api.svelte';
-    import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+    import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
     import { error } from '@sveltejs/kit';
     import { createTable } from '@tanstack/svelte-table';
     import { queryParamsState } from 'kit-query-params';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -396,7 +396,10 @@
             }
 
             isInternalFilterUpdate = false;
-            filters = getCurrentFilters(getListFilterQueryParams(page.url.searchParams));
+            const updatedFilters = getCurrentFilters(getListFilterQueryParams(page.url.searchParams));
+            if (serializeFilters(filters ?? []) !== serializeFilters(updatedFilters)) {
+                filters = updatedFilters;
+            }
         },
         { lazy: true }
     );
@@ -722,8 +725,22 @@
     useEventListener(document, 'refresh', () => loadData());
     useEventListener(document, 'StackChanged', (event) => onStackChanged((event as CustomEvent).detail));
 
+    const automaticLoadDataKey = $derived(
+        JSON.stringify({
+            filter: eventsQueryParameters.filter,
+            isSavedViewRoutePending,
+            limit: eventsQueryParameters.limit,
+            mode: eventsQueryParameters.mode,
+            offset: eventsQueryParameters.offset,
+            organizationId: organization.current,
+            page: eventsQueryParameters.page,
+            time: eventsQueryParameters.time
+        })
+    );
+
     $effect(() => {
-        loadData();
+        void automaticLoadDataKey;
+        untrack(() => loadData());
     });
 
     const chartDataQuery = getOrganizationCountQuery({

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { IFilter } from '$comp/faceted-filter';
     import type { PersistentEvent } from '$features/events/models';
-    import type { ProblemDetails } from '@exceptionless/fetchclient';
+    import type { ProblemDetails } from '@foundatiofx/fetchclient';
 
     import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/event/[eventId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/event/[eventId=objectid]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { IFilter } from '$comp/faceted-filter';
     import type { PersistentEvent } from '$features/events/models';
-    import type { ProblemDetails } from '@exceptionless/fetchclient';
+    import type { ProblemDetails } from '@foundatiofx/fetchclient';
 
     import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -34,7 +34,7 @@
     import { StackStatus } from '$features/stacks/models';
     import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
     import { DEFAULT_LIMIT, DEFAULT_OFFSET, useFetchClientStatus } from '$shared/api/api.svelte';
-    import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@exceptionless/fetchclient';
+    import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
     import { createTable } from '@tanstack/svelte-table';
     import { queryParamsState } from 'kit-query-params';
     import { useEventListener, watch } from 'runed';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/actions/[[category]]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/actions/[[category]]/+page.svelte
@@ -10,7 +10,7 @@
     import { runMaintenanceJobMutation } from '$features/admin/api.svelte';
     import RunMaintenanceJobDialog from '$features/admin/components/dialogs/run-maintenance-job-dialog.svelte';
     import { maintenanceActions } from '$features/admin/models';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import Play from '@lucide/svelte/icons/play';
     import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
     import { toast } from 'svelte-sonner';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/oauth-applications/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/oauth-applications/+page.svelte
@@ -23,7 +23,7 @@
     } from '$features/admin/api.svelte';
     import { type OAuthApplicationFormData, OAuthApplicationSchema } from '$features/admin/schemas';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import Check from '@lucide/svelte/icons/check';
     import CircleSlash from '@lucide/svelte/icons/circle-slash';
     import Plus from '@lucide/svelte/icons/plus';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/saved-views/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/saved-views/+page.svelte
@@ -14,7 +14,7 @@
         putPredefinedSavedViewsMutation
     } from '$features/admin/api.svelte';
     import { organization } from '$features/organizations/context.svelte';
-    import { ProblemDetails } from '@exceptionless/fetchclient';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import Save from '@lucide/svelte/icons/save';
     import { onMount } from 'svelte';
     import { toast } from 'svelte-sonner';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(auth)/oauth/authorize/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(auth)/oauth/authorize/+page.svelte
@@ -14,7 +14,7 @@
     import { accessToken } from '$features/auth/index.svelte';
     import { getOrganizationsQuery } from '$features/organizations/api.svelte';
     import { getMeQuery } from '$features/users/api.svelte';
-    import { useFetchClient } from '@exceptionless/fetchclient';
+    import { useFetchClient } from '@foundatiofx/fetchclient';
     import { SvelteSet } from 'svelte/reactivity';
 
     interface OAuthAuthorizeResponse {

--- a/src/Exceptionless.Web/ClientApp/src/routes/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/+layout.svelte
@@ -8,7 +8,7 @@
     import { Toaster } from '$comp/ui/sonner';
     import { accessToken } from '$features/auth/index.svelte';
     import { normalizeDeserializationFailure } from '$shared/api/fetch-client-response';
-    import { type FetchClientContext, ProblemDetails, setAccessTokenFunc, setBaseUrl, setRequestOptions, useMiddleware } from '@exceptionless/fetchclient';
+    import { type FetchClientContext, ProblemDetails, setAccessTokenFunc, setBaseUrl, setRequestOptions, useMiddleware } from '@foundatiofx/fetchclient';
     import { error } from '@sveltejs/kit';
     import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
     import { SvelteQueryDevtools } from '@tanstack/svelte-query-devtools';

--- a/src/Exceptionless.Web/ClientApp/src/routes/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
     import * as Sidebar from '$comp/ui/sidebar';
     import { Toaster } from '$comp/ui/sonner';
     import { accessToken } from '$features/auth/index.svelte';
+    import { normalizeDeserializationFailure } from '$shared/api/fetch-client-response';
     import { type FetchClientContext, ProblemDetails, setAccessTokenFunc, setBaseUrl, setRequestOptions, useMiddleware } from '@exceptionless/fetchclient';
     import { error } from '@sveltejs/kit';
     import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
@@ -35,6 +36,7 @@
 
     useMiddleware(async (ctx: FetchClientContext, next: () => Promise<void>) => {
         await next();
+        ctx.response = normalizeDeserializationFailure(ctx.response);
 
         const status = ctx.response?.status;
         if (status === undefined) {


### PR DESCRIPTION
## Summary

- Use theme-aware foreground and muted colors for tag tooltip keyboard shortcuts in both light and dark themes.
- Calculate project and stack user cardinality over the same seven-day window.
- Stabilize Stack and Events reactive loading so semantically unchanged parameters do not churn state and each paging transition issues one list request.
- Treat aborted or malformed successful response bodies as errors instead of caching `ProblemDetails` as successful query data.
- Migrate all 73 FetchClient imports from the moved `@exceptionless/fetchclient` 0.44.0 package to the current `@foundatiofx/fetchclient` 1.3.3 package and refresh the lockfile.
- Add focused unit coverage plus Stack and Events chaos tests covering paging, detail teardown and navigation, visibility churn, background ingestion, burst notifications, and route remounts.

## Why

The keyboard shortcut inherited the tooltip inverse styling even though it is rendered on a popover-colored surface, which made the icon nearly invisible. Stack user metrics also compared a seven-day stack count with an all-time project count; besides producing an inconsistent percentage, the broader project query could reach legacy indices and return a 500.

Runtime effect tracing found that eight Stack paging transitions issued 15 list requests. Slower CI tracing then exposed the equivalent timing-sensitive dependency churn on the Events list: the first cursor transition could issue two identical requests. Both list effects now depend on stable semantic request keys and invoke their loaders untracked, reducing eight transitions to eight requests on each page.

Repeated route remounts could also abort a response body read after an HTTP 200, causing FetchClient to return `ProblemDetails` as successful data; TanStack Query then cached that object where array data was expected, eventually producing reactive runtime failures. Deserialization failures no longer enter the success cache. The package-level behavior is tracked upstream in [FoundatioFx/FetchClient#31](https://github.com/FoundatioFx/FetchClient/issues/31).

The FetchClient repository and npm scope moved to FoundatioFX. This updates the application from the final `@exceptionless/fetchclient` release to npm `latest` for the supported package. The latest package retains the exports used by the application; Exceptionless also supplies its own `errorCallback`, preserving its existing `ProblemDetails` error behavior across the upstream major-version change.

## Dependency review

- Current: `@exceptionless/fetchclient` 0.44.0
- Target: `@foundatiofx/fetchclient` 1.3.3 (`latest`, published 2026-03-02)
- Source: [official repository](https://github.com/FoundatioFx/FetchClient), [npm package](https://www.npmjs.com/package/@foundatiofx/fetchclient), and [v0.44.0...v1.3.3 comparison](https://github.com/FoundatioFx/FetchClient/compare/v0.44.0...v1.3.3)
- Compatibility: all 73 imports resolve; Svelte and TypeScript report 0 errors and 0 warnings; the production build succeeds
- Security: `npm audit --omit=dev` reports no advisory path through `@foundatiofx/fetchclient`; existing unrelated repository advisories remain outside this PR

## Verification

- `npm ci`
- `npm run validate`
- `npm run test:unit`: 29 files / 326 tests passed
- `npm run build`
- Focused Vitest suite from the effect work: 45 passed
- Full local Chromium E2E suite from the effect work: 9 passed
- Events chaos regression repeated three times: 3 passed
- Stack chaos regression: eight page transitions / eight list requests; five detail mount cycles / zero list requests; 30 burst notifications / one list request; zero runtime or network errors
- Events chaos regression: eight page transitions / eight list requests; visibility and background resume / at most one list request each; 30 burst notifications / one list request; bounded event and stack detail requests; zero runtime or network errors
- Local Aspire App was healthy during effect validation; `/next/` and `/api/v2/about` returned 200

## Breaking changes

None.