### PR TITLE
Diagnose and prevent Svelte effect depth loops

### DIFF
--- a/src/Exceptionless.Web/ClientApp/package-lock.json
+++ b/src/Exceptionless.Web/ClientApp/package-lock.json
@@ -66,6 +66,7 @@
                 "eslint-plugin-svelte": "^3.22.0",
                 "globals": "^17.8.0",
                 "jsdom": "^30.0.0",
+                "magic-string": "^0.30.21",
                 "prettier": "^3.9.6",
                 "prettier-plugin-svelte": "^4.1.1",
                 "prettier-plugin-tailwindcss": "^0.8.1",
@@ -470,6 +471,7 @@
             "version": "2.0.0-alpha.3",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
             "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "peer": true,
@@ -482,6 +484,7 @@
             "version": "2.0.0-alpha.3",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
             "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "peer": true,
@@ -493,6 +496,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
             "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "peer": true,
@@ -514,6 +518,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -530,6 +535,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -546,6 +552,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -562,6 +569,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -578,6 +586,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -594,6 +603,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -610,6 +620,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -626,6 +637,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -642,6 +654,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -658,6 +671,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -674,6 +688,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -690,6 +705,7 @@
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -706,6 +722,7 @@
             "cpu": [
                 "mips64el"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -722,6 +739,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -738,6 +756,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -754,6 +773,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -770,6 +790,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -786,6 +807,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -802,6 +824,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -818,6 +841,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -834,6 +858,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -850,6 +875,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -866,6 +892,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -882,6 +909,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -898,6 +926,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -914,6 +943,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1348,6 +1378,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
             "integrity": "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2093,6 +2124,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2109,6 +2141,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2125,6 +2158,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2141,6 +2175,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2157,6 +2192,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2173,6 +2209,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2189,6 +2226,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2205,6 +2243,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2221,6 +2260,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2237,6 +2277,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2253,6 +2294,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2269,6 +2311,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2285,6 +2328,7 @@
             "cpu": [
                 "wasm32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2300,6 +2344,7 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
             "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2311,6 +2356,7 @@
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
             "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2321,6 +2367,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
             "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2334,6 +2381,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2350,6 +2398,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3495,6 +3544,7 @@
             "version": "0.10.3",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
             "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -3645,7 +3695,7 @@
             "version": "26.1.2",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
             "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~8.3.0"
@@ -5381,7 +5431,7 @@
             "version": "0.28.1",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
             "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-            "devOptional": true,
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -6204,7 +6254,7 @@
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
             "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
@@ -6449,6 +6499,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6469,6 +6520,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6489,6 +6541,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6509,6 +6562,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6529,6 +6583,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6549,6 +6604,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6569,6 +6625,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6589,6 +6646,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6609,6 +6667,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6629,6 +6688,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -6649,6 +6709,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -9231,7 +9292,7 @@
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
             "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -9279,7 +9340,7 @@
             "version": "8.3.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
             "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/unist-util-is": {
@@ -9513,6 +9574,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -9936,7 +9998,7 @@
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
             "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"

--- a/src/Exceptionless.Web/ClientApp/package-lock.json
+++ b/src/Exceptionless.Web/ClientApp/package-lock.json
@@ -31,7 +31,7 @@
                 "shiki": "^4.3.1",
                 "svelte-intercom": "^0.0.35",
                 "svelte-sonner": "^1.1.1",
-                "svelte-time": "^2.3.0",
+                "svelte-time": "^2.3.1",
                 "tailwind-merge": "^3.6.0",
                 "tailwind-variants": "^3.3.0",
                 "tailwindcss": "^4.3.3",
@@ -8805,9 +8805,9 @@
             }
         },
         "node_modules/svelte-time": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/svelte-time/-/svelte-time-2.3.0.tgz",
-            "integrity": "sha512-XISfzFt1ToijhsaDEH6oDPRSyUGD8eIxGVmpTrKgurCkfVv/H5oopvP7H45j898w5ddauBI4i8KtHGU47Lsr9g==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/svelte-time/-/svelte-time-2.3.1.tgz",
+            "integrity": "sha512-uM6b/cChCSIKpBSTgJdyWTJ0DrhyGbP2zG1weCYyBTebqwJj5fupnejLdQ4do4tqnl0R8KnjmP97kqEHgqe1ig==",
             "license": "MIT",
             "dependencies": {
                 "dayjs": "^1.11.21"

--- a/src/Exceptionless.Web/ClientApp/package.json
+++ b/src/Exceptionless.Web/ClientApp/package.json
@@ -100,7 +100,7 @@
         "shiki": "^4.3.1",
         "svelte-intercom": "^0.0.35",
         "svelte-sonner": "^1.1.1",
-        "svelte-time": "^2.3.0",
+        "svelte-time": "^2.3.1",
         "tailwind-merge": "^3.6.0",
         "tailwind-variants": "^3.3.0",
         "tailwindcss": "^4.3.3",

--- a/src/Exceptionless.Web/ClientApp/package.json
+++ b/src/Exceptionless.Web/ClientApp/package.json
@@ -60,6 +60,7 @@
         "eslint-plugin-svelte": "^3.22.0",
         "globals": "^17.8.0",
         "jsdom": "^30.0.0",
+        "magic-string": "^0.30.21",
         "prettier": "^3.9.6",
         "prettier-plugin-svelte": "^4.1.1",
         "prettier-plugin-tailwindcss": "^0.8.1",

--- a/src/Exceptionless.Web/ClientApp/src/hooks.client.ts
+++ b/src/Exceptionless.Web/ClientApp/src/hooks.client.ts
@@ -4,8 +4,11 @@ import { dev } from '$app/environment';
 import { page } from '$app/state';
 import { env } from '$env/dynamic/public';
 import { normalizePath, normalizeRouteId } from '$lib/telemetry';
+import { installSvelteEffectDepthDiagnostics } from '$lib/telemetry/svelte-effect-depth-diagnostics';
 import { Exceptionless, guid, toError } from '@exceptionless/browser';
 import { useMiddleware } from '@foundatiofx/fetchclient';
+
+installSvelteEffectDepthDiagnostics();
 
 // If any of these are set in local storage, use them instead of the build-time environment variables.
 // This allows you to target other environments from your browser without a rebuild.

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/formatters/time-ago.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/formatters/time-ago.svelte
@@ -5,9 +5,7 @@
         value: Date | string | undefined;
     }
 
-    const LIVE_UPDATE_INTERVAL_MS = 60_000;
-
     let { value }: Props = $props();
 </script>
 
-<Time live={LIVE_UPDATE_INTERVAL_MS} relative={true} timestamp={value}></Time>
+<Time live={true} relative={true} timestamp={value}></Time>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/formatters/time-ago.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/formatters/time-ago.svelte
@@ -5,7 +5,9 @@
         value: Date | string | undefined;
     }
 
