### PR TITLE
Preserve line breaks in extended data values

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/object-dump.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/object-dump.svelte
@@ -64,5 +64,5 @@
 {:else if isNull}
     (Null)
 {:else}
-    {value}
+    <span class="whitespace-pre-wrap">{value}</span>
 {/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/object-dump.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/object-dump.svelte.test.ts
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+
+import ObjectDump from './object-dump.svelte';
+
+describe('ObjectDump', () => {
+    it('preserves line breaks in string values', () => {
+        const sessionContents = 'ApplicationName = ZZZZ\r\nGL_StatusFilter_D = Active\r\nSessionID = abc123';
+
+        const { container } = render(ObjectDump, { value: sessionContents });
+
+        const value = container.firstElementChild;
+
+        expect(value?.textContent).toBe(sessionContents);
+        expect(value?.classList.contains('whitespace-pre-wrap')).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

- preserve newline characters when the Svelte object dump renders primitive values
- add regression coverage for CRLF-delimited extended data

## Root cause

The event payload retained its newline characters, but the new UI rendered primitive extended-data strings as normal inline text. CSS whitespace collapsing made every line appear on one line. The legacy UI renders the same non-JSON string in a `pre` element.

## Verification

- `npm run test:unit` (44 files, 454 tests)
- `npm run validate`
- `npm run build`
- local Svelte UI: seven lines, computed `white-space: pre-wrap`
- local legacy Angular UI: seven lines, computed `white-space: pre`

## Breaking changes

None.

Fixes #2427