### PR TITLE
Fix ghost button hover contrast

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/button/button.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/button/button.svelte
@@ -15,7 +15,7 @@
 				outline: "border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground",
 				secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
 				success: primaryActionVariant,
-				ghost: "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",
+				ghost: "hover:border-accent-foreground/40 hover:bg-accent hover:text-accent-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
 				destructive: "bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30",
 				link: "text-primary underline-offset-4 hover:underline",
 			},


### PR DESCRIPTION
## Summary

- Fixes the shared ghost Button hover state using the existing semantic `accent` theme tokens.
- Overrides the Button base's intentional `border-transparent` only on ghost hover with `accent-foreground/40`.
- Keeps the change limited to `variant="ghost"`; the transparent resting state and every other Button variant remain unchanged.

## Root cause

The pagination `Next` control is a shared Button with `variant="ghost"`. It does not have a Next-specific transparency class:

- Every Button starts with `border border-transparent` so filled, link, and ghost variants do not gain an unintended resting border.
- The old ghost hover used `dark:hover:bg-muted/50` and left that border transparent.
- On the dark page background, that half-opacity fill did not provide a clear hover boundary.

The fix belongs in the shared ghost hover variant: it uses the theme's `accent` hover surface and overrides the transparent border while hovered. Changing the base transparency would incorrectly add borders to unrelated Button variants.

## Screenshots

### Before — dark-mode `Next` hovered

<img width="1280" height="577" alt="Before: dark-mode Next pagination button hovered with no clear boundary" src="https://github.com/user-attachments/assets/835a75f2-e86b-4613-be88-f48133372f65" />

### After — dark-mode `Next` hovered

<img width="1280" height="577" alt="After: dark-mode Next pagination button hovered with a visible accent surface and border" src="https://github.com/user-attachments/assets/8a5fd1a6-cfb3-45f9-94f6-bc1502bd4922" />

## Verification

- Authenticated local `/next/stack` capture at 1280×577 with the real `Next` pagination button confirmed in `:hover`.
- Confirmed the real `Next` button is a `BUTTON` using `variant="ghost"`: at rest its background and border both compute to transparent; on hover the shared variant overrides both.
- Rendered hover state: fill `rgb(26, 31, 36)`, border `rgb(91, 94, 99)`, foreground `rgb(230, 237, 243)`.
- The rendered border has 3.14:1 contrast against the dark page background (`rgb(2, 5, 10)`).
- Audited all shared Button variants and ghost Button call sites; no other Button variant's hover styling changes.
- `npm run validate`
