### PR TITLE
Improve MCP tool metadata and filter validation

### DIFF
--- a/src/Exceptionless.Web/Mcp/ExceptionlessMcpTools.cs
+++ b/src/Exceptionless.Web/Mcp/ExceptionlessMcpTools.cs
@@ -1453,7 +1453,7 @@ public sealed class ExceptionlessMcpTools
         if (String.IsNullOrWhiteSpace(filter))
             return null;
 
-        foreach (Match match in FilterFieldRegex.Matches(filter))
+        foreach (Match match in FilterFieldRegex.Matches(RemoveQuotedFilterValues(filter)))
         {
             string field = match.Groups["field"].Value;
             if (allowedFilterFields.Contains(field))
@@ -1462,7 +1462,7 @@ public sealed class ExceptionlessMcpTools
             if (allowIndexedDataFields && field.StartsWith("data.", StringComparison.OrdinalIgnoreCase))
             {
                 string indexedDataField = field["data.".Length..];
-                if (indexedDataField.IsValidFieldName())
+                if (indexedDataField.StartsWith('@') || indexedDataField.IsValidFieldName())
                     continue;
 
                 return McpErrors.UnknownFilterField(
@@ -1476,6 +1476,45 @@ public sealed class ExceptionlessMcpTools
         }
 
         return null;
+    }
+
+    private static string RemoveQuotedFilterValues(string filter)
+    {
+        char[] characters = filter.ToCharArray();
+        bool isQuoted = false;
+        bool isEscaped = false;
+
+        for (int index = 0; index < characters.Length; index++)
+        {
+            char character = characters[index];
+            if (isEscaped)
+            {
+                isEscaped = false;
+                if (isQuoted)
+                    characters[index] = ' ';
+                continue;
+            }
+
+            if (character == '\\')
+            {
+                isEscaped = true;
+                if (isQuoted)
+                    characters[index] = ' ';
+                continue;
+            }
+
+            if (character == '"')
+            {
+                isQuoted = !isQuoted;
+                characters[index] = ' ';
+                continue;
+            }
+
+            if (isQuoted)
+                characters[index] = ' ';
+        }
+
+        return new string(characters);
     }
 
     private static bool IsLookupError(Exception ex)

--- a/src/Exceptionless.Web/Mcp/ExceptionlessMcpTools.cs
+++ b/src/Exceptionless.Web/Mcp/ExceptionlessMcpTools.cs
@@ -1765,7 +1765,7 @@ public sealed class ExceptionlessMcpTools
 
     private static readonly HashSet<string> ClientSetupPlatforms = new(StringComparer.OrdinalIgnoreCase) { "expo", "react-native" };
 
-    private static readonly Regex FilterFieldRegex = new(@"(?:^|[\s(])(?<field>@?[A-Za-z_][A-Za-z0-9_@.-]*):", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex FilterFieldRegex = new(@"(?:^|[-+\s(])(?<field>@?[A-Za-z_][A-Za-z0-9_@.-]*):", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex IdRegex = new(@"^[A-Za-z0-9]{24,36}$", RegexOptions.Compiled | RegexOptions.CultureInvariant);
     private static readonly Regex RelativeTimeRegex = new(@"^(?<value>\d+)(?<unit>[mhdw])$", RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
     private static readonly Regex IntervalRegex = new(@"^\d+[mhdwM]$", RegexOptions.Compiled | RegexOptions.CultureInvariant);

--- a/src/Exceptionless.Web/Mcp/ExceptionlessMcpTools.cs
+++ b/src/Exceptionless.Web/Mcp/ExceptionlessMcpTools.cs
@@ -425,7 +425,7 @@ public sealed class ExceptionlessMcpTools
             if (projectId is not null && !TryValidateId(projectId, "projectId", out var projectIdError))
                 return McpResponse<McpListData<McpEventResult>>.Failed(projectIdError);
 
-            var validation = await ValidateSearchAsync(filter, sort, limit, EventFilterFields, EventSortFields, _eventQueryValidator);
+            var validation = await ValidateSearchAsync(filter, sort, limit, EventFilterFields, EventSortFields, _eventQueryValidator, allowIndexedDataFields: true);
             if (validation.Error is not null)
                 return McpResponse<McpListData<McpEventResult>>.Failed(validation.Error);
 
@@ -485,7 +485,7 @@ public sealed class ExceptionlessMcpTools
             if (projectId is not null && !TryValidateId(projectId, "projectId", out var idError))
                 return McpResponse<McpListData<McpEventResult>>.Failed(idError);
 
-            var validation = await ValidateSearchAsync(filter, sort, limit, EventFilterFields, EventSortFields, _eventQueryValidator);
+            var validation = await ValidateSearchAsync(filter, sort, limit, EventFilterFields, EventSortFields, _eventQueryValidator, allowIndexedDataFields: true);
             if (validation.Error is not null)
                 return McpResponse<McpListData<McpEventResult>>.Failed(validation.Error);
 
@@ -589,7 +589,7 @@ public sealed class ExceptionlessMcpTools
             if (projectId is not null && !TryValidateId(projectId, "projectId", out var idError))
                 return McpResponse<McpEventCountResult>.Failed(idError);
 
-            var validation = await ValidateSearchAsync(filter, sort: null, DefaultLimit, EventFilterFields, EventSortFields, _eventQueryValidator);
+            var validation = await ValidateSearchAsync(filter, sort: null, DefaultLimit, EventFilterFields, EventSortFields, _eventQueryValidator, allowIndexedDataFields: true);
             if (validation.Error is not null)
                 return McpResponse<McpEventCountResult>.Failed(validation.Error);
 
@@ -681,7 +681,7 @@ public sealed class ExceptionlessMcpTools
         }
     }
 
-    [McpServerTool(Name = "update_stack_status", ReadOnly = false, UseStructuredContent = true)]
+    [McpServerTool(Name = "update_stack_status", ReadOnly = false, Destructive = true, Idempotent = true, UseStructuredContent = true)]
     [Description("Changes a stack status. Use status fixed with fixedInVersion to mark an issue fixed in a release, or use open, ignored, or discarded. Snoozed stacks must use snooze_stack.")]
     public async Task<McpResponse<McpStackUpdateResult>> UpdateStackStatusAsync(
         [Description("The Exceptionless stack id.")]
@@ -709,17 +709,22 @@ public sealed class ExceptionlessMcpTools
                 return McpResponse<McpStackUpdateResult>.Failed(McpErrors.InvalidVersion("fixedInVersion can only be used when status is fixed.", fixedInVersion));
 
             var stack = await GetAccessibleStackForWriteAsync(stackId, projectId);
-            bool changed = stack.Status != stackStatus || (stackStatus == StackStatus.Fixed && !String.Equals(stack.FixedInVersion, NormalizeFixedVersion(fixedInVersion), StringComparison.Ordinal));
+            var semanticVersion = stackStatus == StackStatus.Fixed && !String.IsNullOrWhiteSpace(fixedInVersion)
+                ? _semanticVersionParser.Parse(fixedInVersion)
+                : null;
+            if (stackStatus == StackStatus.Fixed && !String.IsNullOrWhiteSpace(fixedInVersion) && semanticVersion is null)
+                return McpResponse<McpStackUpdateResult>.Failed(McpErrors.InvalidVersion("Invalid semantic version.", fixedInVersion));
 
-            if (stackStatus == StackStatus.Fixed)
+            string? normalizedFixedVersion = semanticVersion?.ToString();
+            bool changed = stackStatus == StackStatus.Fixed
+                ? stack.Status != StackStatus.Fixed || stack.DateFixed is null || !String.Equals(stack.FixedInVersion, normalizedFixedVersion, StringComparison.Ordinal)
+                : stack.Status != stackStatus || stack.DateFixed is not null || stack.FixedInVersion is not null || stack.SnoozeUntilUtc is not null;
+
+            if (changed && stackStatus == StackStatus.Fixed)
             {
-                var semanticVersion = String.IsNullOrWhiteSpace(fixedInVersion) ? null : _semanticVersionParser.Parse(fixedInVersion);
-                if (!String.IsNullOrWhiteSpace(fixedInVersion) && semanticVersion is null)
-                    return McpResponse<McpStackUpdateResult>.Failed(McpErrors.InvalidVersion("Invalid semantic version.", fixedInVersion));
-
                 stack.MarkFixed(semanticVersion, _timeProvider);
             }
-            else
+            else if (changed)
             {
                 stack.Status = stackStatus;
                 stack.DateFixed = null;
@@ -727,7 +732,9 @@ public sealed class ExceptionlessMcpTools
                 stack.SnoozeUntilUtc = null;
             }
 
-            await _stackRepository.SaveAsync(stack, o => o.ImmediateConsistency());
+            if (changed)
+                await _stackRepository.SaveAsync(stack, o => o.ImmediateConsistency());
+
             return McpResponse<McpStackUpdateResult>.Success(new McpStackUpdateResult(
                 ToStackResult(stack),
                 changed,
@@ -743,7 +750,7 @@ public sealed class ExceptionlessMcpTools
         }
     }
 
-    [McpServerTool(Name = "snooze_stack", ReadOnly = false, UseStructuredContent = true)]
+    [McpServerTool(Name = "snooze_stack", ReadOnly = false, Destructive = true, Idempotent = false, UseStructuredContent = true)]
     [Description("Snoozes a stack until a future UTC time or for a relative duration. Snoozing clears fixed metadata and sets the stack status to snoozed.")]
     public async Task<McpResponse<McpStackUpdateResult>> SnoozeStackAsync(
         [Description("The Exceptionless stack id.")]
@@ -790,7 +797,7 @@ public sealed class ExceptionlessMcpTools
         }
     }
 
-    [McpServerTool(Name = "set_stack_critical", ReadOnly = false, UseStructuredContent = true)]
+    [McpServerTool(Name = "set_stack_critical", ReadOnly = false, Destructive = true, Idempotent = true, UseStructuredContent = true)]
     [Description("Controls whether future events for a stack are marked critical.")]
     public async Task<McpResponse<McpStackUpdateResult>> SetStackCriticalAsync(
         [Description("The Exceptionless stack id.")]
@@ -811,9 +818,12 @@ public sealed class ExceptionlessMcpTools
 
             var stack = await GetAccessibleStackForWriteAsync(stackId, projectId);
             bool changed = stack.OccurrencesAreCritical != critical;
-            stack.OccurrencesAreCritical = critical;
+            if (changed)
+            {
+                stack.OccurrencesAreCritical = critical;
+                await _stackRepository.SaveAsync(stack, o => o.ImmediateConsistency());
+            }
 
-            await _stackRepository.SaveAsync(stack, o => o.ImmediateConsistency());
             return McpResponse<McpStackUpdateResult>.Success(new McpStackUpdateResult(
                 ToStackResult(stack),
                 changed,
@@ -831,7 +841,7 @@ public sealed class ExceptionlessMcpTools
         }
     }
 
-    [McpServerTool(Name = "add_stack_reference_link", ReadOnly = false, UseStructuredContent = true)]
+    [McpServerTool(Name = "add_stack_reference_link", ReadOnly = false, Destructive = false, Idempotent = true, UseStructuredContent = true)]
     [Description("Adds a reference link to a stack. Use this to attach an external issue, pull request, deployment, or incident URL to an Exceptionless issue.")]
     public async Task<McpResponse<McpStackUpdateResult>> AddStackReferenceLinkAsync(
         [Description("The Exceptionless stack id.")]
@@ -878,7 +888,7 @@ public sealed class ExceptionlessMcpTools
         }
     }
 
-    [McpServerTool(Name = "remove_stack_reference_link", ReadOnly = false, UseStructuredContent = true)]
+    [McpServerTool(Name = "remove_stack_reference_link", ReadOnly = false, Destructive = true, Idempotent = true, UseStructuredContent = true)]
     [Description("Removes a reference link from a stack.")]
     public async Task<McpResponse<McpStackUpdateResult>> RemoveStackReferenceLinkAsync(
         [Description("The Exceptionless stack id.")]
@@ -1068,9 +1078,9 @@ public sealed class ExceptionlessMcpTools
         if (!TryValidateSort(sort, ProjectSortFields, out string? sortError))
             return SearchValidationResult.Failed(McpErrors.InvalidSort(sortError ?? "Invalid sort.", sort, ProjectSortFields));
 
-        string? unknownField = GetUnknownFilterField(filter, ProjectFilterFields);
-        if (unknownField is not null)
-            return SearchValidationResult.Failed(McpErrors.UnknownFilterField($"Unknown filter field '{unknownField}'.", unknownField, ProjectFilterFields));
+        var filterFieldError = GetFilterFieldError(filter, ProjectFilterFields, allowIndexedDataFields: false);
+        if (filterFieldError is not null)
+            return SearchValidationResult.Failed(filterFieldError);
 
         return new SearchValidationResult(resolvedLimit, warning);
     }
@@ -1081,7 +1091,8 @@ public sealed class ExceptionlessMcpTools
         int limit,
         IReadOnlySet<string> allowedFilterFields,
         IReadOnlySet<string> allowedSortFields,
-        AppQueryValidator queryValidator)
+        AppQueryValidator queryValidator,
+        bool allowIndexedDataFields = false)
     {
         if (!TryValidateLimit(limit, out int resolvedLimit, out string? limitError, out string? warning))
             return SearchValidationResult.Failed(McpErrors.InvalidLimit(limitError ?? "Invalid limit.", limit, MaxSummaryLimit));
@@ -1093,9 +1104,9 @@ public sealed class ExceptionlessMcpTools
         if (!queryValidation.IsValid)
             return SearchValidationResult.Failed(McpErrors.InvalidFilter($"Invalid filter: {queryValidation.Message ?? "Unable to parse filter."}"));
 
-        string? unknownField = GetUnknownFilterField(filter, allowedFilterFields);
-        if (unknownField is not null)
-            return SearchValidationResult.Failed(McpErrors.UnknownFilterField($"Unknown filter field '{unknownField}'.", unknownField, allowedFilterFields));
+        var filterFieldError = GetFilterFieldError(filter, allowedFilterFields, allowIndexedDataFields);
+        if (filterFieldError is not null)
+            return SearchValidationResult.Failed(filterFieldError);
 
         return new SearchValidationResult(resolvedLimit, warning);
     }
