### PR TITLE
Fix Intercom connectivity and update noise

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/api.svelte.ts
@@ -2,13 +2,13 @@ import { env } from '$env/dynamic/public';
 import { getIntercomTokenSessionKey, intercomTokenRefreshIntervalMs } from '$features/intercom/config';
 import { organization } from '$features/organizations/context.svelte';
 import { ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
-import { hide as hideIntercom, shutdown as shutdownIntercom } from '@intercom/messenger-js-sdk';
 import { createQuery, type QueryClient } from '@tanstack/svelte-query';
 
 import type { Login, TokenResult } from './models';
 
 import { endSession } from './exceptionless-session';
-import { accessToken } from './index.svelte';
+import { clearAuthenticationSession } from './session.svelte';
+import { accessToken } from './state.svelte';
 
 const queryKeys = {
     intercom: (accessToken: null | string) => ['Auth', 'intercom', getIntercomTokenSessionKey(accessToken)] as const
@@ -103,17 +103,12 @@ export async function logout(queryClient?: QueryClient, client = useFetchClient(
     await queryClient?.cancelQueries();
     queryClient?.clear();
 
-    if (typeof window !== 'undefined' && 'Intercom' in window && typeof window.Intercom === 'function') {
-        hideIntercom();
-        shutdownIntercom();
-    }
+    clearAuthenticationSession();
 
     organization.current = undefined;
     if (typeof localStorage !== 'undefined') {
         localStorage.removeItem('organization');
     }
-
-    accessToken.current = null;
 }
 
 export async function resetPassword(passwordResetToken: string, password: string) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/api.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/api.test.ts
@@ -1,14 +1,18 @@
 import { FetchClient } from '@foundatiofx/fetchclient';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const clearAuthenticationSession = vi.hoisted(() => vi.fn());
+
 vi.mock('./exceptionless-session', () => ({
     endSession: vi.fn()
 }));
+vi.mock('./session.svelte', () => ({ clearAuthenticationSession }));
 
 import { logout } from './api.svelte';
 
 describe('logout', () => {
     beforeEach(() => {
+        clearAuthenticationSession.mockReset();
         // Mock localStorage for server-side tests
         Object.defineProperty(globalThis, 'localStorage', {
             configurable: true,
@@ -28,5 +32,6 @@ describe('logout', () => {
         await logout(undefined, mockClient);
 
         expect(mockClient.get).toHaveBeenCalledWith('auth/logout', { expectedStatusCodes: [200, 401, 403] });
+        expect(clearAuthenticationSession).toHaveBeenCalledOnce();
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/index.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/index.svelte.ts
@@ -2,10 +2,11 @@ import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
 import { page } from '$app/state';
 import { env } from '$env/dynamic/public';
-import { CachedPersistedState } from '$features/shared/utils/cached-persisted-state.svelte';
 import { useFetchClient } from '@foundatiofx/fetchclient';
 
 import type { TokenResult } from './models';
+
+import { accessToken } from './state.svelte';
 
 // Re-export all API functions for backward compatibility
 export {
@@ -21,6 +22,7 @@ export {
     unlinkOAuthAccount
 } from './api.svelte';
 
+export { accessToken } from './state.svelte';
 // Re-export validators
 export { validateEmailAvailability } from './validators';
 
@@ -43,17 +45,6 @@ export interface OAuthResponseData {
 }
 
 export type SupportedOAuthProviders = 'facebook' | 'github' | 'google' | 'live' | 'slack';
-
-const authSerializer = {
-    deserialize: (value: null | string): null | string => {
-        return value === '' ? null : value;
-    },
-    serialize: (value: null | string): string => {
-        return value === null ? '' : value;
-    }
-};
-
-export const accessToken = new CachedPersistedState<null | string>('satellizer_token', null, { serializer: authSerializer });
 
 export const enableAccountCreation = env.PUBLIC_ENABLE_ACCOUNT_CREATION === 'true';
 export const facebookClientId = env.PUBLIC_FACEBOOK_APPID;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/session.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/session.svelte.ts
@@ -1,0 +1,8 @@
+import { shutdownIntercomSession } from '$features/intercom/session';
+
+import { accessToken } from './state.svelte';
+
+export function clearAuthenticationSession(clearedAccessToken: '' | null = null) {
+    shutdownIntercomSession();
+    accessToken.current = clearedAccessToken;
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/state.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/state.svelte.ts
@@ -1,0 +1,12 @@
+import { CachedPersistedState } from '$features/shared/utils/cached-persisted-state.svelte';
+
+const authSerializer = {
+    deserialize: (value: null | string): null | string => {
+        return value === '' ? null : value;
+    },
+    serialize: (value: null | string): string => {
+        return value === null ? '' : value;
+    }
+};
+
+export const accessToken = new CachedPersistedState<null | string>('satellizer_token', null, { serializer: authSerializer });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/unauthorized.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/unauthorized.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const clearAuthenticationSession = vi.hoisted(() => vi.fn());
+const accessToken = vi.hoisted(() => ({ current: 'token_123' as null | string }));
+
+vi.mock('./session.svelte', () => ({ clearAuthenticationSession }));
+vi.mock('./state.svelte', () => ({ accessToken }));
+
+import { handleUnexpectedUnauthorized } from './unauthorized';
+
+describe('handleUnexpectedUnauthorized', () => {
+    beforeEach(() => {
+        accessToken.current = 'token_123';
+        clearAuthenticationSession.mockReset();
+    });
+
+    it('clears the authenticated session after an unexpected unauthorized response', () => {
+        expect(handleUnexpectedUnauthorized(401)).toBe(true);
+        expect(clearAuthenticationSession).toHaveBeenCalledExactlyOnceWith('');
+    });
+
+    it('ignores expected unauthorized responses and duplicate session cleanup', () => {
+        expect(handleUnexpectedUnauthorized(401, [401])).toBe(false);
+
+        accessToken.current = null;
+        expect(handleUnexpectedUnauthorized(401)).toBe(false);
+        expect(clearAuthenticationSession).not.toHaveBeenCalled();
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/unauthorized.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/unauthorized.ts
@@ -1,0 +1,11 @@
+import { clearAuthenticationSession } from './session.svelte';
+import { accessToken } from './state.svelte';
+
+export function handleUnexpectedUnauthorized(status: number, expectedStatusCodes?: number[]) {
+    if (status !== 401 || expectedStatusCodes?.includes(401) || !accessToken.current) {
+        return false;
+    }
+
+    clearAuthenticationSession('');
+    return true;
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-initializer.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-initializer.svelte
@@ -9,8 +9,6 @@
     import type { BootOptions } from 'svelte-intercom';
 
     import { accessToken } from '$features/auth/index.svelte';
-    import { DocumentVisibility } from '$shared/document-visibility.svelte';
-    import { useInterval } from 'runed';
     import { untrack } from 'svelte';
     import { setContext } from 'svelte';
     import { useIntercom } from 'svelte-intercom';
@@ -21,46 +19,32 @@
         bootOptions?: BootOptions;
         children: Snippet;
         routeKey?: string;
-        updateIntervalMs?: number;
     }
 
-    let { bootOptions = undefined, children, routeKey = undefined, updateIntervalMs = 90_000 }: Props = $props();
+    let { bootOptions = undefined, children, routeKey = undefined }: Props = $props();
 
     const intercom = useIntercom();
-    const visibility = new DocumentVisibility();
+    let hasBooted = false;
 
     setContext<IntercomContext>(INTERCOM_CONTEXT_KEY, intercom);
 
-    const interval = useInterval(() => updateIntervalMs, {
-        callback: () => {
-            if (bootOptions && visibility.visible) {
-                intercom.update(bootOptions);
-            }
-        },
-        immediate: false
-    });
-
-    const shouldUpdate = $derived(bootOptions && visibility.visible);
-
-    // Sync identity/company data and manage interval when boot options or visibility changes.
+    // The provider boots with the initial options. Only update after boot when the route or
+    // identity/company data changes; eager or periodic updates create duplicate impressions.
     $effect(() => {
-        if (!bootOptions) {
-            interval.pause();
+        void routeKey;
+        const options = bootOptions;
+        if (!options) {
+            hasBooted = false;
             return;
         }
 
-        if (visibility.visible) {
-            interval.resume();
-        } else {
-            interval.pause();
+        if (!hasBooted) {
+            hasBooted = true;
+            return;
         }
-    });
 
-    // Sync on route transitions and visibility changes.
-    $effect(() => {
-        void routeKey;
-        if (shouldUpdate) {
-            untrack(() => intercom.update(bootOptions!));
+        if (typeof window.Intercom === 'function') {
+            untrack(() => intercom.update(options));
         }
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-initializer.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-initializer.svelte
@@ -8,12 +8,12 @@
     import type { Snippet } from 'svelte';
     import type { BootOptions } from 'svelte-intercom';
 
-    import { accessToken } from '$features/auth/index.svelte';
     import { untrack } from 'svelte';
     import { setContext } from 'svelte';
     import { useIntercom } from 'svelte-intercom';
 
     import { INTERCOM_CONTEXT_KEY } from './keys';
+    import { buildIntercomDataUpdate, buildIntercomRouteUpdate } from './updates';
 
     interface Props {
         bootOptions?: BootOptions;
@@ -25,33 +25,44 @@
 
     const intercom = useIntercom();
     let hasBooted = false;
+    let previousBootOptions: BootOptions | undefined;
+    let previousRouteKey: string | undefined;
 
     setContext<IntercomContext>(INTERCOM_CONTEXT_KEY, intercom);
 
     // The provider boots with the initial options. Only update after boot when the route or
     // identity/company data changes; eager or periodic updates create duplicate impressions.
     $effect(() => {
-        void routeKey;
         const options = bootOptions;
+        const currentRouteKey = routeKey;
         if (!options) {
             hasBooted = false;
+            previousBootOptions = undefined;
+            previousRouteKey = undefined;
             return;
         }
 
         if (!hasBooted) {
             hasBooted = true;
+            previousBootOptions = options;
+            previousRouteKey = currentRouteKey;
             return;
         }
 
-        if (typeof window.Intercom === 'function') {
-            untrack(() => intercom.update(options));
+        if (typeof window.Intercom !== 'function') {
+            return;
         }
-    });
 
-    // Shutdown when the user logs out.
-    $effect(() => {
-        if (!accessToken.current) {
-            untrack(() => intercom.shutdown());
+        const priorBootOptions = previousBootOptions!;
+        const bootOptionsChanged = options !== priorBootOptions;
+        const routeChanged = currentRouteKey !== previousRouteKey;
+        previousBootOptions = options;
+        previousRouteKey = currentRouteKey;
+
+        if (bootOptionsChanged) {
+            untrack(() => intercom.update(buildIntercomDataUpdate(priorBootOptions, options)));
+        } else if (routeChanged) {
+            untrack(() => intercom.update(buildIntercomRouteUpdate(options)));
         }
     });
 </script>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-initializer.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-initializer.svelte
@@ -19,9 +19,11 @@
         bootOptions?: BootOptions;
         children: Snippet;
         routeKey?: string;
+        /** @deprecated Intercom updates are event-driven; this value is retained as a no-op for compatibility. */
+        updateIntervalMs?: number;
     }
 
-    let { bootOptions = undefined, children, routeKey = undefined }: Props = $props();
+    let { bootOptions = undefined, children, routeKey = undefined, updateIntervalMs = undefined }: Props = $props();
 
     const intercom = useIntercom();
     let hasBooted = false;
@@ -29,6 +31,11 @@
     let previousRouteKey: string | undefined;
 
     setContext<IntercomContext>(INTERCOM_CONTEXT_KEY, intercom);
+
+    // Retain the deprecated prop reactively without restoring periodic updates.
+    $effect(() => {
+        void updateIntervalMs;
+    });
 
     // The provider boots with the initial options. Only update after boot when the route or
     // identity/company data changes; eager or periodic updates create duplicate impressions.

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-shell.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-shell.svelte.test.ts
@@ -97,6 +97,10 @@ describe('IntercomShell', () => {
 
         // Assert
         expect(intercomUpdate).toHaveBeenCalledOnce();
+        expect(intercomUpdate).toHaveBeenLastCalledWith({
+            last_request_at: expect.any(Number),
+            user_id: 'user_123'
+        });
 
         // Act
         await rerender({
@@ -107,6 +111,23 @@ describe('IntercomShell', () => {
 
         // Assert
         expect(intercomUpdate).toHaveBeenCalledTimes(2);
+        expect(intercomUpdate).toHaveBeenLastCalledWith({
+            intercom_user_jwt: 'token_1',
+            user_id: 'user_123'
+        });
+    });
+
+    it('does not update when navigation stays within the same normalized route', async () => {
+        const bootOptions = { email: 'user@example.com', userId: 'user_123' } as BootOptions;
+        const routeKey = '/(app)/project/[projectId]/event/[eventId]';
+        const { rerender } = render(IntercomShellTestHarness, {
+            props: { appId: 'app_123', bootOptions, routeKey }
+        });
+        await tick();
+
+        await rerender({ appId: 'app_123', bootOptions, routeKey });
+
+        expect(intercomUpdate).not.toHaveBeenCalled();
     });
 
     it('does not update before the client SDK initializes', async () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-shell.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-shell.svelte.test.ts
@@ -43,6 +43,7 @@ describe('IntercomShell', () => {
         intercomShowMessages.mockReset();
         intercomUpdate.mockReset();
         vi.restoreAllMocks();
+        window.Intercom = vi.fn();
     });
 
     it('keeps children mounted when Intercom becomes bootable', async () => {
@@ -76,37 +77,62 @@ describe('IntercomShell', () => {
         expect(intercomShowMessages).toHaveBeenCalledTimes(1);
     });
 
-    it('remains stable across repeated tab visibility changes', async () => {
+    it('updates after boot only when the route or boot options change', async () => {
         // Arrange
-        let hidden = false;
-        const addEventListener = vi.spyOn(document, 'addEventListener');
-        vi.spyOn(document, 'hidden', 'get').mockImplementation(() => hidden);
+        const bootOptions = { intercomUserJwt: 'token_0', userId: 'user_123' } as BootOptions;
         const { rerender } = render(IntercomShellTestHarness, {
             props: {
                 appId: 'app_123',
-                bootOptions: { intercomUserJwt: 'token_0', userId: 'user_123' } as BootOptions
+                bootOptions,
+                routeKey: '/event/all'
+            }
+        });
+        await tick();
+
+        // Assert initial boot options are not immediately sent again.
+        expect(intercomUpdate).not.toHaveBeenCalled();
+
+        // Act
+        await rerender({ appId: 'app_123', bootOptions, routeKey: '/stack/all' });
+
+        // Assert
+        expect(intercomUpdate).toHaveBeenCalledOnce();
+
+        // Act
+        await rerender({
+            appId: 'app_123',
+            bootOptions: { intercomUserJwt: 'token_1', userId: 'user_123' } as BootOptions,
+            routeKey: '/stack/all'
+        });
+
+        // Assert
+        expect(intercomUpdate).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not update before the client SDK initializes', async () => {
+        // Arrange
+        window.Intercom = undefined;
+        const bootOptions = { intercomUserJwt: 'token_0', userId: 'user_123' } as BootOptions;
+        const { rerender } = render(IntercomShellTestHarness, {
+            props: {
+                appId: 'app_123',
+                bootOptions,
+                routeKey: '/event/all'
             }
         });
         await tick();
 
         // Act
-        for (let index = 0; index < 100; index++) {
-            hidden = true;
-            document.dispatchEvent(new Event('visibilitychange'));
-            await tick();
-
-            await rerender({
-                appId: 'app_123',
-                bootOptions: { intercomUserJwt: `token_${index + 1}`, userId: 'user_123' } as BootOptions
-            });
-
-            hidden = false;
-            document.dispatchEvent(new Event('visibilitychange'));
-            await tick();
-        }
+        await rerender({ appId: 'app_123', bootOptions, routeKey: '/stack/all' });
 
         // Assert
-        expect(intercomUpdate).toHaveBeenCalled();
-        expect(addEventListener.mock.calls.filter(([eventName]) => eventName === 'visibilitychange')).toHaveLength(1);
+        expect(intercomUpdate).not.toHaveBeenCalled();
+
+        // Act
+        window.Intercom = vi.fn();
+        await rerender({ appId: 'app_123', bootOptions, routeKey: '/event/errors' });
+
+        // Assert
+        expect(intercomUpdate).toHaveBeenCalledOnce();
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-shell.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-shell.test-harness.svelte
@@ -8,12 +8,13 @@
         appId?: string;
         bootOptions?: BootOptions;
         onMountProbe?: () => void;
+        routeKey?: string;
     }
 
-    let { appId = undefined, bootOptions = undefined, onMountProbe = () => {} }: Props = $props();
+    let { appId = undefined, bootOptions = undefined, onMountProbe = () => {}, routeKey = undefined }: Props = $props();
 </script>
 
-<IntercomShell {appId} {bootOptions}>
+<IntercomShell {appId} {bootOptions} {routeKey}>
     {#snippet children(openChat)}
         <IntercomShellTestProbe {onMountProbe} />
         <button data-testid="open-chat" onclick={openChat}>Open chat</button>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/session.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/session.svelte.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hide = vi.hoisted(() => vi.fn());
+const shutdown = vi.hoisted(() => vi.fn());
+
+vi.mock('@intercom/messenger-js-sdk', () => ({ hide, shutdown }));
+
+import { shutdownIntercomSession } from './session';
+
+describe('shutdownIntercomSession', () => {
+    beforeEach(() => {
+        hide.mockReset();
+        shutdown.mockReset();
+        window.Intercom = vi.fn();
+        document.cookie = 'intercom-id-app=visitor; Path=/';
+        document.cookie = 'intercom-session-app=session; Path=/';
+        document.cookie = 'unrelated-cookie=keep; Path=/';
+    });
+
+    it('shuts down the SDK and clears all Intercom cookies', () => {
+        shutdownIntercomSession();
+
+        expect(hide).toHaveBeenCalledOnce();
+        expect(shutdown).toHaveBeenCalledOnce();
+        expect(document.cookie).not.toContain('intercom-id-app');
+        expect(document.cookie).not.toContain('intercom-session-app');
+        expect(document.cookie).toContain('unrelated-cookie=keep');
+    });
+
+    it('still clears cookies when tracking prevention blocks the SDK', () => {
+        window.Intercom = undefined;
+
+        expect(() => shutdownIntercomSession()).not.toThrow();
+        expect(hide).not.toHaveBeenCalled();
+        expect(shutdown).not.toHaveBeenCalled();
+        expect(document.cookie).not.toContain('intercom-id-app');
+        expect(document.cookie).not.toContain('intercom-session-app');
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/session.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/session.ts
@@ -1,0 +1,47 @@
+import { hide, shutdown } from '@intercom/messenger-js-sdk';
+
+export function clearIntercomCookies() {
+    if (typeof document === 'undefined') {
+        return;
+    }
+
+    const cookieNames = new Set(
+        document.cookie
+            .split(';')
+            .map((cookie) => cookie.trim().split('=', 1)[0] ?? '')
+            .filter((name) => name.startsWith('intercom-'))
+    );
+
+    const hostname = typeof window === 'undefined' ? '' : window.location.hostname;
+    const domainCandidates = getCookieDomainCandidates(hostname);
+
+    for (const name of cookieNames) {
+        expireCookie(name);
+        for (const domain of domainCandidates) {
+            expireCookie(name, domain);
+        }
+    }
+}
+
+export function shutdownIntercomSession() {
+    if (typeof window !== 'undefined' && typeof window.Intercom === 'function') {
+        hide();
+        shutdown();
+    }
+
+    clearIntercomCookies();
+}
+
+function expireCookie(name: string, domain?: string) {
+    const domainAttribute = domain ? `; Domain=${domain}` : '';
+    document.cookie = `${name}=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/${domainAttribute}; SameSite=Lax`;
+}
+
+function getCookieDomainCandidates(hostname: string) {
+    if (!hostname.includes('.') || /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) {
+        return [];
+    }
+
+    const parts = hostname.split('.');
+    return parts.slice(0, -1).map((_, index) => parts.slice(index).join('.'));
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/updates.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/updates.test.ts
@@ -1,0 +1,75 @@
+import type { BootOptions } from 'svelte-intercom';
+
+import { describe, expect, it } from 'vitest';
+
+import { buildIntercomDataUpdate, buildIntercomRouteUpdate, getIntercomRouteKey } from './updates';
+
+describe('Intercom updates', () => {
+    it('builds a minimal route update with identity and the current timestamp', () => {
+        const bootOptions = {
+            company: { id: 'organization_123', name: 'Acme' },
+            email: 'user@example.com',
+            intercomUserJwt: 'signed-token',
+            userId: 'user_123'
+        } as BootOptions;
+
+        expect(buildIntercomRouteUpdate(bootOptions, 1_750_000_123_456)).toEqual({
+            email: 'user@example.com',
+            lastRequestAt: 1_750_000_123,
+            userId: 'user_123'
+        });
+    });
+
+    it('includes only identity and changed user data in a data update', () => {
+        const previousBootOptions = {
+            company: { id: 'organization_123', name: 'Acme' },
+            email: 'user@example.com',
+            intercomUserJwt: 'signed-token-1',
+            userId: 'user_123'
+        } as BootOptions;
+        const bootOptions = {
+            company: { id: 'organization_123', name: 'Acme' },
+            email: 'user@example.com',
+            intercomUserJwt: 'signed-token-2',
+            userId: 'user_123'
+        } as BootOptions;
+
+        expect(buildIntercomDataUpdate(previousBootOptions, bootOptions)).toEqual({
+            email: 'user@example.com',
+            intercomUserJwt: 'signed-token-2',
+            userId: 'user_123'
+        });
+    });
+
+    it('includes changed company data without resending unchanged user fields', () => {
+        const previousBootOptions = {
+            company: { id: 'organization_123', name: 'Acme' },
+            email: 'user@example.com',
+            name: 'Example User',
+            userId: 'user_123'
+        } as BootOptions;
+        const bootOptions = {
+            company: { id: 'organization_123', name: 'Acme, Inc.' },
+            email: 'user@example.com',
+            name: 'Example User',
+            userId: 'user_123'
+        } as BootOptions;
+
+        expect(buildIntercomDataUpdate(previousBootOptions, bootOptions)).toEqual({
+            company: { id: 'organization_123', name: 'Acme, Inc.' },
+            email: 'user@example.com',
+            userId: 'user_123'
+        });
+    });
+
+    it('uses the normalized route ID instead of resource identifiers in the pathname', () => {
+        const routeId = '/(app)/project/[projectId]/event/[eventId]';
+
+        expect(getIntercomRouteKey(routeId, '/next/project/project-a/event/event-a')).toBe(routeId);
+        expect(getIntercomRouteKey(routeId, '/next/project/project-a/event/event-b')).toBe(routeId);
+    });
+
+    it('falls back to the pathname when SvelteKit has no route ID', () => {
+        expect(getIntercomRouteKey(null, '/next/status')).toBe('/next/status');
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/updates.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/updates.ts
@@ -1,0 +1,53 @@
+import type { BootOptions, UpdateOptions } from 'svelte-intercom';
+
+export function buildIntercomDataUpdate(previousBootOptions: BootOptions, bootOptions: BootOptions): UpdateOptions {
+    const update: Record<string, unknown> = {};
+    addIntercomIdentity(update, bootOptions);
+
+    for (const [key, value] of Object.entries(bootOptions)) {
+        if (key === 'email' || key === 'userId') {
+            continue;
+        }
+
+        if (!areIntercomValuesEqual(previousBootOptions[key], value)) {
+            update[key] = value;
+        }
+    }
+
+    return update as UpdateOptions;
+}
+
+export function buildIntercomRouteUpdate(bootOptions: BootOptions, now = Date.now()): UpdateOptions {
+    const update: Record<string, unknown> = { lastRequestAt: Math.floor(now / 1000) };
+    addIntercomIdentity(update, bootOptions);
+
+    // Intercom's SPA guidance requires last_request_at for URL-only updates, but
+    // svelte-intercom currently marks this supported field as `never` in its types.
+    return update as UpdateOptions;
+}
+
+export function getIntercomRouteKey(routeId: null | string | undefined, pathname: string) {
+    return routeId ?? pathname;
+}
+
+function addIntercomIdentity(update: Record<string, unknown>, bootOptions: BootOptions) {
+    if (bootOptions.email) {
+        update.email = bootOptions.email;
+    }
+
+    if (bootOptions.userId) {
+        update.userId = bootOptions.userId;
+    }
+}
+
+function areIntercomValuesEqual(previousValue: unknown, value: unknown) {
+    if (Object.is(previousValue, value)) {
+        return true;
+    }
+
+    if (typeof previousValue !== 'object' || previousValue === null || typeof value !== 'object' || value === null) {
+        return false;
+    }
+
+    return JSON.stringify(previousValue) === JSON.stringify(value);
+}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
@@ -18,6 +18,7 @@
     import { filterUsesPremiumFeatures, getSearchResourceForPathname } from '$features/events/premium-filter';
     import { buildIntercomBootOptions, IntercomShell } from '$features/intercom';
     import { shouldLoadIntercomOrganization } from '$features/intercom/config';
+    import { getIntercomRouteKey } from '$features/intercom/updates';
     import Notifications from '$features/notifications/components/notifications.svelte';
     import {
         getOrganizationQuery,
@@ -582,7 +583,7 @@
         appId={intercomAppId || undefined}
         bootOptions={intercomBootOptions}
         onUnreadCountChange={onIntercomUnreadCountChange}
-        routeKey={page.url.pathname}
+        routeKey={getIntercomRouteKey(page.route.id, page.url.pathname)}
     >
         {#snippet children(openChat)}
             {#if isSetupPage}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(auth)/oauth/authorize/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(auth)/oauth/authorize/+page.svelte
@@ -12,6 +12,7 @@
     import { Checkbox } from '$comp/ui/checkbox';
     import { Spinner } from '$comp/ui/spinner';
     import { accessToken } from '$features/auth/index.svelte';
+    import { clearAuthenticationSession } from '$features/auth/session.svelte';
     import { getOrganizationsQuery } from '$features/organizations/api.svelte';
     import { getMeQuery } from '$features/users/api.svelte';
     import { useFetchClient } from '@foundatiofx/fetchclient';
@@ -224,7 +225,7 @@
     }
 
     async function redirectToLogin(): Promise<void> {
-        accessToken.current = null;
+        clearAuthenticationSession();
         const returnUrl = `${page.url.pathname}${page.url.search}`;
         const loginUrl = `${resolve('/(auth)/login')}?redirect=${encodeURIComponent(returnUrl)}`;
         await goto(loginUrl, { replaceState: true });

--- a/src/Exceptionless.Web/ClientApp/src/routes/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
     import * as Sidebar from '$comp/ui/sidebar';
     import { Toaster } from '$comp/ui/sonner';
     import { accessToken } from '$features/auth/index.svelte';
+    import { handleUnexpectedUnauthorized } from '$features/auth/unauthorized';
     import { type FetchClientContext, ProblemDetails, setAccessTokenFunc, setBaseUrl, setRequestOptions, useMiddleware } from '@foundatiofx/fetchclient';
     import { error } from '@sveltejs/kit';
     import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
@@ -41,10 +42,8 @@
             return;
         }
 
-        if (status === 401 && !ctx.options.expectedStatusCodes?.includes(401)) {
-            if (accessToken.current) {
-                accessToken.current = '';
-            }
+        if (handleUnexpectedUnauthorized(status, ctx.options.expectedStatusCodes)) {
+            return;
         } else if (status === 404 && !ctx.options.expectedStatusCodes?.includes(404)) {
             throw error(404, 'Not found');
         } else if ([0, 408, 503].includes(status) && !ctx.options.expectedStatusCodes?.includes(status)) {

--- a/src/Exceptionless.Web/Program.cs
+++ b/src/Exceptionless.Web/Program.cs
@@ -286,8 +286,18 @@ public partial class Program
                     .To("https://collector.exceptionless.io")
                     .To("https://config.exceptionless.io")
                     .To("https://heartbeat.exceptionless.io")
+                    .To("https://via.intercom.io")
+                    .To("https://api.intercom.io")
                     .To("https://api-iam.intercom.io/")
-                    .To("wss://nexus-websocket-a.intercom.io");
+                    .To("https://api-ping.intercom.io")
+                    .To("https://*.intercom-messenger.com")
+                    .To("wss://*.intercom-messenger.com")
+                    .To("https://nexus-websocket-a.intercom.io")
+                    .To("wss://nexus-websocket-a.intercom.io")
+                    .To("https://nexus-websocket-b.intercom.io")
+                    .To("wss://nexus-websocket-b.intercom.io")
+                    .To("https://uploads.intercomcdn.com")
+                    .To("https://uploads.intercomusercontent.com");
 
                 csp.OnSendingHeader = new Func<CspSendingHeaderContext, Task>(context =>
                 {


### PR DESCRIPTION
## Summary

- allow Intercom's current US API, upload, and realtime endpoints in the web CSP
- remove the periodic Intercom update loop and avoid duplicate updates during initial boot
- centralize Intercom teardown for manual logout, automatic `401` logout, and OAuth reauthentication
- clear residual `intercom-*` cookies even when tracking prevention blocks the SDK
- update Intercom only for normalized SvelteKit route changes or changed identity/company data
- send identity plus `last_request_at` for route-only updates instead of the full boot payload
- cover boot, navigation, identity refresh, teardown, cookie cleanup, throttling safeguards, and delayed SDK initialization

## Why

Production browsers blocked dynamically selected Intercom realtime WebSocket hosts because the CSP allowed only one legacy endpoint. The Svelte client also called Intercom update every 90 seconds, consuming the documented 20-calls-per-30-minute quota and repeatedly generating third-party traffic and console noise.

Intercom session cleanup was only explicit during manual logout. Automatic authentication loss relied on a component effect that could be unmounted before running, and `shutdown` alone can leave Intercom's anonymous identifier cookie behind. Session teardown now runs from every Svelte authentication-ending path and clears all visible Intercom cookies.

Normalized route IDs prevent navigation between individual events or stacks from consuming additional update calls. Meaningful route changes send only identity and the current request timestamp, while user or company changes send only the fields that changed.

The legacy Angular application remains isolated from the Svelte lifecycle changes. The shared CSP change preserves every previous source exactly and only adds Intercom connection destinations.

## Validation

- `npm run validate` in `ClientApp`
- `npm run test:unit` in `ClientApp` — 46 files, 464 tests passed
- `npm run build` in `ClientApp`
- `npm run lint` in `ClientApp.angular`
- `npm run build` in `ClientApp.angular`
- `dotnet msbuild src/Exceptionless.Web/Exceptionless.Web.csproj /t:Build /p:Restore=false /m:1 /v:minimal`

## Breaking changes

None.
