### PR TITLE
Fix Exceptionless.Job appsettings files missing in published output

### DIFF
--- a/src/Exceptionless.Job/Exceptionless.Job.csproj
+++ b/src/Exceptionless.Job/Exceptionless.Job.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <ItemGroup>
     <ProjectReference Include="..\Exceptionless.Insulation\Exceptionless.Insulation.csproj" />
   </ItemGroup>
@@ -21,9 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Update="appsettings.yml" CopyToOutputDirectory="Always" />
-    <Content Update="appsettings.*.yml" DependentUpon="appsettings.yml"
-      CopyToOutputDirectory="Always" />
+    <Content Include="appsettings.yml" CopyToOutputDirectory="Always" />
+    <Content Include="appsettings.*.yml" DependentUpon="appsettings.yml"
+             CopyToOutputDirectory="Always" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Overview

This PR fixes an issue where `Exceptionless.Job` published artifacts may not contain the required `appsettings.yml` configuration files.

## Problem

The project file currently uses:

```xml
<Content Update="appsettings.yml" CopyToOutputDirectory="Always" />
<Content Update="appsettings.*.yml" DependentUpon="appsettings.yml"
  CopyToOutputDirectory="Always" />
```

`Update` only modifies existing MSBuild items. If these files are not already included in the project item list, the files will not be copied during build or publish.

As a result, published `Exceptionless.Job` artifacts may miss the required `appsettings.yml` files.

## Impact

When running `Exceptionless.Job` from the published output:

* Runtime configuration may not be loaded correctly.
* Serilog configuration may be unavailable.
* Logging providers may not be initialized as expected.
* The Job process may continue running but produce no application logs.

This issue can be particularly difficult to diagnose in containerized environments where logs are collected from standard output.

## Fix

Replace `Content Update` with `Content Include` so that the `appsettings.yml` files are explicitly included as project content and copied to the output directory during publish.

## Testing

Verified that after publishing:

* `appsettings.yml` files are present in the output directory.
* `Exceptionless.Job` loads configuration correctly.
* Logging output is available when running the published application.
* Containerized deployments can correctly output Job logs.