@@ -1385,11 +1396,6 @@ public sealed class ExceptionlessMcpTools
         return false;
     }
 
-    private static string? NormalizeFixedVersion(string? fixedInVersion)
-    {
-        return String.IsNullOrWhiteSpace(fixedInVersion) ? null : fixedInVersion.Trim();
-    }
-
     private static bool TryNormalizeReferenceUrl(string? url, out string referenceUrl, out McpErrorInfo error)
     {
         referenceUrl = null!;
@@ -1442,7 +1448,7 @@ public sealed class ExceptionlessMcpTools
         return false;
     }
 
-    private static string? GetUnknownFilterField(string? filter, IReadOnlySet<string> allowedFilterFields)
+    private static McpErrorInfo? GetFilterFieldError(string? filter, IReadOnlySet<string> allowedFilterFields, bool allowIndexedDataFields)
     {
         if (String.IsNullOrWhiteSpace(filter))
             return null;
@@ -1450,11 +1456,23 @@ public sealed class ExceptionlessMcpTools
         foreach (Match match in FilterFieldRegex.Matches(filter))
         {
             string field = match.Groups["field"].Value;
-            if (field.StartsWith("data.", StringComparison.OrdinalIgnoreCase))
+            if (allowedFilterFields.Contains(field))
                 continue;
 
-            if (!allowedFilterFields.Contains(field))
-                return field;
+            if (allowIndexedDataFields && field.StartsWith("data.", StringComparison.OrdinalIgnoreCase))
+            {
+                string indexedDataField = field["data.".Length..];
+                if (indexedDataField.IsValidFieldName())
+                    continue;
+
+                return McpErrors.UnknownFilterField(
+                    $"Custom data filter field '{field}' cannot be indexed. Use a top-level scalar custom data field in the form data.<field>, where <field> contains 1 to 25 letters, numbers, or hyphens.",
+                    field,
+                    allowedFilterFields,
+                    "data.<field>");
+            }
+
+            return McpErrors.UnknownFilterField($"Unknown filter field '{field}'.", field, allowedFilterFields);
         }
 
         return null;

--- a/src/Exceptionless.Web/Mcp/McpErrors.cs
+++ b/src/Exceptionless.Web/Mcp/McpErrors.cs
@@ -207,13 +207,18 @@ public static class McpErrors
         return new McpErrorInfo(McpErrorCodes.QueryFailed, message);
     }
 
