### PR TITLE
Expand command palette actions

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/project-command-actions.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/project-command-actions.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+    import type { ViewProject } from '$features/projects/models';
+    import type { Component } from 'svelte';
+
+    import { resolve } from '$app/paths';
+    import * as Command from '$comp/ui/command';
+    import { organization } from '$features/organizations/context.svelte';
+    import { generateSampleData, getOrganizationProjectsQuery } from '$features/projects/api.svelte';
+    import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
+    import ArrowLeft from '@lucide/svelte/icons/arrow-left';
+    import Bell from '@lucide/svelte/icons/bell';
+    import CloudDownload from '@lucide/svelte/icons/cloud-download';
+    import Database from '@lucide/svelte/icons/database';
+    import FolderOpen from '@lucide/svelte/icons/folder-open';
+    import Stacks from '@lucide/svelte/icons/layers';
+    import { toast } from 'svelte-sonner';
+
+    type ProjectActionId = 'client-setup' | 'generate-sample-data' | 'notifications' | 'open' | 'reset-data' | 'stacks';
+
+    type ProjectAction = {
+        icon: Component;
+        id: ProjectActionId;
+        keywords: string[];
+        label: string;
+    };
+
+    interface Props {
+        onReset: (project: ViewProject) => void;
+        onSearchReset: () => void;
+        onSelect: () => void;
+        open: boolean;
+        resetPending: boolean;
+        selectingProject: boolean;
+    }
+
+    let { onReset, onSearchReset, onSelect, open, resetPending, selectingProject = $bindable() }: Props = $props();
+
+    const projectActions: ProjectAction[] = [
+        { icon: FolderOpen, id: 'open', keywords: ['edit', 'manage', 'settings'], label: 'Open Project' },
+        { icon: Stacks, id: 'stacks', keywords: ['errors', 'exceptions', 'issues'], label: 'Project Stacks' },
+        { icon: Bell, id: 'notifications', keywords: ['alerts', 'email'], label: 'Project Notifications' },
+        { icon: CloudDownload, id: 'client-setup', keywords: ['SDK', 'configure client', 'instrumentation'], label: 'Client Setup' },
+        { icon: Database, id: 'generate-sample-data', keywords: ['seed', 'demo events'], label: 'Generate Sample Data' },
+        { icon: AlertTriangle, id: 'reset-data', keywords: ['clear', 'delete events'], label: 'Reset Project Data' }
+    ];
+
+    let selectedAction = $state<ProjectAction>();
+
+    const projectsQuery = getOrganizationProjectsQuery({
+        enabled: () => open,
+        route: {
+            get organizationId() {
+                return organization.current;
+            }
+        }
+    });
+    const projects = $derived([...(projectsQuery.data?.data ?? [])].sort((a, b) => a.name.localeCompare(b.name)));
+
+    let sampleDataProjectId = $state<string>();
+    const generateSampleDataMutation = generateSampleData({
+        route: {
+            get id() {
+                return sampleDataProjectId;
+            }
+        }
+    });
+
+    function selectAction(action: ProjectAction): void {
+        selectedAction = action;
+        selectingProject = true;
+        onSearchReset();
+    }
+
+    function goBack(): void {
+        selectedAction = undefined;
+        selectingProject = false;
+        onSearchReset();
+    }
+
+    function getProjectHref(action: ProjectActionId, project: ViewProject): string | undefined {
+        switch (action) {
+            case 'client-setup':
+                return resolve('/(app)/project/[projectId]/configure', { projectId: project.id });
+            case 'notifications':
+                return `${resolve('/(app)/account/notifications')}?project=${project.id}`;
+            case 'open':
+                return resolve('/(app)/project/[projectId]/manage', { projectId: project.id });
+            case 'stacks':
+                return `${resolve('/(app)/stack')}?filter=project:${project.id}`;
+            default:
+                return undefined;
+        }
+    }
+
+    function closeForProject(project: ViewProject): void {
+        organization.current = project.organization_id;
+        onSelect();
+    }
+
+    async function generateProjectSampleData(project: ViewProject): Promise<void> {
+        closeForProject(project);
+        sampleDataProjectId = project.id;
+
+        try {
+            await generateSampleDataMutation.mutateAsync();
+            toast.success(`Sample data generation has been queued for "${project.name}". Events will appear shortly.`);
+        } catch {
+            toast.error(`Failed to generate sample data for "${project.name}". Please try again.`);
+        } finally {
+            sampleDataProjectId = undefined;
+        }
+    }
+
+    function openResetProjectDataDialog(project: ViewProject): void {
+        closeForProject(project);
+        onReset(project);
+    }
+
+    function selectProject(project: ViewProject): void {
+        if (!selectedAction) {
+            return;
+        }
+
+        if (selectedAction.id === 'generate-sample-data') {
+            void generateProjectSampleData(project);
+        } else if (selectedAction.id === 'reset-data') {
+            openResetProjectDataDialog(project);
+        }
+    }
+</script>
+
+{#if organization.current}
+    {#if selectingProject && selectedAction}
+        <Command.Group heading={selectedAction.label} value={`${selectedAction.label} Select Project`}>
+            <Command.Item onSelect={goBack} value="Back to commands">
+                <ArrowLeft />
+                <span>Back to commands</span>
+            </Command.Item>
+            {#if projectsQuery.isLoading}
+                <Command.Item disabled value="Loading projects">
+                    <Database />
+                    <span>Loading projects...</span>
+                </Command.Item>
+            {:else if projectsQuery.isError}
+                <Command.Item disabled value="Unable to load projects">
+                    <AlertTriangle />
+                    <span>Unable to load projects</span>
+                </Command.Item>
+            {:else if projects.length === 0}
+                <Command.Item disabled value="No projects available">
+                    <Database />
+                    <span>No projects available</span>
+                </Command.Item>
+            {:else}
+                {#each projects as project (project.id)}
+                    {@const href = getProjectHref(selectedAction.id, project)}
+                    {@const Icon = selectedAction.icon}
+                    {#if href}
+                        <Command.LinkItem {href} onclick={() => closeForProject(project)} value={`${selectedAction.label} ${project.name} ${project.id}`}>
+                            <Icon />
+                            <div class="flex min-w-0 flex-col">
+                                <span class="truncate">{project.name}</span>
+                                <span class="text-muted-foreground truncate text-xs">{selectedAction.label}</span>
+                            </div>
+                        </Command.LinkItem>
+                    {:else}
+                        <Command.Item
+                            disabled={generateSampleDataMutation.isPending || resetPending}
+                            onSelect={() => selectProject(project)}
+                            value={`${selectedAction.label} ${project.name} ${project.id}`}
+                        >
+                            <Icon />
+                            <div class="flex min-w-0 flex-col">
+                                <span class="truncate">{project.name}</span>
+                                <span class="text-muted-foreground truncate text-xs">{selectedAction.label}</span>
+                            </div>
+                        </Command.Item>
+                    {/if}
+                {/each}
+            {/if}
+        </Command.Group>
+    {:else}
+        <Command.Group heading="Project Actions" value="Project Actions">
+            {#each projectActions as action (action.id)}
+                {@const Icon = action.icon}
+                <Command.Item keywords={action.keywords} onSelect={() => selectAction(action)} value={`Project Actions ${action.label}`}>
+                    <Icon />
+                    <span>{action.label}</span>
+                </Command.Item>
+            {/each}
+        </Command.Group>
+        <Command.Separator />
+    {/if}
+{/if}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar-organization-switcher.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar-organization-switcher.svelte
@@ -24,6 +24,7 @@
 
     type Props = HTMLAttributes<HTMLUListElement> & {
         currentOrganizationId: string | undefined;
+        impersonateDialogOpen?: boolean;
         impersonatedOrganization: undefined | ViewOrganization;
         isGlobalAdmin: boolean;
         isLoading: boolean;
@@ -34,6 +35,7 @@
     let {
         class: className,
         currentOrganizationId = $bindable(),
+        impersonateDialogOpen = $bindable(false),
         impersonatedOrganization,
         isGlobalAdmin,
         isLoading,
@@ -46,7 +48,6 @@
     const isImpersonating = $derived(!!impersonatedOrganization);
     const useSingleOrganizationShortcut = $derived(!isGlobalAdmin && !isImpersonating && organizations.length === 1 && !!activeOrganization?.id);
     let menuContentElement = $state<HTMLElement | null>(null);
-    let openImpersonateDialog = $state(false);
 
     $effect(() => {
         if (open) {
@@ -218,7 +219,7 @@
                                     <span class="font-medium">Stop Impersonating</span>
                                 </DropdownMenu.Item>
                             {:else}
-                                <DropdownMenu.Item onSelect={() => (openImpersonateDialog = true)} class="gap-2 p-2">
+                                <DropdownMenu.Item onSelect={() => (impersonateDialogOpen = true)} class="gap-2 p-2">
                                     <div class="bg-background flex size-6 items-center justify-center rounded-md border">
                                         <Eye class="size-4" aria-hidden="true" />
                                     </div>
@@ -247,9 +248,9 @@
     </DelayedRender>
 {/if}
 
-{#if openImpersonateDialog}
+{#if impersonateDialogOpen}
     <ImpersonateOrganizationDialog
-        bind:open={openImpersonateDialog}
+        bind:open={impersonateDialogOpen}
         impersonateOrganization={handleImpersonate}
         userOrganizationIds={organizations.map((o) => o.id)}
     />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
@@ -1,21 +1,37 @@
 <script lang="ts">
+    import type { ViewOrganization } from '$features/organizations/models';
+    import type { ViewProject } from '$features/projects/models';
     import type { FetchClientResponse, ProblemDetails } from '@foundatiofx/fetchclient';
 
+    import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';
     import * as Command from '$comp/ui/command';
+    import { logout } from '$features/auth/api.svelte';
     import { accessToken } from '$features/auth/index.svelte';
     import { buildEventDetailsHref, type EventSummaryModel, type StackSummaryModel, type SummaryTemplateKeys } from '$features/events/components/summary/index';
     import { organization } from '$features/organizations/context.svelte';
+    import { resetData } from '$features/projects/api.svelte';
+    import ResetProjectDataDialog from '$features/projects/components/dialogs/reset-project-data-dialog.svelte';
+    import ProjectCommandActions from '$features/projects/components/project-command-actions.svelte';
     import { appKeyboardShortcuts, formatKeyboardShortcut, type ShortcutKey } from '$features/shared/keyboard-shortcuts';
     import { DEFAULT_OFFSET } from '$shared/api/api.svelte';
     import { useFetchClient } from '@foundatiofx/fetchclient';
     import Activity from '@lucide/svelte/icons/activity';
     import Building2 from '@lucide/svelte/icons/building-2';
+    import CircleHelp from '@lucide/svelte/icons/circle-help';
     import CircleUserRound from '@lucide/svelte/icons/circle-user-round';
+    import Eye from '@lucide/svelte/icons/eye';
+    import EyeOff from '@lucide/svelte/icons/eye-off';
     import Keyboard from '@lucide/svelte/icons/keyboard';
     import Stacks from '@lucide/svelte/icons/layers';
+    import LogOut from '@lucide/svelte/icons/log-out';
+    import Plus from '@lucide/svelte/icons/plus';
+    import RefreshCw from '@lucide/svelte/icons/refresh-cw';
     import Search from '@lucide/svelte/icons/search';
-    import { createQuery } from '@tanstack/svelte-query';
+    import SunMoon from '@lucide/svelte/icons/sun-moon';
+    import { createQuery, useQueryClient } from '@tanstack/svelte-query';
+    import { toggleMode } from 'mode-watcher';
+    import { toast } from 'svelte-sonner';
 
     import type { NavigationItem } from '../../routes.svelte';
 
@@ -23,6 +39,7 @@
         group: string;
         href: string;
         icon: NavigationItem['icon'];
+        keywords?: string[];
         openInNewTab?: boolean;
         parentTitle?: string;
         shortcut?: readonly ShortcutKey[];
@@ -31,12 +48,19 @@
     };
 
     type Props = {
+        isChatEnabled: boolean;
+        isGlobalAdmin: boolean;
+        isImpersonating: boolean;
         open: boolean;
+        openChat: () => void;
+        openImpersonateOrganization: () => Promise<void> | void;
         openKeyboardShortcuts: () => Promise<void> | void;
         openOrganizationSwitcher: () => Promise<void> | void;
         openUserMenu: () => Promise<void> | void;
+        organizations: ViewOrganization[];
         resetKey: number;
         routes: NavigationItem[];
+        stopImpersonating: () => Promise<void> | void;
     };
 
     type CommandSearchResult = EventSummaryModel<SummaryTemplateKeys> | StackSummaryModel<SummaryTemplateKeys>;
@@ -46,12 +70,29 @@
     const COMMAND_SEARCH_MIN_LENGTH = 2;
     const COMMAND_SEARCH_TIME_RANGE = '[now-7d TO now]';
 
-    let { open = $bindable(), openKeyboardShortcuts, openOrganizationSwitcher, openUserMenu, resetKey, routes }: Props = $props();
+    let {
+        isChatEnabled,
+        isGlobalAdmin,
+        isImpersonating,
+        open = $bindable(),
+        openChat,
+        openImpersonateOrganization,
+        openKeyboardShortcuts,
+        openOrganizationSwitcher,
+        openUserMenu,
+        organizations,
+        resetKey,
+        routes,
+        stopImpersonating
+    }: Props = $props();
     let searchText = $state('');
     let debouncedSearchText = $state('');
+    let selectingProject = $state(false);
 
     const client = useFetchClient();
+    const queryClient = useQueryClient();
     const hasSearchText = $derived(debouncedSearchText.length >= COMMAND_SEARCH_MIN_LENGTH);
+    const switchableOrganizations = $derived(organizations.filter((organizationItem) => organizationItem.id !== organization.current));
 
     $effect(() => {
         const trimmedSearchText = searchText.trim();
@@ -70,7 +111,7 @@
     });
 
     const eventSearchQuery = createQuery<FetchClientResponse<EventSummaryModel<SummaryTemplateKeys>[]>, ProblemDetails>(() => ({
-        enabled: () => open && !!accessToken.current && !!organization.current && hasSearchText,
+        enabled: () => open && !selectingProject && !!accessToken.current && !!organization.current && hasSearchText,
         queryFn: async ({ signal }: { signal: AbortSignal }) => {
             return client.getJSON<EventSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organization.current}/events`, {
                 params: {
@@ -87,7 +128,7 @@
     }));
 
     const stackSearchQuery = createQuery<FetchClientResponse<StackSummaryModel<SummaryTemplateKeys>[]>, ProblemDetails>(() => ({
-        enabled: () => open && !!accessToken.current && !!organization.current && hasSearchText,
+        enabled: () => open && !selectingProject && !!accessToken.current && !!organization.current && hasSearchText,
         queryFn: async ({ signal }: { signal: AbortSignal }) => {
             return client.getJSON<StackSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organization.current}/events`, {
                 params: {
@@ -115,6 +156,7 @@
         if (resetKey >= 0) {
             searchText = '';
             debouncedSearchText = '';
+            selectingProject = false;
         }
     });
 
@@ -194,6 +236,7 @@
                     group,
                     href: route.href,
                     icon: route.icon,
+                    keywords: route.keywords,
                     openInNewTab: route.openInNewTab,
                     shortcut: route.shortcut,
                     title,
@@ -235,6 +278,37 @@
         open = false;
     }
 
+    function resetCommandSearch(): void {
+        searchText = '';
+        debouncedSearchText = '';
+        commandValue = '';
+    }
+
+    let resetProjectTarget = $state<ViewProject>();
+    let showResetProjectDataDialog = $state(false);
+    const resetProjectDataMutation = resetData({
+        route: {
+            get id() {
+                return resetProjectTarget?.id ?? '';
+            }
+        }
+    });
+
+    function openResetProjectDataDialog(project: ViewProject): void {
+        resetProjectTarget = project;
+        showResetProjectDataDialog = true;
+    }
+
+    async function resetProjectData(): Promise<void> {
+        try {
+            await resetProjectDataMutation.mutateAsync();
+            toast.success(`Successfully queued "${resetProjectTarget?.name}" for data reset.`);
+        } catch (error) {
+            toast.error(`Failed to reset data for "${resetProjectTarget?.name}". Please try again.`);
+            throw error;
+        }
+    }
+
     async function switchOrganization(): Promise<void> {
         closeCommandWindow();
         await openOrganizationSwitcher();
@@ -248,6 +322,52 @@
     async function openKeyboardShortcutsDialog(): Promise<void> {
         closeCommandWindow();
         await openKeyboardShortcuts();
+    }
+
+    async function switchToOrganization(organizationItem: ViewOrganization): Promise<void> {
+        closeCommandWindow();
+        organization.current = organizationItem.id;
+        await goto(resolve('/(app)/stack'));
+    }
+
+    async function openImpersonateOrganizationDialog(): Promise<void> {
+        closeCommandWindow();
+        await openImpersonateOrganization();
+    }
+
+    async function stopImpersonatingOrganization(): Promise<void> {
+        closeCommandWindow();
+        await stopImpersonating();
+    }
+
+    function openSupportChat(): void {
+        closeCommandWindow();
+        openChat();
+    }
+
+    function toggleTheme(): void {
+        closeCommandWindow();
+        toggleMode();
+    }
+
+    let isRefreshing = $state(false);
+    async function refreshCurrentView(): Promise<void> {
+        closeCommandWindow();
+        isRefreshing = true;
+        document.dispatchEvent(new CustomEvent('refresh', { bubbles: true, detail: 'Command Palette' }));
+
+        try {
+            await queryClient.refetchQueries({ type: 'active' });
+            toast.success('Refreshed the current view.');
+        } finally {
+            isRefreshing = false;
+        }
+    }
+
+    async function logOutCurrentUser(): Promise<void> {
+        closeCommandWindow();
+        await logout(queryClient, client);
+        await goto(resolve('/(auth)/login'));
     }
 
     const PAGE_JUMP_SIZE = 7;
@@ -294,10 +414,10 @@
 
 {#key resetKey}
     <Command.Dialog bind:open bind:value={commandValue} filter={filterCommandItem} onkeydown={handleKeydown}>
-        <Command.Input bind:value={searchText} placeholder="Search or jump to..." />
+        <Command.Input bind:value={searchText} placeholder={selectingProject ? 'Select a project...' : 'Search or jump to...'} />
         <Command.List>
             <Command.Empty>No results found.</Command.Empty>
-            {#if hasSearchText && showRemoteSearchResults}
+            {#if !selectingProject && hasSearchText && showRemoteSearchResults}
                 {#key debouncedSearchText}
                     {#if showEventSearchResults}
                         <Command.Group heading="Events" value="Search Events">
@@ -361,59 +481,122 @@
                 {/key}
                 <Command.Separator />
             {/if}
-            {#each Object.entries(groupedRoutes) as [group, items], index (group)}
-                <Command.Group heading={group}>
-                    {#each items as route (route.href)}
-                        <Command.LinkItem
-                            href={route.href}
-                            onclick={closeCommandWindow}
-                            rel={route.openInNewTab ? 'noreferrer' : undefined}
-                            target={route.openInNewTab ? '_blank' : undefined}
-                            value={route.value}
-                        >
-                            {#if route.icon}
-                                {@const Icon = route.icon}
-                                <Icon />
-                            {/if}
-                            <div class="flex min-w-0 flex-col">
-                                <span class="truncate">{route.title}</span>
-                                {#if route.parentTitle}
-                                    <span class="text-muted-foreground text-xs">{route.parentTitle}</span>
+            <ProjectCommandActions
+                {open}
+                bind:selectingProject
+                onReset={openResetProjectDataDialog}
+                onSearchReset={resetCommandSearch}
+                onSelect={closeCommandWindow}
+                resetPending={resetProjectDataMutation.isPending}
+            />
+            {#if !selectingProject}
+                {#each Object.entries(groupedRoutes) as [group, items], index (group)}
+                    <Command.Group heading={group}>
+                        {#each items as route (route.href)}
+                            <Command.LinkItem
+                                href={route.href}
+                                keywords={route.keywords}
+                                onclick={closeCommandWindow}
+                                rel={route.openInNewTab ? 'noreferrer' : undefined}
+                                target={route.openInNewTab ? '_blank' : undefined}
+                                value={route.value}
+                            >
+                                {#if route.icon}
+                                    {@const Icon = route.icon}
+                                    <Icon />
                                 {/if}
-                            </div>
-                            {#if route.shortcut}
-                                <Command.Shortcut>{formatKeyboardShortcut(route.shortcut)}</Command.Shortcut>
+                                <div class="flex min-w-0 flex-col">
+                                    <span class="truncate">{route.title}</span>
+                                    {#if route.parentTitle}
+                                        <span class="text-muted-foreground text-xs">{route.parentTitle}</span>
+                                    {/if}
+                                </div>
+                                {#if route.shortcut}
+                                    <Command.Shortcut>{formatKeyboardShortcut(route.shortcut)}</Command.Shortcut>
+                                {/if}
+                            </Command.LinkItem>
+                        {/each}
+                    </Command.Group>
+                    {#if group === 'Sessions'}
+                        <Command.Separator />
+                        <Command.Group heading="Organizations">
+                            {#each switchableOrganizations as organizationItem (organizationItem.id)}
+                                <Command.Item
+                                    value={`Switch to Organization ${organizationItem.name}`}
+                                    onSelect={() => void switchToOrganization(organizationItem)}
+                                >
+                                    <Building2 />
+                                    <span>Switch to {organizationItem.name}</span>
+                                </Command.Item>
+                            {/each}
+                            <Command.Item value="Switch Organization organizations org" onSelect={() => void switchOrganization()}>
+                                <Building2 />
+                                <span>Switch Organization</span>
+                                <Command.Shortcut>{formatKeyboardShortcut(appKeyboardShortcuts.switchOrganization.keys)}</Command.Shortcut>
+                            </Command.Item>
+                            <Command.LinkItem
+                                href={resolve('/(app)/organization/add')}
+                                onclick={closeCommandWindow}
+                                value="Add Organization create new organization"
+                            >
+                                <Plus />
+                                <span>Add Organization</span>
+                            </Command.LinkItem>
+                            {#if isGlobalAdmin}
+                                {#if isImpersonating}
+                                    <Command.Item value="Stop Impersonating Organization admin" onSelect={() => void stopImpersonatingOrganization()}>
+                                        <EyeOff />
+                                        <span>Stop Impersonating</span>
+                                    </Command.Item>
+                                {:else}
+                                    <Command.Item value="Impersonate Organization admin" onSelect={() => void openImpersonateOrganizationDialog()}>
+                                        <Eye />
+                                        <span>Impersonate Organization</span>
+                                    </Command.Item>
+                                {/if}
                             {/if}
-                        </Command.LinkItem>
-                    {/each}
-                </Command.Group>
-                {#if group === 'Sessions'}
-                    <Command.Separator />
-                    <Command.Group heading="Organizations">
-                        <Command.Item value="Switch Organization organizations org" onSelect={() => void switchOrganization()}>
-                            <Building2 />
-                            <span>Switch Organization</span>
-                            <Command.Shortcut>{formatKeyboardShortcut(appKeyboardShortcuts.switchOrganization.keys)}</Command.Shortcut>
-                        </Command.Item>
-                    </Command.Group>
-                    <Command.Separator />
-                    <Command.Group heading="User">
-                        <Command.Item value="Open User Menu account profile current user" onSelect={() => void openCurrentUserMenu()}>
-                            <CircleUserRound />
-                            <span>Open User Menu</span>
-                            <Command.Shortcut>{formatKeyboardShortcut(appKeyboardShortcuts.userMenu.keys)}</Command.Shortcut>
-                        </Command.Item>
-                        <Command.Item value="Keyboard Shortcuts help shortcuts" onSelect={() => void openKeyboardShortcutsDialog()}>
-                            <Keyboard />
-                            <span>Keyboard Shortcuts</span>
-                            <Command.Shortcut>{formatKeyboardShortcut(appKeyboardShortcuts.keyboardShortcuts.keys)}</Command.Shortcut>
-                        </Command.Item>
-                    </Command.Group>
-                {/if}
-                {#if index !== Object.keys(groupedRoutes).length - 1}
-                    <Command.Separator />
-                {/if}
-            {/each}
+                        </Command.Group>
+                        <Command.Separator />
+                        <Command.Group heading="Actions">
+                            {#if isChatEnabled}
+                                <Command.Item value="Chat with Support help intercom" onSelect={openSupportChat}>
+                                    <CircleHelp />
+                                    <span>Chat with Support</span>
+                                </Command.Item>
+                            {/if}
+                            <Command.Item value="Toggle Theme dark light mode appearance" onSelect={toggleTheme}>
+                                <SunMoon />
+                                <span>Toggle Theme</span>
+                            </Command.Item>
+                            <Command.Item disabled={isRefreshing} value="Refresh Current View reload data" onSelect={() => void refreshCurrentView()}>
+                                <RefreshCw class={isRefreshing ? 'animate-spin' : undefined} />
+                                <span>Refresh Current View</span>
+                            </Command.Item>
+                            <Command.Item value="Open User Menu account profile current user" onSelect={() => void openCurrentUserMenu()}>
+                                <CircleUserRound />
+                                <span>Open User Menu</span>
+                                <Command.Shortcut>{formatKeyboardShortcut(appKeyboardShortcuts.userMenu.keys)}</Command.Shortcut>
+                            </Command.Item>
+                            <Command.Item value="Keyboard Shortcuts help shortcuts" onSelect={() => void openKeyboardShortcutsDialog()}>
+                                <Keyboard />
+                                <span>Keyboard Shortcuts</span>
+                                <Command.Shortcut>{formatKeyboardShortcut(appKeyboardShortcuts.keyboardShortcuts.keys)}</Command.Shortcut>
+                            </Command.Item>
+                            <Command.Item value="Log Out sign out logout" onSelect={() => void logOutCurrentUser()}>
+                                <LogOut />
+                                <span>Log Out</span>
+                            </Command.Item>
+                        </Command.Group>
+                    {/if}
+                    {#if index !== Object.keys(groupedRoutes).length - 1}
+                        <Command.Separator />
+                    {/if}
+                {/each}
+            {/if}
         </Command.List>
     </Command.Dialog>
 {/key}
+
+{#if resetProjectTarget}
+    <ResetProjectDataDialog bind:open={showResetProjectDataDialog} name={resetProjectTarget.name} reset={resetProjectData} />
+{/if}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte.test.ts
@@ -1,0 +1,202 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { NavigationItem } from '../../routes.svelte';
+
+const generateSampleDataMutateAsync = vi.hoisted(() => vi.fn());
+const goto = vi.hoisted(() => vi.fn());
+const logout = vi.hoisted(() => vi.fn());
+const organizationState = vi.hoisted(() => ({ current: 'organization-id' as string | undefined }));
+const refetchQueries = vi.hoisted(() => vi.fn());
+const resetDataMutateAsync = vi.hoisted(() => vi.fn());
+const toast = vi.hoisted(() => ({ dismiss: vi.fn(), error: vi.fn(), success: vi.fn() }));
+const toggleMode = vi.hoisted(() => vi.fn());
+const project = vi.hoisted(() => ({
+    id: '0123456789abcdef01234567',
+    name: 'Test Project',
+    organization_id: 'organization-id'
+}));
+
+vi.mock('$app/navigation', () => ({ goto }));
+vi.mock('$features/auth/api.svelte', () => ({ logout }));
+vi.mock('$features/auth/index.svelte', () => ({ accessToken: { current: 'access-token' } }));
+vi.mock('$features/events/components/summary/index', () => ({ buildEventDetailsHref: vi.fn() }));
+vi.mock('$features/organizations/context.svelte', () => ({ organization: organizationState }));
+vi.mock('$features/projects/api.svelte', () => ({
+    generateSampleData: () => ({ isPending: false, mutateAsync: generateSampleDataMutateAsync }),
+    getOrganizationProjectsQuery: () => ({ data: { data: [project] }, isError: false, isLoading: false }),
+    resetData: () => ({ isPending: false, mutateAsync: resetDataMutateAsync })
+}));
+vi.mock('@foundatiofx/fetchclient', () => ({ useFetchClient: () => ({ getJSON: vi.fn() }) }));
+vi.mock('@tanstack/svelte-query', () => ({
+    createQuery: () => ({ data: undefined, isPending: false }),
+    useQueryClient: () => ({ refetchQueries })
+}));
+vi.mock('mode-watcher', () => ({ toggleMode }));
+vi.mock('svelte-sonner', () => ({ toast }));
+
+import NavigationCommand from './navigation-command.svelte';
+
+type RenderOptions = {
+    isChatEnabled?: boolean;
+    isGlobalAdmin?: boolean;
+    isImpersonating?: boolean;
+    openChat?: () => void;
+    openImpersonateOrganization?: () => Promise<void> | void;
+    organizations?: Array<{ id: string; name: string }>;
+    stopImpersonating?: () => Promise<void> | void;
+};
+
+const sessionsRoute: NavigationItem = {
+    group: 'Dashboards',
+    href: '/next/sessions',
+    icon: undefined as never,
+    title: 'Sessions'
+};
+
+function renderCommandPalette(routes: NavigationItem[] = [], options: RenderOptions = {}) {
+    return render(NavigationCommand, {
+        isChatEnabled: options.isChatEnabled ?? false,
+        isGlobalAdmin: options.isGlobalAdmin ?? false,
+        isImpersonating: options.isImpersonating ?? false,
+        open: true,
+        openChat: options.openChat ?? vi.fn(),
+        openImpersonateOrganization: options.openImpersonateOrganization ?? vi.fn(),
+        openKeyboardShortcuts: vi.fn(),
+        openOrganizationSwitcher: vi.fn(),
+        openUserMenu: vi.fn(),
+        organizations: (options.organizations ?? []) as never,
+        resetKey: 0,
+        routes: [sessionsRoute, ...routes],
+        stopImpersonating: options.stopImpersonating ?? vi.fn()
+    });
+}
+
+describe('NavigationCommand project actions', () => {
+    beforeAll(() => {
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    beforeEach(() => {
+        generateSampleDataMutateAsync.mockResolvedValue(undefined);
+        goto.mockResolvedValue(undefined);
+        logout.mockResolvedValue(undefined);
+        organizationState.current = 'organization-id';
+        refetchQueries.mockResolvedValue(undefined);
+        resetDataMutateAsync.mockResolvedValue(undefined);
+    });
+
+    it.each([
+        ['Open Project', `/next/project/${project.id}/manage`],
+        ['Project Stacks', `/next/stack?filter=project:${project.id}`],
+        ['Project Notifications', `/next/account/notifications?project=${project.id}`],
+        ['Client Setup', `/next/project/${project.id}/configure`]
+    ])('links %s to the selected project', async (action, expectedHref) => {
+        renderCommandPalette();
+
+        await fireEvent.click(screen.getByText(action));
+
+        const projectLink = screen.getByText(project.name).closest('a');
+        expect(projectLink?.getAttribute('href')).toBe(expectedHref);
+        expect(screen.getByPlaceholderText('Select a project...')).toBeTruthy();
+    });
+
+    it('finds AI Tools by its MCP keyword', async () => {
+        renderCommandPalette([
+            {
+                group: 'My Account',
+                href: '/next/account/ai-tools',
+                icon: undefined as never,
+                keywords: ['MCP'],
+                title: 'AI Tools'
+            }
+        ]);
+
+        await fireEvent.input(screen.getByPlaceholderText('Search or jump to...'), { target: { value: 'MCP' } });
+
+        const aiToolsGroup = screen.getByText('AI Tools').closest('[data-command-group]');
+        await waitFor(() => expect(aiToolsGroup?.hasAttribute('hidden')).toBe(false));
+    });
+
+    it('generates sample data for the selected project', async () => {
+        renderCommandPalette();
+
+        await fireEvent.click(screen.getByText('Generate Sample Data'));
+        await fireEvent.click(screen.getByText(project.name));
+
+        await waitFor(() => expect(generateSampleDataMutateAsync).toHaveBeenCalledOnce());
+        expect(toast.success).toHaveBeenCalledWith(`Sample data generation has been queued for "${project.name}". Events will appear shortly.`);
+    });
+
+    it('confirms before resetting the selected project data', async () => {
+        renderCommandPalette();
+
+        await fireEvent.click(screen.getByText('Reset Project Data'));
+        await fireEvent.click(screen.getByText(project.name));
+        expect((await screen.findByText(/Are you sure you want to reset all project data/)).textContent).toContain(project.name);
+
+        await fireEvent.click(screen.getByRole('button', { name: 'Reset Project Data' }));
+
+        await waitFor(() => expect(resetDataMutateAsync).toHaveBeenCalledOnce());
+        expect(toast.success).toHaveBeenCalledWith(`Successfully queued "${project.name}" for data reset.`);
+    });
+
+    it('offers the approved app actions', () => {
+        renderCommandPalette([], { isChatEnabled: true, isGlobalAdmin: true });
+
+        for (const action of ['Add Organization', 'Chat with Support', 'Toggle Theme', 'Refresh Current View', 'Impersonate Organization', 'Log Out']) {
+            expect(screen.getByText(action)).toBeTruthy();
+        }
+    });
+
+    it('switches directly to a named organization', async () => {
+        renderCommandPalette([], { organizations: [{ id: 'other-organization-id', name: 'Other Organization' }] });
+
+        await fireEvent.click(screen.getByText('Switch to Other Organization'));
+
+        expect(organizationState.current).toBe('other-organization-id');
+        await waitFor(() => expect(goto).toHaveBeenCalledWith('/next/stack'));
+    });
+
+    it('opens support chat', async () => {
+        const openChat = vi.fn();
+        renderCommandPalette([], { isChatEnabled: true, openChat });
+        await fireEvent.click(screen.getByText('Chat with Support'));
+        expect(openChat).toHaveBeenCalledOnce();
+    });
+
+    it('toggles the theme', async () => {
+        renderCommandPalette();
+        await fireEvent.click(screen.getByText('Toggle Theme'));
+        expect(toggleMode).toHaveBeenCalledOnce();
+    });
+
+    it('refreshes active data for the current view', async () => {
+        renderCommandPalette();
+        await fireEvent.click(screen.getByText('Refresh Current View'));
+        await waitFor(() => expect(refetchQueries).toHaveBeenCalledWith({ type: 'active' }));
+    });
+
+    it('opens organization impersonation for global admins', async () => {
+        const openImpersonateOrganization = vi.fn();
+        renderCommandPalette([], { isGlobalAdmin: true, openImpersonateOrganization });
+        await fireEvent.click(screen.getByText('Impersonate Organization'));
+        expect(openImpersonateOrganization).toHaveBeenCalledOnce();
+    });
+
+    it('stops organization impersonation for global admins', async () => {
+        const stopImpersonating = vi.fn();
+        renderCommandPalette([], { isGlobalAdmin: true, isImpersonating: true, stopImpersonating });
+
+        await fireEvent.click(screen.getByText('Stop Impersonating'));
+
+        expect(stopImpersonating).toHaveBeenCalledOnce();
+    });
+
+    it('logs out the current user', async () => {
+        renderCommandPalette();
+        await fireEvent.click(screen.getByText('Log Out'));
+        await waitFor(() => expect(logout).toHaveBeenCalledOnce());
+        expect(goto).toHaveBeenCalledWith('/next/login');
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
@@ -67,6 +67,7 @@
     let commandResetKey = $state(0);
     let isKeyboardShortcutsOpen = $state(false);
     let isOrganizationSwitcherOpen = $state(false);
+    let isImpersonateOrganizationOpen = $state(false);
     let isUserMenuOpen = $state(false);
 
     // Auto-reset premium page state on navigation so pages don't need cleanup
@@ -81,6 +82,7 @@
 
     async function openOrganizationSwitcher(): Promise<void> {
         isCommandOpen = false;
+        isImpersonateOrganizationOpen = false;
         isKeyboardShortcutsOpen = false;
         isUserMenuOpen = false;
         if (singleOrganization?.id) {
@@ -94,6 +96,7 @@
 
     async function openUserMenu(): Promise<void> {
         isCommandOpen = false;
+        isImpersonateOrganizationOpen = false;
         isKeyboardShortcutsOpen = false;
         isOrganizationSwitcherOpen = false;
         await tick();
@@ -102,10 +105,26 @@
 
     async function openKeyboardShortcuts(): Promise<void> {
         isCommandOpen = false;
+        isImpersonateOrganizationOpen = false;
         isOrganizationSwitcherOpen = false;
         isUserMenuOpen = false;
         await tick();
         isKeyboardShortcutsOpen = true;
+    }
+
+    async function openImpersonateOrganization(): Promise<void> {
+        isCommandOpen = false;
+        isKeyboardShortcutsOpen = false;
+        isOrganizationSwitcherOpen = false;
+        isUserMenuOpen = false;
+        await tick();
+        isImpersonateOrganizationOpen = true;
+    }
+
+    async function stopImpersonating(): Promise<void> {
+        isCommandOpen = false;
+        await goto(resolve('/(app)/stack'));
+        organization.current = organizations[0]?.id;
     }
 
     useMiddleware(async (ctx, next) => {
@@ -229,6 +248,7 @@
                 e.metaKey ||
                 e.altKey ||
                 isCommandOpen ||
+                isImpersonateOrganizationOpen ||
                 isKeyboardShortcutsOpen ||
                 isOrganizationSwitcherOpen ||
                 isUserMenuOpen ||
@@ -483,6 +503,7 @@
     <Sidebar routes={filteredRoutes}>
         {#snippet header()}
             <SidebarOrganizationSwitcher
+                bind:impersonateDialogOpen={isImpersonateOrganizationOpen}
                 isLoading={organizationsQuery.isLoading}
                 {organizations}
                 {impersonatedOrganization}
@@ -511,11 +532,18 @@
             <main class="flex-1 px-4 pt-4">
                 <NavigationCommand
                     bind:open={isCommandOpen}
+                    {isChatEnabled}
+                    {isGlobalAdmin}
+                    {isImpersonating}
+                    {openChat}
+                    {openImpersonateOrganization}
                     {openKeyboardShortcuts}
                     {openOrganizationSwitcher}
                     {openUserMenu}
+                    {organizations}
                     resetKey={commandResetKey}
                     routes={filteredRoutes}
+                    {stopImpersonating}
                 />
                 <KeyboardShortcutsDialog bind:open={isKeyboardShortcutsOpen} />
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/account/routes.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/account/routes.svelte.ts
@@ -35,6 +35,7 @@ export function routes(): NavigationItem[] {
             group: 'My Account',
             href: resolve('/(app)/account/ai-tools'),
             icon: Bot,
+            keywords: ['MCP', 'Claude', 'Codex', 'Copilot', 'OpenCode', 'AI assistant'],
             title: 'AI Tools'
         },
         {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/routes.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/routes.svelte.ts
@@ -27,6 +27,7 @@ export function routes(): NavigationItem[] {
             group: 'Organization Settings',
             href: resolve('/(app)/organization/[organizationId]/users', { organizationId }),
             icon: Users,
+            keywords: ['members', 'team', 'invite'],
             title: 'Users'
         },
         {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/routes.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/routes.svelte.ts
@@ -64,6 +64,7 @@ export function routes(): NavigationItem[] {
             group: 'Help',
             href: apiReferenceHref,
             icon: ApiDocumentations,
+            keywords: ['OpenAPI', 'Swagger', 'API Reference'],
             openInNewTab: true,
             title: 'API'
         },

--- a/src/Exceptionless.Web/ClientApp/src/routes/routes.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/routes.svelte.ts
@@ -17,6 +17,7 @@ export type NavigationItem = {
     group: string;
     href: ResolvedPathname | string;
     icon: Component | typeof Icon;
+    keywords?: string[];
     openInNewTab?: boolean;
     shortcut?: readonly ShortcutKey[];
     show?: (context: NavigationItemContext) => boolean;


### PR DESCRIPTION
## What changed

- Add a staged project action flow for opening a project, viewing project stacks or notifications, client setup, sample data generation, and confirmed project data reset.
- Add organization switching and creation, global-admin impersonation controls, support chat, theme toggle, active-view refresh, and logout commands.
- Add navigation search aliases for MCP and AI clients, OpenAPI and Swagger, organization members, and client SDK setup.
- Keep the unfinished Stream page out of the command palette.

## Why

The command palette exposed navigation but omitted common project and app-shell actions, and searches such as MCP did not surface AI Tools. Project-specific commands could also scale poorly as one row per action per project, so the new flow asks for an action first and a project second.

## Validation

- `npm run validate`
- `npm run test:unit` (426 tests)