### PR TITLE
chore: update Elasticsearch stack to 9.5.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,6 +83,7 @@ jobs:
     timeout-minutes: 30
     outputs:
       version: ${{ steps.version.outputs.version }}
+      elasticsearch_image_tag: ${{ steps.elasticsearch_image.outputs.tag }}
       should_publish: ${{ (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'dev-preview')) && secrets.DOCKER_USERNAME != '' && secrets.DOCKER_PASSWORD != '' }}
       is_prod_deploy: ${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request' }}
       is_dev_deploy: ${{ (github.event_name == 'repository_dispatch' && github.event.action == 'preview') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dev-preview')) }}
@@ -129,9 +130,52 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "### $version" >> $GITHUB_STEP_SUMMARY
 
+      - name: Resolve Elasticsearch image
+        id: elasticsearch_image
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          version=$(sed -n 's/.*elasticsearch:\([^ ]*\).*/\1/p' build/docker/elasticsearch/9.x/Dockerfile)
+          tag=$version
+          image_changed=false
+
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]] &&
+            ! git diff --quiet "$PR_BASE_SHA"...HEAD -- build/docker/elasticsearch/9.x .github/workflows/elasticsearch-docker-9.yml; then
+            image_changed=true
+          elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]] &&
+            ! git diff --quiet "$PUSH_BEFORE_SHA"..HEAD -- build/docker/elasticsearch/9.x .github/workflows/elasticsearch-docker-9.yml; then
+            image_changed=true
+          fi
+
+          if [[ "$image_changed" == "true" ]]; then
+            image_sha=$(git ls-files -- build/docker/elasticsearch/9.x .github/workflows/elasticsearch-docker-9.yml | sort | xargs sha256sum | sha256sum | cut -d " " -f 1)
+            tag="$version-sha256-$image_sha"
+            image="exceptionless/elasticsearch:$tag"
+
+            for attempt in {1..150}; do
+              if docker manifest inspect "$image" > /dev/null 2>&1; then
+                break
+              fi
+
+              if [[ "$attempt" -eq 150 ]]; then
+                echo "::error::Timed out waiting for $image to be published."
+                exit 1
+              fi
+
+              sleep 10
+            done
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "### Elasticsearch image: exceptionless/elasticsearch:$tag" >> "$GITHUB_STEP_SUMMARY"
+
   test-api:
+    needs: version
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      Elasticsearch__ImageTag: ${{ needs.version.outputs.elasticsearch_image_tag }}
 
     steps:
       - name: Checkout
@@ -223,8 +267,11 @@ jobs:
         run: echo "npm run test:integration"
 
   test-e2e:
+    needs: version
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      Elasticsearch__ImageTag: ${{ needs.version.outputs.elasticsearch_image_tag }}
 
     steps:
       - name: Checkout
@@ -558,27 +605,6 @@ jobs:
           sed -i "s/^appVersion:.*$/appVersion: '${VERSION}'/" ./k8s/exceptionless/Chart.yaml
           helm upgrade --set "version=${VERSION}" --reuse-values --values ./k8s/ex-dev-values.yaml ex-dev --namespace $DEV_NAMESPACE ./k8s/exceptionless
 
-      - name: Run Development Migrations
-        if: ${{ needs.version.outputs.is_dev_deploy == 'true' }}
-        run: |
-          migration_job="ex-dev-jobs-migration-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          kubectl create job --from=cronjob/ex-dev-jobs-migration "$migration_job" --namespace "$DEV_NAMESPACE"
-
-          migration_image=$(kubectl get job "$migration_job" --namespace "$DEV_NAMESPACE" \
-            --output jsonpath='{.spec.template.spec.containers[0].image}')
-          if [[ "$migration_image" != *":${VERSION}" ]]; then
-            echo "::error::Migration job uses ${migration_image}; expected version ${VERSION}."
-            exit 1
-          fi
-
-          if ! kubectl wait --for=condition=complete --timeout=1200s "job/${migration_job}" --namespace "$DEV_NAMESPACE"; then
-            echo "::group::Migration job diagnostics"
-            kubectl describe job "$migration_job" --namespace "$DEV_NAMESPACE"
-            kubectl get pods --selector "job-name=${migration_job}" --namespace "$DEV_NAMESPACE" --output wide
-            echo "::endgroup::"
-            exit 1
-          fi
-
       - name: Ensure Development Workloads are Running
         if: ${{ needs.version.outputs.is_dev_deploy == 'true' }}
         run: |