-    public static McpErrorInfo UnknownFilterField(string message, string field, IReadOnlySet<string> allowedFields)
+    public static McpErrorInfo UnknownFilterField(string message, string field, IReadOnlySet<string> allowedFields, string? allowedDynamicFieldPattern = null)
     {
-        return new McpErrorInfo(McpErrorCodes.UnknownFilterField, message, new Dictionary<string, object?>
+        var details = new Dictionary<string, object?>
         {
             ["field"] = field,
             ["allowedFields"] = allowedFields.Order(StringComparer.OrdinalIgnoreCase).ToArray()
-        });
+        };
+
+        if (allowedDynamicFieldPattern is not null)
+            details["allowedDynamicFieldPattern"] = allowedDynamicFieldPattern;
+
+        return new McpErrorInfo(McpErrorCodes.UnknownFilterField, message, details);
     }
 
     private static IReadOnlyDictionary<string, object?>? ResourceDetails(string? field, string? value)

--- a/tests/Exceptionless.Tests/Mcp/ExceptionlessMcpToolMetadataTests.cs
+++ b/tests/Exceptionless.Tests/Mcp/ExceptionlessMcpToolMetadataTests.cs
@@ -1,0 +1,53 @@
+using System.Runtime.CompilerServices;
+using Exceptionless.Web.Mcp;
+using ModelContextProtocol.Server;
+using Xunit;
+
+namespace Exceptionless.Tests.Mcp;
+
+public sealed class ExceptionlessMcpToolMetadataTests
+{
+    [Theory]
+    [InlineData(nameof(ExceptionlessMcpTools.ListOrganizationsAsync))]
+    [InlineData(nameof(ExceptionlessMcpTools.ResolveProjectAsync))]
+    [InlineData(nameof(ExceptionlessMcpTools.ListProjectsAsync))]
+    [InlineData(nameof(ExceptionlessMcpTools.GetProjectAsync))]
+    [InlineData(nameof(ExceptionlessMcpTools.GetClientSetupInstructionsAsync))]
+    [InlineData(nameof(ExceptionlessMcpTools.SearchStacksAsync))]
+    [InlineData(nameof(ExceptionlessMcpTools.GetStackAsync))]
+    [InlineData(nameof(ExceptionlessMcpTools.GetStackEventsAsync))]
+    [InlineData(nameof(ExceptionlessMcpTools.SearchEventsAsync))]
+    [InlineData(nameof(ExceptionlessMcpTools.GetEventAsync))]
+    [InlineData(nameof(ExceptionlessMcpTools.CountEventsAsync))]
+    [InlineData(nameof(ExceptionlessMcpTools.GetFilterFields))]
+    public void ReadTools_AnnotationsAdvertiseReadOnly(string methodName)
+    {
+        var tool = CreateTool(methodName);
+
+        Assert.NotNull(tool.ProtocolTool.Annotations);
+        Assert.Equal(true, tool.ProtocolTool.Annotations!.ReadOnlyHint);
+    }
+
+    [Theory]
+    [InlineData(nameof(ExceptionlessMcpTools.UpdateStackStatusAsync), true, true)]
+    [InlineData(nameof(ExceptionlessMcpTools.SnoozeStackAsync), true, false)]
+    [InlineData(nameof(ExceptionlessMcpTools.SetStackCriticalAsync), true, true)]
+    [InlineData(nameof(ExceptionlessMcpTools.AddStackReferenceLinkAsync), false, true)]
+    [InlineData(nameof(ExceptionlessMcpTools.RemoveStackReferenceLinkAsync), true, true)]
+    public void StackWriteTools_AnnotationsAdvertiseSideEffects(string methodName, bool destructive, bool idempotent)
+    {
+        var tool = CreateTool(methodName);
+
+        Assert.NotNull(tool.ProtocolTool.Annotations);
+        Assert.Equal(false, tool.ProtocolTool.Annotations!.ReadOnlyHint);
+        Assert.Equal(destructive, tool.ProtocolTool.Annotations.DestructiveHint);
+        Assert.Equal(idempotent, tool.ProtocolTool.Annotations.IdempotentHint);
+    }
+
+    private static McpServerTool CreateTool(string methodName)
+    {
+        var method = typeof(ExceptionlessMcpTools).GetMethod(methodName) ?? throw new InvalidOperationException($"Could not find {methodName}.");
+        var target = (ExceptionlessMcpTools)RuntimeHelpers.GetUninitializedObject(typeof(ExceptionlessMcpTools));
+        return McpServerTool.Create(method, target, new McpServerToolCreateOptions());
+    }
+}

