### PR TITLE
Send Intercom JWT with secured updates

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-shell.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/intercom-shell.svelte.test.ts
@@ -98,6 +98,7 @@ describe('IntercomShell', () => {
         // Assert
         expect(intercomUpdate).toHaveBeenCalledOnce();
         expect(intercomUpdate).toHaveBeenLastCalledWith({
+            intercom_user_jwt: 'token_0',
             last_request_at: expect.any(Number),
             user_id: 'user_123'
         });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/updates.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/updates.test.ts
@@ -15,6 +15,7 @@ describe('Intercom updates', () => {
 
         expect(buildIntercomRouteUpdate(bootOptions, 1_750_000_123_456)).toEqual({
             email: 'user@example.com',
+            intercomUserJwt: 'signed-token',
             lastRequestAt: 1_750_000_123,
             userId: 'user_123'
         });
@@ -45,12 +46,14 @@ describe('Intercom updates', () => {
         const previousBootOptions = {
             company: { id: 'organization_123', name: 'Acme' },
             email: 'user@example.com',
+            intercomUserJwt: 'signed-token',
             name: 'Example User',
             userId: 'user_123'
         } as BootOptions;
         const bootOptions = {
             company: { id: 'organization_123', name: 'Acme, Inc.' },
             email: 'user@example.com',
+            intercomUserJwt: 'signed-token',
             name: 'Example User',
             userId: 'user_123'
         } as BootOptions;
@@ -58,6 +61,7 @@ describe('Intercom updates', () => {
         expect(buildIntercomDataUpdate(previousBootOptions, bootOptions)).toEqual({
             company: { id: 'organization_123', name: 'Acme, Inc.' },
             email: 'user@example.com',
+            intercomUserJwt: 'signed-token',
             userId: 'user_123'
         });
     });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/updates.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/intercom/updates.ts
@@ -31,6 +31,10 @@ export function getIntercomRouteKey(routeId: null | string | undefined, pathname
 }
 
 function addIntercomIdentity(update: Record<string, unknown>, bootOptions: BootOptions) {
+    if (bootOptions.intercomUserJwt) {
+        update.intercomUserJwt = bootOptions.intercomUserJwt;
+    }
+
     if (bootOptions.email) {
         update.email = bootOptions.email;
     }


### PR DESCRIPTION
## Summary

- Include the current `intercom_user_jwt` with every identified Intercom SPA update.
- Cover both route-impression updates and later identity/company-data updates with regression tests.

## Why

Messenger Security rejects identified user updates that omit both `user_hash` and `intercom_user_jwt`. The initial boot contained the JWT, but our update helper only resent the JWT when its value changed. Route updates therefore always sent `user_id` without authentication, producing `403 Forbidden` responses while users navigated the Svelte SPA.

Intercom documents `intercom_user_jwt` as the field used to identify and update secured Messenger users: https://www.intercom.com/help/en/articles/10589769-authenticating-users-in-the-messenger-with-json-web-tokens-jwts

## Impact

Secured Intercom updates remain authenticated while navigating or refreshing user/company data. No API contract or legacy Angular behavior changes.

## Verification

- `npm run test:unit -- --run src/lib/features/intercom/updates.test.ts src/lib/features/intercom/intercom-shell.svelte.test.ts`
- `npm run validate`
- `npm run build`

## Breaking changes

None.