@@ -599,6 +625,7 @@ jobs:
           kubectl patch cronjob/ex-dev-jobs-cleanup-orphaned-data -p '{"spec":{"suspend": false}}' --namespace $DEV_NAMESPACE
           kubectl patch cronjob/ex-dev-jobs-download-geoip-database -p '{"spec":{"suspend": false}}' --namespace $DEV_NAMESPACE
           kubectl patch cronjob/ex-dev-jobs-maintain-indexes -p '{"spec":{"suspend": false}}' --namespace $DEV_NAMESPACE
+          kubectl patch cronjob/ex-dev-jobs-migration -p '{"spec":{"suspend": false}}' --namespace $DEV_NAMESPACE
 
           wait_for_versioned_pod() {
             component="$1"

--- a/.github/workflows/elasticsearch-docker-9.yml
+++ b/.github/workflows/elasticsearch-docker-9.yml
@@ -1,10 +1,10 @@
-name: Elasticsearch 8.x Docker Image CI
+name: Elasticsearch 9.x Docker Image CI
 
 on:
   push:
     paths:
-      - "build/docker/elasticsearch/8.x/**"
-      - ".github/workflows/elasticsearch-docker-8.yml"
+      - "build/docker/elasticsearch/9.x/**"
+      - ".github/workflows/elasticsearch-docker-9.yml"
 
 jobs:
   build:
@@ -39,8 +39,14 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           platforms: linux/amd64,linux/arm64
-      - name: Build custom Elasticsearch 8.x docker image
-        working-directory: build/docker/elasticsearch/8.x
+      - name: Build custom Elasticsearch 9.x docker image
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          VERSION=$(sed -n 's/.*elasticsearch:\([^ ]*\).*/\1/p' Dockerfile)
-          docker buildx build --platform linux/amd64,linux/arm64 --output "type=image,push=true" --file ./Dockerfile . --tag exceptionless/elasticsearch:$VERSION
+          VERSION=$(sed -n 's/.*elasticsearch:\([^ ]*\).*/\1/p' build/docker/elasticsearch/9.x/Dockerfile)
+          IMAGE_SHA=$(git ls-files -- build/docker/elasticsearch/9.x .github/workflows/elasticsearch-docker-9.yml | sort | xargs sha256sum | sha256sum | cut -d " " -f 1)
+          TAGS=(--tag "exceptionless/elasticsearch:$VERSION-sha256-$IMAGE_SHA")
+          if [[ "$GITHUB_REF" == "refs/heads/$DEFAULT_BRANCH" ]]; then
+            TAGS+=(--tag "exceptionless/elasticsearch:$VERSION" --tag "exceptionless/elasticsearch:latest")
+          fi
+          docker buildx build --platform linux/amd64,linux/arm64 --output "type=image,push=true" --file build/docker/elasticsearch/9.x/Dockerfile build/docker/elasticsearch/9.x "${TAGS[@]}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ ENTRYPOINT ["/app/app-docker-entrypoint.sh"]
 
 # completely self-contained
 
-FROM exceptionless/elasticsearch:8.19.15 AS exceptionless
+FROM exceptionless/elasticsearch:9.5.0 AS exceptionless
 
 WORKDIR /app
 COPY --from=job-publish /app/src/Exceptionless.Job/out ./

--- a/build/docker/elasticsearch/9.x/Dockerfile
+++ b/build/docker/elasticsearch/9.x/Dockerfile
@@ -1,0 +1,4 @@
+# https://www.docker.elastic.co/
+FROM docker.elastic.co/elasticsearch/elasticsearch:9.5.0
+
+RUN elasticsearch-plugin install -b mapper-size

--- a/docker/docker-compose.apm.yml
+++ b/docker/docker-compose.apm.yml
@@ -2,7 +2,7 @@ version: "2.2"
 
 services:
   setup:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.5.0
     volumes:
       - certs:/usr/share/elasticsearch/config/certs
     user: "0"
@@ -53,7 +53,7 @@ services:
     depends_on:
       setup:
         condition: service_healthy
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.19.15
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.5.0
     volumes:
       - certs:/usr/share/elasticsearch/config/certs
       - esdata:/usr/share/elasticsearch/data
@@ -98,7 +98,7 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
-    image: docker.elastic.co/kibana/kibana:8.19.15
+    image: docker.elastic.co/kibana/kibana:9.5.0
     volumes:
       - certs:/usr/share/kibana/config/certs
     ports:
@@ -124,7 +124,7 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
-    image: docker.elastic.co/apm/apm-server:8.19.15
+    image: docker.elastic.co/apm/apm-server:9.5.0
     volumes:
       - certs:/usr/share/apm-server/certs
     ports:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -50,7 +50,7 @@ services:
       - appdata:/app/storage
 
   elasticsearch:
-    image: exceptionless/elasticsearch:8.19.15
+    image: exceptionless/elasticsearch:9.5.0
     environment:
       discovery.type: single-node
       xpack.security.enabled: "false"
@@ -59,6 +59,8 @@ services:
       - 9200:9200
       - 9300:9300
     volumes:
+      # Complete the Elasticsearch 8.19 upgrade preflight before reusing this volume with Elasticsearch 9.
+      # See https://exceptionless.com/docs/self-hosting/upgrading-self-hosted-instance
       - esdata7:/usr/share/elasticsearch/data
     healthcheck:
       test:
@@ -74,7 +76,7 @@ services:
   kibana:
     depends_on:
       - elasticsearch
-    image: docker.elastic.co/kibana/kibana:8.19.15
+    image: docker.elastic.co/kibana/kibana:9.5.0
     ports:
       - 5601:5601
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   elasticsearch:
-    image: exceptionless/elasticsearch:8.19.15
+    image: exceptionless/elasticsearch:9.5.0
     environment:
       node.name: elasticsearch
       cluster.name: exceptionless
@@ -11,6 +11,8 @@ services:
     ports:
       - 9200:9200
     volumes:
+      # Complete the Elasticsearch 8.19 upgrade preflight before reusing this volume with Elasticsearch 9.
+      # See https://exceptionless.com/docs/self-hosting/upgrading-self-hosted-instance
       - esdata:/usr/share/elasticsearch/data
     healthcheck:
       test:
@@ -26,7 +28,7 @@ services:
   kibana:
     depends_on:
       - elasticsearch
-    image: docker.elastic.co/kibana/kibana:8.19.15
+    image: docker.elastic.co/kibana/kibana:9.5.0
     environment:
       xpack.security.enabled: "false"
     ports:

--- a/docs/docs/self-hosting/upgrading-self-hosted-instance.md
+++ b/docs/docs/self-hosting/upgrading-self-hosted-instance.md
@@ -8,6 +8,41 @@ title: "Upgrading"
 
 **If you are upgrading from v1 or [v2](https://github.com/exceptionless/Exceptionless/releases/tag/v2.0.0) you will need to upgrade to [v3.0](https://github.com/exceptionless/Exceptionless/releases/tag/v3.0.0) before upgrading to the latest release.**
 
+## Upgrading from v8 to v9
+
+Exceptionless v9 uses Elasticsearch 9. Do not point an Elasticsearch 9 node at an existing data volume until the cluster has been prepared with Elasticsearch 8.19. Elasticsearch 9 can fail to start when incompatible indices created before Elasticsearch 8 remain.
+
+Use this upgrade path for an existing self-hosted installation:
+
+1. Take a current Elasticsearch snapshot or other verified backup and test that it can be restored. Elasticsearch does not support downgrading a data directory after it has been upgraded.
+2. Upgrade Elasticsearch and Kibana to the latest 8.19.x patch release first, using the existing data volume. Do not start Elasticsearch 9 yet.
+3. Stop the Exceptionless app and job services, but leave Elasticsearch and Kibana 8.19 running. This prevents writes while legacy indices are reindexed.
+4. Open Kibana's **Upgrade Assistant** and resolve every critical issue. Reindex every active Exceptionless index created before Elasticsearch 8. Delete only indices you have confirmed are no longer needed; do not mark active Exceptionless indices as read-only.
+5. If this data volume previously ran Elasticsearch 7, temporarily disable the GeoIP downloader while still on Elasticsearch 8.19. Elasticsearch deletes its downloaded `.geoip_databases` system index when this setting is disabled; Exceptionless data is not affected.
+
+   ```bash
+   curl -fsS -X PUT "http://localhost:9200/_cluster/settings" \
+     -H "Content-Type: application/json" \
+     -d '{"persistent":{"ingest.geoip.downloader.enabled":false}}'
+   ```
+
+6. Confirm that the deprecation API reports no critical issues:
+
+   ```bash
+   curl -fsS "http://localhost:9200/_migration/deprecations?pretty"
+   ```
+
+7. Stop Elasticsearch and Kibana 8.19 without deleting their data volume. Update the Elasticsearch and Kibana images to the v9 versions, start them, and verify cluster health before restarting the Exceptionless app and jobs. In Docker Compose, do not run `docker compose down -v` because `-v` deletes the data volume.
+8. After Elasticsearch 9 is healthy, restore the default GeoIP downloader behavior:
+
+   ```bash
+   curl -fsS -X PUT "http://localhost:9200/_cluster/settings" \
+     -H "Content-Type: application/json" \
+     -d '{"persistent":{"ingest.geoip.downloader.enabled":null}}'
+   ```
+
+See Elastic's [prepare-to-upgrade guide](https://www.elastic.co/docs/deploy-manage/upgrade/prepare-to-upgrade) for the supported 8.x to 9.x upgrade requirements and Upgrade Assistant details.
+
 ## Upgrading from v7.1 to v8
 
 We simplified the self hosting process by integrating the UI into the existing app images. As such `exceptionless/ui` docker images are deprecated and we recommend using `exceptionless/app`.

--- a/k8s/elastic-monitor.yaml
+++ b/k8s/elastic-monitor.yaml
@@ -4,7 +4,7 @@ metadata:
   name: elastic-monitor
   namespace: elastic-system
 spec:
-  version: 8.19.15
+  version: 9.5.0
   podDisruptionBudget: {}
   nodeSets:
     - name: main
@@ -228,7 +228,7 @@ metadata:
   name: kibana-monitor
   namespace: elastic-system
 spec:
-  version: 8.19.15
+  version: 9.5.0
   count: 1
   http:
     tls:
@@ -364,7 +364,7 @@ metadata:
   name: fleet-server
   namespace: elastic-system
 spec:
-  version: 8.19.15
+  version: 9.5.0
   kibanaRef:
     name: kibana-monitor
   elasticsearchRefs:
@@ -388,7 +388,7 @@ metadata:
   name: elastic-agent
   namespace: elastic-system
 spec:
-  version: 8.19.15
+  version: 9.5.0
   kibanaRef:
     name: kibana-monitor
   fleetServerRef:

--- a/k8s/ex-dev-elasticsearch.yaml
+++ b/k8s/ex-dev-elasticsearch.yaml
@@ -14,8 +14,8 @@ metadata:
   name: ex-dev
   namespace: ex-dev
 spec:
-  version: 8.19.15
-  image: exceptionless/elasticsearch:8.19.15 # https://github.com/exceptionless/Exceptionless/tree/main/build/docker/elasticsearch
+  version: 9.5.0
+  image: exceptionless/elasticsearch:9.5.0 # https://github.com/exceptionless/Exceptionless/tree/main/build/docker/elasticsearch
   secureSettings:
     - secretName: ex-dev-snapshots
   http:
@@ -68,7 +68,7 @@ metadata:
   name: ex-dev
   namespace: ex-dev
 spec:
-  version: 8.19.15
+  version: 9.5.0
   count: 1
   elasticsearchRef:
     name: ex-dev

--- a/k8s/ex-prod-elasticsearch.yaml
+++ b/k8s/ex-prod-elasticsearch.yaml
@@ -14,8 +14,8 @@ metadata:
   name: ex-prod
   namespace: ex-prod
 spec:
-  version: 8.19.15
-  image: exceptionless/elasticsearch:8.19.15 # https://github.com/exceptionless/Exceptionless/tree/main/build/docker/elasticsearch
+  version: 9.5.0
+  image: exceptionless/elasticsearch:9.5.0 # https://github.com/exceptionless/Exceptionless/tree/main/build/docker/elasticsearch
   monitoring:
     metrics:
       elasticsearchRefs:
@@ -79,7 +79,7 @@ metadata:
   name: ex-prod
   namespace: ex-prod
 spec:
-  version: 8.19.15
+  version: 9.5.0
   count: 1
   elasticsearchRef:
     name: ex-prod

--- a/k8s/exceptionless/values.yaml
+++ b/k8s/exceptionless/values.yaml
@@ -35,7 +35,7 @@ elasticsearch:
   connectionString:
   image:
     repository: exceptionless/elasticsearch
-    tag: 8.19.15
+    tag: 9.5.0
     pullPolicy: IfNotPresent
 
 redis:

--- a/samples/docker-compose.all-in-one.yml
+++ b/samples/docker-compose.all-in-one.yml
@@ -20,7 +20,7 @@ services:
   kibana:
     depends_on:
       - elasticsearch
-    image: docker.elastic.co/kibana/kibana:8.19.15
+    image: docker.elastic.co/kibana/kibana:9.5.0
     ports:
       - 5601:5601
 

--- a/samples/docker-compose.yml
+++ b/samples/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - ex_appdata:/app/storage
 
   elasticsearch:
-    image: exceptionless/elasticsearch:8.19.15
+    image: exceptionless/elasticsearch:9.5.0
     environment:
       discovery.type: single-node
       xpack.security.enabled: "false"
@@ -58,7 +58,7 @@ services:
   kibana:
     depends_on:
       - elasticsearch
-    image: docker.elastic.co/kibana/kibana:8.19.15
+    image: docker.elastic.co/kibana/kibana:9.5.0
     ports:
       - 5601:5601
 

--- a/src/Exceptionless.AppHost/Extensions/ElasticsearchExtensions.cs
+++ b/src/Exceptionless.AppHost/Extensions/ElasticsearchExtensions.cs
@@ -13,7 +13,7 @@ public static class ElasticsearchBuilderExtensions
     private const int KibanaPort = 5601;
 
     /// <summary>
-    /// Adds a Elasticsearch container to the application model. The default image is "docker.elastic.co/elasticsearch/elasticsearch". This version the package defaults to the 8.19.15 tag of the Elasticsearch container image
+    /// Adds a Elasticsearch container to the application model. The default image is "docker.elastic.co/elasticsearch/elasticsearch". This version the package defaults to the 9.5.0 tag of the Elasticsearch container image
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
@@ -60,7 +60,11 @@ public static class ElasticsearchBuilderExtensions
             .PublishAsConnectionString();
     }
 
-    public static IResourceBuilder<ElasticsearchResource> WithKibana(this IResourceBuilder<ElasticsearchResource> builder, Action<IResourceBuilder<KibanaResource>>? configureContainer = null, string? containerName = null)
+    public static IResourceBuilder<ElasticsearchResource> WithKibana(
+        this IResourceBuilder<ElasticsearchResource> builder,
+        Action<IResourceBuilder<KibanaResource>>? configureContainer = null,
+        string? containerName = null,
+        int? port = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
@@ -79,7 +83,7 @@ public static class ElasticsearchBuilderExtensions
             var resourceBuilder = builder.ApplicationBuilder.AddResource(resource)
                                       .WithImage(ElasticsearchContainerImageTags.KibanaImage, ElasticsearchContainerImageTags.Tag)
                                       .WithImageRegistry(ElasticsearchContainerImageTags.KibanaRegistry)
-                                      .WithHttpEndpoint(targetPort: KibanaPort, name: containerName)
+                                      .WithHttpEndpoint(targetPort: KibanaPort, port: port, name: containerName)
                                       .WithUrlForEndpoint(containerName, u => u.DisplayText = "Kibana")
                                       .WithEnvironment("xpack.security.enabled", "false")
                                       .WithEnvironment(ctx =>
@@ -121,7 +125,7 @@ internal static class ElasticsearchContainerImageTags
     public const string Image = "exceptionless/elasticsearch";
     public const string KibanaRegistry = "docker.elastic.co";
     public const string KibanaImage = "kibana/kibana";
-    public const string Tag = "8.19.15";
+    public const string Tag = "9.5.0";
 }
 
 internal sealed class ElasticsearchConnectionHealthCheck(Func<string?> connectionStringFactory) : IHealthCheck
@@ -134,9 +138,17 @@ internal sealed class ElasticsearchConnectionHealthCheck(Func<string?> connectio
 
         using var settings = new ElasticsearchClientSettings(new Uri(connectionString));
         var client = new ElasticsearchClient(settings);
-        var response = await client.PingAsync(cancellationToken);
-        return response.IsValidResponse
-            ? HealthCheckResult.Healthy()
-            : new HealthCheckResult(context.Registration.FailureStatus, $"Elasticsearch ping failed: {response.DebugInformation}");
+        var response = await client.Cluster.HealthAsync(
+            request => request.WaitForStatus(Elastic.Clients.Elasticsearch.HealthStatus.Yellow),
+            cancellationToken);
+        bool isReady = response.IsValidResponse
+            && !response.TimedOut
+            && response.Status is Elastic.Clients.Elasticsearch.HealthStatus.Yellow or Elastic.Clients.Elasticsearch.HealthStatus.Green;
+        if (isReady)
+            return HealthCheckResult.Healthy();
+
+        return new HealthCheckResult(
+            context.Registration.FailureStatus,
+            $"Elasticsearch cluster health check failed. Timed out: {response.TimedOut}; status: {response.Status}. {response.DebugInformation}");
     }
 }

--- a/src/Exceptionless.AppHost/Program.cs
+++ b/src/Exceptionless.AppHost/Program.cs
@@ -9,6 +9,13 @@ var builder = DistributedApplication.CreateBuilder(args);
 bool servicesOnly = HasArgument("--services-only");
 bool ciE2E = HasArgument("--ci-e2e");
 bool includeDevTools = !ciE2E;
+int elasticsearchPort = GetPort("Elasticsearch:Port", 9200);
+string elasticsearchImageTag = builder.Configuration["Elasticsearch:ImageTag"] ?? ElasticsearchContainerImageTags.Tag;
+string kibanaImageTag = builder.Configuration["Elasticsearch:KibanaImageTag"] ?? ElasticsearchContainerImageTags.Tag;
+string elasticsearchContainerName = builder.Configuration["Elasticsearch:ContainerName"] ?? "Exceptionless-Elasticsearch";
+string elasticsearchDataVolume = builder.Configuration["Elasticsearch:DataVolume"] ?? "exceptionless.data.v1";
+string kibanaContainerName = builder.Configuration["Elasticsearch:KibanaContainerName"] ?? "Exceptionless-Kibana";
+int kibanaPort = GetPort("Elasticsearch:KibanaPort", 5601);
 int oldAppHttpPort = worktreePorts?.OldAppHttp ?? 7120;
 int oldAppPort = worktreePorts?.OldAppHttps ?? 7121;
 int oldAppLiveReloadPort = worktreePorts?.OldAppLiveReload ?? 35729;
@@ -19,8 +26,9 @@ const int DefaultApiHttpsPort = 7111;
 string exceptionlessServerUrl = worktreePorts?.ApiHttpsUrl ?? $"https://api-ex.dev.localhost:{DefaultApiHttpsPort}";
 const string SharedEmailConnectionString = "smtp://localhost:1026";
 
-var elastic = builder.AddElasticsearch("Elasticsearch", port: 9200)
-    .WithDataVolume("exceptionless.data.v1")
+var elastic = builder.AddElasticsearch("Elasticsearch", port: elasticsearchPort)
+    .WithImageTag(elasticsearchImageTag)
+    .WithDataVolume(elasticsearchDataVolume)
     .WithEndpointProxySupport(false);
 
 var storage = builder.AddAzureStorage("Storage")
@@ -65,15 +73,17 @@ var mail = builder.AddContainer("Mail", "axllent/mailpit")
 var ownedElastic = elastic;
 elastic = ownedElastic
     .WithLifetime(ContainerLifetime.Persistent)
-    .WithContainerName("Exceptionless-Elasticsearch");
+    .WithContainerName(elasticsearchContainerName);
 
 if (!servicesOnly && includeDevTools)
 {
     elastic = elastic.WithKibana(b => b
+        .WithImageTag(kibanaImageTag)
         .WithLifetime(ContainerLifetime.Persistent)
         .WithEndpointProxySupport(false)
-        .WithContainerName("Exceptionless-Kibana")
-        .WithParentRelationship(ownedElastic));
+        .WithContainerName(kibanaContainerName)
+        .WithParentRelationship(ownedElastic),
+        port: kibanaPort);
 }
 
 var ownedCache = cache;
