### PR TITLE
Fix event and stack detail navigation

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-error-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-error-summary.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-    import { resolve } from '$app/paths';
     import { A, Muted } from '$comp/typography';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
 
-    import type { EventSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
+    import { buildEventDetailsHref, type EventSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         summary: SummaryModel<SummaryTemplateKeys>;
@@ -29,7 +28,7 @@
         </strong>
     {/if}
 
-    <A class="inline" href={resolve('/(app)/event/[eventId=objectid]', { eventId: source.id })}>
+    <A class="inline" href={buildEventDetailsHref(source.id)}>
         {source.data.Message}
     </A>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-error-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-error-summary.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
-    import { A, Muted } from '$comp/typography';
+    import { Muted } from '$comp/typography';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
 
-    import { buildEventDetailsHref, type EventSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
+    import type { EventSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
+
+    import EventSummaryLink from './event-summary-link.svelte';
 
     interface Props {
+        linkToDetails?: boolean;
         summary: SummaryModel<SummaryTemplateKeys>;
     }
 
-    let { summary }: Props = $props();
+    let { linkToDetails = true, summary }: Props = $props();
     let source = $derived(summary as EventSummaryModel<'event-error-summary'>);
 </script>
 
@@ -28,9 +31,9 @@
         </strong>
     {/if}
 
-    <A class="inline" href={buildEventDetailsHref(source.id)}>
+    <EventSummaryLink eventId={source.id} {linkToDetails}>
         {source.data.Message}
-    </A>
+    </EventSummaryLink>
 </div>
 
 {#if source.data.Path}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-feature-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-feature-summary.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-    import { resolve } from '$app/paths';
     import { A } from '$comp/typography';
 
-    import type { EventSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
+    import { buildEventDetailsHref, type EventSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface EventFeatureSummaryProps {
         showType: boolean;
@@ -17,5 +16,5 @@
     {#if showType}
         <strong>Feature:&nbsp;</strong>
     {/if}
-    <A class="inline" href={resolve('/(app)/event/[eventId=objectid]', { eventId: source.id })}>{source.data.Source}</A>
+    <A class="inline" href={buildEventDetailsHref(source.id)}>{source.data.Source}</A>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-feature-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-feature-summary.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
-    import { A } from '$comp/typography';
+    import type { EventSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
 
-    import { buildEventDetailsHref, type EventSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
+    import EventSummaryLink from './event-summary-link.svelte';
 
     interface EventFeatureSummaryProps {
+        linkToDetails?: boolean;
         showType: boolean;
         summary: SummaryModel<SummaryTemplateKeys>;
     }
 
-    let { showType, summary }: EventFeatureSummaryProps = $props();
+    let { linkToDetails = true, showType, summary }: EventFeatureSummaryProps = $props();
     let source = $derived(summary as EventSummaryModel<'event-feature-summary'>);
 </script>
 
@@ -16,5 +17,5 @@
     {#if showType}
         <strong>Feature:&nbsp;</strong>
     {/if}
-    <A class="inline" href={buildEventDetailsHref(source.id)}>{source.data.Source}</A>
+    <EventSummaryLink eventId={source.id} {linkToDetails}>{source.data.Source}</EventSummaryLink>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-log-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-log-summary.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-    import { resolve } from '$app/paths';
     import { A } from '$comp/typography';
 
-    import type { EventSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
-
     import LogLevel from '../log-level.svelte';
+    import { buildEventDetailsHref, type EventSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface EventFeatureSummaryProps {
         showType: boolean;
@@ -34,5 +32,5 @@
         </strong>
     {/if}
     {#if showType || source.data.Source}:&nbsp;{/if}
-    <A class="inline" href={resolve('/(app)/event/[eventId=objectid]', { eventId: source.id })}>{source.data.Message}</A>
+    <A class="inline" href={buildEventDetailsHref(source.id)}>{source.data.Message}</A>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-log-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-log-summary.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
-    import { A } from '$comp/typography';
+    import type { EventSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
 
     import LogLevel from '../log-level.svelte';
-    import { buildEventDetailsHref, type EventSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
+    import EventSummaryLink from './event-summary-link.svelte';
 
     interface EventFeatureSummaryProps {
+        linkToDetails?: boolean;
         showType: boolean;
         summary: SummaryModel<SummaryTemplateKeys>;
     }
 
-    let { showType, summary }: EventFeatureSummaryProps = $props();
+    let { linkToDetails = true, showType, summary }: EventFeatureSummaryProps = $props();
     let source = $derived(summary as EventSummaryModel<'event-log-summary'>);
     let level = $derived(source.data.Level?.toLowerCase());
 </script>
@@ -32,5 +33,5 @@
         </strong>
     {/if}
     {#if showType || source.data.Source}:&nbsp;{/if}
-    <A class="inline" href={buildEventDetailsHref(source.id)}>{source.data.Message}</A>
+    <EventSummaryLink eventId={source.id} {linkToDetails}>{source.data.Message}</EventSummaryLink>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-not-found-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-not-found-summary.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-    import { resolve } from '$app/paths';
     import { A } from '$comp/typography';
 
-    import type { EventSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
+    import { buildEventDetailsHref, type EventSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface EventFeatureSummaryProps {
         showType: boolean;
@@ -17,5 +16,5 @@
     {#if showType}
         <strong>404</strong>:&nbsp;
     {/if}
-    <A class="inline" href={resolve('/(app)/event/[eventId=objectid]', { eventId: source.id })}>{source.data.Source}</A>
+    <A class="inline" href={buildEventDetailsHref(source.id)}>{source.data.Source}</A>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-not-found-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-not-found-summary.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
-    import { A } from '$comp/typography';
+    import type { EventSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
 
-    import { buildEventDetailsHref, type EventSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
+    import EventSummaryLink from './event-summary-link.svelte';
 
     interface EventFeatureSummaryProps {
+        linkToDetails?: boolean;
         showType: boolean;
         summary: SummaryModel<SummaryTemplateKeys>;
     }
 
-    let { showType, summary }: EventFeatureSummaryProps = $props();
+    let { linkToDetails = true, showType, summary }: EventFeatureSummaryProps = $props();
     let source = $derived(summary as EventSummaryModel<'event-notfound-summary'>);
 </script>
 
@@ -16,5 +17,5 @@
     {#if showType}
         <strong>404</strong>:&nbsp;
     {/if}
-    <A class="inline" href={buildEventDetailsHref(source.id)}>{source.data.Source}</A>
+    <EventSummaryLink eventId={source.id} {linkToDetails}>{source.data.Source}</EventSummaryLink>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-session-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-session-summary.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-    import { resolve } from '$app/paths';
     import { A } from '$comp/typography';
 
-    import type { EventSummaryModel, SummaryModel, SummaryTemplateKeys } from '.';
+    import { buildEventDetailsHref, type EventSummaryModel, type SummaryModel, type SummaryTemplateKeys } from '.';
 
     interface EventFeatureSummaryProps {
         showType: boolean;
@@ -26,7 +25,7 @@
         </strong>:&nbsp;
     {/if}
 
-    <A class="inline" href={resolve('/(app)/event/[eventId=objectid]', { eventId: source.id })}>
+    <A class="inline" href={buildEventDetailsHref(source.id)}>
         {#if source.data.Name || source.data.Identity || source.data.SessionId}
             {source.data.Name || source.data.Identity || source.data.SessionId}
             {#if source.data.Name && source.data.Identity}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-session-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-session-summary.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
-    import { A } from '$comp/typography';
+    import type { EventSummaryModel, SummaryModel, SummaryTemplateKeys } from '.';
 
-    import { buildEventDetailsHref, type EventSummaryModel, type SummaryModel, type SummaryTemplateKeys } from '.';
+    import EventSummaryLink from './event-summary-link.svelte';
 
     interface EventFeatureSummaryProps {
+        linkToDetails?: boolean;
         showType: boolean;
         summary: SummaryModel<SummaryTemplateKeys>;
     }
 
-    let { showType, summary }: EventFeatureSummaryProps = $props();
+    let { linkToDetails = true, showType, summary }: EventFeatureSummaryProps = $props();
     let source = $derived(summary as EventSummaryModel<'event-session-summary'>);
 </script>
 
@@ -25,12 +26,12 @@
         </strong>:&nbsp;
     {/if}
 
-    <A class="inline" href={buildEventDetailsHref(source.id)}>
+    <EventSummaryLink eventId={source.id} {linkToDetails}>
         {#if source.data.Name || source.data.Identity || source.data.SessionId}
             {source.data.Name || source.data.Identity || source.data.SessionId}
             {#if source.data.Name && source.data.Identity}
                 <span class="text-muted-foreground"> ({source.data.Identity})</span>
             {/if}
         {/if}
-    </A>
+    </EventSummaryLink>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-simple-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-simple-summary.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-    import { resolve } from '$app/paths';
     import { A, Muted } from '$comp/typography';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
 
-    import type { EventSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
+    import { buildEventDetailsHref, type EventSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         summary: SummaryModel<SummaryTemplateKeys>;
@@ -15,7 +14,7 @@
 
 <div class="line-clamp-2">
     <strong><abbr title={source.data.TypeFullName}>{source.data.Type}</abbr>: </strong>
-    <A class="inline" href={resolve('/(app)/event/[eventId=objectid]', { eventId: source.id })}>{source.data.Message}</A>
+    <A class="inline" href={buildEventDetailsHref(source.id)}>{source.data.Message}</A>
 </div>
 
 {#if source.data.Path}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-simple-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-simple-summary.svelte
@@ -1,20 +1,23 @@
 <script lang="ts">
-    import { A, Muted } from '$comp/typography';
+    import { Muted } from '$comp/typography';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
 
-    import { buildEventDetailsHref, type EventSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
+    import type { EventSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
+
+    import EventSummaryLink from './event-summary-link.svelte';
 
     interface Props {
+        linkToDetails?: boolean;
         summary: SummaryModel<SummaryTemplateKeys>;
     }
 
-    let { summary }: Props = $props();
+    let { linkToDetails = true, summary }: Props = $props();
     let source = $derived(summary as EventSummaryModel<'event-simple-summary'>);
 </script>
 
 <div class="line-clamp-2">
     <strong><abbr title={source.data.TypeFullName}>{source.data.Type}</abbr>: </strong>
-    <A class="inline" href={buildEventDetailsHref(source.id)}>{source.data.Message}</A>
+    <EventSummaryLink eventId={source.id} {linkToDetails}>{source.data.Message}</EventSummaryLink>
 </div>
 
 {#if source.data.Path}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-summary-link.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-summary-link.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+    import type { Snippet } from 'svelte';
+
+    import { A } from '$comp/typography';
+
+    import { buildEventDetailsHref } from './index';
+
+    interface Props {
+        children: Snippet;
+        eventId: string;
+        linkToDetails: boolean;
+    }
+
+    let { children, eventId, linkToDetails }: Props = $props();
+</script>
+
+{#if linkToDetails}
+    <A class="inline" href={buildEventDetailsHref(eventId)}>
+        {@render children()}
+    </A>
+{:else}
+    {@render children()}
+{/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-summary.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-    import { resolve } from '$app/paths';
     import { A } from '$comp/typography';
 
-    import type { EventSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
+    import { buildEventDetailsHref, type EventSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface EventFeatureSummaryProps {
         showType: boolean;
@@ -26,5 +25,5 @@
     {#if showType || source.data.Source}
         :&nbsp;
     {/if}
-    <A class="inline" href={resolve('/(app)/event/[eventId=objectid]', { eventId: source.id })}>{source.data.Message}</A>
+    <A class="inline" href={buildEventDetailsHref(source.id)}>{source.data.Message}</A>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/event-summary.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
-    import { A } from '$comp/typography';
+    import type { EventSummaryModel, SummaryModel, SummaryTemplateKeys } from './index';
 
-    import { buildEventDetailsHref, type EventSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
+    import EventSummaryLink from './event-summary-link.svelte';
 
     interface EventFeatureSummaryProps {
+        linkToDetails?: boolean;
         showType: boolean;
         summary: SummaryModel<SummaryTemplateKeys>;
     }
 
-    let { showType, summary }: EventFeatureSummaryProps = $props();
+    let { linkToDetails = true, showType, summary }: EventFeatureSummaryProps = $props();
     let source = $derived(summary as EventSummaryModel<'event-summary'>);
 </script>
 
@@ -25,5 +26,5 @@
     {#if showType || source.data.Source}
         :&nbsp;
     {/if}
-    <A class="inline" href={buildEventDetailsHref(source.id)}>{source.data.Message}</A>
+    <EventSummaryLink eventId={source.id} {linkToDetails}>{source.data.Message}</EventSummaryLink>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/index.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/index.ts
@@ -165,11 +165,6 @@ export function buildEventDetailsHref(eventId: string, stackId?: string): string
     return resolve('/(app)/event/[eventId=objectid]', { eventId });
 }
 
-export function buildStackEventsHref(stackId: string): string {
-    const queryParams = new URLSearchParams({
-        stack: stackId,
-        time: 'all'
-    });
-
-    return `${resolve('/(app)/event')}?${queryParams}`;
+export function buildStackDetailsHref(stackId: string): string {
+    return resolve('/(app)/stack/[stackId=objectid]', { stackId });
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-error-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-error-summary.svelte
@@ -5,7 +5,7 @@
     import StackStatusBadge from '$features/stacks/components/stack-status-badge.svelte';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
 
-    import { buildStackEventsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
+    import { buildStackDetailsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         badgeStatus: StackStatus;
@@ -36,7 +36,7 @@
         </strong>
     {/if}
 
-    <A class="inline" href={buildStackEventsHref(source.id)}>
+    <A class="inline" href={buildStackDetailsHref(source.id)}>
         {source.title}
     </A>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-feature-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-feature-summary.svelte
@@ -4,7 +4,7 @@
     import { A } from '$comp/typography';
     import StackStatusBadge from '$features/stacks/components/stack-status-badge.svelte';
 
-    import { buildStackEventsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
+    import { buildStackDetailsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         badgeStatus: StackStatus;
@@ -26,7 +26,7 @@
         <strong>Feature</strong>:&nbsp;
     {/if}
 
-    <A class="inline" href={buildStackEventsHref(source.id)}>
+    <A class="inline" href={buildStackDetailsHref(source.id)}>
         {source.title}
     </A>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-log-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-log-summary.svelte
@@ -4,7 +4,7 @@
     import { A } from '$comp/typography';
     import StackStatusBadge from '$features/stacks/components/stack-status-badge.svelte';
 
-    import { buildStackEventsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
+    import { buildStackDetailsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         badgeStatus: StackStatus;
@@ -26,7 +26,7 @@
         <strong>Log source:</strong>&nbsp;
     {/if}
 
-    <A class="inline" href={buildStackEventsHref(source.id)}>
+    <A class="inline" href={buildStackDetailsHref(source.id)}>
         {#if source.data?.Source}
             <abbr title={source.data.Source}>{source.data.SourceShortName}</abbr>
         {:else}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-not-found-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-not-found-summary.svelte
@@ -4,7 +4,7 @@
     import { A } from '$comp/typography';
     import StackStatusBadge from '$features/stacks/components/stack-status-badge.svelte';
 
-    import { buildStackEventsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
+    import { buildStackDetailsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         badgeStatus: StackStatus;
@@ -25,7 +25,7 @@
     {#if showType}
         <strong>404</strong>:&nbsp;
     {/if}
-    <A class="inline" href={buildStackEventsHref(source.id)}>
+    <A class="inline" href={buildStackDetailsHref(source.id)}>
         {source.title}
     </A>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-session-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-session-summary.svelte
@@ -4,7 +4,7 @@
     import { A } from '$comp/typography';
     import StackStatusBadge from '$features/stacks/components/stack-status-badge.svelte';
 
-    import { buildStackEventsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
+    import { buildStackDetailsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         badgeStatus: StackStatus;
@@ -26,7 +26,7 @@
         <strong>Session</strong>:&nbsp;
     {/if}
 
-    <A class="inline" href={buildStackEventsHref(source.id)}>
+    <A class="inline" href={buildStackDetailsHref(source.id)}>
         {source.title}
     </A>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-simple-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-simple-summary.svelte
@@ -5,7 +5,7 @@
     import StackStatusBadge from '$features/stacks/components/stack-status-badge.svelte';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
 
-    import { buildStackEventsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
+    import { buildStackDetailsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         badgeStatus: StackStatus;
@@ -26,7 +26,7 @@
         <abbr title={source.data.TypeFullName}>{source.data.Type}</abbr>:
     </strong>
 
-    <A class="inline" href={buildStackEventsHref(source.id)}>{source.title}</A>
+    <A class="inline" href={buildStackDetailsHref(source.id)}>{source.title}</A>
 </div>
 
 {#if source.data.Path}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/stack-summary.svelte
@@ -4,7 +4,7 @@
     import { A } from '$comp/typography';
     import StackStatusBadge from '$features/stacks/components/stack-status-badge.svelte';
 
-    import { buildStackEventsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
+    import { buildStackDetailsHref, type StackSummaryModel, type SummaryModel, type SummaryTemplateKeys } from './index';
 
     interface Props {
         badgeStatus: StackStatus;
@@ -38,7 +38,7 @@
         :&nbsp;
     {/if}
 
-    <A class="inline" href={buildStackEventsHref(source.id)}>
+    <A class="inline" href={buildStackDetailsHref(source.id)}>
         {source.title}
     </A>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/summary.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/summary.svelte
@@ -19,42 +19,43 @@
     import StackSummary from './stack-summary.svelte';
 
     interface Props {
+        linkToDetails?: boolean;
         showStatus?: boolean;
         showType?: boolean;
         summary: SummaryModel<SummaryTemplateKeys>;
     }
 
-    let { showStatus = true, showType = true, summary }: Props = $props();
+    let { linkToDetails = true, showStatus = true, showType = true, summary }: Props = $props();
     let showBadge: boolean = $derived(showStatus && 'status' in summary && summary.status !== 'open');
     let badgeStatus = $derived<StackStatus>(('status' in summary && (summary.status as StackStatus)) || StackStatus.Open);
 </script>
 
 {#if summary.template_key === 'event-summary'}
-    <EventSummary {showType} {summary} />
+    <EventSummary {linkToDetails} {showType} {summary} />
 {:else if summary.template_key === 'stack-summary'}
     <StackSummary {badgeStatus} {showBadge} {showType} {summary} />
 {:else if summary.template_key === 'event-simple-summary'}
-    <EventSimpleSummary {summary} />
+    <EventSimpleSummary {linkToDetails} {summary} />
 {:else if summary.template_key === 'stack-simple-summary'}
     <StackSimpleSummary {badgeStatus} {showBadge} {summary} />
 {:else if summary.template_key === 'event-error-summary'}
-    <EventErrorSummary {summary} />
+    <EventErrorSummary {linkToDetails} {summary} />
 {:else if summary.template_key === 'stack-error-summary'}
     <StackErrorSummary {badgeStatus} {showBadge} {summary} />
 {:else if summary.template_key === 'event-session-summary'}
-    <EventSessionSummary {showType} {summary} />
+    <EventSessionSummary {linkToDetails} {showType} {summary} />
 {:else if summary.template_key === 'stack-session-summary'}
     <StackSessionSummary {badgeStatus} {showBadge} {showType} {summary} />
 {:else if summary.template_key === 'event-notfound-summary'}
-    <EventNotFoundSummary {showType} {summary} />
+    <EventNotFoundSummary {linkToDetails} {showType} {summary} />
 {:else if summary.template_key === 'stack-notfound-summary'}
     <StackNotFoundSummary {badgeStatus} {showBadge} {showType} {summary} />
 {:else if summary.template_key === 'event-feature-summary'}
-    <EventFeatureSummary {showType} {summary} />
+    <EventFeatureSummary {linkToDetails} {showType} {summary} />
 {:else if summary.template_key === 'stack-feature-summary'}
     <StackFeatureSummary {badgeStatus} {showBadge} {showType} {summary} />
 {:else if summary.template_key === 'event-log-summary'}
-    <EventLogSummary {showType} {summary} />
+    <EventLogSummary {linkToDetails} {showType} {summary} />
 {:else}
     <StackLogSummary {badgeStatus} {showBadge} {showType} {summary} />
 {/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/summary.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/summary.svelte.test.ts
@@ -1,0 +1,53 @@
+import { StackStatus } from '$features/stacks/models';
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+
+import type { EventSummaryModel, StackSummaryModel } from './index';
+
+import Summary from './summary.svelte';
+
+describe('Summary', () => {
+    it('links an event summary to that event details page', () => {
+        const summary: EventSummaryModel<'event-error-summary'> = {
+            data: {
+                Message: 'Unexpected end of Stream, the content may have already been read by another component.',
+                Method: 'MoveNext',
+                Type: 'IOException'
+            },
+            date: '2026-07-28T00:00:00Z',
+            id: 'event-id',
+            project_id: 'project-id',
+            tags: [],
+            template_key: 'event-error-summary'
+        };
+
+        render(Summary, { showStatus: false, summary });
+
+        expect(screen.getByRole('link', { name: summary.data.Message }).getAttribute('href')).toBe('/next/event/event-id');
+    });
+
+    it('links a stack summary to stack details', () => {
+        const summary: StackSummaryModel<'stack-error-summary'> = {
+            data: {
+                Message: 'Unexpected end of Stream, the content may have already been read by another component.',
+                Method: 'MoveNext',
+                Type: 'IOException'
+            },
+            first_occurrence: '2026-07-28T00:00:00Z',
+            id: 'stack-id',
+            last_occurrence: '2026-07-28T00:00:00Z',
+            project_id: 'project-id',
+            status: StackStatus.Open,
+            tags: [],
+            template_key: 'stack-error-summary',
+            title: 'Unexpected end of Stream, the content may have already been read by another component.',
+            total: 1,
+            total_users: 1,
+            users: 1
+        };
+
+        render(Summary, { showStatus: false, summary });
+
+        expect(screen.getByRole('link', { name: summary.title }).getAttribute('href')).toBe('/next/stack/stack-id');
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/summary.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/summary/summary.svelte.test.ts
@@ -26,6 +26,26 @@ describe('Summary', () => {
         expect(screen.getByRole('link', { name: summary.data.Message }).getAttribute('href')).toBe('/next/event/event-id');
     });
 
+    it('renders an event summary without an internal link when linking is disabled', () => {
+        const summary: EventSummaryModel<'event-error-summary'> = {
+            data: {
+                Message: 'Unexpected end of Stream, the content may have already been read by another component.',
+                Method: 'MoveNext',
+                Type: 'IOException'
+            },
+            date: '2026-07-28T00:00:00Z',
+            id: 'event-id',
+            project_id: 'project-id',
+            tags: [],
+            template_key: 'event-error-summary'
+        };
+
+        const { container } = render(Summary, { linkToDetails: false, showStatus: false, summary });
+
+        expect(screen.queryByRole('link')).toBeNull();
+        expect(container.textContent).toContain(summary.data.Message!);
+    });
+
     it('links a stack summary to stack details', () => {
         const summary: StackSummaryModel<'stack-error-summary'> = {
             data: {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
@@ -165,7 +165,7 @@
                     <Table.Row class="cursor-pointer">
                         <Table.Cell class="p-0">
                             <a class="text-foreground block p-2 no-underline" href={eventHref} title="Open event details">
-                                <Summary summary={sessionEvent} showType={true} showStatus={false} />
+                                <Summary linkToDetails={false} summary={sessionEvent} showType={true} showStatus={false} />
                             </a>
                         </Table.Cell>
                         <Table.Cell class="p-0">

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import type { PersistentEvent } from '$features/events/models';
 
-    import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';
     import TimeAgo from '$comp/formatters/time-ago.svelte';
     import * as Alert from '$comp/ui/alert';
@@ -11,6 +10,7 @@
     import { getSessionEventsQuery } from '$features/events/api.svelte';
     import { SessionFilter } from '$features/events/components/filters';
     import { buildFilterCacheKey, toFilter, updateFilterCache } from '$features/events/components/filters/helpers.svelte';
+    import { buildEventDetailsHref } from '$features/events/components/summary';
     import Summary from '$features/events/components/summary/summary.svelte';
     import { getSessionId } from '$features/events/utils/index';
     import { organization } from '$features/organizations/context.svelte';
@@ -66,7 +66,7 @@
     });
 
     function getEventHref(eventId: string): string {
-        return resolve('/(app)/event/[eventId=objectid]', { eventId });
+        return buildEventDetailsHref(eventId);
     }
 
     function getSessionFilter(): SessionFilter | undefined {
@@ -86,19 +86,6 @@
     function handleSessionFilterClick(): void {
         prepareSessionEventsFilter();
         onSessionFilter?.();
-    }
-
-    async function openSessionEvent(eventId: string): Promise<void> {
-        await goto(getEventHref(eventId));
-    }
-
-    function handleSessionEventKeydown(keyboardEvent: KeyboardEvent, eventId: string): void {
-        if (keyboardEvent.key !== 'Enter' && keyboardEvent.key !== ' ') {
-            return;
-        }
-
-        keyboardEvent.preventDefault();
-        void openSessionEvent(eventId);
     }
 </script>
 
@@ -174,20 +161,22 @@
             </Table.Header>
             <Table.Body>
                 {#each sessionEventsQuery.data ?? [] as sessionEvent (sessionEvent.id)}
-                    <Table.Row
-                        aria-label={`Open event ${sessionEvent.id}`}
-                        class="hover:bg-muted/50 focus-visible:ring-ring/50 focus-visible:outline-ring cursor-pointer focus-visible:ring-[3px] focus-visible:outline-1"
-                        onclick={() => openSessionEvent(sessionEvent.id)}
-                        onkeydown={(keyboardEvent) => handleSessionEventKeydown(keyboardEvent, sessionEvent.id)}
-                        role="link"
-                        tabindex={0}
-                        title="Open event details"
-                    >
-                        <Table.Cell>
-                            <Summary summary={sessionEvent} showType={true} showStatus={false} />
+                    {@const eventHref = getEventHref(sessionEvent.id)}
+                    <Table.Row class="cursor-pointer">
+                        <Table.Cell class="p-0">
+                            <a class="text-foreground block p-2 no-underline" href={eventHref} title="Open event details">
+                                <Summary summary={sessionEvent} showType={true} showStatus={false} />
+                            </a>
                         </Table.Cell>
-                        <Table.Cell>
-                            <TimeAgo value={sessionEvent.date} />
+                        <Table.Cell class="p-0">
+                            <a
+                                aria-label={`Open event ${sessionEvent.id}`}
+                                class="text-foreground block p-2 no-underline"
+                                href={eventHref}
+                                title="Open event details"
+                            >
+                                <TimeAgo value={sessionEvent.date} />
+                            </a>
                         </Table.Cell>
                     </Table.Row>
                 {/each}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+
+import DataTableBodyTestHarness from './data-table-body.test-harness.svelte';
+
+describe('DataTableBody', () => {
+    it('opens event details for normal clicks anywhere in an event summary', async () => {
+        const onRowClick = vi.fn();
+        render(DataTableBodyTestHarness, { kind: 'event', onRowClick });
+
+        await fireEvent.click(screen.getByText('IOException'));
+        await fireEvent.click(screen.getByText('Unexpected end of Stream, the content may have already been read by another component.'));
+
+        expect(onRowClick).toHaveBeenCalledTimes(2);
+        expect(onRowClick).toHaveBeenLastCalledWith(expect.objectContaining({ id: 'event-id' }), expect.any(MouseEvent));
+    });
+
+    it('uses that event details URL for middle and modified clicks', () => {
+        render(DataTableBodyTestHarness, { kind: 'event', onRowClick: vi.fn() });
+
+        const messageLink = screen.getByText('Unexpected end of Stream, the content may have already been read by another component.').closest('a');
+
+        expect(messageLink?.getAttribute('href')).toBe('/next/event/event-id');
+    });
+
+    it('opens stack details for normal clicks anywhere in a stack summary', async () => {
+        const onRowClick = vi.fn();
+        render(DataTableBodyTestHarness, { kind: 'stack', onRowClick });
+
+        await fireEvent.click(screen.getByText('IOException'));
+        await fireEvent.click(screen.getByText('Unexpected end of Stream, the content may have already been read by another component.'));
+
+        expect(onRowClick).toHaveBeenCalledTimes(2);
+        expect(onRowClick).toHaveBeenLastCalledWith(expect.objectContaining({ id: 'stack-id' }), expect.any(MouseEvent));
+    });
+
+    it('uses the stack details URL for middle and modified clicks', () => {
+        render(DataTableBodyTestHarness, { kind: 'stack', onRowClick: vi.fn() });
+
+        const messageLink = screen.getByText('Unexpected end of Stream, the content may have already been read by another component.').closest('a');
+
+        expect(messageLink?.getAttribute('href')).toBe('/next/stack/stack-id');
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+    import type { EventSummaryModel, StackSummaryModel, SummaryModel, SummaryTemplateKeys } from '$features/events/components/summary';
+
+    import { buildEventDetailsHref, buildStackDetailsHref } from '$features/events/components/summary';
+    import Summary from '$features/events/components/summary/summary.svelte';
+    import { getSharedTableOptions } from '$features/shared/table.svelte';
+    import { StackStatus } from '$features/stacks/models';
+    import { createTable, renderComponent } from '@tanstack/svelte-table';
+
+    import DataTableBody from './data-table-body.svelte';
+
+    type TestSummary = EventSummaryModel<'event-error-summary'> | StackSummaryModel<'stack-error-summary'>;
+
+    interface Props {
+        kind: 'event' | 'stack';
+        onRowClick: (row: TestSummary) => void;
+    }
+
+    let { kind, onRowClick }: Props = $props();
+
+    const summaryData = {
+        Message: 'Unexpected end of Stream, the content may have already been read by another component.',
+        Method: 'MoveNext',
+        Type: 'IOException'
+    };
+    const eventSummary: EventSummaryModel<'event-error-summary'> = {
+        data: summaryData,
+        date: '2026-07-28T00:00:00Z',
+        id: 'event-id',
+        project_id: 'project-id',
+        tags: [],
+        template_key: 'event-error-summary'
+    };
+    const stackSummary: StackSummaryModel<'stack-error-summary'> = {
+        data: summaryData,
+        first_occurrence: '2026-07-28T00:00:00Z',
+        id: 'stack-id',
+        last_occurrence: '2026-07-28T00:00:00Z',
+        project_id: 'project-id',
+        status: StackStatus.Open,
+        tags: [],
+        template_key: 'stack-error-summary',
+        title: 'Unexpected end of Stream, the content may have already been read by another component.',
+        total: 1,
+        total_users: 1,
+        users: 1
+    };
+    const summary: TestSummary = $derived(kind === 'event' ? eventSummary : stackSummary);
+    const queryParameters = { limit: 20, page: 1 };
+    const table = createTable(
+        getSharedTableOptions<TestSummary, 'memory'>({
+            columnPersistenceKey: 'row-navigation-test',
+            columns: [
+                {
+                    cell: (props) => renderComponent(Summary, { showStatus: false, summary: props.row.original }),
+                    header: 'Summary',
+                    id: 'summary'
+                }
+            ],
+            paginationStrategy: 'memory',
+            get queryData() {
+                return [summary];
+            },
+            queryParameters
+        })
+    );
+</script>
+
+<DataTableBody
+    rowClick={onRowClick}
+    rowHref={(row: SummaryModel<SummaryTemplateKeys>) => (kind === 'event' ? buildEventDetailsHref(row.id) : buildStackDetailsHref(row.id))}
+    {table}
+/>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-    import type { EventSummaryModel, StackSummaryModel, SummaryTemplateKeys } from '$features/events/components/summary/index';
     import type { FetchClientResponse, ProblemDetails } from '@foundatiofx/fetchclient';
 
     import { resolve } from '$app/paths';
     import * as Command from '$comp/ui/command';
     import { accessToken } from '$features/auth/index.svelte';
+    import { buildEventDetailsHref, type EventSummaryModel, type StackSummaryModel, type SummaryTemplateKeys } from '$features/events/components/summary/index';
     import { organization } from '$features/organizations/context.svelte';
     import { appKeyboardShortcuts, formatKeyboardShortcut, type ShortcutKey } from '$features/shared/keyboard-shortcuts';
     import { DEFAULT_OFFSET } from '$shared/api/api.svelte';
@@ -175,7 +175,7 @@
     }
 
     function getEventHref(result: CommandSearchResult): string {
-        return resolve('/(app)/event/[eventId=objectid]', { eventId: result.id });
+        return buildEventDetailsHref(result.id);
     }
 
     function getStackHref(result: CommandSearchResult): string {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-    import type { EventSummaryModel, SummaryTemplateKeys } from '$features/events/components/summary/index';
-
     import { resolve } from '$app/paths';
     import { page } from '$app/state';
     import * as DataTable from '$comp/data-table';
@@ -45,6 +43,7 @@
         updateFilterCache
     } from '$features/events/components/filters/helpers.svelte';
     import OrganizationDefaultsFacetedFilterBuilder from '$features/events/components/filters/organization-defaults-faceted-filter-builder.svelte';
+    import { buildEventDetailsHref, type EventSummaryModel, type SummaryTemplateKeys } from '$features/events/components/summary/index';
     import EventsBulkActionsDropdownMenu from '$features/events/components/table/events-bulk-actions-dropdown-menu.svelte';
     import EventsDataTable from '$features/events/components/table/events-data-table.svelte';
     import { defaultEventColumnVisibility, getColumns } from '$features/events/components/table/options.svelte';
@@ -90,7 +89,7 @@
     }
 
     function rowHref(row: EventSummaryModel<SummaryTemplateKeys>): string {
-        return resolve('/(app)/event/[eventId=objectid]', { eventId: row.id });
+        return buildEventDetailsHref(row.id);
     }
 
     const DEFAULT_TIME_RANGE = '[now-7d TO now]';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
@@ -51,5 +51,5 @@
     id={page.params.eventId || ''}
     {handleError}
     onEventLoaded={handleEventLoaded}
-    onNavigate={(newId) => goto(resolve('/(app)/event/[eventId=objectid]', { eventId: newId }))}
+    onNavigate={(newId) => goto(buildEventDetailsHref(newId))}
 />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/by-ref/[referenceId]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/by-ref/[referenceId]/+page.svelte
@@ -6,6 +6,7 @@
     import { Button } from '$comp/ui/button';
     import { Spinner } from '$comp/ui/spinner';
     import { getEventsByReferenceQuery } from '$features/events/api.svelte';
+    import { buildEventDetailsHref } from '$features/events/components/summary';
     import Summary from '$features/events/components/summary/summary.svelte';
 
     const referenceId = $derived(page.params.referenceId || '');
@@ -23,7 +24,7 @@
         const event = eventsQuery.data?.length === 1 ? eventsQuery.data[0] : undefined;
         if (event?.id && event.id !== redirectedEventId) {
             redirectedEventId = event.id;
-            void goto(resolve('/(app)/event/[eventId=objectid]', { eventId: event.id }), { replaceState: true });
+            void goto(buildEventDetailsHref(event.id), { replaceState: true });
         }
     });
 
@@ -60,7 +61,7 @@
             {#each eventsQuery.data ?? [] as event (event.id)}
                 <div class="rounded-md border p-4">
                     <Summary summary={event} />
-                    <A class="mt-2 inline-block" href={resolve('/(app)/event/[eventId=objectid]', { eventId: event.id })}>Open Event</A>
+                    <A class="mt-2 inline-block" href={buildEventDetailsHref(event.id)}>Open Event</A>
                 </div>
             {/each}
         </div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+    import type { IFilter } from '$comp/faceted-filter';
     import type { Stack } from '$features/stacks/models';
+    import type { ProblemDetails } from '@foundatiofx/fetchclient';
 
     import { resolve } from '$app/paths';
     import { page } from '$app/state';
@@ -8,6 +10,7 @@
     import * as FacetedFilter from '$comp/faceted-filter';
     import RefreshButton from '$comp/refresh-button.svelte';
     import { Muted } from '$comp/typography';
+    import { showBillingDialogOnUpgradeProblem } from '$features/billing';
     import { StatusFilter, StringFilter, TagFilter } from '$features/events/components/filters';
     import {
         buildFilterCacheKey,
@@ -17,9 +20,11 @@
         toFilter,
         updateFilterCache
     } from '$features/events/components/filters/helpers.svelte';
+    import { organization } from '$features/organizations/context.svelte';
     import { removeTableSelection } from '$features/shared/table.svelte';
     import { type GetProjectStacksParams, getProjectStacksQuery } from '$features/stacks/api.svelte';
     import StackFacetedFilterBuilder from '$features/stacks/components/filters/stack-faceted-filter-builder.svelte';
+    import StackDetailSheet from '$features/stacks/components/stack-detail-sheet.svelte';
     import TableStacksBulkActionsDropdownMenu from '$features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte';
     import { getTableOptions } from '$features/stacks/components/table/options.svelte';
     import StacksDataTable from '$features/stacks/components/table/stacks-data-table.svelte';
@@ -33,8 +38,11 @@
     import { useEventListener, watch } from 'runed';
     import { toast } from 'svelte-sonner';
 
+    import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../../../redirect-to-events.svelte';
+
     const projectId = $derived(page.params.projectId);
     const queryClient = useQueryClient();
+    let selectedStackId = $state<string>();
 
     const DEFAULT_PARAMS = {
         filter: '(status:ignored OR status:discarded)',
@@ -207,6 +215,21 @@
         return resolve('/(app)/project/[projectId]/stacks/[stackId]', { projectId: projectId ?? '', stackId: row.id });
     }
 
+    function rowClick(row: Stack): void {
+        selectedStackId = row.id;
+    }
+
+    async function handleStackFilterChanged(filter: IFilter): Promise<void> {
+        await redirectToEventsWithFilter(organization.current, filter, getEventsNavigationOptionsForFilter(filter));
+    }
+
+    function handleStackError(problem: ProblemDetails): void {
+        selectedStackId = undefined;
+        if (!showBillingDialogOnUpgradeProblem(problem, organization.current)) {
+            toast.error('Unable to load stack event details.');
+        }
+    }
+
     const table = createTable(getTableOptions(stacksQueryParameters, stacksQuery, handleTagClick));
 
     const canRefresh = $derived(!table.getIsSomeRowsSelected() && !table.getIsAllRowsSelected() && table.store.state.pagination.pageIndex === 0);
@@ -226,6 +249,10 @@
 
     async function onStackChanged(message: WebSocketMessageValue<'StackChanged'>) {
         if (message.id && message.change_type === ChangeType.Removed) {
+            if (message.id === selectedStackId) {
+                selectedStackId = undefined;
+            }
+
             removeTableSelection(table, message.id);
         }
 
@@ -254,7 +281,7 @@
         </div>
     </div>
 
-    <StacksDataTable bind:limit={queryParams.limit!} isLoading={stacksQuery.isLoading} {rowHref} {table}>
+    <StacksDataTable bind:limit={queryParams.limit!} isLoading={stacksQuery.isLoading} {rowClick} {rowHref} {table}>
         {#snippet footerChildren()}
             <div class="h-9 min-w-35">
                 <TableStacksBulkActionsDropdownMenu {table} />
@@ -269,3 +296,12 @@
         {/snippet}
     </StacksDataTable>
 </div>
+
+<StackDetailSheet
+    stackId={selectedStackId}
+    filterChanged={handleStackFilterChanged}
+    onClose={() => {
+        selectedStackId = undefined;
+    }}
+    onError={handleStackError}
+/>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
@@ -72,6 +72,7 @@
     watch(
         () => projectId,
         () => {
+            selectedStackId = undefined;
             updateFilterCache(filterCacheKey(DEFAULT_PARAMS.filter), DEFAULT_FILTERS);
             Object.assign(queryParams, DEFAULT_PARAMS);
             reset();

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
     import type { GetEventsParams } from '$features/events/api.svelte';
-    import type { EventSummaryModel, SummaryTemplateKeys } from '$features/events/components/summary/index';
 
-    import { resolve } from '$app/paths';
     import { page } from '$app/state';
     import * as DataTable from '$comp/data-table';
     import DataTableViewOptions from '$comp/data-table/data-table-view-options.svelte';
@@ -25,6 +23,7 @@
         updateFilterCache
     } from '$features/events/components/filters/helpers.svelte';
     import OrganizationDefaultsFacetedFilterBuilder from '$features/events/components/filters/organization-defaults-faceted-filter-builder.svelte';
+    import { buildEventDetailsHref, type EventSummaryModel, type SummaryTemplateKeys } from '$features/events/components/summary/index';
     import EventsDataTable from '$features/events/components/table/events-data-table.svelte';
     import { getOrganizationQuery } from '$features/organizations/api.svelte';
     import { organization } from '$features/organizations/context.svelte';
@@ -51,7 +50,7 @@
     }
 
     function rowHref(row: EventSummaryModel<SummaryTemplateKeys>): string {
-        return resolve('/(app)/event/[eventId=objectid]', { eventId: row.id });
+        return buildEventDetailsHref(row.id);
     }
 
     // Register this page as requiring premium features (layout auto-resets on navigation)

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
     import type { GetEventsParams } from '$features/events/api.svelte';
-    import type { EventSummaryModel, SummaryTemplateKeys } from '$features/events/components/summary/index';
 
-    import { resolve } from '$app/paths';
     import { page } from '$app/state';
     import * as DataTable from '$comp/data-table';
     import DelayedRender from '$comp/delayed-render.svelte';
@@ -26,6 +24,7 @@
         updateFilterCache
     } from '$features/events/components/filters/helpers.svelte';
     import OrganizationDefaultsFacetedFilterBuilder from '$features/events/components/filters/organization-defaults-faceted-filter-builder.svelte';
+    import { buildEventDetailsHref, type EventSummaryModel, type SummaryTemplateKeys } from '$features/events/components/summary/index';
     import { defaultEventColumnVisibility, getColumns } from '$features/events/components/table/options.svelte';
     import { organization } from '$features/organizations/context.svelte';
     import SavedViewPicker from '$features/saved-views/components/saved-view-picker.svelte';
@@ -55,7 +54,7 @@
     }
 
     function rowHref(row: EventSummaryModel<SummaryTemplateKeys>): string {
-        return resolve('/(app)/event/[eventId=objectid]', { eventId: row.id });
+        return buildEventDetailsHref(row.id);
     }
 
     const DEFAULT_FILTERS = [new ProjectFilter([]), new StatusFilter([StackStatus.Open, StackStatus.Regressed])];


### PR DESCRIPTION
## Summary

- make every stack summary link open the exact stack details route
- make normal stack-row clicks open the matching stack details panel, including project stack lists
- route every event-opening entry point through the canonical event details URL
- make session-event rows fully linkable for normal, keyboard, middle, and modified clicks
- add regression coverage for exact event and stack row destinations

## Root cause

Stack summaries linked to a filtered events list while row clicks opened stack details, so click behavior differed depending on the clicked text and input method. Event entry points also constructed detail URLs independently, and session-event rows only exposed a real link from part of the row.

## Impact

Normal clicks consistently open the details panel for the selected event or stack. Middle and modified clicks consistently open the standalone details page for that same event or stack.

## Validation

- `npm run validate`
- `npm run test:unit -- --run src/lib/features/events/components/summary/summary.svelte.test.ts src/lib/features/events/components/table/options.svelte.test.ts src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts` (8 tests passed)
- `npm run build`
- `git diff --check`