### PR TITLE
Allow deletion of legacy suspended organizations

### DIFF
--- a/src/Exceptionless.Core/Billing/StripeConstants.cs
+++ b/src/Exceptionless.Core/Billing/StripeConstants.cs
@@ -2,6 +2,5 @@ namespace Exceptionless.Core.Billing;
 
 internal static class StripeConstants
 {
-    public const string LegacySystemUserId = "Stripe";
     public const string SystemUserId = "000000000000000000000000";
 }

--- a/src/Exceptionless.Core/Billing/StripeConstants.cs
+++ b/src/Exceptionless.Core/Billing/StripeConstants.cs
@@ -1,0 +1,7 @@
+namespace Exceptionless.Core.Billing;
+
+internal static class StripeConstants
+{
+    public const string LegacySystemUserId = "Stripe";
+    public const string SystemUserId = "000000000000000000000000";
+}

--- a/src/Exceptionless.Core/Billing/StripeEventHandler.cs
+++ b/src/Exceptionless.Core/Billing/StripeEventHandler.cs
@@ -10,7 +10,6 @@ namespace Exceptionless.Core.Billing;
 
 public class StripeEventHandler
 {
-    private const string STRIPE_USER_ID = "000000000000000000000000";
     private readonly ILogger _logger;
     private readonly IOrganizationRepository _organizationRepository;
     private readonly IUserRepository _userRepository;
@@ -242,7 +241,7 @@ public class StripeEventHandler
         organization.SuspensionDate = utcNow;
         organization.SuspensionCode = SuspensionCode.Billing;
         organization.SuspensionNotes = "Stripe subscription deleted.";
-        organization.SuspendedByUserId = STRIPE_USER_ID;
+        organization.SuspendedByUserId = StripeConstants.SystemUserId;
 
         await _organizationRepository.SaveAsync(organization, o => o.ImmediateConsistency().Cache().Originals());
     }
@@ -290,7 +289,7 @@ public class StripeEventHandler
             organization.SuspensionDate = utcNow;
             organization.SuspensionCode = SuspensionCode.Billing;
             organization.SuspensionNotes = $"Stripe subscription status changed to \"{status.Value}\".";
-            organization.SuspendedByUserId = STRIPE_USER_ID;
+            organization.SuspendedByUserId = StripeConstants.SystemUserId;
         }
         else if (status.Value == BillingStatus.Active || status.Value == BillingStatus.Trialing)
         {

--- a/src/Exceptionless.Core/Migrations/007_MigrateLegacyStripeSuspensionUserId.cs
+++ b/src/Exceptionless.Core/Migrations/007_MigrateLegacyStripeSuspensionUserId.cs
@@ -1,0 +1,55 @@
+using Exceptionless.Core.Billing;
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Repositories;
+using Foundatio.Repositories;
+using Foundatio.Repositories.Migrations;
+using Microsoft.Extensions.Logging;
+
+namespace Exceptionless.Core.Migrations;
+
+public sealed class MigrateLegacyStripeSuspensionUserId : MigrationBase
+{
+    private const int BatchSize = 100;
+    private readonly IOrganizationRepository _organizationRepository;
+
+    public MigrateLegacyStripeSuspensionUserId(IOrganizationRepository organizationRepository, ILoggerFactory loggerFactory) : base(loggerFactory)
+    {
+        _organizationRepository = organizationRepository;
+
+        MigrationType = MigrationType.VersionedAndResumable;
+        Version = 7;
+    }
+
+    public override async Task RunAsync(MigrationContext context)
+    {
+        var organizations = await _organizationRepository.FindAsync(
+            query => query
+                .FieldEquals(organization => organization.IsSuspended, true)
+                .SortAscending(organization => organization.Id),
+            options => options
+                .SoftDeleteMode(SoftDeleteQueryMode.All)
+                .SearchAfterPaging()
+                .PageLimit(BatchSize));
+
+        int migrated = 0;
+        while (organizations.Documents.Count > 0)
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            foreach (var organization in organizations.Documents)
+            {
+                if (!String.Equals(organization.SuspendedByUserId, StripeConstants.LegacySystemUserId, StringComparison.Ordinal))
+                    continue;
+
+                organization.SuspendedByUserId = StripeConstants.SystemUserId;
+                await _organizationRepository.SaveAsync(organization, options => options.Cache());
+                migrated++;
+            }
+
+            if (!await organizations.NextPageAsync())
+                break;
+        }
+
+        _logger.LogInformation("Migrated {OrganizationCount} organizations with the legacy Stripe suspension user id", migrated);
+    }
+}

