### PR TITLE
Use friendly object dump test values

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/object-dump.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/object-dump.svelte.test.ts
@@ -5,13 +5,11 @@ import ObjectDump from './object-dump.svelte';
 
 describe('ObjectDump', () => {
     it('preserves line breaks in string values', () => {
-        const sessionContents = 'ApplicationName = ZZZZ\r\nGL_StatusFilter_D = Active\r\nSessionID = abc123';
-
-        const { container } = render(ObjectDump, { value: sessionContents });
+        const { container } = render(ObjectDump, { value: 'First line\r\nSecond line\r\nThird line' });
 
         const value = container.firstElementChild;
 
-        expect(value?.textContent).toBe(sessionContents);
+        expect(value?.textContent).toBe('First line\r\nSecond line\r\nThird line');
         expect(value?.classList.contains('whitespace-pre-wrap')).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary

- replace customer-shaped object dump test data with friendly generic line text
- pass the test value directly to the component instead of keeping a separate fixture variable

## Why

The regression coverage from #2459 only needs to prove that CRLF-delimited strings retain their line breaks. Generic text keeps the fixture clear without resembling customer data.

## Verification

- `npm run test:unit -- src/lib/features/shared/components/object-dump.svelte.test.ts`
- `npm run validate`

## Breaking changes

None.
