### PR TITLE
Clarify tag interactions

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/event-tags-summary-cell.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/event-tags-summary-cell.svelte.test.ts
@@ -11,7 +11,7 @@ describe('EventTagsSummaryCell', () => {
         expect(screen.getByText('production')).toBeTruthy();
         expect(screen.getByText('+2')).toBeTruthy();
         expect(screen.queryByText('critical')).toBeNull();
-        expect(screen.getByLabelText('Tags: api, production, critical, customer').getAttribute('title')).toBe('api, production, critical, customer');
+        expect(screen.getByLabelText('Tags: api, production, critical, customer').getAttribute('title')).toBeNull();
     });
 
     it('shows an empty value when there are no tags', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte
@@ -3,7 +3,6 @@
     import { Button } from '$comp/ui/button';
     import { Kbd } from '$comp/ui/kbd';
     import * as Tooltip from '$comp/ui/tooltip';
-    import { formatKeyboardShortcut } from '$shared/keyboard-shortcuts';
     import { toast } from 'svelte-sonner';
 
     interface Props {
@@ -15,7 +14,6 @@
 
     let { class: className, maxVisible = Number.POSITIVE_INFINITY, onTagClick, tags }: Props = $props();
 
-    const copyTagShortcut = $derived(formatKeyboardShortcut(['Alt']));
     const visibleTags = $derived(tags?.slice(0, maxVisible) ?? []);
     const hiddenTags = $derived(tags?.slice(maxVisible) ?? []);
     const tagList = $derived(tags?.join(', ') ?? '');
@@ -66,13 +64,13 @@
                 {/snippet}
             </Tooltip.Trigger>
             <Tooltip.Content arrowClasses="hidden" class="border-border bg-popover text-popover-foreground border shadow-md" sideOffset={4}>
-                Click to filter.
+                Click to filter. Hold
                 <Kbd
                     class="border-border in-data-[slot=tooltip-content]:bg-muted in-data-[slot=tooltip-content]:text-foreground dark:border-muted-foreground/50 dark:in-data-[slot=tooltip-content]:bg-muted border"
                 >
-                    {copyTagShortcut}
+                    Alt / Option
                 </Kbd>
-                click to copy.
+                while clicking to copy.
             </Tooltip.Content>
         </Tooltip.Root>
     {:else}
@@ -82,7 +80,7 @@
 
 <Tooltip.Provider>
     {#if visibleTags.length > 0}
-        <div class={['flex flex-wrap items-center gap-1', className]} title={tagList} aria-label={`Tags: ${tagList}`}>
+        <div class={['flex flex-wrap items-center gap-1', className]} aria-label={`Tags: ${tagList}`}>
             {#each visibleTags as value (value)}
                 {@render tag(value)}
             {/each}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte
@@ -4,6 +4,7 @@
     import { Kbd } from '$comp/ui/kbd';
     import * as Tooltip from '$comp/ui/tooltip';
     import { toast } from 'svelte-sonner';
+    import { SvelteSet } from 'svelte/reactivity';
 
     interface Props {
         class?: string;
@@ -17,6 +18,44 @@
     const visibleTags = $derived(tags?.slice(0, maxVisible) ?? []);
     const hiddenTags = $derived(tags?.slice(maxVisible) ?? []);
     const tagList = $derived(tags?.join(', ') ?? '');
+    const truncatedTags = new SvelteSet<string>();
+
+    function observeTruncation(node: HTMLElement, tag: string) {
+        const badge = node.querySelector<HTMLElement>('[data-slot="badge"]');
+        if (!badge) {
+            return;
+        }
+
+        const badgeElement = badge;
+
+        function updateTruncation() {
+            const isTruncated = badgeElement.scrollWidth > badgeElement.clientWidth;
+            if (truncatedTags.has(tag) === isTruncated) {
+                return;
+            }
+
+            if (isTruncated) {
+                truncatedTags.add(tag);
+            } else {
+                truncatedTags.delete(tag);
+            }
+        }
+
+        updateTruncation();
+
+        if (typeof ResizeObserver === 'undefined') {
+            return;
+        }
+
+        const observer = new ResizeObserver(updateTruncation);
+        observer.observe(badgeElement);
+
+        return {
+            destroy() {
+                observer.disconnect();
+            }
+        };
+    }
 
     async function handleTagClick(event: MouseEvent, tag: string): Promise<void> {
         event.preventDefault();
@@ -37,8 +76,9 @@
     }
 </script>
 
-{#snippet tagBadge(tag: string)}
+{#snippet tagBadge(tag: string, title?: string)}
     <Badge
+        {title}
         variant="outline"
         class="border-border bg-muted text-muted-foreground group-hover/button:bg-accent group-hover/button:text-accent-foreground dark:border-muted-foreground/50 max-w-28 truncate rounded-md text-xs"
     >
@@ -59,22 +99,35 @@
                         class="h-auto cursor-pointer p-0"
                         onclick={(event) => handleTagClick(event, tag)}
                     >
-                        {@render tagBadge(tag)}
+                        <span class="contents" use:observeTruncation={tag}>
+                            {@render tagBadge(tag)}
+                        </span>
                     </Button>
                 {/snippet}
             </Tooltip.Trigger>
-            <Tooltip.Content arrowClasses="hidden" class="border-border bg-popover text-popover-foreground border shadow-md" sideOffset={4}>
-                Click to filter. Hold
-                <Kbd
-                    class="border-border in-data-[slot=tooltip-content]:bg-muted in-data-[slot=tooltip-content]:text-foreground dark:border-muted-foreground/50 dark:in-data-[slot=tooltip-content]:bg-muted border"
-                >
-                    Alt / Option
-                </Kbd>
-                while clicking to copy.
+            <Tooltip.Content
+                arrowClasses="hidden"
+                class="border-border bg-popover text-popover-foreground max-w-sm flex-col items-start border shadow-md"
+                sideOffset={4}
+            >
+                {#if truncatedTags.has(tag)}
+                    <span class="max-w-xs font-medium break-all">{tag}</span>
+                {/if}
+                <span class="flex items-center gap-1 whitespace-nowrap">
+                    Click to filter. Hold
+                    <Kbd
+                        class="border-border in-data-[slot=tooltip-content]:bg-muted in-data-[slot=tooltip-content]:text-foreground dark:border-muted-foreground/50 dark:in-data-[slot=tooltip-content]:bg-muted border"
+                    >
+                        Alt / Option
+                    </Kbd>
+                    while clicking to copy.
+                </span>
             </Tooltip.Content>
         </Tooltip.Root>
     {:else}
-        {@render tagBadge(tag)}
+        <span class="contents" use:observeTruncation={tag}>
+            {@render tagBadge(tag, truncatedTags.has(tag) ? tag : undefined)}
+        </span>
     {/if}
 {/snippet}
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte.test.ts
@@ -29,7 +29,7 @@ describe('TagList', () => {
         expect(screen.getByText('production')).toBeTruthy();
         expect(screen.getByText('+2')).toBeTruthy();
         expect(screen.queryByText('critical')).toBeNull();
-        expect(screen.getByLabelText('Tags: api, production, critical, customer').getAttribute('title')).toBe('api, production, critical, customer');
+        expect(screen.getByLabelText('Tags: api, production, critical, customer').getAttribute('title')).toBeNull();
         expect(container.querySelector('svg')).toBeNull();
 
         for (const badge of container.querySelectorAll('[data-slot="badge"]')) {
@@ -56,6 +56,7 @@ describe('TagList', () => {
 
         const shortcut = document.querySelector('[data-slot="tooltip-content"] [data-slot="kbd"]');
         expect(shortcut).not.toBeNull();
+        expect(shortcut?.textContent?.trim()).toBe('Alt / Option');
         expect(shortcut?.classList.contains('in-data-[slot=tooltip-content]:bg-muted')).toBe(true);
         expect(shortcut?.classList.contains('in-data-[slot=tooltip-content]:text-foreground')).toBe(true);
         expect(shortcut?.classList.contains('border-border')).toBe(true);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte.test.ts
@@ -1,18 +1,45 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { tick } from 'svelte';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import TagList from './tag-list.svelte';
 
+const resizeObservers: ResizeObserverMock[] = [];
+
 class ResizeObserverMock {
-    disconnect = vi.fn();
-    observe = vi.fn();
+    private observedElements = new Set<Element>();
+    disconnect = vi.fn(() => {
+        this.observedElements.clear();
+    });
+
+    observe = vi.fn((element: Element) => {
+        this.observedElements.add(element);
+    });
+
     takeRecords = vi.fn(() => []);
-    unobserve = vi.fn();
+    unobserve = vi.fn((element: Element) => {
+        this.observedElements.delete(element);
+    });
+    private callback: ResizeObserverCallback;
+    constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+        resizeObservers.push(this);
+    }
+
+    trigger(element: Element) {
+        if (this.observedElements.has(element)) {
+            this.callback([{ target: element } as ResizeObserverEntry], this as unknown as ResizeObserver);
+        }
+    }
 }
 
 describe('TagList', () => {
     beforeAll(() => {
         vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+    });
+
+    beforeEach(() => {
+        resizeObservers.length = 0;
     });
 
     afterAll(() => {
@@ -54,12 +81,50 @@ describe('TagList', () => {
         await fireEvent.pointerEnter(tagButton);
         await fireEvent.pointerMove(tagButton);
 
-        const shortcut = document.querySelector('[data-slot="tooltip-content"] [data-slot="kbd"]');
+        const tooltip = document.querySelector('[data-slot="tooltip-content"]');
+        const shortcut = tooltip?.querySelector('[data-slot="kbd"]');
         expect(shortcut).not.toBeNull();
         expect(shortcut?.textContent?.trim()).toBe('Alt / Option');
         expect(shortcut?.classList.contains('in-data-[slot=tooltip-content]:bg-muted')).toBe(true);
         expect(shortcut?.classList.contains('in-data-[slot=tooltip-content]:text-foreground')).toBe(true);
         expect(shortcut?.classList.contains('border-border')).toBe(true);
+        expect(tooltip?.textContent).not.toContain('api');
+    });
+
+    it('exposes a full tag value only when its badge is truncated', async () => {
+        const tag = 'a-very-long-tag-value-that-does-not-fit';
+        render(TagList, { tags: [tag] });
+
+        const badge = screen.getByText(tag);
+        expect(badge.getAttribute('title')).toBeNull();
+
+        Object.defineProperties(badge, {
+            clientWidth: { configurable: true, value: 112 },
+            scrollWidth: { configurable: true, value: 240 }
+        });
+        resizeObservers.forEach((observer) => observer.trigger(badge));
+        await tick();
+
+        expect(badge.getAttribute('title')).toBe(tag);
+    });
+
+    it('includes a truncated tag value in the action tooltip', async () => {
+        const tag = 'a-very-long-clickable-tag-value-that-does-not-fit';
+        render(TagList, { onTagClick: vi.fn(), tags: [tag] });
+
+        const badge = screen.getByText(tag);
+        Object.defineProperties(badge, {
+            clientWidth: { configurable: true, value: 112 },
+            scrollWidth: { configurable: true, value: 280 }
+        });
+        resizeObservers.forEach((observer) => observer.trigger(badge));
+        await tick();
+
+        const tagButton = screen.getByRole('button', { name: tag });
+        await fireEvent.pointerEnter(tagButton);
+        await fireEvent.pointerMove(tagButton);
+
+        expect(document.querySelector('[data-slot="tooltip-content"]')?.textContent).toContain(tag);
     });
 
     it('shows an empty value when there are no tags', () => {


### PR DESCRIPTION
## Summary

- remove the browser-native aggregate tooltip that repeated every visible tag
- replace the obscure Alt-key glyph with explicit `Alt / Option` copy instructions
- expose a full tag value only when its badge is actually truncated
- preserve per-tag filtering, modifier-click copying, and the `+N` tooltip for genuinely hidden tags

## Root cause

The shared tag-list wrapper always rendered a `title` containing the complete tag list. That native tooltip overlapped the intentional per-tag action tooltip and provided no value when every tag was already visible. Removing it also exposed a separate edge case: long badges still truncate at their fixed maximum width and need per-tag access to the full value. The copy instruction also used the uncommon `⎇` symbol on non-Apple platforms, making the gesture difficult to discover.

## Impact

Tag interactions now have one useful tooltip with clear cross-platform instructions. Short tags do not repeat their visible value, while truncated tags expose the full value in the existing action tooltip or through a per-tag native tooltip when they are not interactive. Compact tag lists still expose hidden tags through their existing `+N` tooltip.

## Validation

- `npm run validate`
- `npm run test:unit -- --run src/lib/features/shared/components/tag-list.svelte.test.ts src/lib/features/events/components/table/event-tags-summary-cell.svelte.test.ts` (2 files, 7 tests)

## Breaking changes

None.