### PR TITLE
Reduce redundant frontend requests

### DIFF
--- a/src/Exceptionless.Web/Api/Endpoints/StatusEndpoints.cs
+++ b/src/Exceptionless.Web/Api/Endpoints/StatusEndpoints.cs
@@ -36,7 +36,7 @@ public static class StatusEndpoints
         group.MapGet("notifications/system", async (IMediator mediator) =>
         {
             var result = await mediator.InvokeAsync<SystemNotification>(new GetSystemNotification());
-            return result.Date == DateTime.MinValue ? HttpResults.Ok() : HttpResults.Ok(result);
+            return result.Date == DateTime.MinValue ? HttpResults.NoContent() : HttpResults.Ok(result);
         });
 
         group.MapPost("notifications/system", async (IMediator mediator, [FromBody] SetSystemNotificationRequest request, bool publish = true) =>

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/event-effects-chaos.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/event-effects-chaos.e2e.ts
@@ -82,12 +82,12 @@ test('event list and detail effects stay bounded through paging and background c
 
     await measureAction(diagnostics, 'event list paging', async () => {
         for (let index = 0; index < 4; index++) {
-            await clickAndWaitForList(page, e2eScenario.organizationId, 'Go to next page');
+            await clickAndWaitForPage(page, e2eScenario.organizationId, 'Go to next page', 2, index === 0);
             await expect(page.getByRole('button', { name: 'Go to previous page' })).toBeEnabled();
-            await clickAndWaitForList(page, e2eScenario.organizationId, 'Go to previous page');
+            await clickAndWaitForPage(page, e2eScenario.organizationId, 'Go to previous page', 1);
         }
     });
-    expect(actionSample(diagnostics, 'event list paging').eventList).toBe(8);
+    expect(actionSample(diagnostics, 'event list paging').eventList).toBe(1);
 
     await measureAction(diagnostics, 'event detail sheet mount and teardown', async () => {
         for (let index = 0; index < 5; index++) {
@@ -239,11 +239,25 @@ function actionSample(diagnostics: RuntimeDiagnostics, name: string): ActionSamp
     return sample;
 }
 
-function clickAndWaitForList(page: Page, organizationId: string, buttonName: string): Promise<unknown> {
-    return Promise.all([
-        page.waitForResponse((response) => isEventListResponse(response, organizationId)),
-        page.getByRole('button', { name: buttonName }).click()
-    ]);
+async function clickAndWaitForPage(
+    page: Page,
+    organizationId: string,
+    buttonName: string,
+    expectedPage: number,
+    waitForNetwork: boolean = false
+): Promise<void> {
+    const response = waitForNetwork ? page.waitForResponse((candidate) => isEventListResponse(candidate, organizationId)) : undefined;
+
+    await page.getByRole('button', { name: buttonName }).click();
+    await expect(
+        page
+            .getByText(new RegExp(`^Page ${expectedPage} of`))
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    if (response) {
+        expect((await response).ok()).toBe(true);
+    }
 }
 
 function createGroupedEvent(appUrl: string, message: string, run: string, index: number): { event: Record<string, unknown>; referenceId: string } {

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/list-query-cache.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/list-query-cache.e2e.ts
@@ -1,0 +1,127 @@
+import type { Page, Request } from '@playwright/test';
+
+import { expect, test } from '../fixtures/e2e-test';
+
+interface RequestCounts {
+    eventList: number;
+    eventStats: number;
+    stackList: number;
+    stackStats: number;
+}
+
+test('stack and event queries reuse fresh parameterized data during in-app navigation', async ({ e2eApi, page }) => {
+    const userToken = await e2eApi.login();
+    const organizations = await e2eApi.getOrganizations(userToken);
+    const organizationId = organizations[0]?.id;
+    expect(organizationId).toBeTruthy();
+    await page.addInitScript(
+        ({ organizationId, token }) => {
+            window.localStorage.setItem('satellizer_token', token);
+            window.localStorage.setItem('organization', JSON.stringify(organizationId));
+        },
+        { organizationId, token: userToken }
+    );
+
+    const requestCounts: RequestCounts = {
+        eventList: 0,
+        eventStats: 0,
+        stackList: 0,
+        stackStats: 0
+    };
+    const failedListRequests: string[] = [];
+    page.on('request', (request) => recordListRequest(requestCounts, request));
+    page.on('requestfailed', (request) => {
+        if (isListRequest(request)) {
+            failedListRequests.push(request.url());
+        }
+    });
+
+    await navigateToList(page, 'Stacks');
+    await expect.poll(() => requestCounts.stackList).toBe(1);
+    await expect.poll(() => requestCounts.stackStats).toBe(1);
+
+    await navigateToList(page, 'Events');
+    await expect.poll(() => requestCounts.eventList).toBe(1);
+    await expect.poll(() => requestCounts.eventStats).toBe(1);
+    expect(failedListRequests).toEqual([]);
+
+    const initialRequestCounts = { ...requestCounts };
+
+    for (let index = 0; index < 3; index++) {
+        await navigateToList(page, 'Stacks');
+        await navigateToList(page, 'Events');
+    }
+
+    expect(requestCounts).toEqual(initialRequestCounts);
+
+    await navigateToStackView(page, 'Most Frequent Errors', 'most-frequent-errors');
+    await expect.poll(() => requestCounts.stackList).toBe(initialRequestCounts.stackList + 1);
+    await expect.poll(() => requestCounts.stackStats).toBe(initialRequestCounts.stackStats + 1);
+    const initialStackViewRequestCounts = { ...requestCounts };
+
+    for (let index = 0; index < 3; index++) {
+        await navigateToStackView(page, 'All', 'all');
+        await navigateToStackView(page, 'Most Frequent Errors', 'most-frequent-errors');
+    }
+
+    expect(requestCounts).toEqual(initialStackViewRequestCounts);
+});
+
+function isListRequest(request: Request): boolean {
+    return /^\/api\/v2\/organizations\/[^/]+\/events(?:\/count)?$/.test(new URL(request.url()).pathname);
+}
+
+async function navigateToList(page: Page, name: 'Events' | 'Stacks'): Promise<void> {
+    if (page.url() === 'about:blank') {
+        await page.goto(`/next/${name.toLowerCase().replace(/s$/, '')}/all`);
+    } else {
+        const directLink = page.getByRole('link', { exact: true, name });
+        if ((await directLink.count()) > 0) {
+            await directLink.click();
+        } else {
+            const allLink = page.locator(`a[href="/next/${name.toLowerCase().replace(/s$/, '')}/all"]`);
+            if (!(await allLink.isVisible())) {
+                await page.getByRole('button', { exact: true, name }).click();
+            }
+
+            await allLink.click();
+        }
+    }
+
+    const path = name.toLowerCase().replace(/s$/, '');
+    await expect(page).toHaveURL(new RegExp(`/next/${path}(?:/all)?(?:[?#]|$)`));
+    await waitForListRefresh(page);
+}
+
+async function navigateToStackView(page: Page, name: string, slug: string): Promise<void> {
+    const link = page.locator(`a[href="/next/stack/${slug}"]`);
+    if (!(await link.isVisible())) {
+        await page.getByRole('button', { exact: true, name: 'Stacks' }).click();
+    }
+
+    await link.click();
+    await expect(page).toHaveURL(new RegExp(`/next/stack/${slug}(?:[?#]|$)`));
+    await expect(page.getByRole('heading', { exact: true, name })).toBeVisible();
+    await waitForListRefresh(page);
+}
+
+function recordListRequest(counts: RequestCounts, request: Request): void {
+    const url = new URL(request.url());
+    if (!isListRequest(request)) {
+        return;
+    }
+
+    const isStats = url.pathname.endsWith('/count');
+    const mode = url.searchParams.get('mode');
+    if (mode === 'stack_frequent') {
+        counts[isStats ? 'stackStats' : 'stackList']++;
+    } else if (isStats || mode === 'summary') {
+        counts[isStats ? 'eventStats' : 'eventList']++;
+    }
+}
+
+async function waitForListRefresh(page: Page): Promise<void> {
+    const refreshIcon = page.getByTitle('Refresh results').locator('svg');
+    await expect(refreshIcon).toBeVisible();
+    await expect(refreshIcon).not.toHaveClass(/animate-spin/);
+}

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/stack-effects-chaos.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/stack-effects-chaos.e2e.ts
@@ -71,7 +71,7 @@ test('stack effects stay bounded through background, paging, and navigation chao
             await expect(page).not.toHaveURL(/(?:\?|&)page=2(?:&|$)/);
         }
     });
-    expect(actionSample(diagnostics, 'paging').listRequests).toBe(8);
+    expect(actionSample(diagnostics, 'paging').listRequests).toBe(1);
 
     await measureAction(diagnostics, 'stack detail mount and teardown', async () => {
         for (let index = 0; index < 5; index++) {

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/stripe-loading.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/stripe-loading.e2e.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '../fixtures/e2e-test';
+
+test('authenticated application pages defer loading Stripe until billing is opened', async ({ e2eApi, page }) => {
+    const userToken = await e2eApi.login();
+    const organizations = await e2eApi.getOrganizations(userToken);
+    const organizationId = organizations[0]?.id;
+    expect(organizationId).toBeTruthy();
+
+    await page.addInitScript(
+        ({ organizationId, token }) => {
+            window.localStorage.setItem('satellizer_token', token);
+            window.localStorage.setItem('organization', JSON.stringify(organizationId));
+        },
+        { organizationId, token: userToken }
+    );
+
+    const stripeRequests: string[] = [];
+    page.on('request', (request) => {
+        const hostname = new URL(request.url()).hostname;
+        if (hostname === 'js.stripe.com' || hostname === 'm.stripe.com' || hostname.endsWith('.stripe.network')) {
+            stripeRequests.push(request.url());
+        }
+    });
+
+    await page.goto('/next/stack/all');
+    await expect(page.getByRole('heading', { exact: true, name: 'All' })).toBeVisible();
+    await expect(page.getByTitle('Refresh results').locator('svg')).not.toHaveClass(/animate-spin/);
+    await page.waitForTimeout(1_000);
+
+    expect(stripeRequests).toEqual([]);
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/billing/stripe.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/billing/stripe.svelte.ts
@@ -1,7 +1,7 @@
 import type { Stripe, StripeElements } from '@stripe/stripe-js';
 
 import { env } from '$env/dynamic/public';
-import { loadStripe } from '@stripe/stripe-js';
+import { loadStripe } from '@stripe/stripe-js/pure';
 import { getContext, setContext } from 'svelte';
 
 const STRIPE_CONTEXT_KEY = Symbol('stripe-context');

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
@@ -10,6 +10,14 @@ import { createMutation, createQuery, keepPreviousData, QueryClient, useQueryCli
 import type { EventSummaryModel, SummaryTemplateKeys } from './components/summary/index';
 import type { PersistentEvent } from './models';
 
+export async function invalidateOrganizationEventListQueries(queryClient: QueryClient, organizationId?: string) {
+    await queryClient.invalidateQueries({
+        predicate: (query) => isOrganizationEventsQueryKey(query.queryKey),
+        queryKey: organizationId ? queryKeys.organizations(organizationId) : queryKeys.type,
+        refetchType: 'none'
+    });
+}
+
 export async function invalidatePersistentEventQueries(queryClient: QueryClient, message: WebSocketMessageValue<'PersistentEventChanged'>) {
     const { id, organization_id, project_id, stack_id } = message;
     if (id) {
@@ -27,6 +35,8 @@ export async function invalidatePersistentEventQueries(queryClient: QueryClient,
     if (organization_id) {
         await queryClient.invalidateQueries({ exact: true, queryKey: queryKeys.organizations(organization_id) });
     }
+
+    await invalidateOrganizationEventListQueries(queryClient, organization_id);
 
     if (!id && !stack_id) {
         await queryClient.invalidateQueries({
@@ -59,6 +69,7 @@ export const queryKeys = {
 export const PERSISTENT_EVENT_DELETE_RECONCILE_EVENT = 'PersistentEventDeleteReconcile';
 export const PERSISTENT_EVENT_DELETE_RECONCILE_DELAY = 1500;
 export const PERSISTENT_EVENT_DELETE_RECONCILE_RETRY_DELAY = 5000;
+export const ORGANIZATION_EVENT_QUERY_STALE_TIME_MS = 60 * 1000;
 
 export interface DeleteEventsRequest {
     route: {
@@ -331,7 +342,8 @@ export function getOrganizationCountQuery(request: GetOrganizationCountRequest) 
 
                 return response.data!;
             },
-            queryKey: queryKeys.organizationsCount(organizationId, params)
+            queryKey: queryKeys.organizationsCount(organizationId, params),
+            staleTime: ORGANIZATION_EVENT_QUERY_STALE_TIME_MS
         };
     });
 }
@@ -351,7 +363,8 @@ export function getOrganizationEventsQuery(request: GetOrganizationEventsRequest
                     signal
                 });
             },
-            queryKey: queryKeys.organizationsEvents(organizationId, params)
+            queryKey: queryKeys.organizationsEvents(organizationId, params),
+            staleTime: ORGANIZATION_EVENT_QUERY_STALE_TIME_MS
         };
     });
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
@@ -312,23 +312,28 @@ export function getEventWithNavigationQuery(request: GetEventRequest) {
 export function getOrganizationCountQuery(request: GetOrganizationCountRequest) {
     const queryClient = useQueryClient();
 
-    return createQuery<CountResult, ProblemDetails>(() => ({
-        enabled: () => !!accessToken.current && !!request.route.organizationId && (request.enabled?.() ?? true),
-        queryClient,
-        queryFn: async ({ signal }: { signal: AbortSignal }) => {
-            const client = useFetchClient();
-            const response = await client.getJSON<CountResult>(`/organizations/${request.route.organizationId}/events/count`, {
-                params: {
-                    ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
-                    ...request.params
-                },
-                signal
-            });
+    return createQuery<CountResult, ProblemDetails>(() => {
+        const organizationId = request.route.organizationId;
+        const params = request.params ? { ...request.params } : undefined;
 
-            return response.data!;
-        },
-        queryKey: queryKeys.organizationsCount(request.route.organizationId, request.params)
-    }));
+        return {
+            enabled: () => !!accessToken.current && !!organizationId && (request.enabled?.() ?? true),
+            queryClient,
+            queryFn: async ({ signal }: { signal: AbortSignal }) => {
+                const client = useFetchClient();
+                const response = await client.getJSON<CountResult>(`/organizations/${organizationId}/events/count`, {
+                    params: {
+                        ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
+                        ...params
+                    },
+                    signal
+                });
+
+                return response.data!;
+            },
+            queryKey: queryKeys.organizationsCount(organizationId, params)
+        };
+    });
 }
 
 export function getOrganizationEventsQuery(request: GetOrganizationEventsRequest) {
@@ -346,9 +351,7 @@ export function getOrganizationEventsQuery(request: GetOrganizationEventsRequest
                     signal
                 });
             },
-            queryKey: queryKeys.organizationsEvents(organizationId, params),
-            refetchOnWindowFocus: false,
-            staleTime: 0
+            queryKey: queryKeys.organizationsEvents(organizationId, params)
         };
     });
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.test.ts
@@ -17,10 +17,14 @@ afterEach(() => {
 });
 
 describe('invalidatePersistentEventQueries', () => {
-    it('does not invalidate nested count aggregation queries for event updates', async () => {
+    it('marks cached organization event lists stale without refetching them immediately', async () => {
         // Arrange
         const queryClient = new QueryClient();
-        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries').mockImplementation(async () => {});
+        const eventListKey = queryKeys.organizationsEvents('organization-id', { mode: 'summary' });
+        const otherOrganizationEventListKey = queryKeys.organizationsEvents('other-organization-id', { mode: 'summary' });
+        queryClient.setQueryData(eventListKey, { data: [] });
+        queryClient.setQueryData(otherOrganizationEventListKey, { data: [] });
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
         // Act
         await invalidatePersistentEventQueries(queryClient, {
@@ -39,9 +43,19 @@ describe('invalidatePersistentEventQueries', () => {
         expect(invalidateSpy).toHaveBeenCalledWith({ exact: true, queryKey: queryKeys.projects('project-id') });
         expect(invalidateSpy).toHaveBeenCalledWith({ exact: true, queryKey: queryKeys.organizations('organization-id') });
         expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: queryKeys.stacks('stack-id') });
+
+        const listInvalidation = invalidateSpy.mock.calls.find(([filters]) => filters?.refetchType === 'none')?.[0];
+        expect(listInvalidation).toMatchObject({
+            queryKey: queryKeys.organizations('organization-id'),
+            refetchType: 'none'
+        });
+        expect(listInvalidation?.predicate?.({ queryKey: eventListKey } as never)).toBe(true);
+        expect(listInvalidation?.predicate?.({ queryKey: queryKeys.organizationsCount('organization-id') } as never)).toBe(false);
+        expect(queryClient.getQueryState(eventListKey)?.isInvalidated).toBe(true);
+        expect(queryClient.getQueryState(otherOrganizationEventListKey)?.isInvalidated).toBe(false);
     });
 
-    it('leaves organization event list refreshes to the document event handler for bulk updates', async () => {
+    it('marks all cached organization event lists stale for bulk updates', async () => {
         // Arrange
         const queryClient = new QueryClient();
         const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries').mockImplementation(async () => {});
@@ -62,6 +76,10 @@ describe('invalidatePersistentEventQueries', () => {
         const broadInvalidation = invalidateSpy.mock.calls.find(([filters]) => filters?.queryKey === queryKeys.type)?.[0];
         expect(broadInvalidation?.predicate?.({ queryKey: queryKeys.organizationsEvents('organization-id') } as never)).toBe(false);
         expect(broadInvalidation?.predicate?.({ queryKey: queryKeys.organizationsCount('organization-id') } as never)).toBe(true);
+
+        const listInvalidation = invalidateSpy.mock.calls.find(([filters]) => filters?.refetchType === 'none')?.[0];
+        expect(listInvalidation?.predicate?.({ queryKey: queryKeys.organizationsEvents('organization-id') } as never)).toBe(true);
+        expect(listInvalidation?.predicate?.({ queryKey: queryKeys.organizationsCount('organization-id') } as never)).toBe(false);
     });
 });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -50,6 +50,7 @@ export interface UseSavedViewsReturn {
     handleClearSavedView: () => void;
     handleLoadView: (view: SavedView) => void;
     handleResetToSaved: () => void;
+    hydratedSavedViewId: string | undefined;
     isEnabled: boolean;
     isLoading: boolean;
     isMissing: boolean;
@@ -204,6 +205,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     // Hydrate saved view state when a saved view loads. Query params remain URL overrides.
     // lastLoadedViewId prevents re-hydration on background refetches (which would stomp user edits).
     let lastLoadedViewId = '';
+    let hydratedSavedViewId = $state<string>();
     $effect(() => {
         const savedViewKey = options.slug ?? options.queryParams.saved;
         const view = activeSavedView;
@@ -221,10 +223,12 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
                 lastLoadedViewId = '';
             }
 
+            hydratedSavedViewId = undefined;
             return;
         }
 
         if (!view) {
+            hydratedSavedViewId = undefined;
             // Skip while refetching to avoid false-positive clears during cache invalidation
             if (isFetching) {
                 return;
@@ -235,6 +239,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
         // Already loaded this view — skip to avoid stomping user edits on background refetch
         if (view.id === lastLoadedViewId) {
+            hydratedSavedViewId = view.id;
             return;
         }
 
@@ -251,6 +256,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
         applyColumnState(view);
         applyDisplayState(view);
+        hydratedSavedViewId = view.id;
     });
 
     // Detect if current filters or columns differ from the active saved view
@@ -362,6 +368,9 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         handleClearSavedView,
         handleLoadView,
         handleResetToSaved,
+        get hydratedSavedViewId() {
+            return hydratedSavedViewId;
+        },
         get isEnabled() {
             return isEnabled;
         },

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/api.svelte.ts
@@ -8,9 +8,14 @@ import { createMutation, createQuery, QueryClient, useQueryClient } from '@tanst
 import type { Stack, StackStatus } from './models';
 
 export async function invalidateStackQueries(queryClient: QueryClient, message: WebSocketMessageValue<'StackChanged'>) {
-    const { id } = message;
+    const { id, project_id } = message;
     if (id) {
         await queryClient.invalidateQueries({ queryKey: queryKeys.id(id) });
+        await queryClient.invalidateQueries({
+            predicate: (query) => isProjectStacksQueryKey(query.queryKey),
+            queryKey: project_id ? queryKeys.projects(project_id) : queryKeys.type,
+            refetchType: 'none'
+        });
     } else {
         await queryClient.invalidateQueries({ queryKey: queryKeys.type });
     }
@@ -28,7 +33,8 @@ export const queryKeys = {
     postMarkSnoozed: (ids: string[] | undefined) => [...queryKeys.ids(ids), 'mark-snoozed'] as const,
     postPromote: (ids: string[] | undefined) => [...queryKeys.ids(ids), 'promote'] as const,
     postRemoveLink: (id: string | undefined) => [...queryKeys.id(id), 'remove-link'] as const,
-    project: (projectId: string | undefined, params?: GetProjectStacksParams) => [...queryKeys.type, 'project', projectId, { params }] as const,
+    project: (projectId: string | undefined, params?: GetProjectStacksParams) => [...queryKeys.projects(projectId), { params }] as const,
+    projects: (projectId: string | undefined) => [...queryKeys.type, 'project', projectId] as const,
     type: ['Stack'] as const
 };
 
@@ -324,4 +330,8 @@ export async function prefetchStack(request: GetStackRequest) {
         },
         queryKey: queryKeys.id(request.route.id)
     });
+}
+
+function isProjectStacksQueryKey(queryKey: readonly unknown[]): boolean {
+    return queryKey[0] === queryKeys.type[0] && queryKey[1] === 'project';
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/api.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/api.test.ts
@@ -1,0 +1,38 @@
+import { ChangeType } from '$features/websockets/models';
+import { QueryClient } from '@tanstack/svelte-query';
+import { describe, expect, it, vi } from 'vitest';
+
+import { invalidateStackQueries, queryKeys } from './api.svelte';
+
+describe('invalidateStackQueries', () => {
+    it('marks cached project stack lists stale without refetching them immediately', async () => {
+        // Arrange
+        const queryClient = new QueryClient();
+        const projectListKey = queryKeys.project('project-id', { filter: 'status:open' });
+        const otherProjectListKey = queryKeys.project('other-project-id', { filter: 'status:open' });
+        queryClient.setQueryData(projectListKey, { data: [] });
+        queryClient.setQueryData(otherProjectListKey, { data: [] });
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+        // Act
+        await invalidateStackQueries(queryClient, {
+            change_type: ChangeType.Saved,
+            data: {},
+            id: 'stack-id',
+            organization_id: 'organization-id',
+            project_id: 'project-id',
+            type: 'Stack'
+        });
+
+        // Assert
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.id('stack-id') });
+        const listInvalidation = invalidateSpy.mock.calls.find(([filters]) => filters?.refetchType === 'none')?.[0];
+        expect(listInvalidation).toMatchObject({
+            queryKey: queryKeys.projects('project-id'),
+            refetchType: 'none'
+        });
+        expect(listInvalidation?.predicate?.({ queryKey: projectListKey } as never)).toBe(true);
+        expect(queryClient.getQueryState(projectListKey)?.isInvalidated).toBe(true);
+        expect(queryClient.getQueryState(otherProjectListKey)?.isInvalidated).toBe(false);
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
@@ -10,7 +10,7 @@
     import { getIntercomTokenQuery } from '$features/auth/api.svelte';
     import { accessToken, gotoLogin } from '$features/auth/index.svelte';
     import { UpgradeRequiredDialog } from '$features/billing';
-    import { invalidatePersistentEventQueries } from '$features/events/api.svelte';
+    import { invalidateOrganizationEventListQueries, invalidatePersistentEventQueries } from '$features/events/api.svelte';
     import { filterUsesPremiumFeatures, getSearchResourceForPathname } from '$features/events/premium-filter';
     import { buildIntercomBootOptions, IntercomShell } from '$features/intercom';
     import { shouldLoadIntercomOrganization } from '$features/intercom/config';
@@ -169,6 +169,7 @@
                     break;
                 case 'StackChanged':
                     await invalidateStackQueries(queryClient, data.message);
+                    await invalidateOrganizationEventListQueries(queryClient, data.message.organization_id);
                     break;
                 case 'TokenChanged':
                     await invalidateTokenQueries(queryClient, data.message);

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -53,7 +53,7 @@
     import SavedViewPicker from '$features/saved-views/components/saved-view-picker.svelte';
     import { useSavedViews } from '$features/saved-views/use-saved-views.svelte';
     import * as agg from '$features/shared/api/aggregations';
-    import { createPageSizePreference, getSharedTableOptions, isTableEmpty, removeTableData, removeTableSelection } from '$features/shared/table.svelte';
+    import { createPageSizePreference, getSharedTableOptions, removeTableData, removeTableSelection } from '$features/shared/table.svelte';
     import { fillDateSeries } from '$features/shared/utils/charts.js';
     import { toDateMathRange } from '$features/shared/utils/datemath';
     import { parseDateMathRange } from '$features/shared/utils/datemath.js';
@@ -277,7 +277,11 @@
         view: VIEW
     });
     const pageTitle = $derived(savedViewsState.activeSavedView?.name ?? 'Events');
-    const isSavedViewRoutePending = $derived(!!page.params.slug && !savedViewsState.activeSavedView);
+    // Keep queries disabled until saved-view state and its URL overrides have both settled.
+    let normalizedSavedViewId = $state<string>();
+    const isSavedViewRoutePending = $derived(
+        !!page.params.slug && (!savedViewsState.activeSavedView || savedViewsState.activeSavedView.id !== normalizedSavedViewId)
+    );
 
     $effect(() => {
         document.title = `${pageTitle} - Exceptionless`;
@@ -520,13 +524,15 @@
 
     $effect(() => {
         const activeSavedViewId = savedViewsState.activeSavedView?.id;
-        if (!activeSavedViewId) {
+        if (!activeSavedViewId || activeSavedViewId !== savedViewsState.hydratedSavedViewId) {
+            normalizedSavedViewId = undefined;
             return;
         }
 
         untrack(() => {
             updateFilters(getCurrentFilters(getListFilterQueryParams(page.url.searchParams)), { clearPagination: false });
         });
+        normalizedSavedViewId = activeSavedViewId;
     });
 
     function getQueryFilterParams(filters: FacetedFilter.IFilter[]) {
@@ -914,19 +920,6 @@
             totalEvents,
             totalStacks
         };
-    });
-
-    let lastStatsRefreshKey = $state<string>();
-
-    $effect(() => {
-        const refreshKey = `${organization.current}:${page.url.search}:${stats.totalEvents}`;
-
-        if (!eventsQuery.data?.ok || stats.totalEvents <= 0 || !isTableEmpty(table) || lastStatsRefreshKey === refreshKey) {
-            return;
-        }
-
-        lastStatsRefreshKey = refreshKey;
-        void eventsQuery.refetch();
     });
 
     function onRangeSelect(start: Date, end: Date) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -266,7 +266,11 @@
         view: VIEW
     });
     const pageTitle = $derived(savedViewsState.activeSavedView?.name ?? 'Stacks');
-    const isSavedViewRoutePending = $derived(!!page.params.slug && !savedViewsState.activeSavedView);
+    // Keep queries disabled until saved-view state and its URL overrides have both settled.
+    let normalizedSavedViewId = $state<string>();
+    const isSavedViewRoutePending = $derived(
+        !!page.params.slug && (!savedViewsState.activeSavedView || savedViewsState.activeSavedView.id !== normalizedSavedViewId)
+    );
 
     $effect(() => {
         document.title = `${pageTitle} - Exceptionless`;
@@ -511,13 +515,15 @@
 
     $effect(() => {
         const activeSavedViewId = savedViewsState.activeSavedView?.id;
-        if (!activeSavedViewId) {
+        if (!activeSavedViewId || activeSavedViewId !== savedViewsState.hydratedSavedViewId) {
+            normalizedSavedViewId = undefined;
             return;
         }
 
         untrack(() => {
             updateFilters(getCurrentFilters(getListFilterQueryParams(page.url.searchParams)), { clearPagination: false });
         });
+        normalizedSavedViewId = activeSavedViewId;
     });
 
     function getQueryFilterParams(filters: FacetedFilter.IFilter[]) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/+layout.svelte
@@ -104,7 +104,7 @@
 
                     return true;
                 },
-                staleTime: 5 * 60 * 1000
+                staleTime: 60 * 1000
             }
         }
     });

--- a/src/Exceptionless.Web/ClientApp/src/routes/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/+layout.svelte
@@ -104,7 +104,7 @@
 
                     return true;
                 },
-                staleTime: 60 * 1000
+                staleTime: 5 * 60 * 1000
             }
         }
     });

--- a/tests/Exceptionless.Tests/Api/Endpoints/StatusEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/StatusEndpointTests.cs
@@ -94,12 +94,12 @@ public class StatusEndpointTests : IntegrationTestsBase
     }
 
     [Fact]
-    public Task GetSystemNotificationAsync_WhenNoneSet_ReturnsOk()
+    public Task GetSystemNotificationAsync_WhenNoneSet_ReturnsNoContent()
     {
         return SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPath("notifications/system")
-            .StatusCodeShouldBeOk());
+            .StatusCodeShouldBeNoContent());
     }
 
     [Fact]
@@ -168,7 +168,7 @@ public class StatusEndpointTests : IntegrationTestsBase
         var response = await SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .AppendPath("notifications/system")
-            .StatusCodeShouldBeOk());
+            .StatusCodeShouldBeNoContent());
         string content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.DoesNotContain("To be removed", content);
     }

--- a/tests/http/status.http
+++ b/tests/http/status.http
@@ -32,6 +32,7 @@ GET {{apiUrl}}/queue-stats
 Authorization: Bearer {{token}}
 
 ### System Notification
+# Returns 204 No Content when no system notification is configured.
 GET {{apiUrl}}/notifications/system
 Authorization: Bearer {{token}}
 


### PR DESCRIPTION
## Summary

- cache parameterized Event and Stack list queries for one minute and rely on TanStack Query keys plus existing invalidation
- wait for saved-view filters and URL overrides to finish hydrating before starting list and stats queries
- remove the Events recovery refetch that duplicated successful list requests
- defer Stripe.js loading until the billing flow actually mounts
- return `204 No Content` when no system notification is configured
- add browser regressions for cached navigation, first-load request counts, canceled requests, and eager Stripe traffic

## Root cause

The Events query overrode the global cache policy with `staleTime: 0`, and the page included a manual recovery refetch. Saved-view routes could also enable their list and count queries before saved-view state finished normalizing, causing an initial request pair to be canceled and restarted. Separately, importing Stripe's default loader injected Stripe.js on every authenticated page.

The system-notification endpoint represented the absence of a notification as an empty `200 OK` response, which had no response body or content type. It now uses the HTTP status intended for that response shape.

## Impact

Switching between fresh Event and Stack views no longer repeats equivalent server work. First entry into a saved view issues one list request and one stats request without aborted duplicates. Normal authenticated pages no longer send Stripe telemetry unless the billing UI is opened. The system-notification request now clearly reports an absent notification as `204 No Content`.

## Validation

- `npm run validate`
- `npm exec vitest run -- src/lib/features/saved-views/use-saved-views.test.ts` (38 tests)
- `E2E_URL=https://localhost:37315 npm exec playwright test -- e2e/tests/list-query-cache.e2e.ts e2e/tests/stripe-loading.e2e.ts`
- focused local browser trace confirmed one list request, one count request, both HTTP 200, and zero cancellations
- `dotnet test --project tests/Exceptionless.Tests/Exceptionless.Tests.csproj -- --filter-class Exceptionless.Tests.Api.Endpoints.StatusEndpointTests` (14 tests)
- `dotnet test --project tests/Exceptionless.Tests/Exceptionless.Tests.csproj -- --filter-class Exceptionless.Tests.Api.OpenApiSnapshotTests` (4 tests)

## Breaking changes

- `GET /api/v2/notifications/system` now returns `204 No Content` instead of an empty `200 OK` when no system notification exists. Configured notifications are unchanged.