+    const LIVE_UPDATE_INTERVAL_MS = 60_000;
+
     let { value }: Props = $props();
 </script>
 
-<Time live={true} relative={true} timestamp={value}></Time>
+<Time live={LIVE_UPDATE_INTERVAL_MS} relative={true} timestamp={value}></Time>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/formatters/time-ago.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/formatters/time-ago.svelte.test.ts
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import Time from 'svelte-time';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import TimeAgo from './time-ago.svelte';
+
+describe('TimeAgo', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('uses a fixed clock when adaptive clocks straddle an age boundary', async () => {
+        vi.useFakeTimers();
+        const base = new Date('2026-08-11T12:00:00Z');
+        vi.setSystemTime(base);
+
+        render(Time, {
+            live: true,
+            relative: true,
+            timestamp: new Date(base.getTime() - 2 * 60 * 60 * 1_000)
+        });
+        await tick();
+
+        vi.setSystemTime(new Date(base.getTime() + 2_000));
+        render(Time, {
+            live: true,
+            relative: true,
+            timestamp: new Date(base.getTime() - 30 * 60 * 1_000)
+        });
+        await tick();
+
+        render(TimeAgo, {
+            value: new Date(base.getTime() - (60 * 60 * 1_000 - 1_000))
+        });
+        await tick();
+
+        expect(screen.getByText('an hour ago')).toBeTruthy();
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/formatters/time-ago.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/formatters/time-ago.svelte.test.ts
@@ -10,7 +10,7 @@ describe('TimeAgo', () => {
         vi.useRealTimers();
     });
 
-    it('uses a fixed clock when adaptive clocks straddle an age boundary', async () => {
+    it('does not loop when adaptive clocks straddle an age boundary', async () => {
         vi.useFakeTimers();
         const base = new Date('2026-08-11T12:00:00Z');
         vi.setSystemTime(base);

--- a/src/Exceptionless.Web/ClientApp/src/lib/telemetry/svelte-effect-depth-diagnostics.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/telemetry/svelte-effect-depth-diagnostics.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { installSvelteEffectDepthDiagnostics } from './svelte-effect-depth-diagnostics';
+
+describe('Svelte effect-depth diagnostics', () => {
+    afterEach(() => {
+        delete globalThis.__exceptionlessSvelteEffectDepthDiagnostics;
+    });
+
+    it('attaches repeated state-write locations to the Svelte error', () => {
+        installSvelteEffectDepthDiagnostics();
+        const diagnostics = globalThis.__exceptionlessSvelteEffectDepthDiagnostics!;
+        const source = {};
+
+        diagnostics.startFlush();
+        for (let index = 0; index < 8; index++) {
+            diagnostics.recordStateUpdate(source);
+        }
+
+        const error = new Error('effect_update_depth_exceeded');
+        diagnostics.attachEffectDepthError(error, {
+            f: 4,
+            fn: function effectOwner() {},
+            parent: { f: 8, fn: function parentOwner() {}, parent: null }
+        });
+
+        expect(error).toHaveProperty('svelte_effect_depth');
+        expect(error.stack).toContain('Reactive state update call sites:');
+        expect(error.stack).toContain('recordStateUpdate');
+        expect(Object.keys(error)).toContain('svelte_effect_depth');
+
+        const attached = (error as Error & { svelte_effect_depth: { effectChain: { functionName?: string }[]; stateSources: { count: number }[] } })
+            .svelte_effect_depth;
+        expect(attached.effectChain.map((entry) => entry.functionName)).toEqual(['effectOwner', 'parentOwner']);
+        expect(attached.stateSources).toEqual([expect.objectContaining({ count: 8 })]);
+    });
+
+    it('clears state-write data after the flush finishes', () => {
+        installSvelteEffectDepthDiagnostics();
+        const diagnostics = globalThis.__exceptionlessSvelteEffectDepthDiagnostics!;
+        const source = {};
+
+        diagnostics.startFlush();
+        for (let index = 0; index < 8; index++) {
+            diagnostics.recordStateUpdate(source);
+        }
+
+        diagnostics.endFlush();
+
+        const error = new Error('effect_update_depth_exceeded');
+        diagnostics.attachEffectDepthError(error, null);
+
+        expect(error).not.toHaveProperty('svelte_effect_depth');
+    });
+
+    it('bounds captured stacks without recording state values', () => {
+        installSvelteEffectDepthDiagnostics();
+        const diagnostics = globalThis.__exceptionlessSvelteEffectDepthDiagnostics!;
+        const source = { v: 'secret-state-value' };
+
+        diagnostics.startFlush();
+        for (let index = 0; index < 1_500; index++) {
+            diagnostics.recordStateUpdate(source);
+        }
+
+        const error = new Error('effect_update_depth_exceeded');
+        diagnostics.attachEffectDepthError(error, null);
+
+        const attached = (error as Error & { svelte_effect_depth: { stateSources: { stacks: { stack: string }[] }[]; totalStateUpdates: number } })
+            .svelte_effect_depth;
+        expect(attached.totalStateUpdates).toBe(1_500);
+        expect(attached.stateSources[0]?.stacks.length).toBeLessThanOrEqual(4);
+        expect(JSON.stringify(attached)).not.toContain('secret-state-value');
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/telemetry/svelte-effect-depth-diagnostics.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/telemetry/svelte-effect-depth-diagnostics.test.ts
@@ -72,4 +72,27 @@ describe('Svelte effect-depth diagnostics', () => {
         expect(attached.stateSources[0]?.stacks.length).toBeLessThanOrEqual(4);
         expect(JSON.stringify(attached)).not.toContain('secret-state-value');
     });
+
+    it('bounds state source collection during high-fan-out updates', () => {
+        installSvelteEffectDepthDiagnostics();
+        const diagnostics = globalThis.__exceptionlessSvelteEffectDepthDiagnostics!;
+
+        diagnostics.startFlush();
+        for (let index = 0; index < 100; index++) {
+            diagnostics.recordStateUpdate({ index });
+        }
+
+        const overflowSource = {};
+        for (let index = 0; index < 100; index++) {
+            diagnostics.recordStateUpdate(overflowSource);
+        }
+
+        const error = new Error('effect_update_depth_exceeded');
+        diagnostics.attachEffectDepthError(error, null);
+
+        const attached = (error as Error & { svelte_effect_depth: { stateSources: { count: number }[]; totalStateUpdates: number } }).svelte_effect_depth;
+        expect(attached.totalStateUpdates).toBe(200);
+        expect(attached.stateSources).toHaveLength(8);
+        expect(attached.stateSources.every((source) => source.count === 1)).toBe(true);
+    });
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/telemetry/svelte-effect-depth-diagnostics.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/telemetry/svelte-effect-depth-diagnostics.ts
@@ -1,0 +1,213 @@
+const DIAGNOSTIC_PROPERTY = 'svelte_effect_depth';
+const MAX_APPENDED_STACK_FRAMES = 60;
+const MAX_EFFECT_CHAIN_LENGTH = 12;
+const MAX_STACK_CAPTURES_PER_SOURCE = 12;
+const MAX_STACK_FRAMES = 12;
+const MAX_STACKS_PER_SOURCE = 4;
+const MAX_STATE_SOURCES = 8;
+const STATE_UPDATE_CAPTURE_THRESHOLD = 5;
+
+interface EffectDepthDiagnostics {
+    activeElement: null | {
+        dataSlot?: string;
+        role?: string;
+        tagName: string;
+        type?: string;
+    };
+    effectChain: { flags?: number; functionName?: string }[];
+    lastInteraction: null | {
+        target: EffectDepthDiagnostics['activeElement'];
+        timestamp: string;
+        type: string;
+    };
+    route: string;
+    stateSources: {
+        count: number;
+        stacks: { count: number; stack: string }[];
+    }[];
+    totalStateUpdates: number;
+    version: 1;
+    visibility: DocumentVisibilityState;
+}
+
+interface StateSourceUpdates {
+    captureCount: number;
+    count: number;
+    stacks: Map<string, number>;
+}
+
+interface SvelteEffectDepthRuntimeDiagnostics {
+    attachEffectDepthError: (error: unknown, effect: unknown) => void;
+    endFlush: () => void;
+    recordStateUpdate: (source: unknown) => void;
+    startFlush: () => void;
+}
+
+declare global {
+    var __exceptionlessSvelteEffectDepthDiagnostics: SvelteEffectDepthRuntimeDiagnostics | undefined;
+}
+
+let stateSourceUpdates: Map<object, StateSourceUpdates> | undefined;
+let totalStateUpdates = 0;
+let lastInteraction: EffectDepthDiagnostics['lastInteraction'] = null;
+
+export function installSvelteEffectDepthDiagnostics() {
+    if (globalThis.__exceptionlessSvelteEffectDepthDiagnostics) {
+        return;
+    }
+
+    Object.defineProperty(globalThis, '__exceptionlessSvelteEffectDepthDiagnostics', {
+        configurable: true,
+        value: {
+            attachEffectDepthError,
+            endFlush,
+            recordStateUpdate,
+            startFlush
+        }
+    });
+
+    for (const type of ['change', 'click', 'keydown', 'pointerdown', 'pointerup']) {
+        globalThis.addEventListener?.(type, recordInteraction, { capture: true, passive: true });
+    }
+}
+
+function attachEffectDepthError(error: unknown, effect: unknown) {
+    if (!(error instanceof Error) || !stateSourceUpdates) {
+        return;
+    }
+
+    try {
+        const diagnostics = createDiagnostics(effect);
+        Object.defineProperty(error, DIAGNOSTIC_PROPERTY, {
+            configurable: true,
+            enumerable: true,
+            value: diagnostics
+        });
+
+        const updateFrames = diagnostics.stateSources
+            .flatMap((source) => source.stacks.flatMap((entry) => getStackFrames(entry.stack)))
+            .slice(0, MAX_APPENDED_STACK_FRAMES);
+        if (updateFrames.length > 0) {
+            error.stack = [error.stack ?? `${error.name}: ${error.message}`, 'Reactive state update call sites:', ...new Set(updateFrames)].join('\n');
+        }
+    } catch {
+        // Diagnostics must never replace the original Svelte error.
+    }
+}
+
+function createDiagnostics(effect: unknown): EffectDepthDiagnostics {
+    const stateSources = [...(stateSourceUpdates?.values() ?? [])]
+        .sort((left, right) => right.count - left.count)
+        .slice(0, MAX_STATE_SOURCES)
+        .map((source) => ({
+            count: source.count,
+            stacks: [...source.stacks.entries()].sort((left, right) => right[1] - left[1]).map(([stack, count]) => ({ count, stack }))
+        }));
+
+    return {
+        activeElement: getActiveElement(),
+        effectChain: getEffectChain(effect),
+        lastInteraction,
+        route: globalThis.location?.pathname ?? '',
+        stateSources,
+        totalStateUpdates,
+        version: 1,
+        visibility: globalThis.document?.visibilityState ?? 'hidden'
+    };
+}
+
+function endFlush() {
+    stateSourceUpdates = undefined;
+    totalStateUpdates = 0;
+}
+
+function getActiveElement(): EffectDepthDiagnostics['activeElement'] {
+    return getElementDetails(globalThis.document?.activeElement);
+}
+
+function getEffectChain(effect: unknown): EffectDepthDiagnostics['effectChain'] {
+    const chain: EffectDepthDiagnostics['effectChain'] = [];
+    let current = effect;
+
+    while (isEffect(current) && chain.length < MAX_EFFECT_CHAIN_LENGTH) {
+        chain.push({
+            flags: typeof current.f === 'number' ? current.f : undefined,
+            functionName: typeof current.fn === 'function' ? current.fn.name || undefined : undefined
+        });
+        current = current.parent;
+    }
+
+    return chain;
+}
+
+function getElementDetails(element: EventTarget | null | undefined): EffectDepthDiagnostics['activeElement'] {
+    if (typeof HTMLElement === 'undefined' || !(element instanceof HTMLElement)) {
+        return null;
+    }
+
+    return {
+        dataSlot: element.dataset.slot,
+        role: element.getAttribute('role') ?? undefined,
+        tagName: element.tagName.toLowerCase(),
+        type:
+            (typeof HTMLInputElement !== 'undefined' && element instanceof HTMLInputElement) ||
+            (typeof HTMLButtonElement !== 'undefined' && element instanceof HTMLButtonElement)
+                ? element.type
+                : undefined
+    };
+}
+
+function getStackFrames(stack: string): string[] {
+    return stack
+        .split('\n')
+        .filter((line) => /^\s*at\s/.test(line))
+        .slice(0, MAX_STACK_FRAMES);
+}
+
+function isEffect(value: unknown): value is { f?: unknown; fn?: unknown; parent?: unknown } {
+    return typeof value === 'object' && value !== null;
+}
+
+function recordInteraction(event: Event) {
+    lastInteraction = {
+        target: getElementDetails(event.target),
+        timestamp: new Date().toISOString(),
+        type: event.type
+    };
+}
+
+function recordStateUpdate(source: unknown) {
+    if (!stateSourceUpdates || (typeof source !== 'object' && typeof source !== 'function') || source === null) {
+        return;
+    }
+
+    totalStateUpdates++;
+    let updates = stateSourceUpdates.get(source);
+    if (!updates) {
+        updates = { captureCount: 0, count: 0, stacks: new Map() };
+        stateSourceUpdates.set(source, updates);
+    }
+
+    updates.count++;
+    if (
+        updates.count <= STATE_UPDATE_CAPTURE_THRESHOLD ||
+        updates.captureCount >= MAX_STACK_CAPTURES_PER_SOURCE ||
+        updates.stacks.size >= MAX_STACKS_PER_SOURCE
+    ) {
+        return;
+    }
+
+    updates.captureCount++;
+    const stack = new Error('Reactive state updated').stack;
+    if (stack) {
+        const frames = getStackFrames(stack).join('\n');
+        if (frames) {
+            updates.stacks.set(frames, (updates.stacks.get(frames) ?? 0) + 1);
+        }
+    }
+}
+
+function startFlush() {
+    stateSourceUpdates = new Map();
+    totalStateUpdates = 0;
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/telemetry/svelte-effect-depth-diagnostics.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/telemetry/svelte-effect-depth-diagnostics.ts
@@ -184,6 +184,10 @@ function recordStateUpdate(source: unknown) {
     totalStateUpdates++;
     let updates = stateSourceUpdates.get(source);
     if (!updates) {
+        if (stateSourceUpdates.size >= MAX_STATE_SOURCES) {
+            return;
+        }
+
         updates = { captureCount: 0, count: 0, stacks: new Map() };
         stateSourceUpdates.set(source, updates);
     }

--- a/src/Exceptionless.Web/ClientApp/vite.config.ts
+++ b/src/Exceptionless.Web/ClientApp/vite.config.ts
@@ -3,6 +3,10 @@ import type { Plugin } from 'vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { svelteTesting } from '@testing-library/svelte/vite';
+import MagicString from 'magic-string';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 const apiTarget = process.env.API_HTTPS || process.env.API_HTTP;
@@ -18,6 +22,86 @@ const hmr = codespaceName && codespaceDomain ? { clientPort: 443, host: `${codes
 const allowedHosts = ['web-ex.dev.localhost', 'localhost', '127.0.0.1'];
 if (codespaceName && codespaceDomain) {
     allowedHosts.push(`${codespaceName}-${port}.${codespaceDomain}`);
+}
+
+const SVELTE_RUNTIME_DIAGNOSTICS_GLOBAL = '__exceptionlessSvelteEffectDepthDiagnostics';
+const SUPPORTED_SVELTE_RUNTIME_VERSION = '5.56.8';
+
+// Svelte's useful effect-depth diagnostics are development-only. Preserve the
+// minimal state-write tracking needed to diagnose production-only loops.
+function svelteEffectDepthDiagnostics(): Plugin {
+    const require = createRequire(import.meta.url);
+    const packagePath = require.resolve('svelte/package.json');
+    const packageDirectory = dirname(packagePath);
+    const sourcesPath = join(packageDirectory, 'src/internal/client/reactivity/sources.js');
+    const batchPath = join(packageDirectory, 'src/internal/client/reactivity/batch.js');
+
+    const stateUpdateNeedle = '\tif (!source.equals(value)) {\n';
+    const stateUpdateReplacement = `${stateUpdateNeedle}\t\tglobalThis.${SVELTE_RUNTIME_DIAGNOSTICS_GLOBAL}?.recordStateUpdate(source);\n`;
+    const flushStartNeedle = '\tflush() {\n\t\ttry {\n';
+    const flushStartReplacement = `\tflush() {\n\t\tglobalThis.${SVELTE_RUNTIME_DIAGNOSTICS_GLOBAL}?.startFlush();\n\n\t\ttry {\n`;
+    const flushEndNeedle = '\t\t} finally {\n\t\t\tflush_count = 0;\n';
+    const flushEndReplacement = `\t\t} finally {\n\t\t\tglobalThis.${SVELTE_RUNTIME_DIAGNOSTICS_GLOBAL}?.endFlush();\n\t\t\tflush_count = 0;\n`;
+    const effectDepthNeedle = '\t} catch (error) {\n\t\tif (DEV) {\n\t\t\t// stack contains no useful information, replace it\n';
+    const effectDepthReplacement = `\t} catch (error) {\n\t\tglobalThis.${SVELTE_RUNTIME_DIAGNOSTICS_GLOBAL}?.attachEffectDepthError(error, last_scheduled_effect);\n\n\t\tif (DEV) {\n\t\t\t// stack contains no useful information, replace it\n`;
+
+    function instrumentRuntime(code: string, id: string, replacements: [needle: string, replacement: string][]) {
+        const instrumented = new MagicString(code, { filename: id });
+        for (const [needle, replacement] of replacements) {
+            const start = code.indexOf(needle);
+            if (start < 0) {
+                throw new Error(`Unable to instrument ${id}; the expected Svelte runtime source was not found.`);
+            }
+
+            instrumented.overwrite(start, start + needle.length, replacement);
+        }
+
+        return {
+            code: instrumented.toString(),
+            map: instrumented.generateMap({ hires: true, includeContent: true, source: id })
+        };
+    }
+
+    function assertRuntimeShape() {
+        const packageJson = JSON.parse(readFileSync(packagePath, 'utf8')) as { version?: string };
+        if (packageJson.version !== SUPPORTED_SVELTE_RUNTIME_VERSION) {
+            throw new Error(
+                `Svelte effect-depth diagnostics support ${SUPPORTED_SVELTE_RUNTIME_VERSION}, but ${packageJson.version ?? 'an unknown version'} is installed. Review Svelte's runtime before updating the supported version.`
+            );
+        }
+
+        const sources = readFileSync(sourcesPath, 'utf8');
+        const batch = readFileSync(batchPath, 'utf8');
+        if (
+            !sources.includes(stateUpdateNeedle) ||
+            !batch.includes(flushStartNeedle) ||
+            !batch.includes(flushEndNeedle) ||
+            !batch.includes(effectDepthNeedle)
+        ) {
+            throw new Error('Svelte runtime internals changed; update the effect-depth diagnostic instrumentation before building.');
+        }
+    }
+
+    return {
+        apply: 'build',
+        configResolved: assertRuntimeShape,
+        enforce: 'pre',
+        name: 'exceptionless-svelte-effect-depth-diagnostics',
+        transform(code, id) {
+            const path = id.split('?', 1)[0]?.replaceAll('\\', '/');
+            if (path?.endsWith('/svelte/src/internal/client/reactivity/sources.js')) {
+                return instrumentRuntime(code, id, [[stateUpdateNeedle, stateUpdateReplacement]]);
+            }
+
+            if (path?.endsWith('/svelte/src/internal/client/reactivity/batch.js')) {
+                return instrumentRuntime(code, id, [
+                    [flushStartNeedle, flushStartReplacement],
+                    [flushEndNeedle, flushEndReplacement],
+                    [effectDepthNeedle, effectDepthReplacement]
+                ]);
+            }
+        }
+    };
 }
 
 function svelteKitRuntimeDefines(): Plugin {
@@ -56,7 +140,7 @@ export default defineConfig({
     },
     clearScreen: false,
     logLevel: 'info',
-    plugins: [tailwindcss(), sveltekit(), svelteKitRuntimeDefines()],
+    plugins: [tailwindcss(), sveltekit(), svelteKitRuntimeDefines(), svelteEffectDepthDiagnostics()],
     server: {
         allowedHosts,
         hmr,


### PR DESCRIPTION
## Summary

- add bounded production diagnostics for `effect_update_depth_exceeded`
- append repeated reactive state-write call sites to the captured error stack so existing source maps resolve application locations
- attach structured `svelte_effect_depth` extended data with update counts, effect ancestry, pathname, visibility, and safe interaction metadata
- update `svelte-time` from 2.3.0 to 2.3.1 for its adaptive live-interval loop fix
- retain adaptive relative-time updates and add a deterministic regression test covering shared clocks on opposite sides of the one-hour boundary

## Root cause

`svelte-time@2.3.0` computed its adaptive interval from a shared cached `now` value selected by that same interval. When active shared clocks straddled an age boundary, a live timestamp could alternate between ticker tiers until Svelte threw `effect_update_depth_exceeded`.

The defect was reported with a standalone reproduction in [metonym/svelte-time#107](https://github.com/metonym/svelte-time/issues/107) and fixed upstream in [svelte-time 2.3.1](https://github.com/metonym/svelte-time/releases/tag/v2.3.1). We removed the application-level fixed-minute workaround and restored `live={true}` after upgrading.

## Diagnostics

The production instrumentation mirrors the useful part of Svelte's development-only state-write tracking while keeping collection bounded:

- starts stack collection only after repeated writes to the same state source
- limits sources, unique stacks, captures, and appended frames
- does not capture state values, query strings, DOM text, or user input
- fails the build if the supported Svelte runtime version or expected internal source shape changes

A minified production preview with an intentional reactive loop captured 1,001 writes and resolved the generated frame through the production source map to the exact Svelte assignment.

## Dependency review

- reviewed the complete 2.3.0...2.3.1 source diff; the runtime change uses a fresh `dayjs()` value for adaptive tier selection in `Time` and `Duration`
- no API or migration changes
- same-day patch release risk is covered by the upstream boundary regressions and our application-level deterministic regression
- `npm audit` still reports the same 6 existing findings (1 low, 1 moderate, 4 high); this update introduced no additional findings

## Validation

- deterministic formatter regression fails with 2.3.0 and passes with 2.3.1 while keeping adaptive `live={true}` behavior
- focused diagnostics tests: 4 passed
- `npm run validate`
- `npm run test:unit -- --run`
- `npm run build`

## Breaking changes

None.
