### PR TITLE
Reduce SigNoz infrastructure metric volume

### DIFF
--- a/k8s/signoz.yaml
+++ b/k8s/signoz.yaml
@@ -17,6 +17,15 @@ presets:
     detectors:
       - azure
       - system
+  hostMetrics:
+    enabled: true
+    collectionInterval: 60s
+  kubeletMetrics:
+    enabled: true
+    collectionInterval: 60s
+  clusterMetrics:
+    enabled: true
+    collectionInterval: 60s
   prometheus:
     enabled: true
     scrapeInterval: 30s
@@ -79,6 +88,11 @@ otelAgent:
               - ex.events.parse.jsoneventparserplugin
               - ex.events.field.count
               - ex.eventpipeline.markascriticalaction
+      filter/volumes_pvc_only:
+        error_mode: ignore
+        metrics:
+          datapoint:
+            - 'IsMatch(metric.name, "^k8s\\.volume\\.") and attributes["k8s.volume.type"] != "persistentVolumeClaim"'
       filter/drop_cache_spans:
         error_mode: ignore
         traces:
@@ -91,5 +105,5 @@ otelAgent:
           processors: [filter/drop_cache_spans, batch]
           exporters: [otlphttp, otlp/elastic]
         metrics:
-          processors: [filter/drop_unused_metrics, batch]
+          processors: [filter/drop_unused_metrics, filter/volumes_pvc_only, batch]
           exporters: [otlphttp, otlp/elastic]


### PR DESCRIPTION
## Summary

- collect host, kubelet, and cluster infrastructure metrics every 60 seconds instead of every 30 seconds
- retain only persistent-volume-claim datapoints from the `k8s.volume.*` family
- preserve all existing application, Elasticsearch, Redis, and PVC metrics

## Impact

This reduces SigNoz infrastructure metric ingestion while preserving every metric family and label other than non-PVC volume datapoints.

The expected result is approximately a 36% reduction in the affected infrastructure block: from about 2.22M datapoints/hour to 1.42M datapoints/hour. Kubernetes infrastructure charts move to 60-second resolution. The PVC dashboard retains all real PVCs, while emptyDir, ConfigMap, Secret, downwardAPI, and similar ephemeral volumes no longer appear in the Infra Volumes view.

## Validation

- rendered `signoz/k8s-infra` 0.16.0 with Helm 4.2.3 and the updated values
- confirmed `hostmetrics`, `kubeletstats`, and `k8s_cluster` render with `collection_interval: 60s`
- confirmed the rendered agent pipeline retains `resource/deployenv`, `resourcedetection`, and `k8sattributes`
- confirmed `filter/drop_unused_metrics` and `filter/volumes_pvc_only` run before `batch`
- confirmed Collector 0.139.0 parses the new filter and pipeline configuration
- `git diff --check`

## Deployment

Apply the updated `k8s/signoz.yaml` through the existing `signoz-collector` Helm release. Helm will roll both the agent DaemonSet and central deployment because the receiver intervals change in both components.