### PR TITLE
Reduce noisy change events

### DIFF
--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/OrganizationMaintenanceWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/OrganizationMaintenanceWorkItemHandler.cs
@@ -56,7 +56,7 @@ public class OrganizationMaintenanceWorkItemHandler : WorkItemHandlerBase
             }
 
             if (wi.UpgradePlans || wi.RemoveOldUsageStats)
-                await _organizationRepository.SaveAsync(results.Documents);
+                await _organizationRepository.SaveAsync(results.Documents, o => o.Notifications(wi.UpgradePlans));
 
             // Sleep so we are not hammering the backend.
             await Task.Delay(TimeSpan.FromSeconds(2.5), _timeProvider);

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/ProjectMaintenanceWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/ProjectMaintenanceWorkItemHandler.cs
@@ -58,7 +58,7 @@ public class ProjectMaintenanceWorkItemHandler : WorkItemHandlerBase
             }
 
             if (workItem.UpdateDefaultBotList || workItem.IncrementConfigurationVersion || workItem.RemoveOldUsageStats)
-                await _projectRepository.SaveAsync(results.Documents);
+                await _projectRepository.SaveAsync(results.Documents, o => o.Notifications(workItem.UpdateDefaultBotList || workItem.IncrementConfigurationVersion));
 
             // Sleep so we are not hammering the backend.
             await Task.Delay(TimeSpan.FromSeconds(2.5), _timeProvider);

--- a/src/Exceptionless.Core/Migrations/UpdateEventUsage.cs
+++ b/src/Exceptionless.Core/Migrations/UpdateEventUsage.cs
@@ -70,6 +70,9 @@ public sealed class UpdateEventUsage : MigrationBase
                 using var _ = _logger.BeginScope(new ExceptionlessState().Organization(organization.Id));
                 try
                 {
+                    int effectiveMonthlyLimit = organization.GetMaxEventsPerMonthWithBonus(_timeProvider);
+                    var currentMonthUtc = _timeProvider.GetUtcNow().UtcDateTime.StartOfMonth();
+                    int currentMonthTotalBeforeRepair = organization.Usage.FirstOrDefault(u => u.Date == currentMonthUtc)?.Total ?? 0;
                     var result = await _eventRepository.CountAsync(q => q.Organization(organization.Id).AggregationsExpression("date:date~1M"));
                     var dateAggs = result.Aggregations.DateHistogram("date_date");
                     if (dateAggs?.Buckets is null)
@@ -86,7 +89,11 @@ public sealed class UpdateEventUsage : MigrationBase
                         }
                     }
 
-                    await _organizationRepository.SaveAsync(organization, o => o.Notifications(false));
+                    int currentMonthTotalAfterRepair = organization.Usage.FirstOrDefault(u => u.Date == currentMonthUtc)?.Total ?? 0;
+                    bool monthlyOverageStarted = effectiveMonthlyLimit >= 0
+                        && currentMonthTotalBeforeRepair < effectiveMonthlyLimit
+                        && currentMonthTotalAfterRepair >= effectiveMonthlyLimit;
+                    await _organizationRepository.SaveAsync(organization, o => o.Notifications(monthlyOverageStarted));
                     await UpdateProjectsUsageAsync(context, organization);
                     processed++;
                     await context.Lock.RenewAsync();

--- a/src/Exceptionless.Core/Migrations/UpdateEventUsage.cs
+++ b/src/Exceptionless.Core/Migrations/UpdateEventUsage.cs
@@ -86,7 +86,7 @@ public sealed class UpdateEventUsage : MigrationBase
                         }
                     }
 
-                    await _organizationRepository.SaveAsync(organization);
+                    await _organizationRepository.SaveAsync(organization, o => o.Notifications(false));
                     await UpdateProjectsUsageAsync(context, organization);
                     processed++;
                     await context.Lock.RenewAsync();
@@ -142,7 +142,7 @@ public sealed class UpdateEventUsage : MigrationBase
                             usage.Limit = organization.GetMaxEventsPerMonthWithBonus(_timeProvider);
                     }
 
-                    await _projectRepository.SaveAsync(project);
+                    await _projectRepository.SaveAsync(project, o => o.Notifications(false));
                 }
                 catch (Exception ex)
                 {

--- a/src/Exceptionless.Core/Services/UsageService.cs
+++ b/src/Exceptionless.Core/Services/UsageService.cs
@@ -69,6 +69,9 @@ public class UsageService
         {
             if (organizationIdsValue.HasValue)
             {
+                foreach (string? organizationId in organizationIdsValue.Value)
+                    await PublishPendingHourlyOverageAsync(bucketUtc, organizationId);
+
                 // Should we wait to remove this in case there is a failure? We should just remove the organization id once processed.
                 await _cache.RemoveAsync(GetOrganizationSetKey(bucketUtc));
 
@@ -268,7 +271,8 @@ public class UsageService
         {
             await _cache.SetAsync(GetThrottledKey(utcNow, modified.Id), true, TimeSpan.FromMinutes(5));
             await _cache.SetAsync(GetHourlyThrottleTransitionKey(utcNow, modified.Id), true, TimeSpan.FromHours(8));
-            await _messagePublisher.PublishAsync(new PlanOverage { OrganizationId = modified.Id, IsHourly = true });
+            await _cache.SetAsync(GetHourlyOveragePendingKey(utcNow, modified.Id), true, TimeSpan.FromHours(8));
+            await PublishPendingHourlyOverageAsync(utcNow, modified.Id);
         }
     }
 
@@ -461,8 +465,20 @@ public class UsageService
             // org will be throttled during the current bucket of time
             await _cache.SetAsync(GetThrottledKey(utcNow, organizationId), true, TimeSpan.FromMinutes(5));
             await _cache.SetAsync(GetHourlyThrottleTransitionKey(utcNow, organizationId), true, TimeSpan.FromHours(8));
-            await _messagePublisher.PublishAsync(new PlanOverage { OrganizationId = organizationId, IsHourly = true });
+            await _cache.SetAsync(GetHourlyOveragePendingKey(utcNow, organizationId), true, TimeSpan.FromHours(8));
+            await PublishPendingHourlyOverageAsync(utcNow, organizationId);
         }
+    }
+
+    private async Task PublishPendingHourlyOverageAsync(DateTime utcTime, string organizationId)
+    {
+        string pendingKey = GetHourlyOveragePendingKey(utcTime, organizationId);
+        var pending = await _cache.GetAsync<bool>(pendingKey);
+        if (!pending.HasValue || !pending.Value)
+            return;
+
+        await _messagePublisher.PublishAsync(new PlanOverage { OrganizationId = organizationId, IsHourly = true });
+        await _cache.RemoveAsync(pendingKey);
     }
 
     public async Task IncrementBlockedAsync(string organizationId, string? projectId, int eventCount = 1)
@@ -633,6 +649,12 @@ public class UsageService
     {
         int bucket = GetCurrentBucket(utcTime);
         return $"usage:{bucket}:{organizationId}:throttled-transition";
+    }
+
+    private string GetHourlyOveragePendingKey(DateTime utcTime, string organizationId)
+    {
+        int bucket = GetCurrentBucket(utcTime);
+        return $"usage:{bucket}:{organizationId}:hourly-overage-pending";
     }
 
     private string GetProjectSetKey(DateTime utcTime)

--- a/src/Exceptionless.Core/Services/UsageService.cs
+++ b/src/Exceptionless.Core/Services/UsageService.cs
@@ -91,6 +91,16 @@ public class UsageService
                     if (hasIngestion)
                         organization.LastEventDateUtc = _timeProvider.GetUtcNow().UtcDateTime;
 
+                    var currentMonthUtc = bucketUtc.StartOfMonth();
+                    var previousMonthUtc = currentMonthUtc.AddMonths(-1);
+                    bool hasCurrentMonthUsage = organization.Usage.Any(u => u.Date.Year == currentMonthUtc.Year && u.Date.Month == currentMonthUtc.Month);
+                    var previousMonthUsage = organization.Usage.FirstOrDefault(u => u.Date.Year == previousMonthUtc.Year && u.Date.Month == previousMonthUtc.Month);
+                    bool monthlyOverageCleared = !hasCurrentMonthUsage && previousMonthUsage is { Limit: > 0 } && previousMonthUsage.Total >= previousMonthUsage.Limit;
+                    int bucketLimit = GetBucketEventLimit(organization.GetMaxEventsPerMonthWithBonus(_timeProvider), bucketUtc);
+                    bool hourlyThrottleCleared = hourlyThrottleTransition is { HasValue: true } transition
+                        ? transition.Value
+                        : bucketLimit >= 0 && bucketTotal is { HasValue: true } total && total.Value >= bucketLimit;
+
                     var usage = organization.GetUsage(bucketUtc, _timeProvider);
                     usage.Limit = organization.GetMaxEventsPerMonthWithBonus(_timeProvider);
                     usage.Total += bucketTotal?.Value ?? 0;
@@ -119,8 +129,8 @@ public class UsageService
                     });
 
                     await _cache.SetAsync(GetTotalCacheKey(utcNow, organizationId), usage.Total, TimeSpan.FromHours(8));