--- a/src/Exceptionless.Core/Migrations/007_MigrateLegacyStripeSuspensionUserId.cs
+++ b/src/Exceptionless.Core/Migrations/007_MigrateLegacyStripeSuspensionUserId.cs
@@ -44,14 +44,16 @@ public sealed class MigrateLegacyStripeSuspensionUserId : MigrationBase
         {
             context.CancellationToken.ThrowIfCancellationRequested();
 
-            foreach (var organization in organizations.Documents)
+            // SuspendedByUserId is not mapped on OrganizationIndex, so the legacy marker must be
+            // filtered after the typed repository query loads the current document source.
+            var organizationsToMigrate = organizations.Documents
+                .Where(organization => String.Equals(organization.SuspendedByUserId, StripeConstants.LegacySystemUserId, StringComparison.Ordinal))
+                .ToList();
+            if (organizationsToMigrate.Count > 0)
             {
-                if (!String.Equals(organization.SuspendedByUserId, StripeConstants.LegacySystemUserId, StringComparison.Ordinal))
-                    continue;
-
-                organization.SuspendedByUserId = StripeConstants.SystemUserId;
-                await _organizationRepository.SaveAsync(organization, options => options.Cache());
-                migrated++;
+                organizationsToMigrate.ForEach(organization => organization.SuspendedByUserId = StripeConstants.SystemUserId);
+                await _organizationRepository.SaveAsync(organizationsToMigrate, options => options.Cache());
+                migrated += organizationsToMigrate.Count;
             }
 
             if (!await organizations.NextPageAsync())

--- a/src/Exceptionless.Core/Migrations/007_MigrateLegacyStripeSuspensionUserId.cs
+++ b/src/Exceptionless.Core/Migrations/007_MigrateLegacyStripeSuspensionUserId.cs
@@ -13,6 +13,7 @@ namespace Exceptionless.Core.Migrations;
 public sealed class MigrateLegacyStripeSuspensionUserId : MigrationBase
 {
     private const int BatchSize = 100;
+    internal const string LegacySystemUserId = "Stripe";
     private readonly ExceptionlessElasticConfiguration _configuration;
     private readonly IOrganizationRepository _organizationRepository;
 
@@ -47,7 +48,7 @@ public sealed class MigrateLegacyStripeSuspensionUserId : MigrationBase
             // SuspendedByUserId is not mapped on OrganizationIndex, so the legacy marker must be
             // filtered after the typed repository query loads the current document source.
             var organizationsToMigrate = organizations.Documents
-                .Where(organization => String.Equals(organization.SuspendedByUserId, StripeConstants.LegacySystemUserId, StringComparison.Ordinal))
+                .Where(organization => String.Equals(organization.SuspendedByUserId, LegacySystemUserId, StringComparison.Ordinal))
                 .ToList();
             if (organizationsToMigrate.Count > 0)
             {

--- a/src/Exceptionless.Core/Migrations/007_MigrateLegacyStripeSuspensionUserId.cs
+++ b/src/Exceptionless.Core/Migrations/007_MigrateLegacyStripeSuspensionUserId.cs
@@ -1,7 +1,10 @@
+using Elastic.Clients.Elasticsearch;
 using Exceptionless.Core.Billing;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
+using Exceptionless.Core.Repositories.Configuration;
 using Foundatio.Repositories;
+using Foundatio.Repositories.Elasticsearch.Extensions;
 using Foundatio.Repositories.Migrations;
 using Microsoft.Extensions.Logging;
 
@@ -10,11 +13,16 @@ namespace Exceptionless.Core.Migrations;
 public sealed class MigrateLegacyStripeSuspensionUserId : MigrationBase
 {
     private const int BatchSize = 100;
+    private readonly ExceptionlessElasticConfiguration _configuration;
     private readonly IOrganizationRepository _organizationRepository;
 
-    public MigrateLegacyStripeSuspensionUserId(IOrganizationRepository organizationRepository, ILoggerFactory loggerFactory) : base(loggerFactory)
+    public MigrateLegacyStripeSuspensionUserId(
+        IOrganizationRepository organizationRepository,
+        ExceptionlessElasticConfiguration configuration,
+        ILoggerFactory loggerFactory) : base(loggerFactory)
     {
         _organizationRepository = organizationRepository;
+        _configuration = configuration;
 
         MigrationType = MigrationType.VersionedAndResumable;
         Version = 7;
@@ -48,6 +56,16 @@ public sealed class MigrateLegacyStripeSuspensionUserId : MigrationBase
 
             if (!await organizations.NextPageAsync())
                 break;
+        }
+
+        if (migrated > 0)
+        {
+            var refreshResponse = await _configuration.Client.Indices.RefreshAsync(
+                _configuration.Organizations.VersionedName,
+                context.CancellationToken);
+            _logger.LogRequest(refreshResponse);
+            if (!refreshResponse.IsValidResponse)
+                throw new InvalidOperationException("Unable to refresh organizations after the legacy Stripe suspension user id migration.");
         }
 
         _logger.LogInformation("Migrated {OrganizationCount} organizations with the legacy Stripe suspension user id", migrated);

--- a/src/Exceptionless.Core/Services/OrganizationService.cs
+++ b/src/Exceptionless.Core/Services/OrganizationService.cs
@@ -1,4 +1,5 @@
 using Exceptionless.Core.Billing;
+using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
 using Foundatio.Extensions.Hosting.Startup;
@@ -205,6 +206,7 @@ public class OrganizationService : IStartupAction
         await RemoveUsersAsync(organization, currentUserId);
         await CleanupProjectNotificationSettingsAsync(organization, []);
 
+        organization.RemoveSuspension();
         organization.IsDeleted = true;
         await _organizationRepository.SaveAsync(organization);
     }

--- a/src/Exceptionless.Core/Services/OrganizationService.cs
+++ b/src/Exceptionless.Core/Services/OrganizationService.cs
@@ -1,5 +1,4 @@
 using Exceptionless.Core.Billing;
-using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
 using Foundatio.Extensions.Hosting.Startup;
@@ -206,7 +205,6 @@ public class OrganizationService : IStartupAction
         await RemoveUsersAsync(organization, currentUserId);
         await CleanupProjectNotificationSettingsAsync(organization, []);
 
-        organization.RemoveSuspension();
         organization.IsDeleted = true;
         await _organizationRepository.SaveAsync(organization);
     }

--- a/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
@@ -1,12 +1,10 @@
 using System.Net;
-using Elastic.Clients.Elasticsearch;
 using Exceptionless.Core;
 using Exceptionless.Core.Billing;
 using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Models.Billing;
 using Exceptionless.Core.Repositories;
-using Exceptionless.Core.Repositories.Configuration;
 using Exceptionless.Core.Services;
 using Exceptionless.Core.Utility;
 using Exceptionless.Tests.Extensions;
@@ -24,8 +22,8 @@ namespace Exceptionless.Tests.Api.Endpoints;
 
 public sealed class OrganizationEndpointTests : IntegrationTestsBase
 {
+    private const string ValidSuspendedByUserId = "660000000000000000000001";
     private readonly IOrganizationRepository _organizationRepository;
-    private readonly ExceptionlessElasticConfiguration _configuration;
     private readonly IProjectRepository _projectRepository;
     private readonly IUserRepository _userRepository;
     private readonly BillingManager _billingManager;
@@ -35,7 +33,6 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     public OrganizationEndpointTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
     {
         _organizationRepository = GetService<IOrganizationRepository>();
-        _configuration = GetService<ExceptionlessElasticConfiguration>();
         _projectRepository = GetService<IProjectRepository>();
         _userRepository = GetService<IUserRepository>();
         _billingManager = GetService<BillingManager>();
@@ -877,7 +874,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task DeleteAsync_SuspendedOrganizationWithLegacySystemMarker_RemovesOrganization()
+    public async Task DeleteAsync_SuspendedOrganization_PreservesSuspensionState()
     {
         // Arrange
         var newOrganization = new NewOrganization
@@ -899,17 +896,8 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         organization.SuspensionCode = SuspensionCode.Billing;
         organization.SuspensionDate = DateTime.UtcNow;
         organization.SuspensionNotes = "Synthetic legacy billing suspension.";
-        organization.SuspendedByUserId = "660000000000000000000001";
+        organization.SuspendedByUserId = ValidSuspendedByUserId;
         await _organizationRepository.SaveAsync(organization, o => o.ImmediateConsistency());
-
-        var legacyMarkerUpdate = await _configuration.Client.UpdateAsync<Organization, Dictionary<string, object>>(
-            _configuration.Organizations.VersionedName,
-            viewOrg.Id,
-            update => update
-                .Doc(new Dictionary<string, object> { ["suspended_by_user_id"] = "legacy-billing-system" })
-                .Refresh(Refresh.WaitFor),
-            TestCancellationToken);
-        Assert.True(legacyMarkerUpdate.IsValidResponse);
 
         // Act
         await SendRequestAsync(r => r
@@ -925,6 +913,24 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
             .AppendPaths("organizations", viewOrg.Id)
             .StatusCodeShouldBeNotFound()
         );
+
+        var deletedOrganization = await _organizationRepository.GetByIdAsync(viewOrg.Id, o => o.SoftDeleteMode(SoftDeleteQueryMode.All));
+        Assert.NotNull(deletedOrganization);
+        Assert.True(deletedOrganization.IsDeleted);
+        Assert.True(deletedOrganization.IsSuspended);
+        Assert.Equal(SuspensionCode.Billing, deletedOrganization.SuspensionCode);
+        Assert.Equal(ValidSuspendedByUserId, deletedOrganization.SuspendedByUserId);
+        Assert.Equal("Synthetic legacy billing suspension.", deletedOrganization.SuspensionNotes);
+
+        deletedOrganization.IsDeleted = false;
+        await _organizationRepository.SaveAsync(deletedOrganization, o => o.ImmediateConsistency());
+
+        var undeletedOrganization = await _organizationRepository.GetByIdAsync(viewOrg.Id);
+        Assert.NotNull(undeletedOrganization);
+        Assert.True(undeletedOrganization.IsSuspended);
+        Assert.Equal(SuspensionCode.Billing, undeletedOrganization.SuspensionCode);
+        Assert.Equal(ValidSuspendedByUserId, undeletedOrganization.SuspendedByUserId);
+        Assert.Equal("Synthetic legacy billing suspension.", undeletedOrganization.SuspensionNotes);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
@@ -359,27 +359,27 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     public async Task PostAsync_NewOrganization_MapsToOrganizationAndCreates()
     {
         // Arrange
-        var newOrg = new NewOrganization
+        var newOrganization = new NewOrganization
         {
             Name = "Test Organization"
         };
 
         // Act
-        var viewOrg = await SendRequestAsAsync<ViewOrganization>(r => r
+        var organizationView = await SendRequestAsAsync<ViewOrganization>(r => r
             .AsTestOrganizationUser()
             .Post()
             .AppendPath("organizations")
-            .Content(newOrg)
+            .Content(newOrganization)
             .StatusCodeShouldBeCreated()
         );
 
         // Assert
-        Assert.NotNull(viewOrg);
-        Assert.NotNull(viewOrg.Id);
-        Assert.Equal("Test Organization", viewOrg.Name);
-        Assert.True(viewOrg.CreatedUtc > DateTime.MinValue);
+        Assert.NotNull(organizationView);
+        Assert.NotNull(organizationView.Id);
+        Assert.Equal("Test Organization", organizationView.Name);
+        Assert.True(organizationView.CreatedUtc > DateTime.MinValue);
 
-        var organization = await _organizationRepository.GetByIdAsync(viewOrg.Id);
+        var organization = await _organizationRepository.GetByIdAsync(organizationView.Id);
         Assert.NotNull(organization);
         Assert.Equal("Test Organization", organization.Name);
     }
@@ -408,25 +408,25 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     public async Task GetAsync_ExistingOrganization_MapsToViewOrganization()
     {
         // Act
-        var viewOrg = await SendRequestAsAsync<ViewOrganization>(r => r
+        var organizationView = await SendRequestAsAsync<ViewOrganization>(r => r
             .AsTestOrganizationUser()
             .AppendPaths("organizations", SampleDataService.TEST_ORG_ID)
             .StatusCodeShouldBeOk()
         );
 
         // Assert
-        Assert.NotNull(viewOrg);
-        Assert.Equal(SampleDataService.TEST_ORG_ID, viewOrg.Id);
-        Assert.False(String.IsNullOrEmpty(viewOrg.Name));
-        Assert.NotNull(viewOrg.PlanId);
-        Assert.NotNull(viewOrg.PlanName);
+        Assert.NotNull(organizationView);
+        Assert.Equal(SampleDataService.TEST_ORG_ID, organizationView.Id);
+        Assert.False(String.IsNullOrEmpty(organizationView.Name));
+        Assert.NotNull(organizationView.PlanId);
+        Assert.NotNull(organizationView.PlanName);
     }
 
     [Fact]
     public async Task GetAsync_WithStatsMode_ReturnsPopulatedViewOrganization()
     {
         // Act
-        var viewOrg = await SendRequestAsAsync<ViewOrganization>(r => r
+        var organizationView = await SendRequestAsAsync<ViewOrganization>(r => r
             .AsTestOrganizationUser()
             .AppendPaths("organizations", SampleDataService.TEST_ORG_ID)
             .QueryString("mode", "stats")
@@ -434,10 +434,10 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         );
 
         // Assert
-        Assert.NotNull(viewOrg);
-        Assert.Equal(SampleDataService.TEST_ORG_ID, viewOrg.Id);
-        Assert.NotNull(viewOrg.Usage);
-        Assert.NotNull(viewOrg.UsageHours);
+        Assert.NotNull(organizationView);
+        Assert.Equal(SampleDataService.TEST_ORG_ID, organizationView.Id);
+        Assert.NotNull(organizationView.Usage);
+        Assert.NotNull(organizationView.UsageHours);
     }
 
     [Fact]
@@ -487,20 +487,20 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     public async Task GetAllAsync_ReturnsViewOrganizationCollection()
     {
         // Act
-        var viewOrgs = await SendRequestAsAsync<List<ViewOrganization>>(r => r
+        var organizationViews = await SendRequestAsAsync<List<ViewOrganization>>(r => r
             .AsTestOrganizationUser()
             .AppendPath("organizations")
             .StatusCodeShouldBeOk()
         );
 
         // Assert
-        Assert.NotNull(viewOrgs);
-        Assert.True(viewOrgs.Count > 0);
-        Assert.All(viewOrgs, vo =>
+        Assert.NotNull(organizationViews);
+        Assert.True(organizationViews.Count > 0);
+        Assert.All(organizationViews, organizationView =>
         {
-            Assert.NotNull(vo.Id);
-            Assert.NotNull(vo.Name);
-            Assert.NotNull(vo.PlanId);
+            Assert.NotNull(organizationView.Id);
+            Assert.NotNull(organizationView.Name);
+            Assert.NotNull(organizationView.PlanId);
         });
     }
 
@@ -508,7 +508,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     public async Task GetAllAsync_WithFilter_ReturnsMatchingViewOrganizations()
     {
         // Act
-        var viewOrgs = await SendRequestAsAsync<List<ViewOrganization>>(r => r
+        var organizationViews = await SendRequestAsAsync<List<ViewOrganization>>(r => r
             .AsTestOrganizationUser()
             .AppendPath("organizations")
             .QueryString("filter", "Acme")
@@ -516,16 +516,16 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         );
 
         // Assert
-        Assert.NotNull(viewOrgs);
-        var viewOrg = Assert.Single(viewOrgs);
-        Assert.Equal("Acme", viewOrg.Name);
+        Assert.NotNull(organizationViews);
+        var organizationView = Assert.Single(organizationViews);
+        Assert.Equal("Acme", organizationView.Name);
     }
 
     [Fact]
     public async Task GetAllAsync_WithFilter_ReturnsOnlyAssociatedOrganizations()
     {
         // Act
-        var viewOrgs = await SendRequestAsAsync<List<ViewOrganization>>(r => r
+        var organizationViews = await SendRequestAsAsync<List<ViewOrganization>>(r => r
             .AsTestOrganizationUser()
             .AppendPath("organizations")
             .QueryString("filter", "Free")
@@ -533,47 +533,47 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         );
 
         // Assert
-        Assert.NotNull(viewOrgs);
-        Assert.Empty(viewOrgs);
+        Assert.NotNull(organizationViews);
+        Assert.Empty(organizationViews);
     }
 
     [Fact]
     public async Task PostAsync_NewOrganization_AssignsDefaultPlan()
     {
         // Arrange
-        var newOrg = new NewOrganization
+        var newOrganization = new NewOrganization
         {
             Name = "Organization With Default Plan"
         };
 
         // Act
-        var viewOrg = await SendRequestAsAsync<ViewOrganization>(r => r
+        var organizationView = await SendRequestAsAsync<ViewOrganization>(r => r
             .AsTestOrganizationUser()
             .Post()
             .AppendPath("organizations")
-            .Content(newOrg)
+            .Content(newOrganization)
             .StatusCodeShouldBeCreated()
         );
 
         // Assert
-        Assert.NotNull(viewOrg);
-        Assert.NotNull(viewOrg.PlanId);
-        Assert.NotNull(viewOrg.PlanName);
+        Assert.NotNull(organizationView);
+        Assert.NotNull(organizationView.PlanId);
+        Assert.NotNull(organizationView.PlanName);
     }
 
     [Fact]
     public async Task GetAsync_ViewOrganization_IncludesIsOverMonthlyLimit()
     {
         // Act
-        var viewOrg = await SendRequestAsAsync<ViewOrganization>(r => r
+        var organizationView = await SendRequestAsAsync<ViewOrganization>(r => r
             .AsTestOrganizationUser()
             .AppendPaths("organizations", SampleDataService.TEST_ORG_ID)
             .StatusCodeShouldBeOk()
         );
 
         // Assert
-        Assert.NotNull(viewOrg);
-        Assert.False(viewOrg.IsOverMonthlyLimit);
+        Assert.NotNull(organizationView);
+        Assert.False(organizationView.IsOverMonthlyLimit);
     }
 
     [Fact]
@@ -639,31 +639,31 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     public async Task PostAsync_NewOrganization_SetsCreatedAndUpdatedDates()
     {
         // Arrange
-        var newOrg = new NewOrganization
+        var newOrganization = new NewOrganization
         {
             Name = "Organization With Dates"
         };
 
         // Act
-        var viewOrg = await SendRequestAsAsync<ViewOrganization>(r => r
+        var organizationView = await SendRequestAsAsync<ViewOrganization>(r => r
             .AsTestOrganizationUser()
             .Post()
             .AppendPath("organizations")
-            .Content(newOrg)
+            .Content(newOrganization)
             .StatusCodeShouldBeCreated()
         );
 
         // Assert
-        Assert.NotNull(viewOrg);
-        Assert.True(viewOrg.CreatedUtc > DateTime.MinValue);
-        Assert.True(viewOrg.UpdatedUtc > DateTime.MinValue);
+        Assert.NotNull(organizationView);
+        Assert.True(organizationView.CreatedUtc > DateTime.MinValue);
+        Assert.True(organizationView.UpdatedUtc > DateTime.MinValue);
     }
 
     [Fact]
     public Task PostAsync_EmptyName_ReturnsValidationError()
     {
         // Arrange
-        var newOrg = new NewOrganization
+        var newOrganization = new NewOrganization
         {
             Name = String.Empty
         };
@@ -673,7 +673,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
             .AsTestOrganizationUser()
             .Post()
             .AppendPath("organizations")
-            .Content(newOrg)
+            .Content(newOrganization)
             .StatusCodeShouldBeUnprocessableEntity()
         );
     }
@@ -801,16 +801,16 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         );
 
         // Act
-        var viewOrg = await SendRequestAsAsync<ViewOrganization>(r => r
+        var organizationView = await SendRequestAsAsync<ViewOrganization>(r => r
             .AsTestOrganizationUser()
             .AppendPaths("organizations", SampleDataService.TEST_ORG_ID)
             .StatusCodeShouldBeOk()
         );
 
         // Assert - Features is included in the ViewOrganization DTO
-        Assert.NotNull(viewOrg);
-        Assert.NotNull(viewOrg.Features);
-        Assert.Contains("feature-saved-views", viewOrg.Features);
+        Assert.NotNull(organizationView);
+        Assert.NotNull(organizationView.Features);
+        Assert.Contains("feature-saved-views", organizationView.Features);
     }
 
     [Fact]
@@ -841,33 +841,33 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     public async Task DeleteAsync_ExistingOrganization_RemovesOrganization()
     {
         // Arrange
-        var newOrg = new NewOrganization
+        var newOrganization = new NewOrganization
         {
             Name = "Organization To Delete"
         };
 
-        var viewOrg = await SendRequestAsAsync<ViewOrganization>(r => r
+        var organizationView = await SendRequestAsAsync<ViewOrganization>(r => r
             .AsTestOrganizationUser()
             .Post()
             .AppendPath("organizations")
-            .Content(newOrg)
+            .Content(newOrganization)
             .StatusCodeShouldBeCreated()
         );
 
-        Assert.NotNull(viewOrg);
+        Assert.NotNull(organizationView);
 
         // Act
         await SendRequestAsync(r => r
             .AsTestOrganizationUser()
             .Delete()
-            .AppendPaths("organizations", viewOrg.Id)
+            .AppendPaths("organizations", organizationView.Id)
             .StatusCodeShouldBeAccepted()
         );
 
         // Assert
         await SendRequestAsync(r => r
             .AsTestOrganizationUser()
-            .AppendPaths("organizations", viewOrg.Id)
+            .AppendPaths("organizations", organizationView.Id)
             .StatusCodeShouldBeNotFound()
         );
     }
@@ -881,7 +881,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
             Name = "Legacy Billing Organization"
         };
 
-        var viewOrg = await SendRequestAsAsync<ViewOrganization>(r => r
+        var organizationView = await SendRequestAsAsync<ViewOrganization>(r => r
             .AsTestOrganizationUser()
             .Post()
             .AppendPath("organizations")
@@ -889,7 +889,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
             .StatusCodeShouldBeCreated()
         );
 
-        var organization = await _organizationRepository.GetByIdAsync(viewOrg!.Id);
+        var organization = await _organizationRepository.GetByIdAsync(organizationView!.Id);
         Assert.NotNull(organization);
         organization.IsSuspended = true;
         organization.SuspensionCode = SuspensionCode.Billing;
@@ -902,18 +902,18 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         await SendRequestAsync(r => r
             .AsGlobalAdminUser()
             .Delete()
-            .AppendPaths("organizations", viewOrg.Id)
+            .AppendPaths("organizations", organizationView.Id)
             .StatusCodeShouldBeAccepted()
         );
 
         // Assert
         await SendRequestAsync(r => r
             .AsGlobalAdminUser()
-            .AppendPaths("organizations", viewOrg.Id)
+            .AppendPaths("organizations", organizationView.Id)
             .StatusCodeShouldBeNotFound()
         );
 
-        var deletedOrganization = await _organizationRepository.GetByIdAsync(viewOrg.Id, o => o.SoftDeleteMode(SoftDeleteQueryMode.All));
+        var deletedOrganization = await _organizationRepository.GetByIdAsync(organizationView.Id, o => o.SoftDeleteMode(SoftDeleteQueryMode.All));
         Assert.NotNull(deletedOrganization);
         Assert.True(deletedOrganization.IsDeleted);
         Assert.True(deletedOrganization.IsSuspended);
@@ -924,7 +924,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         deletedOrganization.IsDeleted = false;
         await _organizationRepository.SaveAsync(deletedOrganization, o => o.ImmediateConsistency());
 
-        var undeletedOrganization = await _organizationRepository.GetByIdAsync(viewOrg.Id);
+        var undeletedOrganization = await _organizationRepository.GetByIdAsync(organizationView.Id);
         Assert.NotNull(undeletedOrganization);
         Assert.True(undeletedOrganization.IsSuspended);
         Assert.Equal(SuspensionCode.Billing, undeletedOrganization.SuspensionCode);
@@ -1287,8 +1287,8 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     public async Task GetPlansAsync_CurrentPlanOverlay_ReflectsOrgValues()
     {
         // Arrange
-        var org = await _organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
-        Assert.NotNull(org);
+        var organization = await _organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(organization);
 
         // Act
         var plans = await SendRequestAsAsync<List<BillingPlan>>(r => r
@@ -1299,15 +1299,15 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
 
         // Assert
         Assert.NotNull(plans);
-        var currentPlan = plans.SingleOrDefault(p => String.Equals(p.Id, org.PlanId, StringComparison.Ordinal));
+        var currentPlan = plans.SingleOrDefault(p => String.Equals(p.Id, organization.PlanId, StringComparison.Ordinal));
         Assert.NotNull(currentPlan);
-        Assert.Equal(org.PlanName, currentPlan.Name);
-        Assert.Equal(org.BillingPrice, currentPlan.Price);
-        Assert.Equal(org.MaxProjects, currentPlan.MaxProjects);
-        Assert.Equal(org.MaxUsers, currentPlan.MaxUsers);
-        Assert.Equal(org.RetentionDays, currentPlan.RetentionDays);
-        Assert.Equal(org.MaxEventsPerMonth, currentPlan.MaxEventsPerMonth);
-        Assert.Equal(org.HasPremiumFeatures, currentPlan.HasPremiumFeatures);
+        Assert.Equal(organization.PlanName, currentPlan.Name);
+        Assert.Equal(organization.BillingPrice, currentPlan.Price);
+        Assert.Equal(organization.MaxProjects, currentPlan.MaxProjects);
+        Assert.Equal(organization.MaxUsers, currentPlan.MaxUsers);
+        Assert.Equal(organization.RetentionDays, currentPlan.RetentionDays);
+        Assert.Equal(organization.MaxEventsPerMonth, currentPlan.MaxEventsPerMonth);
+        Assert.Equal(organization.HasPremiumFeatures, currentPlan.HasPremiumFeatures);
     }
 
     [Fact]
@@ -1363,7 +1363,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     [Fact]
     public Task ChangePlanAsync_UnauthorizedOrg_ReturnsNotFound()
     {
-        // Act & Assert — free user should not be able to change plan for the test org they don't belong to
+        // Act & Assert — free user should not be able to change plan for the test organization they don't belong to
         return SendRequestAsync(r => r
             .AsFreeOrganizationUser()
             .Post()
@@ -2345,15 +2345,15 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     [Fact]
     public async Task CanDownGradeAsync_TooManyUsers_ReturnsFailure()
     {
-        // Arrange — test org has 2 users (global admin + org user); free plan allows max 1
-        var org = await _organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
-        Assert.NotNull(org);
+        // Arrange — test organization has 2 users (global admin + organization user); free plan allows max 1
+        var organization = await _organizationRepository.GetByIdAsync(SampleDataService.TEST_ORG_ID);
+        Assert.NotNull(organization);
 
         var user = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_ORG_USER_EMAIL);
         Assert.NotNull(user);
 
         // Act
-        var result = await _billingManager.CanDownGradeAsync(org, _plans.FreePlan, user);
+        var result = await _billingManager.CanDownGradeAsync(organization, _plans.FreePlan, user);
 
         // Assert
         Assert.False(result.Success);
@@ -2364,14 +2364,14 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     [Fact]
     public async Task CanDownGradeAsync_TooManyProjects_ReturnsFailure()
     {
-        // Arrange — free org has 1 user and 1 project; add a second project so project check fails
-        var org = await _organizationRepository.GetByIdAsync(SampleDataService.FREE_ORG_ID);
-        Assert.NotNull(org);
+        // Arrange — free organization has 1 user and 1 project; add a second project so project check fails
+        var organization = await _organizationRepository.GetByIdAsync(SampleDataService.FREE_ORG_ID);
+        Assert.NotNull(organization);
 
         var extraProject = new Project
         {
             Name = "Extra Project",
-            OrganizationId = org.Id,
+            OrganizationId = organization.Id,
             NextSummaryEndOfDayTicks = TimeProvider.GetUtcNow().UtcDateTime.Date.AddDays(1).AddHours(1).Ticks
         };
         await _projectRepository.AddAsync(extraProject, o => o.ImmediateConsistency());
@@ -2380,7 +2380,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         Assert.NotNull(user);
 
         // Act
-        var result = await _billingManager.CanDownGradeAsync(org, _plans.FreePlan, user);
+        var result = await _billingManager.CanDownGradeAsync(organization, _plans.FreePlan, user);
 
         // Assert
         Assert.False(result.Success);
@@ -2391,22 +2391,22 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     [Fact]
     public async Task CanDownGradeAsync_AlreadyHasFreePlan_ReturnsFailure()
     {
-        // Arrange — create a second org for the free user, so they already have 1 free org
+        // Arrange — create a second organization for the free user, so they already have 1 free organization
         var freeUser = await _userRepository.GetByEmailAddressAsync(SampleDataService.FREE_USER_EMAIL);
         Assert.NotNull(freeUser);
 
-        var secondOrg = new Organization { Name = "Second Org" };
-        _billingManager.ApplyBillingPlan(secondOrg, _plans.Plans.First(p => p.Id == "EX_SMALL"), freeUser);
-        secondOrg.StripeCustomerId = "cus_test";
-        secondOrg.CardLast4 = "4242";
-        secondOrg.SubscribeDate = TimeProvider.GetUtcNow().UtcDateTime;
-        secondOrg = await _organizationRepository.AddAsync(secondOrg, o => o.ImmediateConsistency());
+        var secondOrganization = new Organization { Name = "Second Organization" };
+        _billingManager.ApplyBillingPlan(secondOrganization, _plans.Plans.First(p => p.Id == "EX_SMALL"), freeUser);
+        secondOrganization.StripeCustomerId = "cus_test";
+        secondOrganization.CardLast4 = "4242";
+        secondOrganization.SubscribeDate = TimeProvider.GetUtcNow().UtcDateTime;
+        secondOrganization = await _organizationRepository.AddAsync(secondOrganization, o => o.ImmediateConsistency());
 
-        freeUser.OrganizationIds.Add(secondOrg.Id);
+        freeUser.OrganizationIds.Add(secondOrganization.Id);
         await _userRepository.SaveAsync(freeUser, o => o.ImmediateConsistency());
 
-        // Act — try to downgrade second org to free plan (user already has FREE_ORG on free plan)
-        var result = await _billingManager.CanDownGradeAsync(secondOrg, _plans.FreePlan, freeUser);
+        // Act — try to downgrade the second organization to free plan (user already has FREE_ORG on free plan)
+        var result = await _billingManager.CanDownGradeAsync(secondOrganization, _plans.FreePlan, freeUser);
 
         // Assert
         Assert.False(result.Success);
@@ -2416,9 +2416,9 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     [Fact]
     public async Task CanDownGradeAsync_ValidDowngrade_ReturnsSuccess()
     {
-        // Arrange — the free org (1 user, 1 project) should be able to "downgrade" to small plan
-        var org = await _organizationRepository.GetByIdAsync(SampleDataService.FREE_ORG_ID);
-        Assert.NotNull(org);
+        // Arrange — the free organization (1 user, 1 project) should be able to "downgrade" to small plan
+        var organization = await _organizationRepository.GetByIdAsync(SampleDataService.FREE_ORG_ID);
+        Assert.NotNull(organization);
 
         var smallPlan = _plans.Plans.FirstOrDefault(p => p.Id == "EX_SMALL");
         Assert.NotNull(smallPlan);
@@ -2427,7 +2427,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         Assert.NotNull(user);
 
         // Act — "upgrading" from free to small, downgrade check should succeed
-        var result = await _billingManager.CanDownGradeAsync(org, smallPlan, user);
+        var result = await _billingManager.CanDownGradeAsync(organization, smallPlan, user);
 
         // Assert
         Assert.True(result.Success);

--- a/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
@@ -684,7 +684,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         // Act & Assert
         return SendRequestAsync(r => r
             .AsTestOrganizationUser()
-            .AppendPaths("organizations", "nonexistent-org-id")
+            .AppendPaths("organizations", "nonexistent-organization-id")
             .StatusCodeShouldBeNotFound()
         );
     }

--- a/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
@@ -880,7 +880,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     public async Task DeleteAsync_SuspendedOrganizationWithLegacySystemMarker_RemovesOrganization()
     {
         // Arrange
-        var newOrg = new NewOrganization
+        var newOrganization = new NewOrganization
         {
             Name = "Legacy Billing Organization"
         };
@@ -889,7 +889,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
             .AsTestOrganizationUser()
             .Post()
             .AppendPath("organizations")
-            .Content(newOrg)
+            .Content(newOrganization)
             .StatusCodeShouldBeCreated()
         );
 

--- a/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
@@ -22,7 +22,6 @@ namespace Exceptionless.Tests.Api.Endpoints;
 
 public sealed class OrganizationEndpointTests : IntegrationTestsBase
 {
-    private const string ValidSuspendedByUserId = "660000000000000000000001";
     private readonly IOrganizationRepository _organizationRepository;
     private readonly IProjectRepository _projectRepository;
     private readonly IUserRepository _userRepository;
@@ -896,7 +895,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         organization.SuspensionCode = SuspensionCode.Billing;
         organization.SuspensionDate = DateTime.UtcNow;
         organization.SuspensionNotes = "Synthetic legacy billing suspension.";
-        organization.SuspendedByUserId = ValidSuspendedByUserId;
+        organization.SuspendedByUserId = StripeConstants.SystemUserId;
         await _organizationRepository.SaveAsync(organization, o => o.ImmediateConsistency());
 
         // Act
@@ -919,7 +918,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         Assert.True(deletedOrganization.IsDeleted);
         Assert.True(deletedOrganization.IsSuspended);
         Assert.Equal(SuspensionCode.Billing, deletedOrganization.SuspensionCode);
-        Assert.Equal(ValidSuspendedByUserId, deletedOrganization.SuspendedByUserId);
+        Assert.Equal(StripeConstants.SystemUserId, deletedOrganization.SuspendedByUserId);
         Assert.Equal("Synthetic legacy billing suspension.", deletedOrganization.SuspensionNotes);
 
         deletedOrganization.IsDeleted = false;
@@ -929,7 +928,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         Assert.NotNull(undeletedOrganization);
         Assert.True(undeletedOrganization.IsSuspended);
         Assert.Equal(SuspensionCode.Billing, undeletedOrganization.SuspensionCode);
-        Assert.Equal(ValidSuspendedByUserId, undeletedOrganization.SuspendedByUserId);
+        Assert.Equal(StripeConstants.SystemUserId, undeletedOrganization.SuspendedByUserId);
         Assert.Equal("Synthetic legacy billing suspension.", undeletedOrganization.SuspensionNotes);
     }
 

--- a/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
@@ -1,10 +1,12 @@
 using System.Net;
+using Elastic.Clients.Elasticsearch;
 using Exceptionless.Core;
 using Exceptionless.Core.Billing;
 using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Models.Billing;
 using Exceptionless.Core.Repositories;
+using Exceptionless.Core.Repositories.Configuration;
 using Exceptionless.Core.Services;
 using Exceptionless.Core.Utility;
 using Exceptionless.Tests.Extensions;
@@ -23,6 +25,7 @@ namespace Exceptionless.Tests.Api.Endpoints;
 public sealed class OrganizationEndpointTests : IntegrationTestsBase
 {
     private readonly IOrganizationRepository _organizationRepository;
+    private readonly ExceptionlessElasticConfiguration _configuration;
     private readonly IProjectRepository _projectRepository;
     private readonly IUserRepository _userRepository;
     private readonly BillingManager _billingManager;
@@ -32,6 +35,7 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
     public OrganizationEndpointTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
     {
         _organizationRepository = GetService<IOrganizationRepository>();
+        _configuration = GetService<ExceptionlessElasticConfiguration>();
         _projectRepository = GetService<IProjectRepository>();
         _userRepository = GetService<IUserRepository>();
         _billingManager = GetService<BillingManager>();
@@ -867,6 +871,57 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         // Assert
         await SendRequestAsync(r => r
             .AsTestOrganizationUser()
+            .AppendPaths("organizations", viewOrg.Id)
+            .StatusCodeShouldBeNotFound()
+        );
+    }
+
+    [Fact]
+    public async Task DeleteAsync_SuspendedOrganizationWithLegacySystemMarker_RemovesOrganization()
+    {
+        // Arrange
+        var newOrg = new NewOrganization
+        {
+            Name = "Legacy Billing Organization"
+        };
+
+        var viewOrg = await SendRequestAsAsync<ViewOrganization>(r => r
+            .AsTestOrganizationUser()
+            .Post()
+            .AppendPath("organizations")
+            .Content(newOrg)
+            .StatusCodeShouldBeCreated()
+        );
+
+        var organization = await _organizationRepository.GetByIdAsync(viewOrg!.Id);
+        Assert.NotNull(organization);
+        organization.IsSuspended = true;
+        organization.SuspensionCode = SuspensionCode.Billing;
+        organization.SuspensionDate = DateTime.UtcNow;
+        organization.SuspensionNotes = "Synthetic legacy billing suspension.";
+        organization.SuspendedByUserId = "660000000000000000000001";
+        await _organizationRepository.SaveAsync(organization, o => o.ImmediateConsistency());
+
+        var legacyMarkerUpdate = await _configuration.Client.UpdateAsync<Organization, Dictionary<string, object>>(
+            _configuration.Organizations.VersionedName,
+            viewOrg.Id,
+            update => update
+                .Doc(new Dictionary<string, object> { ["suspended_by_user_id"] = "legacy-billing-system" })
+                .Refresh(Refresh.WaitFor),
+            TestCancellationToken);
+        Assert.True(legacyMarkerUpdate.IsValidResponse);
+
+        // Act
+        await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .Delete()
+            .AppendPaths("organizations", viewOrg.Id)
+            .StatusCodeShouldBeAccepted()
+        );
+
+        // Assert
+        await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
             .AppendPaths("organizations", viewOrg.Id)
             .StatusCodeShouldBeNotFound()
         );

--- a/tests/Exceptionless.Tests/Migrations/MigrateLegacyStripeSuspensionUserIdMigrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrateLegacyStripeSuspensionUserIdMigrationTests.cs
@@ -15,8 +15,6 @@ namespace Exceptionless.Tests.Migrations;
 
 public sealed class MigrateLegacyStripeSuspensionUserIdMigrationTests : IntegrationTestsBase
 {
-    private const string LegacySystemUserId = "Stripe";
-    private const string ExpectedSystemUserId = "000000000000000000000000";
     private const string ValidSuspendedByUserId = "660000000000000000000001";
     private readonly ExceptionlessElasticConfiguration _configuration;
     private readonly IOrganizationRepository _organizationRepository;
@@ -56,7 +54,7 @@ public sealed class MigrateLegacyStripeSuspensionUserIdMigrationTests : Integrat
             _configuration.Organizations.VersionedName,
             organization.Id,
             update => update
-                .Doc(new Dictionary<string, object> { ["suspended_by_user_id"] = LegacySystemUserId })
+                .Doc(new Dictionary<string, object> { ["suspended_by_user_id"] = StripeConstants.LegacySystemUserId })
                 .Refresh(Refresh.WaitFor),
             TestCancellationToken);
         Assert.True(legacyMarkerUpdate.IsValidResponse);
@@ -73,6 +71,6 @@ public sealed class MigrateLegacyStripeSuspensionUserIdMigrationTests : Integrat
         Assert.Equal(SuspensionCode.Billing, migratedOrganization.SuspensionCode);
         Assert.Equal(organization.SuspensionDate, migratedOrganization.SuspensionDate);
         Assert.Equal(organization.SuspensionNotes, migratedOrganization.SuspensionNotes);
-        Assert.Equal(ExpectedSystemUserId, migratedOrganization.SuspendedByUserId);
+        Assert.Equal(StripeConstants.SystemUserId, migratedOrganization.SuspendedByUserId);
     }
 }

--- a/tests/Exceptionless.Tests/Migrations/MigrateLegacyStripeSuspensionUserIdMigrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrateLegacyStripeSuspensionUserIdMigrationTests.cs
@@ -9,15 +9,13 @@ using Foundatio.Repositories;
 using Foundatio.Repositories.Migrations;
 using Foundatio.Repositories.Utility;
 using Foundatio.Utility;
+using Exceptionless.Tests.Utility;
 using Xunit;
 
 namespace Exceptionless.Tests.Migrations;
 
 public sealed class MigrateLegacyStripeSuspensionUserIdMigrationTests : IntegrationTestsBase
 {
-    // This is the exact value written by StripeEventHandler before the system user id was introduced.
-    private const string HistoricalStripeSuspensionUserId = "Stripe";
-    private const string ValidSuspendedByUserId = "660000000000000000000001";
     private readonly ExceptionlessElasticConfiguration _configuration;
     private readonly IOrganizationRepository _organizationRepository;
     private readonly BillingPlans _plans;
@@ -40,10 +38,10 @@ public sealed class MigrateLegacyStripeSuspensionUserIdMigrationTests : Integrat
     public async Task RunAsync_HistoricalStripeMarker_IsMigratedAndSuspensionStateIsPreserved()
     {
         // Arrange
-        var organization = await AddSuspendedOrganizationAsync(ValidSuspendedByUserId, "Legacy Stripe Suspension Organization");
+        var organization = await AddSuspendedOrganizationAsync(TestConstants.UserId, "Legacy Stripe Suspension Organization");
         await UpdateOrganizationDocumentAsync(organization.Id, new Dictionary<string, object>
         {
-            ["suspended_by_user_id"] = HistoricalStripeSuspensionUserId
+            ["suspended_by_user_id"] = MigrateLegacyStripeSuspensionUserId.LegacySystemUserId
         });
 
         // Act
@@ -66,7 +64,7 @@ public sealed class MigrateLegacyStripeSuspensionUserIdMigrationTests : Integrat
     public async Task RunAsync_SuspendedOrganizationWithNonLegacyMarker_AndUnsuspendedLegacyRecord_AreUnchanged()
     {
         // Arrange
-        var organizationWithCurrentUser = await AddSuspendedOrganizationAsync(ValidSuspendedByUserId, "Current Suspension Organization");
+        var organizationWithCurrentUser = await AddSuspendedOrganizationAsync(TestConstants.UserId, "Current Suspension Organization");
         var unsuspendedOrganization = await _organizationRepository.AddAsync(new Organization
         {
             Name = "Unsuspended Legacy Organization",
@@ -75,7 +73,7 @@ public sealed class MigrateLegacyStripeSuspensionUserIdMigrationTests : Integrat
         await UpdateOrganizationDocumentAsync(unsuspendedOrganization.Id, new Dictionary<string, object>
         {
             ["is_suspended"] = false,
-            ["suspended_by_user_id"] = HistoricalStripeSuspensionUserId
+            ["suspended_by_user_id"] = MigrateLegacyStripeSuspensionUserId.LegacySystemUserId
         });
 
         // Act
@@ -85,24 +83,24 @@ public sealed class MigrateLegacyStripeSuspensionUserIdMigrationTests : Integrat
         var unchangedSuspension = await GetOrganizationAsync(organizationWithCurrentUser.Id);
         Assert.NotNull(unchangedSuspension);
         Assert.True(unchangedSuspension.IsSuspended);
-        Assert.Equal(ValidSuspendedByUserId, unchangedSuspension.SuspendedByUserId);
+        Assert.Equal(TestConstants.UserId, unchangedSuspension.SuspendedByUserId);
 
         var unchangedUnsuspendedOrganization = await GetOrganizationAsync(unsuspendedOrganization.Id);
         Assert.NotNull(unchangedUnsuspendedOrganization);
         Assert.False(unchangedUnsuspendedOrganization.IsSuspended);
-        Assert.Equal(HistoricalStripeSuspensionUserId, unchangedUnsuspendedOrganization.SuspendedByUserId);
+        Assert.Equal(MigrateLegacyStripeSuspensionUserId.LegacySystemUserId, unchangedUnsuspendedOrganization.SuspendedByUserId);
     }
 
     [Fact]
     public async Task RunAsync_SoftDeletedSuspendedOrganization_MigratesAndRemainsDeleted()
     {
         // Arrange
-        var organization = await AddSuspendedOrganizationAsync(ValidSuspendedByUserId, "Deleted Legacy Stripe Organization");
+        var organization = await AddSuspendedOrganizationAsync(TestConstants.UserId, "Deleted Legacy Stripe Organization");
         organization.IsDeleted = true;
         await _organizationRepository.SaveAsync(organization, o => o.ImmediateConsistency());
         await UpdateOrganizationDocumentAsync(organization.Id, new Dictionary<string, object>
         {
-            ["suspended_by_user_id"] = HistoricalStripeSuspensionUserId
+            ["suspended_by_user_id"] = MigrateLegacyStripeSuspensionUserId.LegacySystemUserId
         });
 
         // Act
@@ -120,10 +118,10 @@ public sealed class MigrateLegacyStripeSuspensionUserIdMigrationTests : Integrat
     public async Task RunAsync_WhenRerun_DoesNotChangeAlreadyMigratedRecord()
     {
         // Arrange
-        var organization = await AddSuspendedOrganizationAsync(ValidSuspendedByUserId, "Idempotent Legacy Stripe Organization");
+        var organization = await AddSuspendedOrganizationAsync(TestConstants.UserId, "Idempotent Legacy Stripe Organization");
         await UpdateOrganizationDocumentAsync(organization.Id, new Dictionary<string, object>
         {
-            ["suspended_by_user_id"] = HistoricalStripeSuspensionUserId
+            ["suspended_by_user_id"] = MigrateLegacyStripeSuspensionUserId.LegacySystemUserId
         });
 
         // Act
@@ -155,7 +153,7 @@ public sealed class MigrateLegacyStripeSuspensionUserIdMigrationTests : Integrat
                 SuspensionCode = SuspensionCode.Billing,
                 SuspensionDate = DateTime.UtcNow,
                 SuspensionNotes = "Stripe subscription deleted.",
-                SuspendedByUserId = ValidSuspendedByUserId
+                SuspendedByUserId = TestConstants.UserId
             })
             .ToList();
         await _organizationRepository.AddAsync(organizations, o => o.ImmediateConsistency());
@@ -219,7 +217,7 @@ public sealed class MigrateLegacyStripeSuspensionUserIdMigrationTests : Integrat
             .Indices(_configuration.Organizations.VersionedName)
             .Query(query => query.QueryString(queryString => queryString.Query("is_suspended:true")))
             .Script(script => script
-                .Source("ctx._source.suspended_by_user_id = 'Stripe';")
+                .Source($"ctx._source.suspended_by_user_id = '{MigrateLegacyStripeSuspensionUserId.LegacySystemUserId}';")
                 .Lang(ScriptLanguage.Painless))
             .Conflicts(Conflicts.Proceed),
             TestCancellationToken);

--- a/tests/Exceptionless.Tests/Migrations/MigrateLegacyStripeSuspensionUserIdMigrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrateLegacyStripeSuspensionUserIdMigrationTests.cs
@@ -15,6 +15,8 @@ namespace Exceptionless.Tests.Migrations;
 
 public sealed class MigrateLegacyStripeSuspensionUserIdMigrationTests : IntegrationTestsBase
 {
+    // This is the exact value written by StripeEventHandler before the system user id was introduced.
+    private const string HistoricalStripeSuspensionUserId = "Stripe";
     private const string ValidSuspendedByUserId = "660000000000000000000001";
     private readonly ExceptionlessElasticConfiguration _configuration;
     private readonly IOrganizationRepository _organizationRepository;
@@ -35,42 +37,197 @@ public sealed class MigrateLegacyStripeSuspensionUserIdMigrationTests : Integrat
     }
 
     [Fact]
-    public async Task RunAsync_ReplacesHistoricalStripeMarkerAndPreservesSuspensionState()
+    public async Task RunAsync_HistoricalStripeMarker_IsMigratedAndSuspensionStateIsPreserved()
     {
         // Arrange
-        var organization = new Organization
+        var organization = await AddSuspendedOrganizationAsync(ValidSuspendedByUserId, "Legacy Stripe Suspension Organization");
+        await UpdateOrganizationDocumentAsync(organization.Id, new Dictionary<string, object>
         {
-            Name = "Legacy Stripe Suspension Organization",
-            PlanId = _plans.FreePlan.Id,
-            IsSuspended = true,
-            SuspensionCode = SuspensionCode.Billing,
-            SuspensionDate = DateTime.UtcNow,
-            SuspensionNotes = "Stripe subscription deleted.",
-            SuspendedByUserId = ValidSuspendedByUserId
-        };
-        organization = await _organizationRepository.AddAsync(organization, o => o.ImmediateConsistency());
-
-        var legacyMarkerUpdate = await _configuration.Client.UpdateAsync<Organization, Dictionary<string, object>>(
-            _configuration.Organizations.VersionedName,
-            organization.Id,
-            update => update
-                .Doc(new Dictionary<string, object> { ["suspended_by_user_id"] = StripeConstants.LegacySystemUserId })
-                .Refresh(Refresh.WaitFor),
-            TestCancellationToken);
-        Assert.True(legacyMarkerUpdate.IsValidResponse);
+            ["suspended_by_user_id"] = HistoricalStripeSuspensionUserId
+        });
 
         // Act
-        var migration = GetService<MigrateLegacyStripeSuspensionUserId>();
-        var context = new MigrationContext(GetService<ILock>(), _logger, TestCancellationToken);
-        await migration.RunAsync(context);
+        await RunMigrationAsync();
 
         // Assert
-        var migratedOrganization = await _organizationRepository.GetByIdAsync(organization.Id);
+        var migratedOrganization = await GetOrganizationAsync(organization.Id);
         Assert.NotNull(migratedOrganization);
+        Assert.Equal(organization.Name, migratedOrganization.Name);
+        Assert.Equal(organization.PlanId, migratedOrganization.PlanId);
         Assert.True(migratedOrganization.IsSuspended);
+        Assert.False(migratedOrganization.IsDeleted);
         Assert.Equal(SuspensionCode.Billing, migratedOrganization.SuspensionCode);
         Assert.Equal(organization.SuspensionDate, migratedOrganization.SuspensionDate);
         Assert.Equal(organization.SuspensionNotes, migratedOrganization.SuspensionNotes);
         Assert.Equal(StripeConstants.SystemUserId, migratedOrganization.SuspendedByUserId);
+    }
+
+    [Fact]
+    public async Task RunAsync_SuspendedOrganizationWithNonLegacyMarker_AndUnsuspendedLegacyRecord_AreUnchanged()
+    {
+        // Arrange
+        var organizationWithCurrentUser = await AddSuspendedOrganizationAsync(ValidSuspendedByUserId, "Current Suspension Organization");
+        var unsuspendedOrganization = await _organizationRepository.AddAsync(new Organization
+        {
+            Name = "Unsuspended Legacy Organization",
+            PlanId = _plans.FreePlan.Id
+        }, o => o.ImmediateConsistency());
+        await UpdateOrganizationDocumentAsync(unsuspendedOrganization.Id, new Dictionary<string, object>
+        {
+            ["is_suspended"] = false,
+            ["suspended_by_user_id"] = HistoricalStripeSuspensionUserId
+        });
+
+        // Act
+        await RunMigrationAsync();
+
+        // Assert
+        var unchangedSuspension = await GetOrganizationAsync(organizationWithCurrentUser.Id);
+        Assert.NotNull(unchangedSuspension);
+        Assert.True(unchangedSuspension.IsSuspended);
+        Assert.Equal(ValidSuspendedByUserId, unchangedSuspension.SuspendedByUserId);
+
+        var unchangedUnsuspendedOrganization = await GetOrganizationAsync(unsuspendedOrganization.Id);
+        Assert.NotNull(unchangedUnsuspendedOrganization);
+        Assert.False(unchangedUnsuspendedOrganization.IsSuspended);
+        Assert.Equal(HistoricalStripeSuspensionUserId, unchangedUnsuspendedOrganization.SuspendedByUserId);
+    }
+
+    [Fact]
+    public async Task RunAsync_SoftDeletedSuspendedOrganization_MigratesAndRemainsDeleted()
+    {
+        // Arrange
+        var organization = await AddSuspendedOrganizationAsync(ValidSuspendedByUserId, "Deleted Legacy Stripe Organization");
+        organization.IsDeleted = true;
+        await _organizationRepository.SaveAsync(organization, o => o.ImmediateConsistency());
+        await UpdateOrganizationDocumentAsync(organization.Id, new Dictionary<string, object>
+        {
+            ["suspended_by_user_id"] = HistoricalStripeSuspensionUserId
+        });
+
+        // Act
+        await RunMigrationAsync();
+
+        // Assert
+        var migratedOrganization = await GetOrganizationAsync(organization.Id, includeSoftDeletes: true);
+        Assert.NotNull(migratedOrganization);
+        Assert.True(migratedOrganization.IsDeleted);
+        Assert.True(migratedOrganization.IsSuspended);
+        Assert.Equal(StripeConstants.SystemUserId, migratedOrganization.SuspendedByUserId);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenRerun_DoesNotChangeAlreadyMigratedRecord()
+    {
+        // Arrange
+        var organization = await AddSuspendedOrganizationAsync(ValidSuspendedByUserId, "Idempotent Legacy Stripe Organization");
+        await UpdateOrganizationDocumentAsync(organization.Id, new Dictionary<string, object>
+        {
+            ["suspended_by_user_id"] = HistoricalStripeSuspensionUserId
+        });
+
+        // Act
+        await RunMigrationAsync();
+        var migratedOrganization = await GetOrganizationAsync(organization.Id);
+        Assert.NotNull(migratedOrganization);
+
+        await RunMigrationAsync();
+
+        // Assert
+        var rerunOrganization = await GetOrganizationAsync(organization.Id);
+        Assert.NotNull(rerunOrganization);
+        Assert.Equal(migratedOrganization.UpdatedUtc, rerunOrganization.UpdatedUtc);
+        Assert.Equal(StripeConstants.SystemUserId, rerunOrganization.SuspendedByUserId);
+        Assert.Equal(migratedOrganization.SuspensionDate, rerunOrganization.SuspensionDate);
+        Assert.Equal(migratedOrganization.SuspensionNotes, rerunOrganization.SuspensionNotes);
+    }
+
+    [Fact]
+    public async Task RunAsync_MoreThanOnePageOfLegacyRecords_MigratesEveryRecord()
+    {
+        // Arrange
+        var organizations = Enumerable.Range(0, 101)
+            .Select(index => new Organization
+            {
+                Name = $"Legacy Stripe Page Organization {index}",
+                PlanId = _plans.FreePlan.Id,
+                IsSuspended = true,
+                SuspensionCode = SuspensionCode.Billing,
+                SuspensionDate = DateTime.UtcNow,
+                SuspensionNotes = "Stripe subscription deleted.",
+                SuspendedByUserId = ValidSuspendedByUserId
+            })
+            .ToList();
+        await _organizationRepository.AddAsync(organizations, o => o.ImmediateConsistency());
+        await SetLegacyMarkerOnSuspendedOrganizationsAsync();
+
+        // Act
+        await RunMigrationAsync();
+
+        // Assert
+        var migratedOrganizations = await _organizationRepository.FindAsync(
+            query => query.FieldEquals(organization => organization.IsSuspended, true),
+            options => options.PageLimit(organizations.Count));
+        Assert.Equal(organizations.Count, migratedOrganizations.Documents.Count);
+        Assert.All(migratedOrganizations.Documents, organization =>
+            Assert.Equal(StripeConstants.SystemUserId, organization.SuspendedByUserId));
+    }
+
+    private Task<Organization> AddSuspendedOrganizationAsync(string suspendedByUserId, string name)
+    {
+        return _organizationRepository.AddAsync(new Organization
+        {
+            Name = name,
+            PlanId = _plans.FreePlan.Id,
+            IsSuspended = true,
+            SuspensionCode = SuspensionCode.Billing,
+            SuspensionDate = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+            SuspensionNotes = "Stripe subscription deleted.",
+            SuspendedByUserId = suspendedByUserId
+        }, o => o.ImmediateConsistency());
+    }
+
+    private Task RunMigrationAsync()
+    {
+        var migration = GetService<MigrateLegacyStripeSuspensionUserId>();
+        var context = new MigrationContext(GetService<ILock>(), _logger, TestCancellationToken);
+        return migration.RunAsync(context);
+    }
+
+    private Task<Organization?> GetOrganizationAsync(string id, bool includeSoftDeletes = false)
+    {
+        return _organizationRepository.GetByIdAsync(
+            id,
+            options => options.SoftDeleteMode(includeSoftDeletes ? SoftDeleteQueryMode.All : SoftDeleteQueryMode.ActiveOnly));
+    }
+
+    private async Task UpdateOrganizationDocumentAsync(string id, Dictionary<string, object> document)
+    {
+        var response = await _configuration.Client.UpdateAsync<Organization, Dictionary<string, object>>(
+            _configuration.Organizations.VersionedName,
+            id,
+            update => update
+                .Doc(document)
+                .Refresh(Refresh.WaitFor),
+            TestCancellationToken);
+        Assert.True(response.IsValidResponse);
+    }
+
+    private async Task SetLegacyMarkerOnSuspendedOrganizationsAsync()
+    {
+        var response = await _configuration.Client.UpdateByQueryAsync<Organization>(update => update
+            .Indices(_configuration.Organizations.VersionedName)
+            .Query(query => query.QueryString(queryString => queryString.Query("is_suspended:true")))
+            .Script(script => script
+                .Source("ctx._source.suspended_by_user_id = 'Stripe';")
+                .Lang(ScriptLanguage.Painless))
+            .Conflicts(Conflicts.Proceed),
+            TestCancellationToken);
+        Assert.True(response.IsValidResponse);
+
+        var refreshResponse = await _configuration.Client.Indices.RefreshAsync(
+            _configuration.Organizations.VersionedName,
+            TestCancellationToken);
+        Assert.True(refreshResponse.IsValidResponse);
     }
 }

--- a/tests/Exceptionless.Tests/Migrations/MigrateLegacyStripeSuspensionUserIdMigrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrateLegacyStripeSuspensionUserIdMigrationTests.cs
@@ -1,0 +1,78 @@
+using Elastic.Clients.Elasticsearch;
+using Exceptionless.Core.Billing;
+using Exceptionless.Core.Migrations;
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Repositories;
+using Exceptionless.Core.Repositories.Configuration;
+using Foundatio.Lock;
+using Foundatio.Repositories;
+using Foundatio.Repositories.Migrations;
+using Foundatio.Repositories.Utility;
+using Foundatio.Utility;
+using Xunit;
+
+namespace Exceptionless.Tests.Migrations;
+
+public sealed class MigrateLegacyStripeSuspensionUserIdMigrationTests : IntegrationTestsBase
+{
+    private const string LegacySystemUserId = "Stripe";
+    private const string ExpectedSystemUserId = "000000000000000000000000";
+    private const string ValidSuspendedByUserId = "660000000000000000000001";
+    private readonly ExceptionlessElasticConfiguration _configuration;
+    private readonly IOrganizationRepository _organizationRepository;
+    private readonly BillingPlans _plans;
+
+    public MigrateLegacyStripeSuspensionUserIdMigrationTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
+    {
+        _configuration = GetService<ExceptionlessElasticConfiguration>();
+        _organizationRepository = GetService<IOrganizationRepository>();
+        _plans = GetService<BillingPlans>();
+    }
+
+    protected override void RegisterServices(IServiceCollection services)
+    {
+        services.AddTransient<MigrateLegacyStripeSuspensionUserId>();
+        services.AddSingleton<ILock>(EmptyLock.Empty);
+        base.RegisterServices(services);
+    }
+
+    [Fact]
+    public async Task RunAsync_ReplacesHistoricalStripeMarkerAndPreservesSuspensionState()
+    {
+        // Arrange
+        var organization = new Organization
+        {
+            Name = "Legacy Stripe Suspension Organization",
+            PlanId = _plans.FreePlan.Id,
+            IsSuspended = true,
+            SuspensionCode = SuspensionCode.Billing,
+            SuspensionDate = DateTime.UtcNow,
+            SuspensionNotes = "Stripe subscription deleted.",
+            SuspendedByUserId = ValidSuspendedByUserId
+        };
+        organization = await _organizationRepository.AddAsync(organization, o => o.ImmediateConsistency());
+
+        var legacyMarkerUpdate = await _configuration.Client.UpdateAsync<Organization, Dictionary<string, object>>(
+            _configuration.Organizations.VersionedName,
+            organization.Id,
+            update => update
+                .Doc(new Dictionary<string, object> { ["suspended_by_user_id"] = LegacySystemUserId })
+                .Refresh(Refresh.WaitFor),
+            TestCancellationToken);
+        Assert.True(legacyMarkerUpdate.IsValidResponse);
+
+        // Act
+        var migration = GetService<MigrateLegacyStripeSuspensionUserId>();
+        var context = new MigrationContext(GetService<ILock>(), _logger, TestCancellationToken);
+        await migration.RunAsync(context);
+
+        // Assert
+        var migratedOrganization = await _organizationRepository.GetByIdAsync(organization.Id);
+        Assert.NotNull(migratedOrganization);
+        Assert.True(migratedOrganization.IsSuspended);
+        Assert.Equal(SuspensionCode.Billing, migratedOrganization.SuspensionCode);
+        Assert.Equal(organization.SuspensionDate, migratedOrganization.SuspensionDate);
+        Assert.Equal(organization.SuspensionNotes, migratedOrganization.SuspensionNotes);
+        Assert.Equal(ExpectedSystemUserId, migratedOrganization.SuspendedByUserId);
+    }
+}

--- a/tests/Exceptionless.Tests/Migrations/MigrateSavedViewColumnsIntegrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrateSavedViewColumnsIntegrationTests.cs
@@ -92,6 +92,7 @@ public sealed class MigrateSavedViewColumnsIntegrationTests : IntegrationTestsBa
     public async Task DataSeedStartupAction_OnlyRepeatableMigrationsPending_SeedsData()
     {
         // Arrange
+        // Mark all current versioned migrations complete so this test isolates repeatable data seeding.
         var migrationStateRepository = GetService<IMigrationStateRepository>();
         await migrationStateRepository.AddAsync(new MigrationState
         {

--- a/tests/Exceptionless.Tests/Migrations/MigrateSavedViewColumnsIntegrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrateSavedViewColumnsIntegrationTests.cs
@@ -95,8 +95,8 @@ public sealed class MigrateSavedViewColumnsIntegrationTests : IntegrationTestsBa
         var migrationStateRepository = GetService<IMigrationStateRepository>();
         await migrationStateRepository.AddAsync(new MigrationState
         {
-            Id = "5",
-            Version = 5,
+            Id = "7",
+            Version = 7,
             MigrationType = MigrationType.VersionedAndResumable,
             StartedUtc = DateTime.UtcNow,
             CompletedUtc = DateTime.UtcNow

--- a/tests/Exceptionless.Tests/Migrations/MigrationRegistrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrationRegistrationTests.cs
@@ -1,3 +1,4 @@
+using Exceptionless.Core.Migrations;
 using Foundatio.Repositories.Migrations;
 using Xunit;
 
@@ -25,5 +26,17 @@ public sealed class MigrationRegistrationTests : TestWithServices
             .ToList();
 
         Assert.Empty(duplicateVersions);
+    }
+
+    [Fact]
+    public void LegacyStripeSuspensionMigration_IsRegisteredAsVersionedAndResumable()
+    {
+        var migration = GetService<IEnumerable<IMigration>>()
+            .DistinctBy(migration => migration.GetType())
+            .SingleOrDefault(migration => migration is MigrateLegacyStripeSuspensionUserId);
+
+        Assert.NotNull(migration);
+        Assert.Equal(MigrationType.VersionedAndResumable, migration.MigrationType);
+        Assert.Equal(7, migration.Version);
     }
 }

--- a/tests/Exceptionless.Tests/Migrations/MigrationRegistrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrationRegistrationTests.cs
@@ -29,7 +29,7 @@ public sealed class MigrationRegistrationTests : TestWithServices
     }
 
     [Fact]
-    public void LegacyStripeSuspensionMigration_IsRegisteredAsVersionedAndResumable()
+    public void MigrationRegistration_LegacyStripeSuspensionMigration_IsRegisteredAsVersionedAndResumable()
     {
         var migration = GetService<IEnumerable<IMigration>>()
             .DistinctBy(migration => migration.GetType())


### PR DESCRIPTION
## What changed

Migrate the exact legacy Stripe suspension marker before normal organization writes validate it.

## Evidence

- Git history shows the old Stripe event handler wrote the literal `"Stripe"` into `SuspendedByUserId` in both suspension paths.
- A later Stripe billing change introduced the all-zero 24-character system user ID used today.
- Existing `SystemUserId` constants for OAuth and predefined saved views are different IDs, so they are not interchangeable.

## Fix

- Centralize the Stripe-specific legacy and current IDs.
- Add version 7 as a versioned, resumable migration.
- Scan suspended organizations, including soft-deleted records, through the existing typed organization repository.
- Filter the unmapped legacy field from loaded source and replace only the exact legacy marker.
- Refresh the current organization index after writes so reruns and subsequent API requests observe the migration.
- Preserve suspension metadata so deleting and restoring an organization does not silently clear its suspension state.

## Verification

- Five integration tests cover historical conversion, non-target records, soft-deleted records, idempotent reruns, and more than one migration page.
- Organization endpoint regression coverage verifies suspension state survives delete and restore.
- Migration registration test verifies version 7 and VersionedAndResumable registration.
- dotnet build Exceptionless.slnx --no-restore -m:1
- Hosted Build run 31840728876 passed all required checks.

No production identifiers or customer data are included.