@@ -231,3 +241,15 @@ if (!servicesOnly)
 await builder.Build().RunAsync();
 
 bool HasArgument(string name) => args.Any(arg => StringComparer.OrdinalIgnoreCase.Equals(arg, name) || StringComparer.OrdinalIgnoreCase.Equals(arg, name.TrimStart('-')));
+
+int GetPort(string key, int defaultValue)
+{
+    string? value = builder.Configuration[key];
+    if (String.IsNullOrWhiteSpace(value))
+        return defaultValue;
+
+    if (!Int32.TryParse(value, out int port) || port is < 1 or > 65535)
+        throw new InvalidOperationException($"Configuration value '{key}' must be a valid TCP port.");
+
+    return port;
+}

--- a/tests/Exceptionless.Tests/AppHostConfigurationTests.cs
+++ b/tests/Exceptionless.Tests/AppHostConfigurationTests.cs
@@ -1,0 +1,30 @@
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Testing;
+using Xunit;
+
+namespace Exceptionless.Tests;
+
+public class AppHostConfigurationTests
+{
+    [Fact]
+    public async Task CreateAsync_WithSeparateElasticsearchAndKibanaOverrides_UsesIndependentImageTags()
+    {
+        const string elasticsearchImageTag = "9.5.0-sha256-candidate";
+        const string kibanaImageTag = "9.5.0";
+        var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.Exceptionless_AppHost>(
+            [
+                $"--Elasticsearch:ImageTag={elasticsearchImageTag}",
+                $"--Elasticsearch:KibanaImageTag={kibanaImageTag}"
+            ],
+            TestContext.Current.CancellationToken);
+
+        var elasticsearch = Assert.Single(appHost.Resources.OfType<ElasticsearchResource>());
+        var kibana = Assert.Single(appHost.Resources.OfType<KibanaResource>());
+        var elasticsearchImage = Assert.Single(elasticsearch.Annotations.OfType<ContainerImageAnnotation>());
+        var kibanaImage = Assert.Single(kibana.Annotations.OfType<ContainerImageAnnotation>());
+
+        Assert.Equal(elasticsearchImageTag, elasticsearchImage.Tag);
+        Assert.Equal(kibanaImageTag, kibanaImage.Tag);
+    }
+}