-                    // Routine usage updates stay silent, but clients need one refresh when an hourly throttle clears.
-                    await _organizationRepository.SaveAsync(organization, o => o.Notifications(hourlyThrottleTransition?.Value ?? false));
+                    // Routine usage updates stay silent, but clients need one refresh when an overage clears.
+                    await _organizationRepository.SaveAsync(organization, o => o.Notifications(hourlyThrottleCleared || monthlyOverageCleared));
                 }
             }
 
@@ -534,10 +544,14 @@ public class UsageService
 
     private int GetBucketEventLimit(int maxEventsPerMonth)
     {
+        return GetBucketEventLimit(maxEventsPerMonth, _timeProvider.GetUtcNow().UtcDateTime);
+    }
+
+    private int GetBucketEventLimit(int maxEventsPerMonth, DateTime utcNow)
+    {
         if (maxEventsPerMonth < 5000)
             return maxEventsPerMonth;
 
-        var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
         var timeLeftInMonth = utcNow.EndOfMonth() - utcNow;
         if (timeLeftInMonth < TimeSpan.FromDays(1))
             return maxEventsPerMonth;

--- a/src/Exceptionless.Core/Services/UsageService.cs
+++ b/src/Exceptionless.Core/Services/UsageService.cs
@@ -117,7 +117,8 @@ public class UsageService
                     });
 
                     await _cache.SetAsync(GetTotalCacheKey(utcNow, organizationId), usage.Total, TimeSpan.FromHours(8));
-                    await _organizationRepository.SaveAsync(organization);
+                    // Usage counters and last-event timestamps are operational updates, not user-facing entity changes.
+                    await _organizationRepository.SaveAsync(organization, o => o.Notifications(false));
                 }
             }
 
@@ -204,7 +205,8 @@ public class UsageService
 
                     await _cache.SetAsync(GetTotalCacheKey(utcNow, project.OrganizationId, projectId), usage.Total, TimeSpan.FromHours(8));
 
-                    await _projectRepository.SaveAsync(project);
+                    // Project configuration changes have their own save path and should remain the source of ProjectChanged messages.
+                    await _projectRepository.SaveAsync(project, o => o.Notifications(false));
                 }
             }
 

--- a/src/Exceptionless.Core/Services/UsageService.cs
+++ b/src/Exceptionless.Core/Services/UsageService.cs
@@ -85,6 +85,7 @@ public class UsageService
                     var bucketDiscarded = await _cache.GetAsync<int>(GetBucketDiscardedCacheKey(bucketUtc, organizationId));
                     var bucketTooBig = await _cache.GetAsync<int>(GetBucketTooBigCacheKey(bucketUtc, organizationId));
                     var bucketDeleted = await _cache.GetAsync<int>(GetBucketDeletedCacheKey(bucketUtc, organizationId));
+                    var hourlyThrottleTransition = await _cache.GetAsync<bool>(GetHourlyThrottleTransitionKey(bucketUtc, organizationId));
 
                     bool hasIngestion = (bucketTotal?.Value ?? 0) > 0 || (bucketBlocked?.Value ?? 0) > 0 || (bucketDiscarded?.Value ?? 0) > 0 || (bucketTooBig?.Value ?? 0) > 0;
                     if (hasIngestion)
@@ -113,12 +114,13 @@ public class UsageService
                         GetBucketDiscardedCacheKey(bucketUtc, organizationId),
                         GetBucketTooBigCacheKey(bucketUtc, organizationId),
                         GetBucketDeletedCacheKey(bucketUtc, organizationId),
-                        GetThrottledKey(bucketUtc, organizationId)
+                        GetThrottledKey(bucketUtc, organizationId),
+                        GetHourlyThrottleTransitionKey(bucketUtc, organizationId)
                     });
 
                     await _cache.SetAsync(GetTotalCacheKey(utcNow, organizationId), usage.Total, TimeSpan.FromHours(8));
-                    // Usage counters and last-event timestamps are operational updates, not user-facing entity changes.
-                    await _organizationRepository.SaveAsync(organization, o => o.Notifications(false));
+                    // Routine usage updates stay silent, but clients need one refresh when an hourly throttle clears.
+                    await _organizationRepository.SaveAsync(organization, o => o.Notifications(hourlyThrottleTransition?.Value ?? false));
                 }
             }
 
@@ -260,6 +262,7 @@ public class UsageService
         if (bucketTotal.Value >= bucketLimit)
         {
             await _cache.SetAsync(GetThrottledKey(utcNow, modified.Id), true, TimeSpan.FromMinutes(5));
+            await _cache.SetAsync(GetHourlyThrottleTransitionKey(utcNow, modified.Id), true, TimeSpan.FromHours(8));
             await _messagePublisher.PublishAsync(new PlanOverage { OrganizationId = modified.Id, IsHourly = true });
         }
     }
@@ -452,6 +455,7 @@ public class UsageService
         {
             // org will be throttled during the current bucket of time
             await _cache.SetAsync(GetThrottledKey(utcNow, organizationId), true, TimeSpan.FromMinutes(5));
+            await _cache.SetAsync(GetHourlyThrottleTransitionKey(utcNow, organizationId), true, TimeSpan.FromHours(8));
             await _messagePublisher.PublishAsync(new PlanOverage { OrganizationId = organizationId, IsHourly = true });
         }
     }
@@ -614,6 +618,12 @@ public class UsageService
     {
         int bucket = GetCurrentBucket(utcTime);
         return $"usage:{bucket}:{organizationId}:throttled";
+    }
+
+    private string GetHourlyThrottleTransitionKey(DateTime utcTime, string organizationId)
+    {
+        int bucket = GetCurrentBucket(utcTime);
+        return $"usage:{bucket}:{organizationId}:throttled-transition";
     }
 
     private string GetProjectSetKey(DateTime utcTime)

--- a/src/Exceptionless.Core/Services/UsageService.cs
+++ b/src/Exceptionless.Core/Services/UsageService.cs
@@ -91,11 +91,6 @@ public class UsageService
                     if (hasIngestion)
                         organization.LastEventDateUtc = _timeProvider.GetUtcNow().UtcDateTime;
 
-                    var currentMonthUtc = bucketUtc.StartOfMonth();
-                    var previousMonthUtc = currentMonthUtc.AddMonths(-1);
-                    bool hasCurrentMonthUsage = organization.Usage.Any(u => u.Date.Year == currentMonthUtc.Year && u.Date.Month == currentMonthUtc.Month);
-                    var previousMonthUsage = organization.Usage.FirstOrDefault(u => u.Date.Year == previousMonthUtc.Year && u.Date.Month == previousMonthUtc.Month);
-                    bool monthlyOverageCleared = !hasCurrentMonthUsage && previousMonthUsage is { Limit: > 0 } && previousMonthUsage.Total >= previousMonthUsage.Limit;
                     int bucketLimit = GetBucketEventLimit(organization.GetMaxEventsPerMonthWithBonus(_timeProvider), bucketUtc);
                     bool hourlyThrottleCleared = hourlyThrottleTransition is { HasValue: true } transition
                         ? transition.Value
@@ -129,8 +124,8 @@ public class UsageService
                     });
 
                     await _cache.SetAsync(GetTotalCacheKey(utcNow, organizationId), usage.Total, TimeSpan.FromHours(8));
-                    // Routine usage updates stay silent, but clients need one refresh when an overage clears.
-                    await _organizationRepository.SaveAsync(organization, o => o.Notifications(hourlyThrottleCleared || monthlyOverageCleared));
+                    // Routine usage updates stay silent, but clients need one refresh when hourly throttling clears.
+                    await _organizationRepository.SaveAsync(organization, o => o.Notifications(hourlyThrottleCleared));
                 }
             }
 

--- a/src/Exceptionless.Core/Services/UsageService.cs
+++ b/src/Exceptionless.Core/Services/UsageService.cs
@@ -259,8 +259,8 @@ public class UsageService
 
         if (bucketTotal.Value >= bucketLimit)
         {
-            await _messagePublisher.PublishAsync(new PlanOverage { OrganizationId = modified.Id, IsHourly = true });
             await _cache.SetAsync(GetThrottledKey(utcNow, modified.Id), true, TimeSpan.FromMinutes(5));
+            await _messagePublisher.PublishAsync(new PlanOverage { OrganizationId = modified.Id, IsHourly = true });
         }
     }
 
@@ -451,8 +451,8 @@ public class UsageService
         if (bucketTotal >= bucketLimit && bucketTotal - bucketLimit < eventCount)
         {
             // org will be throttled during the current bucket of time
-            await _messagePublisher.PublishAsync(new PlanOverage { OrganizationId = organizationId, IsHourly = true });
             await _cache.SetAsync(GetThrottledKey(utcNow, organizationId), true, TimeSpan.FromMinutes(5));
+            await _messagePublisher.PublishAsync(new PlanOverage { OrganizationId = organizationId, IsHourly = true });
         }
     }
 

