### PR TITLE
Create missing predefined saved views during force updates

### DIFF
--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/ForcePredefinedSavedViewsWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/ForcePredefinedSavedViewsWorkItemHandler.cs
@@ -195,7 +195,7 @@ public class ForcePredefinedSavedViewsWorkItemHandler : WorkItemHandlerBase
         return (savedViewsToAdd.Count, savedViewsToSave.Count);
     }
 
-    private static string GetUniqueSlug(string slug, IReadOnlyCollection<SavedView> existingViews, string? excludingId)
+    internal static string GetUniqueSlug(string slug, IReadOnlyCollection<SavedView> existingViews, string? excludingId)
     {
         string baseSlug = ToSlug(slug);
         if (String.IsNullOrWhiteSpace(baseSlug))
@@ -205,7 +205,9 @@ public class ForcePredefinedSavedViewsWorkItemHandler : WorkItemHandlerBase
         string candidate = baseSlug;
         int suffix = 2;
 
-        while (existingViews.Any(view => view.Id != excludingId && String.Equals(view.Slug, candidate, StringComparison.OrdinalIgnoreCase)))
+        while (existingViews.Any(view =>
+            (excludingId is null || view.Id != excludingId)
+            && String.Equals(view.Slug, candidate, StringComparison.OrdinalIgnoreCase)))
         {
             string suffixText = $"-{suffix}";
             int maxBaseLength = 100 - suffixText.Length;

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/ForcePredefinedSavedViewsWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/ForcePredefinedSavedViewsWorkItemHandler.cs
@@ -43,6 +43,7 @@ public class ForcePredefinedSavedViewsWorkItemHandler : WorkItemHandlerBase
             workItem.UserId);
 
         int organizationsUpdated = 0;
+        int savedViewsCreated = 0;
         int savedViewsUpdated = 0;
         var savedViews = await _savedViewRepository.GetPredefinedForForceUpdateAsync(
             PredefinedSavedViewsDataSeed.SystemOrganizationId,
@@ -62,11 +63,11 @@ public class ForcePredefinedSavedViewsWorkItemHandler : WorkItemHandlerBase
                     workItem.UserId,
                     predefinedSavedViewsByKey);
 
-                int updatedForOrganization = updateResult;
-                if (updatedForOrganization > 0)
+                if (updateResult.Created > 0 || updateResult.Updated > 0)
                 {
                     organizationsUpdated++;
-                    savedViewsUpdated += updatedForOrganization;
+                    savedViewsCreated += updateResult.Created;
+                    savedViewsUpdated += updateResult.Updated;
                 }
 
                 await context.RenewLockAsync();
@@ -74,8 +75,9 @@ public class ForcePredefinedSavedViewsWorkItemHandler : WorkItemHandlerBase
         } while (!context.CancellationToken.IsCancellationRequested && await savedViews.NextPageAsync());
 
         Log.LogInformation(
-            "Completed predefined saved view force update. OrganizationsUpdated: {OrganizationsUpdated} SavedViewsUpdated: {SavedViewsUpdated} InitiatedByUserId: {UserId}",
+            "Completed predefined saved view force update. OrganizationsUpdated: {OrganizationsUpdated} SavedViewsCreated: {SavedViewsCreated} SavedViewsUpdated: {SavedViewsUpdated} InitiatedByUserId: {UserId}",
             organizationsUpdated,
+            savedViewsCreated,
             savedViewsUpdated,
             workItem.UserId);
     }
@@ -97,34 +99,36 @@ public class ForcePredefinedSavedViewsWorkItemHandler : WorkItemHandlerBase
         return savedViewsByKey;
     }
 