--- a/tests/Exceptionless.Tests/Mcp/ExceptionlessMcpToolsTests.cs
+++ b/tests/Exceptionless.Tests/Mcp/ExceptionlessMcpToolsTests.cs
@@ -424,6 +424,8 @@ public sealed class ExceptionlessMcpToolsTests : IntegrationTestsBase
 
     [Theory]
     [InlineData("data.Customer.plan:Business")]
+    [InlineData("-data.Customer.plan:Business")]
+    [InlineData("+data.Customer.plan:Business")]
     [InlineData("data.customer_plan:Business")]
     [InlineData("data.abcdefghijklmnopqrstuvwxyz:Business")]
     public async Task SearchEventsAsync_UnindexableCustomDataFilter_ReturnsUnknownFilterField(string filter)

--- a/tests/Exceptionless.Tests/Mcp/ExceptionlessMcpToolsTests.cs
+++ b/tests/Exceptionless.Tests/Mcp/ExceptionlessMcpToolsTests.cs
@@ -422,6 +422,44 @@ public sealed class ExceptionlessMcpToolsTests : IntegrationTestsBase
         Assert.Null(result.Data);
     }
 
+    [Theory]
+    [InlineData("data.Customer.plan:Business")]
+    [InlineData("data.customer_plan:Business")]
+    [InlineData("data.abcdefghijklmnopqrstuvwxyz:Business")]
+    public async Task SearchEventsAsync_UnindexableCustomDataFilter_ReturnsUnknownFilterField(string filter)
+    {
+        var tools = await CreateToolsAsync(AuthorizationRoles.McpRead, AuthorizationRoles.EventsRead);
+
+        var result = await tools.SearchEventsAsync(TestConstants.ProjectId, filter: filter);
+
+        Assert.False(result.Ok);
+        Assert.Equal(McpErrorCodes.UnknownFilterField, result.Error?.Code);
+        Assert.Contains("top-level scalar custom data field", result.Error?.Message);
+        Assert.Equal("data.<field>", result.Error?.Details?["allowedDynamicFieldPattern"]);
+        Assert.Null(result.Data);
+    }
+
+    [Fact]
+    public async Task SearchEventsAsync_IndexableCustomDataFilter_ReturnsMatchingEvent()
+    {
+        var (_, events) = await CreateDataAsync(d => d.Event()
+            .TestProject()
+            .Mutate(ev =>
+            {
+                ev.Data ??= [];
+                ev.Data["plan"] = "Business";
+            })
+            .Message("MCP indexed custom data"));
+        await RefreshDataAsync();
+        var tools = await CreateToolsAsync(AuthorizationRoles.McpRead, AuthorizationRoles.EventsRead);
+
+        var result = await tools.SearchEventsAsync(TestConstants.ProjectId, filter: "data.plan:Business");
+
+        Assert.True(result.Ok);
+        Assert.Null(result.Error);
+        Assert.Contains(Items(result), ev => ev.Id == events[0].Id);
+    }
+
     [Fact]
     public async Task SearchStacksAsync_MalformedFilter_ReturnsSpecificError()
     {
@@ -788,6 +826,33 @@ public sealed class ExceptionlessMcpToolsTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task UpdateStackStatusAsync_UnchangedFixedStatus_DoesNotSaveAgain()
+    {
+        try
+        {
+            TimeProvider.SetUtcNow(new DateTimeOffset(2026, 6, 25, 12, 0, 0, TimeSpan.Zero));
+            var (stacks, _) = await CreateDataAsync(d => d.Event().TestProject().Message("MCP write fixed idempotent"));
+            var tools = await CreateToolsAsync(AuthorizationRoles.McpRead, AuthorizationRoles.StacksWrite);
+
+            var firstResult = await tools.UpdateStackStatusAsync(stacks[0].Id, "fixed", TestConstants.ProjectId, "1.0.2");
+            var first = Data(firstResult);
+            TimeProvider.Advance(TimeSpan.FromHours(1));
+
+            var secondResult = await tools.UpdateStackStatusAsync(stacks[0].Id, "fixed", TestConstants.ProjectId, "1.0.2");
+            var second = Data(secondResult);
+
+            Assert.True(secondResult.Ok);
+            Assert.False(second.Changed);
+            Assert.Equal(first.Stack.DateFixed, second.Stack.DateFixed);
+            Assert.Equal(first.Stack.UpdatedUtc, second.Stack.UpdatedUtc);
+        }
+        finally
+        {
+            TimeProvider.Restore();
+        }
+    }
+
+    [Fact]
     public async Task UpdateStackStatusAsync_MissingStacksWriteScope_ReturnsError()
     {
         var (stacks, _) = await CreateDataAsync(d => d.Event().TestProject().Message("MCP write missing scope"));
@@ -887,6 +952,32 @@ public sealed class ExceptionlessMcpToolsTests : IntegrationTestsBase
         var stack = await _stackRepository.GetByIdAsync(stacks[0].Id, o => o.ImmediateConsistency());
         Assert.NotNull(stack);
         Assert.True(stack.OccurrencesAreCritical);
+    }
+
+    [Fact]
+    public async Task SetStackCriticalAsync_UnchangedValue_DoesNotSaveAgain()
+    {
+        try
+        {
+            TimeProvider.SetUtcNow(new DateTimeOffset(2026, 6, 25, 12, 0, 0, TimeSpan.Zero));
+            var (stacks, _) = await CreateDataAsync(d => d.Event().TestProject().Message("MCP write critical idempotent"));
+            var tools = await CreateToolsAsync(AuthorizationRoles.McpRead, AuthorizationRoles.StacksWrite);
+
+            var firstResult = await tools.SetStackCriticalAsync(stacks[0].Id, critical: true, projectId: TestConstants.ProjectId);
+            var first = Data(firstResult);
+            TimeProvider.Advance(TimeSpan.FromHours(1));
+
+            var secondResult = await tools.SetStackCriticalAsync(stacks[0].Id, critical: true, projectId: TestConstants.ProjectId);
+            var second = Data(secondResult);
+
+            Assert.True(secondResult.Ok);
+            Assert.False(second.Changed);
+            Assert.Equal(first.Stack.UpdatedUtc, second.Stack.UpdatedUtc);
+        }
+        finally
+        {
+            TimeProvider.Restore();
+        }
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Mcp/ExceptionlessMcpToolsTests.cs
+++ b/tests/Exceptionless.Tests/Mcp/ExceptionlessMcpToolsTests.cs
@@ -461,6 +461,40 @@ public sealed class ExceptionlessMcpToolsTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task SearchEventsAsync_BuiltInDataFilter_ReturnsMatchingEvent()
+    {
+        var (_, events) = await CreateDataAsync(d => d.Event()
+            .TestProject()
+            .UserIdentity("mcp-filter@example.com")
+            .Message("MCP built-in data filter"));
+        await RefreshDataAsync();
+        var tools = await CreateToolsAsync(AuthorizationRoles.McpRead, AuthorizationRoles.EventsRead);
+
+        var result = await tools.SearchEventsAsync(TestConstants.ProjectId, filter: "data.@user.identity:mcp-filter@example.com");
+
+        Assert.True(result.Ok);
+        Assert.Null(result.Error);
+        Assert.Contains(Items(result), ev => ev.Id == events[0].Id);
+    }
+
+    [Fact]
+    public async Task SearchEventsAsync_DataFieldTextInsideQuotedValue_ReturnsMatchingEvent()
+    {
+        const string message = "failed evaluating data.customer.plan:Business";
+        var (_, events) = await CreateDataAsync(d => d.Event()
+            .TestProject()
+            .Message(message));
+        await RefreshDataAsync();
+        var tools = await CreateToolsAsync(AuthorizationRoles.McpRead, AuthorizationRoles.EventsRead);
+
+        var result = await tools.SearchEventsAsync(TestConstants.ProjectId, filter: $"message:\"{message}\"");
+
+        Assert.True(result.Ok);
+        Assert.Null(result.Error);
+        Assert.Contains(Items(result), ev => ev.Id == events[0].Id);
+    }
+
+    [Fact]
     public async Task SearchStacksAsync_MalformedFilter_ReturnsSpecificError()
     {
         var tools = await CreateToolsAsync(AuthorizationRoles.McpRead, AuthorizationRoles.StacksRead);


### PR DESCRIPTION
## Summary

- publish precise read-only, destructive, and idempotent MCP tool annotations
- make idempotent stack mutations avoid unchanged saves
- reject structurally unindexable `data.*` filters with actionable recovery details
- add metadata and behavior regression coverage

## Why

MCP clients need reliable annotations to gate write operations without name-based heuristics. Custom event-data filters also previously accepted nested or otherwise unindexable field paths and returned an indistinguishable empty result.

## Behavior

`update_stack_status`, `set_stack_critical`, and reference-link mutations now advertise and honor idempotency. Relative `snooze_stack` remains non-idempotent. Event filters accept only indexable top-level custom data keys in the form `data.<field>`; invalid fields return `unknown_filter_field` with `allowedDynamicFieldPattern`.

Client setup instructions and API-key output are unchanged.

## Verification

- `dotnet build tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-restore` — passed with 0 warnings/errors
- `dotnet test --project tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-build -- --filter-class Exceptionless.Tests.Mcp.ExceptionlessMcpToolMetadataTests` — 17 passed
- focused MCP integration class — blocked before test execution because the shared Elasticsearch fixture failed to start; no shared data was reset

## Breaking changes

None.