--- a/src/Exceptionless.Web/Api/Handlers/OrganizationHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/OrganizationHandler.cs
@@ -929,6 +929,7 @@ public class OrganizationHandler(
             currentUsage.Discarded = realTimeUsage.CurrentUsage.Discarded;
             currentUsage.TooBig = realTimeUsage.CurrentUsage.TooBig;
             currentUsage.Deleted = realTimeUsage.CurrentUsage.Deleted;
+            viewOrganization.IsOverMonthlyLimit = currentUsage.Limit >= 0 && currentUsage.Total >= currentUsage.Limit;
 
             var currentHourUsage = viewOrganization.GetCurrentHourlyUsage(timeProvider);
             currentHourUsage.Total = realTimeUsage.CurrentHourUsage.Total;

--- a/src/Exceptionless.Web/Api/Handlers/OrganizationHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/OrganizationHandler.cs
@@ -923,7 +923,7 @@ public class OrganizationHandler(
             viewOrganization.TrimUsage(timeProvider);
 
             var currentUsage = viewOrganization.GetCurrentUsage(timeProvider);
-            currentUsage.Limit = realTimeUsage.CurrentUsage.Limit;
+            currentUsage.Limit = viewOrganization.GetMaxEventsPerMonthWithBonus(timeProvider);
             currentUsage.Total = realTimeUsage.CurrentUsage.Total;
             currentUsage.Blocked = realTimeUsage.CurrentUsage.Blocked;
             currentUsage.Discarded = realTimeUsage.CurrentUsage.Discarded;

--- a/src/Exceptionless.Web/ClientApp.angular/app/organization/manage/manage.tpl.html
+++ b/src/Exceptionless.Web/ClientApp.angular/app/organization/manage/manage.tpl.html
@@ -2,7 +2,7 @@
 
 <div
     class="hbox hbox-auto-xs hbox-auto-sm"
-    refresh-on="OrganizationChanged"
+    refresh-on="OrganizationChanged UsageChanged"
     refresh-action="vm.get(data)"
     refresh-debounce="5000"
 >

--- a/src/Exceptionless.Web/ClientApp.angular/app/project/manage/manage.tpl.html
+++ b/src/Exceptionless.Web/ClientApp.angular/app/project/manage/manage.tpl.html
@@ -2,7 +2,7 @@
 
 <div
     class="hbox hbox-auto-xs hbox-auto-sm"
-    refresh-on="ProjectChanged"
+    refresh-on="ProjectChanged UsageChanged"
     refresh-action="vm.get(data)"
     refresh-throttle="10000"
 >

--- a/src/Exceptionless.Web/ClientApp.angular/components/organization/organization-service.js
+++ b/src/Exceptionless.Web/ClientApp.angular/components/organization/organization-service.js
@@ -3,14 +3,30 @@
 
     angular
         .module("exceptionless.organization", ["restangular"])
-        .factory("organizationService", function ($cacheFactory, $rootScope, objectIDService, Restangular) {
+        .factory("organizationService", function ($cacheFactory, $interval, $rootScope, objectIDService, Restangular) {
             var _cache = $cacheFactory("http:organization");
+            var _usageMonth = getUsageMonth();
             $rootScope.$on("cache:clear", _cache.removeAll);
             $rootScope.$on("cache:clear-organization", _cache.removeAll);
             $rootScope.$on("auth:logout", _cache.removeAll);
             $rootScope.$on("OrganizationChanged", _cache.removeAll);
             $rootScope.$on("ProjectChanged", _cache.removeAll);
             $rootScope.$on("PlanOverage", _cache.removeAll);
+
+            $interval(function () {
+                var usageMonth = getUsageMonth();
+                if (usageMonth === _usageMonth) {
+                    return;
+                }
+
+                _usageMonth = usageMonth;
+                $rootScope.$broadcast("OrganizationChanged");
+            }, 60000);
+
+            function getUsageMonth() {
+                var now = new Date();
+                return now.getUTCFullYear() * 12 + now.getUTCMonth();
+            }
 
             $rootScope.$on("StackChanged", function ($event, data) {
                 if (data.added) {

--- a/src/Exceptionless.Web/ClientApp.angular/components/organization/organization-service.js
+++ b/src/Exceptionless.Web/ClientApp.angular/components/organization/organization-service.js
@@ -10,6 +10,7 @@
             $rootScope.$on("auth:logout", _cache.removeAll);
             $rootScope.$on("OrganizationChanged", _cache.removeAll);
             $rootScope.$on("ProjectChanged", _cache.removeAll);
+            $rootScope.$on("PlanOverage", _cache.removeAll);
 
             $rootScope.$on("StackChanged", function ($event, data) {
                 if (data.added) {

--- a/src/Exceptionless.Web/ClientApp.angular/components/organization/organization-service.js
+++ b/src/Exceptionless.Web/ClientApp.angular/components/organization/organization-service.js
@@ -12,6 +12,7 @@
             $rootScope.$on("OrganizationChanged", _cache.removeAll);
             $rootScope.$on("ProjectChanged", _cache.removeAll);
             $rootScope.$on("PlanOverage", _cache.removeAll);
+            $rootScope.$on("UsageChanged", _cache.removeAll);
 
             $interval(function () {
                 var usageMonth = getUsageMonth();
@@ -22,6 +23,10 @@
                 _usageMonth = usageMonth;
                 $rootScope.$broadcast("OrganizationChanged", {});
             }, 60000);
+
+            $interval(function () {
+                $rootScope.$broadcast("UsageChanged");
+            }, 300000);
 
             function getUsageMonth() {
                 var now = new Date();
@@ -51,7 +56,7 @@
                     plan_id: options.planId,
                     stripe_token: options.stripeToken,
                     last4: options.last4,
-                    coupon_id: options.couponId
+                    coupon_id: options.couponId,
                 };
                 return Restangular.one("organizations", id).customPOST(body, "change-plan");
             }

--- a/src/Exceptionless.Web/ClientApp.angular/components/organization/organization-service.js
+++ b/src/Exceptionless.Web/ClientApp.angular/components/organization/organization-service.js
@@ -20,7 +20,7 @@
                 }
 
                 _usageMonth = usageMonth;
-                $rootScope.$broadcast("OrganizationChanged");
+                $rootScope.$broadcast("OrganizationChanged", {});
             }, 60000);
 
             function getUsageMonth() {

--- a/src/Exceptionless.Web/ClientApp.angular/components/project/project-service.js
+++ b/src/Exceptionless.Web/ClientApp.angular/components/project/project-service.js
@@ -10,6 +10,7 @@
             $rootScope.$on("auth:logout", _cache.removeAll);
             $rootScope.$on("OrganizationChanged", _cache.removeAll);
             $rootScope.$on("ProjectChanged", _cache.removeAll);
+            $rootScope.$on("UsageChanged", _cache.removeAll);
 
             $rootScope.$on("StackChanged", function ($event, data) {
                 if (data.added) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/api.svelte.ts
@@ -23,10 +23,18 @@ export async function invalidateOrganizationQueries(queryClient: QueryClient, me
     }
 }
 
+export async function invalidateOrganizationUsageQueries(queryClient: QueryClient, organizationId?: string) {
+    const invalidations = [queryClient.invalidateQueries({ queryKey: queryKeys.list(undefined) })];
+    if (organizationId) {
+        invalidations.push(queryClient.invalidateQueries({ exact: true, queryKey: queryKeys.id(organizationId, undefined) }));
+        invalidations.push(queryClient.invalidateQueries({ exact: true, queryKey: queryKeys.id(organizationId, 'stats') }));
+    }
+
+    await Promise.all(invalidations);
+}
+
 export async function invalidatePlanOverageQueries(queryClient: QueryClient, message: WebSocketMessageValue<'PlanOverage'>) {
-    await queryClient.invalidateQueries({ queryKey: queryKeys.id(message.organization_id, undefined) });
-    await queryClient.invalidateQueries({ queryKey: queryKeys.id(message.organization_id, 'stats') });
-    await queryClient.invalidateQueries({ queryKey: queryKeys.list(undefined) });
+    await invalidateOrganizationUsageQueries(queryClient, message.organization_id);
 }
 
 export const queryKeys = {
@@ -114,6 +122,7 @@ export interface GetOrganizationRequest {
     params?: {
         mode: 'stats' | undefined;
     };
+    refetchInterval?: false | number;
     route: {
         id: string | undefined;
     };
@@ -366,7 +375,8 @@ export function getOrganizationQuery(request: GetOrganizationRequest) {
 
             return response.data!;
         },
-        queryKey: queryKeys.id(request.route.id, request.params?.mode)
+        queryKey: queryKeys.id(request.route.id, request.params?.mode),
+        refetchInterval: request.refetchInterval
     }));
 }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/api.svelte.ts
@@ -23,6 +23,12 @@ export async function invalidateOrganizationQueries(queryClient: QueryClient, me
     }
 }
 
+export async function invalidatePlanOverageQueries(queryClient: QueryClient, message: WebSocketMessageValue<'PlanOverage'>) {
+    await queryClient.invalidateQueries({ queryKey: queryKeys.id(message.organization_id, undefined) });
+    await queryClient.invalidateQueries({ queryKey: queryKeys.id(message.organization_id, 'stats') });
+    await queryClient.invalidateQueries({ queryKey: queryKeys.list(undefined) });
+}
+
 export const queryKeys = {
     adminSearch: (params: GetAdminSearchOrganizationsParams) => [...queryKeys.list(params.mode), 'admin', { ...params }] as const,
     changePlan: (id: string | undefined) => [...queryKeys.type, id, 'change-plan'] as const,

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/api.svelte.ts
@@ -137,6 +137,7 @@ export interface GetOrganizationsParams {
 
 export interface GetOrganizationsRequest {
     params?: GetOrganizationsParams;
+    refetchInterval?: false | number;
 }
 
 export interface GetPlansRequest {
@@ -404,7 +405,8 @@ export function getOrganizationsQuery(request: GetOrganizationsRequest) {
 
             return response;
         },
-        queryKey: [...queryKeys.list(request.params?.mode ?? undefined), { params: { ...request.params } }]
+        queryKey: [...queryKeys.list(request.params?.mode ?? undefined), { params: { ...request.params } }],
+        refetchInterval: request.refetchInterval
     }));
 }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/api.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/api.test.ts
@@ -1,0 +1,24 @@
+import { QueryClient } from '@tanstack/svelte-query';
+import { describe, expect, it, vi } from 'vitest';
+
+import { invalidatePlanOverageQueries, queryKeys } from './api.svelte';
+
+describe('invalidatePlanOverageQueries', () => {
+    it('invalidates only the affected organization state', async () => {
+        // Arrange
+        const queryClient = new QueryClient();
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries').mockImplementation(async () => {});
+
+        // Act
+        await invalidatePlanOverageQueries(queryClient, {
+            is_hourly: false,
+            organization_id: 'organization-id'
+        });
+
+        // Assert
+        expect(invalidateSpy).toHaveBeenCalledTimes(3);
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.id('organization-id', undefined) });
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.id('organization-id', 'stats') });
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.list(undefined) });
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/api.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/api.test.ts
@@ -1,7 +1,7 @@
 import { QueryClient } from '@tanstack/svelte-query';
 import { describe, expect, it, vi } from 'vitest';
 
-import { invalidatePlanOverageQueries, queryKeys } from './api.svelte';
+import { invalidateOrganizationUsageQueries, invalidatePlanOverageQueries, queryKeys } from './api.svelte';
 
 describe('invalidatePlanOverageQueries', () => {
     it('invalidates only the affected organization state', async () => {
@@ -17,8 +17,23 @@ describe('invalidatePlanOverageQueries', () => {
 
         // Assert
         expect(invalidateSpy).toHaveBeenCalledTimes(3);
-        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.id('organization-id', undefined) });
-        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.id('organization-id', 'stats') });
+        expect(invalidateSpy).toHaveBeenCalledWith({ exact: true, queryKey: queryKeys.id('organization-id', undefined) });
+        expect(invalidateSpy).toHaveBeenCalledWith({ exact: true, queryKey: queryKeys.id('organization-id', 'stats') });
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.list(undefined) });
+    });
+});
+
+describe('invalidateOrganizationUsageQueries', () => {
+    it('invalidates organization lists when there is no active organization', async () => {
+        // Arrange
+        const queryClient = new QueryClient();
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries').mockImplementation(async () => {});
+
+        // Act
+        await invalidateOrganizationUsageQueries(queryClient);
+
+        // Assert
+        expect(invalidateSpy).toHaveBeenCalledOnce();
         expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.list(undefined) });
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/organization-notifications.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/organization-notifications.svelte
@@ -9,7 +9,6 @@
     import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
     import { useEventListener } from 'runed';
     import { SvelteSet } from 'svelte/reactivity';
-    import { debounce } from 'throttle-debounce';
 
     import FreePlanNotification from './notifications/free-plan-notification.svelte';
     import HourlyOverageNotification from './notifications/hourly-overage-notification.svelte';
@@ -95,19 +94,21 @@
     );
     const requiresPremiumUpgrade = $derived(requiresPremium && !organization?.has_premium_features && !needsProjectConfiguration);
 
-    const refetchConfigurationState = debounce(1500, async () => {
-        await Promise.all([organizationQuery.refetch(), projectsQuery.refetch()]);
-    });
-
     useEventListener(document, 'PersistentEventChanged', (event) => {
         const message = (event as CustomEvent<WebSocketMessageValue<'PersistentEventChanged'>>).detail;
+        const projectNeedsConfiguration = projects.some((project) => project.id === message.project_id && project.is_configured === false);
 
-        if (message.change_type === ChangeType.Removed || message.organization_id !== currentOrganizationId.current || !message.project_id) {
+        if (
+            message.change_type === ChangeType.Removed ||
+            message.organization_id !== currentOrganizationId.current ||
+            !message.project_id ||
+            !projectNeedsConfiguration ||
+            configuredProjectIds.has(message.project_id)
+        ) {
             return;
         }
 
         configuredProjectIds.add(message.project_id);
-        void refetchConfigurationState();
     });
 </script>
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/organization-notifications.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/organization-notifications.svelte
@@ -1,3 +1,25 @@
+<script module lang="ts">
+    import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
+
+    export function recordConfiguredProjectId(
+        message: WebSocketMessageValue<'PersistentEventChanged'>,
+        organizationId: string | undefined,
+        configuredProjectIds: Set<string>
+    ): boolean {
+        if (
+            message.change_type === ChangeType.Removed ||
+            message.organization_id !== organizationId ||
+            !message.project_id ||
+            configuredProjectIds.has(message.project_id)
+        ) {
+            return false;
+        }
+
+        configuredProjectIds.add(message.project_id);
+        return true;
+    }
+</script>
+
 <script lang="ts">
     import type { NotificationProps } from '$comp/notification';
 
@@ -6,7 +28,6 @@
     import { SuspensionCode } from '$features/organizations/models';
     import { getOrganizationProjectsQuery } from '$features/projects/api.svelte';
     import { getMeQuery } from '$features/users/api.svelte';
-    import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
     import { useEventListener } from 'runed';
     import { SvelteSet } from 'svelte/reactivity';
 
@@ -96,19 +117,7 @@
 
     useEventListener(document, 'PersistentEventChanged', (event) => {
         const message = (event as CustomEvent<WebSocketMessageValue<'PersistentEventChanged'>>).detail;
-        const projectNeedsConfiguration = projects.some((project) => project.id === message.project_id && project.is_configured === false);
-
-        if (
-            message.change_type === ChangeType.Removed ||
-            message.organization_id !== currentOrganizationId.current ||
-            !message.project_id ||
-            !projectNeedsConfiguration ||
-            configuredProjectIds.has(message.project_id)
-        ) {
-            return;
-        }
-
-        configuredProjectIds.add(message.project_id);
+        recordConfiguredProjectId(message, currentOrganizationId.current, configuredProjectIds);
     });
 </script>
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/organization-notifications.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/organization-notifications.svelte.test.ts
@@ -1,0 +1,77 @@
+import { ChangeType } from '$features/websockets/models';
+import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import OrganizationNotifications from './organization-notifications.svelte';
+
+const organizationRefetch = vi.hoisted(() => vi.fn());
+const projectsRefetch = vi.hoisted(() => vi.fn());
+const projects = vi.hoisted(() => [{ id: 'project-id', is_configured: false, organization_id: 'organization-id' }]);
+
+vi.mock('$features/organizations/api.svelte', () => ({
+    getOrganizationQuery: () => ({ data: undefined, refetch: organizationRefetch }),
+    getOrganizationsQuery: () => ({ data: { data: [] } })
+}));
+
+vi.mock('$features/organizations/context.svelte', () => ({
+    organization: { current: 'organization-id' }
+}));
+
+vi.mock('$features/projects/api.svelte', () => ({
+    getOrganizationProjectsQuery: () => ({ data: { data: projects }, isSuccess: true, refetch: projectsRefetch })
+}));
+
+vi.mock('$features/users/api.svelte', () => ({
+    getMeQuery: () => ({ data: { organization_ids: ['organization-id'], roles: [] } })
+}));
+
+describe('OrganizationNotifications', () => {
+    beforeEach(() => {
+        organizationRefetch.mockReset();
+        projectsRefetch.mockReset();
+        projects[0]!.is_configured = false;
+    });
+
+    it('does not refetch organization or project state for persistent event changes', async () => {
+        render(OrganizationNotifications, {
+            isChatEnabled: false,
+            openChat: vi.fn()
+        });
+
+        const message = {
+            change_type: ChangeType.Added,
+            organization_id: 'organization-id',
+            project_id: 'project-id'
+        };
+
+        document.dispatchEvent(new CustomEvent('PersistentEventChanged', { detail: message }));
+        document.dispatchEvent(new CustomEvent('PersistentEventChanged', { detail: message }));
+        await tick();
+
+        expect(organizationRefetch).not.toHaveBeenCalled();
+        expect(projectsRefetch).not.toHaveBeenCalled();
+    });
+
+    it('does not refresh configuration state for an already configured project', async () => {
+        projects[0]!.is_configured = true;
+        render(OrganizationNotifications, {
+            isChatEnabled: false,
+            openChat: vi.fn()
+        });
+
+        document.dispatchEvent(
+            new CustomEvent('PersistentEventChanged', {
+                detail: {
+                    change_type: ChangeType.Added,
+                    organization_id: 'organization-id',
+                    project_id: 'project-id'
+                }
+            })
+        );
+        await tick();
+
+        expect(organizationRefetch).not.toHaveBeenCalled();
+        expect(projectsRefetch).not.toHaveBeenCalled();
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/organization-notifications.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/organization-notifications.svelte.test.ts
@@ -3,7 +3,7 @@ import { render } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import OrganizationNotifications from './organization-notifications.svelte';
+import OrganizationNotifications, { recordConfiguredProjectId } from './organization-notifications.svelte';
 
 const organizationRefetch = vi.hoisted(() => vi.fn());
 const projectsRefetch = vi.hoisted(() => vi.fn());
@@ -31,6 +31,25 @@ describe('OrganizationNotifications', () => {
         organizationRefetch.mockReset();
         projectsRefetch.mockReset();
         projects[0]!.is_configured = false;
+    });
+
+    it('records configuration events before project data loads', () => {
+        const configuredProjectIds = new Set<string>();
+
+        const recorded = recordConfiguredProjectId(
+            {
+                change_type: ChangeType.Added,
+                data: {},
+                organization_id: 'organization-id',
+                project_id: 'project-id',
+                type: 'PersistentEvent'
+            },
+            'organization-id',
+            configuredProjectIds
+        );
+
+        expect(recorded).toBe(true);
+        expect(configuredProjectIds).toContain('project-id');
     });
 
     it('does not refetch organization or project state for persistent event changes', async () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/utils.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/utils.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { getUtcMonthKey } from './utils';
+
+describe('getUtcMonthKey', () => {
+    it('changes only when the UTC month changes', () => {
+        expect(getUtcMonthKey(new Date('2026-08-01T00:00:00.000Z'))).toBe(getUtcMonthKey(new Date('2026-08-31T23:59:59.999Z')));
+        expect(getUtcMonthKey(new Date('2026-09-01T00:00:00.000Z'))).not.toBe(getUtcMonthKey(new Date('2026-08-31T23:59:59.999Z')));
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/utils.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/utils.ts
@@ -2,6 +2,9 @@ import { isSameUtcMonth } from '$features/shared/dates';
 
 import type { ViewOrganization } from './models';
 
+export const ORGANIZATION_USAGE_REFETCH_INTERVAL_MS = 5 * 60 * 1000;
+export const ORGANIZATION_USAGE_ROLLOVER_CHECK_INTERVAL_MS = 60 * 1000;
+
 export function getNextBillingDateUtc(organization?: ViewOrganization): Date {
     if (organization?.subscribe_date) {
         console.log('Organization subscribe date for next billing date:', organization.subscribe_date);
@@ -29,4 +32,8 @@ export function getRemainingEventLimit(organization?: ViewOrganization): number 
     }
 
     return organization.max_events_per_month + bonusEvents;
+}
+
+export function getUtcMonthKey(date = new Date()): number {
+    return date.getUTCFullYear() * 12 + date.getUTCMonth();
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/api.svelte.ts
@@ -135,6 +135,7 @@ export interface GetProjectsParams {
 
 export interface GetProjectsRequest {
     params?: GetProjectsParams;
+    refetchInterval?: false | number;
 }
 
 export interface GetProjectUserNotificationSettingsRequest {
@@ -425,7 +426,8 @@ export function getProjectsQuery(request: GetProjectsRequest) {
 
             return response;
         },
-        queryKey: [queryKeys.projects(), { params: request.params }]
+        queryKey: [queryKeys.projects(), { params: request.params }],
+        refetchInterval: request.refetchInterval
     }));
 }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/api.svelte.ts
@@ -117,6 +117,7 @@ export interface GetProjectIntegrationNotificationSettingsRequest {
 }
 
 export interface GetProjectRequest {
+    refetchInterval?: false | number;
     route: {
         id: string | undefined;
     };
@@ -396,7 +397,8 @@ export function getProjectQuery(request: GetProjectRequest) {
 
             return response.data!;
         },
-        queryKey: queryKeys.id(request.route.id)
+        queryKey: queryKeys.id(request.route.id),
+        refetchInterval: request.refetchInterval
     }));
 }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/websockets/models.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/websockets/models.ts
@@ -67,6 +67,10 @@ export function isEntityChangedType(message: { message: unknown; type: WebSocket
     return message.type !== 'PlanChanged' && message.type !== 'UserMembershipChanged' && message.type.endsWith('Changed');
 }
 
+export function isPlanOverageType(message: { message: unknown; type: WebSocketMessageType }): message is WebSocketMessage<'PlanOverage'> {
+    return message.type === 'PlanOverage';
+}
+
 export function isWebSocketMessageType(type: string): type is WebSocketMessageType {
     return (
         (['PlanChanged', 'PlanOverage', 'UserMembershipChanged', 'ReleaseNotification', 'SystemNotification'] as const).includes(

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
@@ -15,7 +15,12 @@
     import { buildIntercomBootOptions, IntercomShell } from '$features/intercom';
     import { shouldLoadIntercomOrganization } from '$features/intercom/config';
     import Notifications from '$features/notifications/components/notifications.svelte';
-    import { getOrganizationQuery, getOrganizationsQuery, invalidateOrganizationQueries } from '$features/organizations/api.svelte';
+    import {
+        getOrganizationQuery,
+        getOrganizationsQuery,
+        invalidateOrganizationQueries,
+        invalidatePlanOverageQueries
+    } from '$features/organizations/api.svelte';
     import OrganizationNotifications from '$features/organizations/components/organization-notifications.svelte';
     import { organization, showOrganizationNotifications } from '$features/organizations/context.svelte';
     import { premiumPage } from '$features/organizations/premium-page.svelte';
@@ -28,7 +33,7 @@
     import { getMeQuery, invalidateUserQueries } from '$features/users/api.svelte';
     import { getGravatarFromCurrentUser } from '$features/users/gravatar.svelte';
     import { invalidateWebhookQueries } from '$features/webhooks/api.svelte';
-    import { isEntityChangedType, type WebSocketMessageType } from '$features/websockets/models';
+    import { isEntityChangedType, isPlanOverageType, type WebSocketMessageType } from '$features/websockets/models';
     import { WebSocketClient } from '$features/websockets/web-socket-client.svelte';
     import { Telemetry } from '$lib/telemetry';
     import { useMiddleware } from '@foundatiofx/fetchclient';
@@ -129,7 +134,9 @@
             })
         );
 
-        if (isEntityChangedType(data)) {
+        if (isPlanOverageType(data)) {
+            await invalidatePlanOverageQueries(queryClient, data.message);
+        } else if (isEntityChangedType(data)) {
             switch (data.type) {
                 case 'OrganizationChanged':
                     await invalidateOrganizationQueries(queryClient, data.message);

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
@@ -19,11 +19,13 @@
         getOrganizationQuery,
         getOrganizationsQuery,
         invalidateOrganizationQueries,
+        invalidateOrganizationUsageQueries,
         invalidatePlanOverageQueries
     } from '$features/organizations/api.svelte';
     import OrganizationNotifications from '$features/organizations/components/organization-notifications.svelte';
     import { organization, showOrganizationNotifications } from '$features/organizations/context.svelte';
     import { premiumPage } from '$features/organizations/premium-page.svelte';
+    import { getUtcMonthKey, ORGANIZATION_USAGE_ROLLOVER_CHECK_INTERVAL_MS } from '$features/organizations/utils';
     import { invalidateProjectQueries } from '$features/projects/api.svelte';
     import { getSavedViewsQuery, invalidateSavedViewQueries, isSavedViewDeleted } from '$features/saved-views/api.svelte';
     import { savedViewHref } from '$features/saved-views/slugs';
@@ -38,6 +40,7 @@
     import { Telemetry } from '$lib/telemetry';
     import { useMiddleware } from '@foundatiofx/fetchclient';
     import { useQueryClient } from '@tanstack/svelte-query';
+    import { useInterval } from 'runed';
     import { tick } from 'svelte';
     import { fade } from 'svelte/transition';
 
@@ -120,6 +123,20 @@
     });
 
     const queryClient = useQueryClient();
+    let organizationUsageMonth = getUtcMonthKey();
+    useInterval(() => ORGANIZATION_USAGE_ROLLOVER_CHECK_INTERVAL_MS, {
+        callback: () => {
+            const currentMonth = getUtcMonthKey();
+            if (currentMonth === organizationUsageMonth) {
+                return;
+            }
+
+            organizationUsageMonth = currentMonth;
+            void invalidateOrganizationUsageQueries(queryClient, organization.current);
+        },
+        immediate: false
+    });
+
     async function onMessage(message: MessageEvent) {
         const data: { message: unknown; type: WebSocketMessageType } = message.data ? JSON.parse(message.data) : null;
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/usage/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/usage/+page.svelte
@@ -10,13 +10,14 @@
     import { env } from '$env/dynamic/public';
     import { ChangePlanDialog } from '$features/billing';
     import { getOrganizationQuery } from '$features/organizations/api.svelte';
-    import { getNextBillingDateUtc, getRemainingEventLimit } from '$features/organizations/utils';
+    import { getNextBillingDateUtc, getRemainingEventLimit, ORGANIZATION_USAGE_REFETCH_INTERVAL_MS } from '$features/organizations/utils';
     import { formatDateLabel, formatLongDate } from '$shared/dates';
     import { scaleUtc } from 'd3-scale';
     import { curveNatural } from 'd3-shape';
     import { AreaChart } from 'layerchart';
 
     const organizationQuery = getOrganizationQuery({
+        refetchInterval: ORGANIZATION_USAGE_REFETCH_INTERVAL_MS,
         route: {
             get id() {
                 return page.params.organizationId || '';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/list/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/list/+page.svelte
@@ -13,6 +13,7 @@
     import OrganizationsDataTable from '$features/organizations/components/table/organizations-data-table.svelte';
     import { organization } from '$features/organizations/context.svelte';
     import { useHideOrganizationNotifications } from '$features/organizations/hooks/use-hide-organization-notifications.svelte';
+    import { ORGANIZATION_USAGE_REFETCH_INTERVAL_MS } from '$features/organizations/utils';
     import Plus from '@lucide/svelte/icons/plus';
     import { createTable } from '@tanstack/svelte-table';
     import { queryParamsState } from 'kit-query-params';
@@ -42,7 +43,8 @@
     const organizationsQuery = getOrganizationsQuery({
         get params() {
             return organizationsQueryParameters;
-        }
+        },
+        refetchInterval: ORGANIZATION_USAGE_REFETCH_INTERVAL_MS
     });
 
     const table = createTable(getTableOptions<ViewOrganization>(organizationsQueryParameters, organizationsQuery));

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/usage/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/usage/+page.svelte
@@ -11,7 +11,7 @@
     import { ChangePlanDialog } from '$features/billing';
     import { getOrganizationQuery } from '$features/organizations/api.svelte';
     import { organization } from '$features/organizations/context.svelte';
-    import { getNextBillingDateUtc, getRemainingEventLimit } from '$features/organizations/utils';
+    import { getNextBillingDateUtc, getRemainingEventLimit, ORGANIZATION_USAGE_REFETCH_INTERVAL_MS } from '$features/organizations/utils';
     import { getProjectQuery } from '$features/projects/api.svelte';
     import { formatDateLabel, formatLongDate } from '$shared/dates';
     import { scaleUtc } from 'd3-scale';
@@ -22,6 +22,7 @@
         params: {
             mode: 'stats'
         },
+        refetchInterval: ORGANIZATION_USAGE_REFETCH_INTERVAL_MS,
         route: {
             get id() {
                 return organization.current;
@@ -35,6 +36,7 @@
     const nextBillingDate = $derived(getNextBillingDateUtc(organizationQuery.data));
 
     const projectQuery = getProjectQuery({
+        refetchInterval: ORGANIZATION_USAGE_REFETCH_INTERVAL_MS,
         route: {
             get id() {
                 return page.params.projectId || '';

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/list/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/list/+page.svelte
@@ -9,6 +9,7 @@
     import { Input } from '$comp/ui/input';
     import { organization } from '$features/organizations/context.svelte';
     import { useHideOrganizationNotifications } from '$features/organizations/hooks/use-hide-organization-notifications.svelte';
+    import { ORGANIZATION_USAGE_REFETCH_INTERVAL_MS } from '$features/organizations/utils';
     import { type GetProjectsParams, getProjectsQuery } from '$features/projects/api.svelte';
     import { getTableOptions } from '$features/projects/components/table/options.svelte';
     import ProjectsDataTable from '$features/projects/components/table/projects-data-table.svelte';
@@ -50,7 +51,8 @@
     const projectsQuery = getProjectsQuery({
         get params() {
             return projectsQueryParameters;
-        }
+        },
+        refetchInterval: ORGANIZATION_USAGE_REFETCH_INTERVAL_MS
     });
 
     const table = createTable(getTableOptions<ViewProject>(projectsQueryParameters, projectsQuery, { includeOrganizationColumn: true }));

--- a/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
@@ -605,6 +605,37 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task GetAsync_WithExpiredBonusAndStaleUsageLimit_ReturnsLiveOverageState()
+    {
+        // Arrange
+        var organization = await _organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(organization);
+
+        organization.MaxEventsPerMonth = 1;
+        organization.BonusEventsPerMonth = 10;
+        organization.BonusExpiration = TimeProvider.GetUtcNow().UtcDateTime.Subtract(TimeSpan.FromMinutes(1));
+        organization.Usage.Clear();
+        organization.UsageHours.Clear();
+        var currentUsage = organization.GetCurrentUsage(TimeProvider);
+        currentUsage.Limit = organization.MaxEventsPerMonth + organization.BonusEventsPerMonth;
+        currentUsage.Total = 2;
+        await _organizationRepository.SaveAsync(organization, o => o.ImmediateConsistency().Cache().Originals());
+
+        // Act
+        var viewOrganization = await SendRequestAsAsync<ViewOrganization>(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", organization.Id)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(viewOrganization);
+        Assert.Equal(organization.MaxEventsPerMonth, viewOrganization.GetCurrentUsage(TimeProvider).Limit);
+        Assert.Equal(2, viewOrganization.GetCurrentUsage(TimeProvider).Total);
+        Assert.True(viewOrganization.IsOverMonthlyLimit);
+    }
+
+    [Fact]
     public async Task PostAsync_NewOrganization_SetsCreatedAndUpdatedDates()
     {
         // Arrange

--- a/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
@@ -5,6 +5,7 @@ using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Models.Billing;
 using Exceptionless.Core.Repositories;
+using Exceptionless.Core.Services;
 using Exceptionless.Core.Utility;
 using Exceptionless.Tests.Extensions;
 using Exceptionless.Tests.Utility;
@@ -573,6 +574,34 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         // Assert
         Assert.NotNull(viewOrg);
         Assert.False(viewOrg.IsOverMonthlyLimit);
+    }
+
+    [Fact]
+    public async Task GetAsync_WithPendingUsageAtMonthlyLimit_ReturnsRealTimeOverageState()
+    {
+        // Arrange
+        var organization = await _organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(organization);
+
+        organization.MaxEventsPerMonth = 1;
+        organization.Usage.Clear();
+        organization.UsageHours.Clear();
+        await _organizationRepository.SaveAsync(organization, o => o.ImmediateConsistency().Cache().Originals());
+
+        var usageService = GetService<UsageService>();
+        await usageService.IncrementTotalAsync(organization.Id, SampleDataService.TEST_PROJECT_ID);
+
+        // Act
+        var viewOrganization = await SendRequestAsAsync<ViewOrganization>(r => r
+            .AsTestOrganizationUser()
+            .AppendPaths("organizations", organization.Id)
+            .StatusCodeShouldBeOk()
+        );
+
+        // Assert
+        Assert.NotNull(viewOrganization);
+        Assert.Equal(1, viewOrganization.GetCurrentUsage(TimeProvider).Total);
+        Assert.True(viewOrganization.IsOverMonthlyLimit);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Migrations/UpdateEventUsageMigrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/UpdateEventUsageMigrationTests.cs
@@ -1,12 +1,15 @@
 using Exceptionless.Core.Billing;
 using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Migrations;
+using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
 using Exceptionless.DateTimeExtensions;
 using Exceptionless.Tests.Utility;
 using Foundatio.Lock;
 using Foundatio.Repositories;
+using Foundatio.Repositories.Elasticsearch;
 using Foundatio.Repositories.Migrations;
+using Foundatio.Repositories.Models;
 using Foundatio.Utility;
 using Xunit;
 
@@ -84,5 +87,50 @@ public class UpdateEventUsageMigrationTests : IntegrationTestsBase
         currentMonthsUsage = project.GetUsage(currentMonthUsageDate);
         Assert.Equal(10, currentMonthsUsage.Total);
         Assert.Equal(limit, currentMonthsUsage.Limit);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenCurrentMonthRepairCrossesLimit_PublishesOneOrganizationChangedMessage()
+    {
+        // Arrange
+        var billingPlans = GetService<BillingPlans>();
+        var organization = _organizationData.GenerateSampleOrganizationWithPlan(GetService<BillingManager>(), billingPlans, billingPlans.SmallPlan);
+        organization.MaxEventsPerMonth = 10;
+        organization.GetCurrentUsage(TimeProvider).Total = 5;
+        organization = await _organizationRepository.AddAsync(organization, o => o.ImmediateConsistency());
+
+        var project = await _projectRepository.AddAsync(_projectData.GenerateSampleProject(), o => o.ImmediateConsistency());
+        var stack = await _stackRepository.AddAsync(_stackData.GenerateSampleStack(), o => o.ImmediateConsistency());
+        var currentMonthUsageDate = DateTime.UtcNow.StartOfMonth();
+        await _eventRepository.AddAsync(_eventData.GenerateEvents(count: 10, stackId: stack.Id, startDate: currentMonthUsageDate, endDate: DateTime.UtcNow), o => o.ImmediateConsistency());
+
+        var organizationRepository = Assert.IsAssignableFrom<ElasticRepositoryBase<Organization>>(GetService<IOrganizationRepository>());
+        int notificationCount = 0;
+        Func<object, BeforePublishEntityChangedEventArgs<Organization>, Task> organizationHandler = (_, _) =>
+        {
+            Interlocked.Increment(ref notificationCount);
+            return Task.CompletedTask;
+        };
+        organizationRepository.BeforePublishEntityChanged.AddHandler(organizationHandler);
+
+        try
+        {
+            var migration = GetService<UpdateEventUsage>();
+            var context = new MigrationContext(GetService<ILock>(), _logger, TestCancellationToken);
+
+            // Act
+            await migration.RunAsync(context);
+            await migration.RunAsync(context);
+
+            // Assert
+            Assert.Equal(1, notificationCount);
+            var updatedOrganization = await _organizationRepository.GetByIdAsync(organization.Id);
+            Assert.NotNull(updatedOrganization);
+            Assert.Equal(10, updatedOrganization.GetCurrentUsage(TimeProvider).Total);
+        }
+        finally
+        {
+            organizationRepository.BeforePublishEntityChanged.RemoveHandler(organizationHandler);
+        }
     }
 }

--- a/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
@@ -453,6 +453,48 @@ public sealed class UsageServiceTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task IncrementTotalAsync_WhenHourlyOveragePublicationFails_RetriesDuringPendingUsageSave()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(new Organization { Name = "Test", MaxEventsPerMonth = 750, PlanId = _plans.SmallPlan.Id }, o => o.ImmediateConsistency().Cache());
+        var project = await _projectRepository.AddAsync(new Project { Name = "Test", OrganizationId = organization.Id, NextSummaryEndOfDayTicks = TimeProvider.GetUtcNow().UtcDateTime.Ticks }, o => o.ImmediateConsistency().Cache());
+        int eventsLeftInBucket = await _usageService.GetEventsLeftAsync(organization.Id);
+        var cache = GetService<ICacheClient>();
+        var messageBus = GetService<IMessageBus>();
+        var publisher = new FailOnceHourlyPlanOveragePublisher(messageBus);
+        var usageService = new UsageService(
+            _organizationRepository,
+            _projectRepository,
+            cache,
+            publisher,
+            _notificationService,
+            TimeProvider,
+            GetService<ILoggerFactory>());
+        var published = new AsyncCountdownEvent(1);
+        await messageBus.SubscribeAsync<PlanOverage>(overage =>
+        {
+            if (overage.OrganizationId == organization.Id && overage.IsHourly)
+                published.Signal();
+        }, TestCancellationToken);
+
+        int bucket = TimeProvider.GetUtcNow().UtcDateTime.Floor(TimeSpan.FromMinutes(5)).ToEpoch();
+        string pendingPublicationKey = $"usage:{bucket}:{organization.Id}:hourly-overage-pending";
+
+        // Act
+        await Assert.ThrowsAsync<InvalidOperationException>(() => usageService.IncrementTotalAsync(organization.Id, project.Id, eventsLeftInBucket));
+
+        // Assert
+        Assert.True((await cache.GetAsync<bool>(pendingPublicationKey)).Value);
+
+        TimeProvider.Advance(TimeSpan.FromMinutes(10));
+        await usageService.SavePendingUsageAsync();
+        await published.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(2, publisher.HourlyAttempts);
+        Assert.False((await cache.GetAsync<bool>(pendingPublicationKey)).HasValue);
+    }
+
+    [Fact]
     public async Task CanIncrementOverageUsageAsync()
     {
         var messageBus = GetService<IMessageBus>();
@@ -811,5 +853,20 @@ public sealed class UsageServiceTests : IntegrationTestsBase
 
         sw.Stop();
         _logger.LogInformation("Time: {Duration:g}, Avg: ({AverageTickDuration:g}ticks | {AverageDuration}ms)", sw.Elapsed, sw.ElapsedTicks / iterations, sw.ElapsedMilliseconds / iterations);
+    }
+
+    private sealed class FailOnceHourlyPlanOveragePublisher(IMessagePublisher inner) : IMessagePublisher
+    {
+        private int _hourlyAttempts;
+
+        public int HourlyAttempts => _hourlyAttempts;
+
+        public Task PublishAsync(Type messageType, object message, MessageOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            if (message is PlanOverage { IsHourly: true } && Interlocked.Increment(ref _hourlyAttempts) == 1)
+                return Task.FromException(new InvalidOperationException("Simulated hourly overage publication failure."));
+
+            return inner.PublishAsync(messageType, message, options, cancellationToken);
+        }
     }
 }

--- a/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
@@ -359,7 +359,7 @@ public sealed class UsageServiceTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task SavePendingUsageAsync_WhenMonthlyOverageClearsAfterPlanIncrease_PublishesOrganizationChangedMessage()
+    public async Task SavePendingUsageAsync_WhenMonthRollsOver_DoesNotPublishOrganizationChangedMessage()
     {
         // Arrange
         TimeProvider.SetUtcNow(new DateTime(2015, 2, 28, 23, 55, 0, DateTimeKind.Utc));
@@ -390,12 +390,12 @@ public sealed class UsageServiceTests : IntegrationTestsBase
             organization = await _organizationRepository.GetByIdAsync(organization.Id);
             Assert.NotNull(organization);
             Assert.False(organization.IsOverMonthlyLimit(TimeProvider));
-            Assert.Equal(1, notificationCount);
+            Assert.Equal(0, notificationCount);
 
             await _usageService.IncrementTotalAsync(organization.Id, project.Id);
             TimeProvider.Advance(TimeSpan.FromMinutes(10));
             await _usageService.SavePendingUsageAsync();
-            Assert.Equal(1, notificationCount);
+            Assert.Equal(0, notificationCount);
         }
         finally
         {

--- a/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
@@ -5,8 +5,10 @@ using Exceptionless.Core.Messaging.Models;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Services;
+using Exceptionless.DateTimeExtensions;
 using Exceptionless.Tests.Extensions;
 using Foundatio.AsyncEx;
+using Foundatio.Caching;
 using Foundatio.Messaging;
 using Foundatio.Repositories;
 using Foundatio.Repositories.Elasticsearch;
@@ -314,8 +316,10 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         }
     }
 
-    [Fact]
-    public async Task SavePendingUsageAsync_HourlyThrottleClears_PublishesOrganizationChangedMessage()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SavePendingUsageAsync_HourlyThrottleClears_PublishesOrganizationChangedMessage(bool removeTransitionMarker)
     {
         // Arrange
         var organization = await _organizationRepository.AddAsync(new Organization { Name = "Test", MaxEventsPerMonth = 750, PlanId = _plans.SmallPlan.Id }, o => o.ImmediateConsistency().Cache());
@@ -334,6 +338,11 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         {
             await _usageService.IncrementTotalAsync(organization.Id, project.Id, eventsLeftInBucket);
             Assert.True((await _usageService.GetUsageAsync(organization.Id)).IsThrottled);
+            if (removeTransitionMarker)
+            {
+                int bucket = TimeProvider.GetUtcNow().UtcDateTime.Floor(TimeSpan.FromMinutes(5)).ToEpoch();
+                await GetService<ICacheClient>().RemoveAsync($"usage:{bucket}:{organization.Id}:throttled-transition");
+            }
 
             // Act
             TimeProvider.Advance(TimeSpan.FromMinutes(10));
@@ -341,6 +350,51 @@ public sealed class UsageServiceTests : IntegrationTestsBase
 
             // Assert
             Assert.False((await _usageService.GetUsageAsync(organization.Id)).IsThrottled);
+            Assert.Equal(1, notificationCount);
+        }
+        finally
+        {
+            organizationRepository.BeforePublishEntityChanged.RemoveHandler(organizationHandler);
+        }
+    }
+
+    [Fact]
+    public async Task SavePendingUsageAsync_WhenMonthlyOverageClearsAfterPlanIncrease_PublishesOrganizationChangedMessage()
+    {
+        // Arrange
+        TimeProvider.SetUtcNow(new DateTime(2015, 2, 28, 23, 55, 0, DateTimeKind.Utc));
+        var organization = new Organization { Name = "Test", MaxEventsPerMonth = 750, PlanId = _plans.SmallPlan.Id };
+        organization.GetCurrentUsage(TimeProvider).Total = organization.MaxEventsPerMonth;
+        organization.MaxEventsPerMonth = 1_500;
+        organization = await _organizationRepository.AddAsync(organization, o => o.ImmediateConsistency().Cache());
+        var project = await _projectRepository.AddAsync(new Project { Name = "Test", OrganizationId = organization.Id, NextSummaryEndOfDayTicks = TimeProvider.GetUtcNow().UtcDateTime.Ticks }, o => o.ImmediateConsistency().Cache());
+        var organizationRepository = Assert.IsAssignableFrom<ElasticRepositoryBase<Organization>>(_organizationRepository);
+        int notificationCount = 0;
+        Func<object, BeforePublishEntityChangedEventArgs<Organization>, Task> organizationHandler = (_, _) =>
+        {
+            Interlocked.Increment(ref notificationCount);
+            return Task.CompletedTask;
+        };
+        organizationRepository.BeforePublishEntityChanged.AddHandler(organizationHandler);
+
+        try
+        {
+            TimeProvider.SetUtcNow(new DateTime(2015, 3, 1, 0, 0, 0, DateTimeKind.Utc));
+            await _usageService.IncrementTotalAsync(organization.Id, project.Id);
+
+            // Act
+            TimeProvider.Advance(TimeSpan.FromMinutes(10));
+            await _usageService.SavePendingUsageAsync();
+
+            // Assert
+            organization = await _organizationRepository.GetByIdAsync(organization.Id);
+            Assert.NotNull(organization);
+            Assert.False(organization.IsOverMonthlyLimit(TimeProvider));
+            Assert.Equal(1, notificationCount);
+
+            await _usageService.IncrementTotalAsync(organization.Id, project.Id);
+            TimeProvider.Advance(TimeSpan.FromMinutes(10));
+            await _usageService.SavePendingUsageAsync();
             Assert.Equal(1, notificationCount);
         }
         finally

--- a/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
@@ -9,6 +9,8 @@ using Exceptionless.Tests.Extensions;
 using Foundatio.AsyncEx;
 using Foundatio.Messaging;
 using Foundatio.Repositories;
+using Foundatio.Repositories.Elasticsearch;
+using Foundatio.Repositories.Models;
 using Xunit;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
@@ -271,6 +273,45 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         Assert.Equal(0, usage.Blocked);
         Assert.Equal(0, usage.TooBig);
         Assert.Equal(0, usage.Deleted);
+    }
+
+    [Fact]
+    public async Task SavePendingUsageAsync_UsageOnlyChanges_DoesNotPublishEntityChangedMessages()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(new Organization { Name = "Test", MaxEventsPerMonth = 750, PlanId = _plans.SmallPlan.Id }, o => o.ImmediateConsistency().Cache());
+        var project = await _projectRepository.AddAsync(new Project { Name = "Test", OrganizationId = organization.Id, NextSummaryEndOfDayTicks = TimeProvider.GetUtcNow().UtcDateTime.Ticks }, o => o.ImmediateConsistency().Cache());
+        var organizationRepository = Assert.IsAssignableFrom<ElasticRepositoryBase<Organization>>(_organizationRepository);
+        var projectRepository = Assert.IsAssignableFrom<ElasticRepositoryBase<Project>>(_projectRepository);
+        int notificationCount = 0;
+        Func<object, BeforePublishEntityChangedEventArgs<Organization>, Task> organizationHandler = (_, _) =>
+        {
+            Interlocked.Increment(ref notificationCount);
+            return Task.CompletedTask;
+        };
+        Func<object, BeforePublishEntityChangedEventArgs<Project>, Task> projectHandler = (_, _) =>
+        {
+            Interlocked.Increment(ref notificationCount);
+            return Task.CompletedTask;
+        };
+        organizationRepository.BeforePublishEntityChanged.AddHandler(organizationHandler);
+        projectRepository.BeforePublishEntityChanged.AddHandler(projectHandler);
+
+        try
+        {
+            // Act
+            await _usageService.IncrementTotalAsync(organization.Id, project.Id);
+            TimeProvider.Advance(TimeSpan.FromMinutes(10));
+            await _usageService.SavePendingUsageAsync();
+
+            // Assert
+            Assert.Equal(0, notificationCount);
+        }
+        finally
+        {
+            organizationRepository.BeforePublishEntityChanged.RemoveHandler(organizationHandler);
+            projectRepository.BeforePublishEntityChanged.RemoveHandler(projectHandler);
+        }
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
@@ -337,6 +337,33 @@ public sealed class UsageServiceTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task IncrementTotalAsync_WhenHourlyLimitCrosses_PublishesAfterThrottleStateIsSet()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(new Organization { Name = "Test", MaxEventsPerMonth = 750, PlanId = _plans.SmallPlan.Id }, o => o.ImmediateConsistency().Cache());
+        var project = await _projectRepository.AddAsync(new Project { Name = "Test", OrganizationId = organization.Id, NextSummaryEndOfDayTicks = TimeProvider.GetUtcNow().UtcDateTime.Ticks }, o => o.ImmediateConsistency().Cache());
+        int eventsLeftInBucket = await _usageService.GetEventsLeftAsync(organization.Id);
+        var throttleState = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var messageBus = GetService<IMessageBus>();
+        await messageBus.SubscribeAsync<PlanOverage>(async overage =>
+        {
+            if (overage.OrganizationId != organization.Id || !overage.IsHourly)
+            {
+                return;
+            }
+
+            var usage = await _usageService.GetUsageAsync(organization.Id);
+            throttleState.TrySetResult(usage.IsThrottled);
+        }, TestCancellationToken);
+
+        // Act
+        await _usageService.IncrementTotalAsync(organization.Id, project.Id, eventsLeftInBucket);
+
+        // Assert
+        Assert.True(await throttleState.Task.WaitAsync(TimeSpan.FromSeconds(5), TestCancellationToken));
+    }
+
+    [Fact]
     public async Task CanIncrementOverageUsageAsync()
     {
         var messageBus = GetService<IMessageBus>();

--- a/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
+++ b/tests/Exceptionless.Tests/Services/UsageServiceTests.cs
@@ -279,7 +279,7 @@ public sealed class UsageServiceTests : IntegrationTestsBase
     public async Task SavePendingUsageAsync_UsageOnlyChanges_DoesNotPublishEntityChangedMessages()
     {
         // Arrange
-        var organization = await _organizationRepository.AddAsync(new Organization { Name = "Test", MaxEventsPerMonth = 750, PlanId = _plans.SmallPlan.Id }, o => o.ImmediateConsistency().Cache());
+        var organization = await _organizationRepository.AddAsync(new Organization { Name = "Test", MaxEventsPerMonth = 1_000_000, PlanId = _plans.SmallPlan.Id }, o => o.ImmediateConsistency().Cache());
         var project = await _projectRepository.AddAsync(new Project { Name = "Test", OrganizationId = organization.Id, NextSummaryEndOfDayTicks = TimeProvider.GetUtcNow().UtcDateTime.Ticks }, o => o.ImmediateConsistency().Cache());
         var organizationRepository = Assert.IsAssignableFrom<ElasticRepositoryBase<Organization>>(_organizationRepository);
         var projectRepository = Assert.IsAssignableFrom<ElasticRepositoryBase<Project>>(_projectRepository);
@@ -311,6 +311,41 @@ public sealed class UsageServiceTests : IntegrationTestsBase
         {
             organizationRepository.BeforePublishEntityChanged.RemoveHandler(organizationHandler);
             projectRepository.BeforePublishEntityChanged.RemoveHandler(projectHandler);
+        }
+    }
+
+    [Fact]
+    public async Task SavePendingUsageAsync_HourlyThrottleClears_PublishesOrganizationChangedMessage()
+    {
+        // Arrange
+        var organization = await _organizationRepository.AddAsync(new Organization { Name = "Test", MaxEventsPerMonth = 750, PlanId = _plans.SmallPlan.Id }, o => o.ImmediateConsistency().Cache());
+        var project = await _projectRepository.AddAsync(new Project { Name = "Test", OrganizationId = organization.Id, NextSummaryEndOfDayTicks = TimeProvider.GetUtcNow().UtcDateTime.Ticks }, o => o.ImmediateConsistency().Cache());
+        int eventsLeftInBucket = await _usageService.GetEventsLeftAsync(organization.Id);
+        var organizationRepository = Assert.IsAssignableFrom<ElasticRepositoryBase<Organization>>(_organizationRepository);
+        int notificationCount = 0;
+        Func<object, BeforePublishEntityChangedEventArgs<Organization>, Task> organizationHandler = (_, _) =>
+        {
+            Interlocked.Increment(ref notificationCount);
+            return Task.CompletedTask;
+        };
+        organizationRepository.BeforePublishEntityChanged.AddHandler(organizationHandler);
+
+        try
+        {
+            await _usageService.IncrementTotalAsync(organization.Id, project.Id, eventsLeftInBucket);
+            Assert.True((await _usageService.GetUsageAsync(organization.Id)).IsThrottled);
+
+            // Act
+            TimeProvider.Advance(TimeSpan.FromMinutes(10));
+            await _usageService.SavePendingUsageAsync();
+
+            // Assert
+            Assert.False((await _usageService.GetUsageAsync(organization.Id)).IsThrottled);
+            Assert.Equal(1, notificationCount);
+        }
+        finally
+        {
+            organizationRepository.BeforePublishEntityChanged.RemoveHandler(organizationHandler);
         }
     }
 


### PR DESCRIPTION
## What changed

- Stop routine organization/project usage persistence, usage repair, and usage-only maintenance from publishing entity-change notifications.
- Keep meaningful maintenance notifications for plan, bot-list, configuration-version, usage-repair overage, and hourly-throttle-clear transitions.
- Handle persistent-event configuration state locally in Svelte, including events received before project data loads.
- Refresh organization state on targeted `PlanOverage` messages without invalidating unrelated organization queries.
- Refresh organization usage state at UTC month rollover in both clients, independent of new ingestion.
- Poll organization and project usage pages every five minutes while those pages are active.
- Evaluate current overage state against the live effective limit when temporary bonuses expire.
- Clear the legacy Angular organization cache on `PlanOverage`.
- Add focused backend and frontend regression coverage.

## Why

Routine usage counters and persistent-event traffic were causing repeated organization and project reloads while the app was otherwise idle. The remaining notifications and refreshes are limited to state transitions and views that users need to see.

## Verification

- `dotnet build tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-restore --disable-build-servers` — passed with 0 warnings and 0 errors
- Full .NET test assembly — 2,686 passed / 2 skipped
- `UpdateEventUsageMigrationTests` — 2 passed
- `OrganizationEndpointTests` — 103 passed
- `UsageServiceTests` — 22 passed
- `npm run validate` — passed with 0 errors and 0 warnings
- `npm run test:unit` — 36 files / 406 tests passed
- Svelte `npm run build` — passed
- Legacy Angular `npm run build` — passed

## Breaking changes

None.
