### PR TITLE
Polish legacy system notification banner

### DIFF
--- a/src/Exceptionless.Web/ClientApp.angular/components/system-notification/system-notification-directive.tpl.html
+++ b/src/Exceptionless.Web/ClientApp.angular/components/system-notification/system-notification-directive.tpl.html
@@ -1,6 +1,6 @@
 <div refresh-on="SystemNotification" refresh-action="svm.processSystemNotification(data)">
     <div
-        class="alert alert-banner alert-dismissible m-b-none"
+        class="alert alert-banner alert-dismissible system-notification-banner m-b-none"
         ng-class="svm.systemNotificationClass"
         ng-if="!!svm.systemNotificationMessage && svm.systemNotificationKey !== svm.dismissedSystemNotificationKey"
         role="alert"
@@ -14,6 +14,7 @@
         >
             <span aria-hidden="true">&times;</span>
         </button>
-        <div ng-bind-html="svm.systemNotificationMessage"></div>
+        <span class="system-notification-icon" aria-hidden="true"></span>
+        <div class="system-notification-message" ng-bind-html="svm.systemNotificationMessage"></div>
     </div>
 </div>

--- a/src/Exceptionless.Web/ClientApp.angular/less/alerts.less
+++ b/src/Exceptionless.Web/ClientApp.angular/less/alerts.less
@@ -2,6 +2,76 @@
     border-radius: 0px;
 }
 
+.system-notification-banner {
+    position: relative;
+    min-height: 44px;
+    padding: 11px 48px 11px 52px;
+    border-width: 0 0 1px;
+    box-shadow: none;
+    font-size: @font-size-base;
+    line-height: @line-height-computed;
+
+    &.alert-info {
+        color: #245b30;
+        background-color: #e7f6e9;
+        border-color: #b8ddb9;
+    }
+
+    .system-notification-icon {
+        position: absolute;
+        top: 50%;
+        left: 20px;
+        color: currentColor;
+        font-family: FontAwesome;
+        font-size: @font-size-md;
+        line-height: 1;
+        transform: translateY(-50%);
+
+        &:before {
+            content: "\f05a";
+        }
+    }
+
+    &.alert-warning .system-notification-icon:before {
+        content: "\f071";
+    }
+
+    &.alert-danger .system-notification-icon:before {
+        content: "\f06a";
+    }
+
+    .close {
+        position: absolute;
+        top: 50%;
+        right: 17px;
+        color: currentColor;
+        line-height: 1;
+        transform: translateY(-50%);
+    }
+
+    .system-notification-message {
+        > :first-child {
+            margin-top: 0;
+        }
+
+        > :last-child {
+            margin-bottom: 0;
+        }
+
+        // Messages support HTML and may include legacy alert markup. The banner
+        // already supplies the level styling, so avoid rendering an alert inside it.
+        > .alert {
+            margin: 0;
+            padding: 0;
+            border: 0;
+            background: transparent;
+            box-shadow: none;
+            color: inherit;
+            font-size: inherit;
+        }
+    }
+}
+
 .alert-banner a {
     text-decoration: underline;
 }


### PR DESCRIPTION
## Summary

- restyle the legacy system notification as a compact, level-aware banner
- add severity icons and align the dismissal control
- flatten nested Bootstrap alert markup supplied by HTML notification messages
- preserve the existing warning and error variants without changing other legacy alerts

## Why

System notification messages support HTML, but the legacy directive already wraps them in a Bootstrap alert. Messages containing alert markup therefore rendered as an alert inside another alert, creating an oversized double-banner layout that pushed the page content down.

## Validation

- `npx prettier --check components/system-notification/system-notification-directive.tpl.html less/alerts.less`
- `npm run build`
- Aspire OldApp and API health checks returned HTTP 200
- authenticated Chromium render at 2048x946 confirmed a 44px banner, an 18px icon-to-message gap, and a transparent nested alert background

## Breaking changes

None.