### PR TITLE
Fix row selection column width

### DIFF
--- a/src/Exceptionless.Web/ClientApp/e2e/tests/selection-column-width.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/selection-column-width.e2e.ts
@@ -65,4 +65,14 @@ test('row selection column stays fixed at desktop and narrow widths', async ({ e
     }
 
     expect(selectionWidths[0]).toBeCloseTo(selectionWidths[1]!, 1);
+
+    await page.setViewportSize({ height: 900, width: 1440 });
+    for (const columnId of ['summary', 'user', 'date']) {
+        await table.getByRole('button', { name: `Resize ${columnId} column` }).press('ArrowRight');
+    }
+
+    const explicitlySizedTableBox = await table.boundingBox();
+    const explicitlySizedSelectionBox = await table.locator('thead th').first().boundingBox();
+    expect(explicitlySizedTableBox!.width).toBeCloseTo(816, 1);
+    expect(explicitlySizedSelectionBox!.width).toBeCloseTo(32, 1);
 });

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/selection-column-width.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/selection-column-width.e2e.ts
@@ -1,0 +1,68 @@
+import { resolve } from 'node:path';
+
+import { expect, test } from '../fixtures/e2e-test';
+import { ExceptionlessE2EJourney } from '../support/exceptionless-journey';
+import { getVisibleText } from '../support/page-helpers';
+
+test('row selection column stays fixed at desktop and narrow widths', async ({ e2eApi, e2eScenario, page }) => {
+    const journey = ExceptionlessE2EJourney.fromScenario(page, e2eApi, e2eScenario);
+    await journey.submitRepresentativeEvent();
+
+    await page.goto(`/next/event?reference=${encodeURIComponent(journey.referenceId)}&time=all`);
+    await expect(getVisibleText(page, journey.message)).toBeVisible({ timeout: 30_000 });
+
+    const table = page.locator('table:has(thead [role="checkbox"])').first();
+    const eventRow = table.locator('tbody tr').filter({ has: getVisibleText(page, journey.message) });
+    await expect(eventRow).toBeVisible();
+    const selectionWidths: number[] = [];
+
+    for (const viewport of [
+        { height: 900, name: 'desktop', width: 1440 },
+        { height: 900, name: 'narrow', width: 520 }
+    ]) {
+        await test.step(`${viewport.name} selection column is 32px`, async () => {
+            await page.setViewportSize({ height: viewport.height, width: viewport.width });
+
+            const tableBox = await table.boundingBox();
+            const selectHeaderBox = await table.locator('thead th').first().boundingBox();
+            const selectCellBox = await eventRow.locator('td').first().boundingBox();
+            const summaryHeaderBox = await table.locator('thead th').nth(1).boundingBox();
+
+            expect(tableBox).not.toBeNull();
+            expect(selectHeaderBox).not.toBeNull();
+            expect(selectCellBox).not.toBeNull();
+            expect(summaryHeaderBox).not.toBeNull();
+            selectionWidths.push(selectHeaderBox!.width);
+            expect(selectHeaderBox!.width).toBeCloseTo(32, 1);
+            expect(selectCellBox!.width).toBeCloseTo(selectHeaderBox!.width, 1);
+            expect(summaryHeaderBox!.x - tableBox!.x).toBeCloseTo(selectHeaderBox!.width, 1);
+
+            if (process.env.E2E_CAPTURE_SELECTION_COLUMN_SCREENSHOTS === 'true') {
+                const border = table.locator('xpath=ancestor::div[contains(@class, "rounded-md") and contains(@class, "border")][1]');
+                const borderBox = await border.boundingBox();
+                expect(borderBox).not.toBeNull();
+
+                await page.screenshot({
+                    clip: {
+                        height: Math.min(borderBox!.height, 760),
+                        width: Math.min(borderBox!.width, viewport.width - borderBox!.x),
+                        x: borderBox!.x,
+                        y: borderBox!.y
+                    },
+                    path: resolve(process.cwd(), `../../../dogfood-output/selection-column-width/${viewport.name}.png`)
+                });
+            }
+
+            if (viewport.name === 'desktop') {
+                const summaryHeader = table.locator('thead th').nth(1);
+                const summaryWidthBeforeResize = (await summaryHeader.boundingBox())!.width;
+                const resizeHandle = summaryHeader.getByRole('button', { name: 'Resize summary column' });
+                await resizeHandle.press('ArrowRight');
+                await expect.poll(async () => (await summaryHeader.boundingBox())!.width).toBeGreaterThan(summaryWidthBeforeResize);
+                await resizeHandle.press('ArrowLeft');
+            }
+        });
+    }
+
+    expect(selectionWidths[0]).toBeCloseTo(selectionWidths[1]!, 1);
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
@@ -21,6 +21,7 @@
     let { children, rowClick, rowHref, table }: Props = $props();
 
     const selectColumnClass = 'w-8 min-w-8 max-w-8';
+    const selectColumnWidth = 32;
 
     function getHeaderColumnClass(header: Header<StockFeatures, TData, unknown>) {
         if (header.column.id === 'select') {
@@ -62,6 +63,10 @@
     }
 
     function getColumnStyle(column: Cell<StockFeatures, TData, unknown>['column'] | Header<StockFeatures, TData, unknown>['column']): string | undefined {
+        if (column.id === 'select') {
+            return `width: ${selectColumnWidth}px; min-width: ${selectColumnWidth}px; max-width: ${selectColumnWidth}px;`;
+        }
+
         if (!column.getCanResize() || getVisibleDataColumnCount() === 1) {
             return undefined;
         }
@@ -75,6 +80,10 @@
 
     function getVisibleDataColumnCount(): number {
         return table.getVisibleLeafColumns().filter((column) => column.id !== 'select').length;
+    }
+
+    function hasSelectColumn(): boolean {
+        return table.getVisibleLeafColumns().some((column) => column.id === 'select');
     }
 
     function isWidthClass(className: string): boolean {
@@ -138,7 +147,7 @@
 </script>
 
 <div class="rounded-md border">
-    <Table.Root>
+    <Table.Root class={hasSelectColumn() ? 'table-fixed' : undefined}>
         <Table.Header class="bg-card">
             {#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
                 <Table.Row>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
@@ -22,6 +22,7 @@
 
     const selectColumnClass = 'w-8 min-w-8 max-w-8';
     const selectColumnWidth = 32;
+    const tanstackDefaultColumnWidth = 150;
 
     function getHeaderColumnClass(header: Header<StockFeatures, TData, unknown>) {
         if (header.column.id === 'select') {
@@ -67,6 +68,10 @@
             return `width: ${selectColumnWidth}px; min-width: ${selectColumnWidth}px; max-width: ${selectColumnWidth}px;`;
         }
 
+        if (hasSelectColumn() && column.id === getFlexibleDataColumnId()) {
+            return 'width: 100%;';
+        }
+
         if (!column.getCanResize() || getVisibleDataColumnCount() === 1) {
             return undefined;
         }
@@ -78,8 +83,26 @@
         return (meta as { class?: string })?.class ?? '';
     }
 
+    function getFlexibleDataColumnId(): string | undefined {
+        const unsizedColumns = getVisibleDataColumns().filter((column) => column.getSize() === (column.columnDef.size ?? tanstackDefaultColumnWidth));
+        return unsizedColumns.at(-1)?.id ?? getVisibleDataColumns().at(-1)?.id;
+    }
+
     function getVisibleDataColumnCount(): number {
-        return table.getVisibleLeafColumns().filter((column) => column.id !== 'select').length;
+        return getVisibleDataColumns().length;
+    }
+
+    function getVisibleDataColumns() {
+        return table.getVisibleLeafColumns().filter((column) => column.id !== 'select');
+    }
+
+    function getTableStyle(): string | undefined {
+        if (!hasSelectColumn()) {
+            return undefined;
+        }
+
+        const minimumWidth = selectColumnWidth + getVisibleDataColumns().reduce((total, column) => total + column.getSize(), 0);
+        return `min-width: ${minimumWidth}px;`;
     }
 
     function hasSelectColumn(): boolean {
@@ -147,7 +170,7 @@
 </script>
 
 <div class="rounded-md border">
-    <Table.Root class={hasSelectColumn() ? 'table-fixed' : undefined}>
+    <Table.Root class={hasSelectColumn() ? 'table-fixed' : undefined} style={getTableStyle()}>
         <Table.Header class="bg-card">
             {#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
                 <Table.Row>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
@@ -22,7 +22,6 @@
 
     const selectColumnClass = 'w-8 min-w-8 max-w-8';
     const selectColumnWidth = 32;
-    const tanstackDefaultColumnWidth = 150;
 
     function getHeaderColumnClass(header: Header<StockFeatures, TData, unknown>) {
         if (header.column.id === 'select') {
@@ -84,8 +83,9 @@
     }
 
     function getFlexibleDataColumnId(): string | undefined {
-        const unsizedColumns = getVisibleDataColumns().filter((column) => column.getSize() === (column.columnDef.size ?? tanstackDefaultColumnWidth));
-        return unsizedColumns.at(-1)?.id ?? getVisibleDataColumns().at(-1)?.id;
+        const columnSizing = table.atoms.columnSizing?.get() ?? {};
+        const unsizedColumns = getVisibleDataColumns().filter((column) => columnSizing[column.id] === undefined);
+        return unsizedColumns.at(-1)?.id;
     }
 
     function getVisibleDataColumnCount(): number {
@@ -102,7 +102,7 @@
         }
 
         const minimumWidth = selectColumnWidth + getVisibleDataColumns().reduce((total, column) => total + column.getSize(), 0);
-        return `min-width: ${minimumWidth}px;`;
+        return getFlexibleDataColumnId() ? `min-width: ${minimumWidth}px;` : `width: ${minimumWidth}px; min-width: ${minimumWidth}px;`;
     }
 
     function hasSelectColumn(): boolean {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
@@ -16,6 +16,18 @@ describe('DataTableBody', () => {
         expect(selectCell?.style.cssText).toBe('width: 32px; min-width: 32px; max-width: 32px;');
     });
 
+    it('preserves every explicitly sized data column', () => {
+        render(DataTableBodyTestHarness, { allColumnsSized: true, kind: 'event', onRowClick: vi.fn() });
+
+        const table = screen.getByRole('table');
+        const summaryHeader = screen.getByRole('columnheader', { name: 'Summary' });
+        const dateHeader = screen.getByRole('columnheader', { name: 'Date' });
+
+        expect(table.style.cssText).toBe('width: 302px; min-width: 302px;');
+        expect(summaryHeader.style.cssText).toBe('width: 140px; min-width: 140px; max-width: 140px;');
+        expect(dateHeader.style.cssText).toBe('width: 130px; min-width: 130px; max-width: 130px;');
+    });
+
     it('lets a resized header shrink below its metadata width', () => {
         render(DataTableBodyTestHarness, { kind: 'event', onRowClick: vi.fn() });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
@@ -4,6 +4,18 @@ import { describe, expect, it, vi } from 'vitest';
 import DataTableBodyTestHarness from './data-table-body.test-harness.svelte';
 
 describe('DataTableBody', () => {
+    it('keeps the row selection column at a fixed width', () => {
+        render(DataTableBodyTestHarness, { kind: 'event', onRowClick: vi.fn() });
+
+        const table = screen.getByRole('table');
+        const selectHeader = screen.getByRole('columnheader', { name: 'Select' });
+        const selectCell = screen.getByText('Select row').closest('td');
+
+        expect(table.classList.contains('table-fixed')).toBe(true);
+        expect(selectHeader.style.cssText).toBe('width: 32px; min-width: 32px; max-width: 32px;');
+        expect(selectCell?.style.cssText).toBe('width: 32px; min-width: 32px; max-width: 32px;');
+    });
+
     it('lets a resized header shrink below its metadata width', () => {
         render(DataTableBodyTestHarness, { kind: 'event', onRowClick: vi.fn() });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
@@ -52,6 +52,12 @@
             columnPersistenceKey: 'row-navigation-test',
             columns: [
                 {
+                    cell: 'Select row',
+                    enableResizing: false,
+                    header: 'Select',
+                    id: 'select'
+                },
+                {
                     cell: (props) => renderComponent(Summary, { showStatus: false, summary: props.row.original }),
                     header: 'Summary',
                     id: 'summary',

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
@@ -12,11 +12,12 @@
     type TestSummary = EventSummaryModel<'event-error-summary'> | StackSummaryModel<'stack-error-summary'>;
 
     interface Props {
+        allColumnsSized?: boolean;
         kind: 'event' | 'stack';
         onRowClick: (row: TestSummary) => void;
     }
 
-    let { kind, onRowClick }: Props = $props();
+    let { allColumnsSized = false, kind, onRowClick }: Props = $props();
 
     const summaryData = {
         Message: 'Unexpected end of Stream, the content may have already been read by another component.',
@@ -67,11 +68,13 @@
                 },
                 {
                     cell: (props) => props.row.original.id,
-                    enableResizing: false,
                     header: 'Date',
                     id: 'date'
                 }
             ],
+            get defaultColumnSizing() {
+                return allColumnsSized ? { date: 130, summary: 140 } : undefined;
+            },
             enableColumnResizing: true,
             paginationStrategy: 'memory',
             get queryData() {


### PR DESCRIPTION
## Summary

- keep the row-selection checkbox column fixed at 32px at desktop and narrow widths
- reserve spare table width for an unsized data column so the checkbox never stretches
- preserve saved/resized widths and automatic layout for tables without row selection
- add a browser regression test covering responsive sizing and Summary resizing

## Root cause

The selection cells had width utility classes, but browser table layout proportionally distributed leftover width across every fixed column. The selection column therefore grew with the table even though users could not resize it.

## Verification

- `npm run test:unit -- src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts` (6 passed)
- `E2E_URL=https://localhost:46195 E2E_CAPTURE_SELECTION_COLUMN_SCREENSHOTS=true npm run test:e2e -- e2e/tests/selection-column-width.e2e.ts --project=chromium` (1 passed)
- `npm run validate`
- `git diff --check`
- dogfooded against local Aspire at 1440x900 and 520x900; selection header and row cell measured 32px in both viewports

## Breaking changes

None.