--- a/tests/Exceptionless.Tests/AppWebHostFactory.cs
+++ b/tests/Exceptionless.Tests/AppWebHostFactory.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Net;
+using System.Text.Json;
 using Aspire.Hosting;
 using Aspire.Hosting.Testing;
 using Exceptionless.Core;
@@ -21,7 +22,7 @@ namespace Exceptionless.Tests;
 
 public class AppWebHostFactory : WebApplicationFactory<Exceptionless.Web.Program>, IAsyncLifetime
 {
-    private const string SharedElasticsearchUrl = "http://localhost:9200";
+    private static readonly string SharedElasticsearchUrl = GetSharedElasticsearchUrl();
     private static readonly TimeSpan SharedElasticsearchStartupTimeout = TimeSpan.FromMinutes(3);
     private static int s_counter = -1;
     private static readonly Lazy<Task<DistributedApplication>> s_sharedAppHost = new(StartSharedAppHostAsync, LazyThreadSafetyMode.ExecutionAndPublication);
@@ -58,20 +59,38 @@ public class AppWebHostFactory : WebApplicationFactory<Exceptionless.Web.Program
         return app;
     }
 
+    private static string GetSharedElasticsearchUrl()
+    {
+        const int defaultPort = 9200;
+        string? configuredPort = Environment.GetEnvironmentVariable("Elasticsearch__Port");
+        if (String.IsNullOrWhiteSpace(configuredPort))
+            return $"http://localhost:{defaultPort}";
+
+        if (!Int32.TryParse(configuredPort, out int port) || port is < 1 or > 65535)
+            throw new InvalidOperationException("Environment variable 'Elasticsearch__Port' must be a valid TCP port.");
+
+        return $"http://localhost:{port}";
+    }
+
     private static async Task WaitForElasticsearchAsync(Uri elasticsearchUri)
     {
-        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(1) };
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
         var deadline = TimeProvider.System.GetUtcNow() + SharedElasticsearchStartupTimeout;
