### PR TITLE
Add locale-specific memory formatting coverage

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/formatters/bytes.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/formatters/bytes.svelte.test.ts
@@ -1,9 +1,21 @@
 import { render, screen } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import Bytes from './bytes.svelte';
 
 describe('Bytes', () => {
+    it('uses readable units instead of locale-specific compact byte notation', () => {
+        vi.spyOn(Navigator.prototype, 'language', 'get').mockReturnValue('en-GB');
+
+        render(Bytes, { value: 25_000_000_000 });
+        render(Bytes, { value: 17_000_000_000 });
+        render(Bytes, { value: 156_000_000 });
+
+        expect(screen.getByText('25 GB')).toBeTruthy();
+        expect(screen.getByText('17 GB')).toBeTruthy();
+        expect(screen.getByText('156 MB')).toBeTruthy();
+    });
+
     it('formats event memory values with a readable GB unit', () => {
         render(Bytes, { value: 17_179_869_184 });
 


### PR DESCRIPTION
## Summary

- Adds a regression test for readable memory units under a locale where compact byte notation is ambiguous.

## Root cause

The former compact byte formatter produced locale-specific compact labels rather than explicit scaled byte units.

## Validation

- Focused Vitest: bytes formatter and environment view tests (4 passed)
- Svelte check: 0 errors, 0 warnings
- Prettier and ESLint on the changed test
- Local Aspire browser dogfood with a synthetic event: Environment view rendered readable GB and MB values

## Breaking changes

None.