-    private async Task<int> UpdateOrganizationSavedViewsAsync(
+    private async Task<(int Created, int Updated)> UpdateOrganizationSavedViewsAsync(
         string organizationId,
         IEnumerable<string> savedViewIds,
         string userId,
         IReadOnlyDictionary<string, SavedView> predefinedSavedViewsByKey)
     {
-        int updatedSavedViews = 0;
+        (int Created, int Updated) updateResult = default;
         bool lockAcquired = await _lockProvider.TryUsingAsync($"predefined-saved-views:{organizationId}", async () =>
         {
-            updatedSavedViews = await UpdateOrganizationSavedViewsWithLockAsync(organizationId, savedViewIds, userId, predefinedSavedViewsByKey);
+            updateResult = await UpdateOrganizationSavedViewsWithLockAsync(organizationId, savedViewIds, userId, predefinedSavedViewsByKey);
         }, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(15));
 
         if (!lockAcquired)
             Log.LogWarning("Skipping force update for organization {OrganizationId} because the saved view synchronization lock could not be acquired", organizationId);
 
-        return updatedSavedViews;
+        return updateResult;
     }
 
-    private async Task<int> UpdateOrganizationSavedViewsWithLockAsync(
+    private async Task<(int Created, int Updated)> UpdateOrganizationSavedViewsWithLockAsync(
         string organizationId,
         IEnumerable<string> savedViewIds,
         string userId,
         IReadOnlyDictionary<string, SavedView> predefinedSavedViewsByKey)
     {
+        var savedViewsToAdd = new List<SavedView>();
         var savedViewsToSave = new List<SavedView>();
         var savedViewIdsToUpdate = savedViewIds.ToHashSet(StringComparer.Ordinal);
         var results = await _savedViewRepository.FindAsync(q => q.Organization(organizationId), o => o.PageLimit(SavedViewPageLimit));
-        var savedViewsByViewType = results.Documents.GroupBy(savedView => savedView.ViewType, StringComparer.OrdinalIgnoreCase)
+        var organizationSavedViews = results.Documents.ToList();
+        var savedViewsByViewType = organizationSavedViews.GroupBy(savedView => savedView.ViewType, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.OrdinalIgnoreCase);
 
         foreach (var savedViews in savedViewsByViewType.Values)
@@ -147,10 +151,48 @@ public class ForcePredefinedSavedViewsWorkItemHandler : WorkItemHandlerBase
             }
         }
 
-        if (savedViewsToSave.Count > 0)
-            await _savedViewRepository.SaveAsync(savedViewsToSave, o => o.Cache());
+        foreach (var predefinedSavedView in predefinedSavedViewsByKey.Values)
+        {
+            if (organizationSavedViews.Any(savedView =>
+                savedView.UserId is null
+                && String.Equals(savedView.PredefinedKey, predefinedSavedView.PredefinedKey, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
 
-        return savedViewsToSave.Count;
+            var savedViews = organizationSavedViews
+                .Where(savedView => String.Equals(savedView.ViewType, predefinedSavedView.ViewType, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            var savedView = new SavedView
+            {
+                OrganizationId = organizationId,
+                CreatedByUserId = userId,
+                Name = predefinedSavedView.Name,
+                Slug = GetUniqueSlug(predefinedSavedView.Slug, savedViews, null),
+                ViewType = predefinedSavedView.ViewType
+            };
+
+            PredefinedSavedViewConfiguration.Apply(
+                savedView,
+                predefinedSavedView,
+                predefinedSavedView.PredefinedKey!,
+                savedView.Slug);
+
+            organizationSavedViews.Add(savedView);
+            savedViewsToAdd.Add(savedView);
+        }
+
+        if (savedViewsToAdd.Count > 0)
+        {
+            await _savedViewRepository.AddAsync(savedViewsToAdd, o => o.Cache().ImmediateConsistency());
+        }
+
+        if (savedViewsToSave.Count > 0)
+        {
+            await _savedViewRepository.SaveAsync(savedViewsToSave, o => o.Cache());
+        }
+
+        return (savedViewsToAdd.Count, savedViewsToSave.Count);
     }
 
     private static string GetUniqueSlug(string slug, IReadOnlyCollection<SavedView> existingViews, string? excludingId)

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/saved-views/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/saved-views/+page.svelte
@@ -155,8 +155,9 @@
         <AlertDialog.Header>
             <AlertDialog.Title>Force Update Matching Organization Saved Views</AlertDialog.Title>
             <AlertDialog.Description>
-                This queues a background job that overwrites every organization-wide saved view whose predefined key matches a saved system definition. It
-                discards customizations to those views. Private, unmatched, and missing views are not changed. Unsaved JSON edits are not included.
+                This queues a background job that overwrites every organization-wide saved view whose predefined key matches a saved system definition. It also
+                creates missing predefined views for organizations with matching views. It discards customizations to matching views. Private and unmatched
+                views are not changed. Unsaved JSON edits are not included.
             </AlertDialog.Description>
         </AlertDialog.Header>
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/saved-views/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/saved-views/+page.svelte
@@ -2,8 +2,6 @@
     import CopyToClipboardButton from '$comp/copy-to-clipboard-button.svelte';
     import * as AlertDialog from '$comp/ui/alert-dialog';
     import { Button, buttonVariants } from '$comp/ui/button';
-    import * as Field from '$comp/ui/field';
-    import { Input } from '$comp/ui/input';
     import { Spinner } from '$comp/ui/spinner';
     import * as Tabs from '$comp/ui/tabs';
     import { Textarea } from '$comp/ui/textarea';
@@ -23,7 +21,6 @@
     let predefinedTab = $state('config');
     let savedPredefinedJson = $state('');
     let forceUpdateOpen = $state(false);
-    let forceUpdateConfirmation = $state('');
     let toastId = $state<number | string>();
 
     const predefinedSavedViews = getPredefinedSavedViewsMutation();
@@ -83,19 +80,12 @@
         }
     }
 
-    $effect(() => {
-        if (!forceUpdateOpen) {
-            forceUpdateConfirmation = '';
-        }
-    });
-
     async function handleForceUpdatePredefined() {
         toast.dismiss(toastId);
 
         try {
             await forceUpdatePredefined.mutateAsync();
             forceUpdateOpen = false;
-            forceUpdateConfirmation = '';
             toastId = toast.success('Force update of matching organization saved views was queued.');
         } catch (error: unknown) {
             toastId = toast.error(`An error occurred while queuing the force update: ${getErrorMessage(error, 'Please try again.')}`);
@@ -161,18 +151,11 @@
             </AlertDialog.Description>
         </AlertDialog.Header>
 
-        <div class="py-4">
-            <Field.Field>
-                <Field.Label for="force-update-confirmation">Type FORCE to confirm</Field.Label>
-                <Input id="force-update-confirmation" bind:value={forceUpdateConfirmation} autocomplete="off" placeholder="FORCE" />
-            </Field.Field>
-        </div>
-
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
             <AlertDialog.Action
                 class={buttonVariants({ variant: 'destructive' })}
-                disabled={forceUpdatePredefined.isPending || forceUpdateConfirmation !== 'FORCE'}
+                disabled={forceUpdatePredefined.isPending}
                 onclick={handleForceUpdatePredefined}
             >
                 {forceUpdatePredefined.isPending ? 'Queuing...' : 'Force Update'}

--- a/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
@@ -145,7 +145,7 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task PostForceUpdatePredefinedAsync_GlobalAdmin_OverwritesMatchingOrganizationSavedViews()
+    public async Task PostForceUpdatePredefinedAsync_GlobalAdmin_OverwritesMatchingAndCreatesMissingOrganizationSavedViews()
     {
         // Arrange
         var predefinedViews = await SendRequestAsAsync<List<ViewSavedView>>(r => r
@@ -157,12 +157,14 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
 
         Assert.NotNull(predefinedViews);
         var logs = predefinedViews.First(view => IsPredefinedSavedView(view, "events", "Logs"));
+        var allStacks = predefinedViews.First(view => IsPredefinedSavedView(view, "stacks", "All"));
         var savedLogs = await _savedViewRepository.GetByIdAsync(logs.Id);
         Assert.NotNull(savedLogs);
         savedLogs.PredefinedKey = "EVENTS:LOGS";
         savedLogs.Filter = "type:error";
         savedLogs.Slug = "custom-logs";
         await _savedViewRepository.SaveAsync(savedLogs, o => o.ImmediateConsistency());
+        await _savedViewRepository.RemoveAsync(allStacks.Id, o => o.ImmediateConsistency());
 
         var testUser = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_ORG_USER_EMAIL);
         Assert.NotNull(testUser);
@@ -209,6 +211,16 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         Assert.Equal("type:log (status:open OR status:regressed)", updatedLogs.Filter);
         Assert.Equal("logs", updatedLogs.Slug);
         Assert.Equal(PredefinedSavedViewContentHasher.GetContentHash(updatedLogs), updatedLogs.PredefinedContentHash);
+
+        var recreatedAllStacks = await _savedViewRepository.GetByViewAsync(
+            SampleDataService.TEST_ORG_ID,
+            "stacks",
+            o => o.ImmediateConsistency());
+        var recreatedAllStacksView = Assert.Single(
+            recreatedAllStacks.Documents,
+            view => String.Equals(view.PredefinedKey, "stacks:all", StringComparison.OrdinalIgnoreCase));
+        Assert.True(IsPredefinedSavedView(recreatedAllStacksView, "stacks", "All"));
+        Assert.Equal(PredefinedSavedViewContentHasher.GetContentHash(recreatedAllStacksView), recreatedAllStacksView.PredefinedContentHash);
 
         var unchangedPrivateLogs = await _savedViewRepository.GetByIdAsync(privateLogs.Id);
         Assert.NotNull(unchangedPrivateLogs);

--- a/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/ForcePredefinedSavedViewsWorkItemHandlerTests.cs
+++ b/tests/Exceptionless.Tests/Jobs/WorkItemHandlers/ForcePredefinedSavedViewsWorkItemHandlerTests.cs
@@ -1,0 +1,33 @@
+using Exceptionless.Core.Jobs.WorkItemHandlers;
+using Exceptionless.Core.Models;
+using Xunit;
+
+namespace Exceptionless.Tests.Jobs.WorkItemHandlers;
+
+public class ForcePredefinedSavedViewsWorkItemHandlerTests
+{
+    [Fact]
+    public void GetUniqueSlug_QueuedViewWithoutId_ReturnsUniqueSlug()
+    {
+        // Arrange
+        var existingViews = new[]
+        {
+            new SavedView
+            {
+                Id = "existing-view",
+                Slug = "foo"
+            },
+            new SavedView
+            {
+                Id = null!,
+                Slug = "foo-2"
+            }
+        };
+
+        // Act
+        string slug = ForcePredefinedSavedViewsWorkItemHandler.GetUniqueSlug("foo", existingViews, null);
+
+        // Assert
+        Assert.Equal("foo-3", slug);
+    }
+}


### PR DESCRIPTION
## Summary

- create missing predefined saved views when a force update processes an organization with matching predefined views
- preserve private and unmatched views while using collision-safe slugs for newly created views
- report created and updated counts separately
- remove the requirement to type `FORCE` while retaining the destructive confirmation dialog
- add regression coverage for recreating a missing `stacks:all` view

## Why

The force-update worker only queried existing matching predefined records and passed their IDs into an update-only loop. A definition with no organization record was therefore never created, leaving organizations without newly added or previously missing views such as **All Stacks**.

The confirmation dialog already clearly describes the destructive operation and provides explicit Cancel and Force Update actions, so the additional typed token added unnecessary friction.

## Validation

- `dotnet build tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-restore --verbosity minimal`
- `npm run validate` in `src/Exceptionless.Web/ClientApp`
- `git diff --check`

The focused integration test is included but could not execute locally because the persistent `exceptionless.data.v1` Docker volume contains Elasticsearch 9/Lucene 10 metadata while this checkout starts Elasticsearch 8.19 (`indexCreatedVersionMajor is in the future: 10`). The test project compiles cleanly, and the existing persistent data was left untouched.

## Breaking changes

None.