+        var healthUri = new Uri(elasticsearchUri, "/_cluster/health?wait_for_status=yellow&timeout=1s");
 
         while (TimeProvider.System.GetUtcNow() < deadline)
         {
             try
             {
-                using var response = await client.GetAsync(elasticsearchUri);
-                if (response.StatusCode == HttpStatusCode.OK)
+                using var response = await client.GetAsync(healthUri);
+                using var document = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+                if (IsElasticsearchReady(response.StatusCode, document.RootElement))
                     return;
             }
             catch (HttpRequestException)
+            {
+            }
+            catch (JsonException)
             {
             }
             catch (TaskCanceledException)
@@ -82,6 +101,20 @@ public class AppWebHostFactory : WebApplicationFactory<Exceptionless.Web.Program
         }
 
         throw new TimeoutException("Timed out waiting for the shared Elasticsearch container to be ready.");
+    }
+
+    internal static bool IsElasticsearchReady(HttpStatusCode statusCode, JsonElement health)
+    {
+        if (statusCode != HttpStatusCode.OK)
+            return false;
+
+        bool requestCompleted = health.TryGetProperty("timed_out", out var timedOut)
+            && timedOut.ValueKind == JsonValueKind.False;
+        bool clusterReady = health.TryGetProperty("status", out var status)
+            && status.ValueKind == JsonValueKind.String
+            && status.GetString() is "yellow" or "green";
+
+        return requestCompleted && clusterReady;
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/tests/Exceptionless.Tests/AppWebHostFactoryTests.cs
+++ b/tests/Exceptionless.Tests/AppWebHostFactoryTests.cs
@@ -1,4 +1,6 @@
+using System.Net;
 using System.Text;
+using System.Text.Json;
 using Foundatio.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -7,6 +9,22 @@ namespace Exceptionless.Tests;
 
 public sealed class AppWebHostFactoryTests
 {
+    [Theory]
+    [InlineData(HttpStatusCode.OK, """{"timed_out":false,"status":"yellow"}""", true)]
+    [InlineData(HttpStatusCode.OK, """{"timed_out":false,"status":"green"}""", true)]
+    [InlineData(HttpStatusCode.OK, """{"timed_out":true,"status":"yellow"}""", false)]
+    [InlineData(HttpStatusCode.OK, """{"timed_out":false,"status":"red"}""", false)]
+    [InlineData(HttpStatusCode.OK, """{"timed_out":false,"status":1}""", false)]
+    [InlineData(HttpStatusCode.ServiceUnavailable, """{"timed_out":false,"status":"yellow"}""", false)]
+    public void IsElasticsearchReady_ClusterHealthResponse_ReturnsExpectedResult(HttpStatusCode statusCode, string json, bool expected)
+    {
+        using var document = JsonDocument.Parse(json);
+
+        bool isReady = AppWebHostFactory.IsElasticsearchReady(statusCode, document.RootElement);
+
+        Assert.Equal(expected, isReady);
+    }
+
     [Fact]
     public async Task ConfigureWebHost_MultipleFactories_IsolatesFileStorageByAppScope()
     {


### PR DESCRIPTION
## Summary

- Port Elasticsearch 9 compatibility changes from #2416 onto current `main`
- Update active Elasticsearch, Kibana, APM, Docker Compose, samples, AppHost, Helm, and ECK references to 9.5.0
- Preserve the 8.19.15 image as the supported major-upgrade source
- Add the Elasticsearch 9.5.0 custom image/workflow and deterministic candidate-image handling
- Keep Upgrade Assistant guidance for pre-8 indices and verified live-cluster remediation

## Upgrade Assistant report

A local 7.17.28 -> 8.19.15 -> 9.5.0 rehearsal was performed using Exceptionless-style indices:

- `organizations-v1`
- `projects-v1`
- `stacks-v1`
- `events-v1-*`
- `users-v1`
- `webhooks-v1`
- `migrations`

The 8.19 Upgrade Assistant reported critical `reindex_required` findings for indices created under 7.x. Starting 9.5.0 against the unreindexed volume failed as expected, requiring the old indices to be reindexed or archived/read-only before the upgrade.

Fresh indices created directly on 9.5.0 produced no migration/deprecation findings.

## Validation

- Docker Compose configuration validation passed
- YAML parsing passed
- AppHost build passed
- Test project build passed
- AppHost configuration test passed
- Elasticsearch readiness tests passed (6)
- `git diff --check` passed

## Notes

No speculative index-schema changes or application migration behavior were added. Existing 8.19 -> 9.x Upgrade Assistant remediation remains required for deployed data volumes.
