### PR TITLE
Enforce Svelte brace and object formatting

### DIFF
--- a/src/Exceptionless.Web/ClientApp/eslint.config.js
+++ b/src/Exceptionless.Web/ClientApp/eslint.config.js
@@ -1,5 +1,6 @@
 import { includeIgnoreFile } from '@eslint/compat';
 import js from '@eslint/js';
+import stylistic from '@stylistic/eslint-plugin';
 import pluginQuery from '@tanstack/eslint-plugin-query';
 import prettier from 'eslint-config-prettier';
 import perfectionist from 'eslint-plugin-perfectionist';
@@ -44,9 +45,15 @@ export default ts.config(
         }
     },
     {
+        files: ['**/*.svelte', '**/*.svelte.ts'],
+        plugins: {
+            '@stylistic': stylistic
+        },
         rules: {
+            '@stylistic/brace-style': ['error', '1tbs', { allowSingleLine: false }],
+            '@stylistic/object-curly-newline': ['error', { ObjectExpression: { minProperties: 1 } }],
             curly: ['error', 'all'],
-            'padding-line-between-statements': ['error', { blankLine: 'always', next: '*', prev: 'block-like' }]
+            'padding-line-between-statements': ['error', { blankLine: 'always', next: ['if', 'while', 'for', 'do'], prev: 'block-like' }]
         }
     },
     {

--- a/src/Exceptionless.Web/ClientApp/package-lock.json
+++ b/src/Exceptionless.Web/ClientApp/package-lock.json
@@ -50,6 +50,7 @@
                 "@storybook/addon-docs": "^10.5.5",
                 "@storybook/addon-svelte-csf": "^5.1.2",
                 "@storybook/sveltekit": "^10.5.5",
+                "@stylistic/eslint-plugin": "^5.10.0",
                 "@sveltejs/adapter-static": "^3.0.10",
                 "@sveltejs/kit": "^2.70.1",
                 "@sveltejs/vite-plugin-svelte": "^7.2.0",
@@ -2960,6 +2961,58 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.16"
+            }
+        },
+        "node_modules/@stylistic/eslint-plugin": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+            "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/types": "^8.56.0",
+                "eslint-visitor-keys": "^4.2.1",
+                "espree": "^10.4.0",
+                "estraverse": "^5.3.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "peerDependencies": {
+                "eslint": "^9.0.0 || ^10.0.0"
+            }
+        },
+        "node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@stylistic/eslint-plugin/node_modules/espree": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^4.2.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@sveltejs/acorn-typescript": {

--- a/src/Exceptionless.Web/ClientApp/package.json
+++ b/src/Exceptionless.Web/ClientApp/package.json
@@ -42,6 +42,7 @@
         "@storybook/addon-docs": "^10.5.5",
         "@storybook/addon-svelte-csf": "^5.1.2",
         "@storybook/sveltekit": "^10.5.5",
+        "@stylistic/eslint-plugin": "^5.10.0",
         "@sveltejs/adapter-static": "^3.0.10",
         "@sveltejs/kit": "^2.70.1",
         "@sveltejs/vite-plugin-svelte": "^7.2.0",

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
@@ -41,7 +41,9 @@ export function deleteOAuthApplicationMutation() {
             }
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.oauthApplications });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.oauthApplications
+            });
         }
     }));
 }
@@ -198,7 +200,9 @@ export function postOAuthApplicationMutation() {
             return response.data!;
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.oauthApplications });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.oauthApplications
+            });
         }
     }));
 }
@@ -218,7 +222,9 @@ export function putOAuthApplicationMutation() {
             return response.data!;
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.oauthApplications });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.oauthApplications
+            });
         }
     }));
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/dialogs/run-maintenance-job-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/dialogs/run-maintenance-job-dialog.svelte
@@ -58,7 +58,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred, please try again.' };
+                    return {
+                        form: 'An unexpected error occurred, please try again.'
+                    };
                 }
             }
         }
@@ -199,7 +201,9 @@
 
                 <form.Field
                     name="confirmText"
-                    validators={{ onChange: ({ value }) => (value === action.name ? undefined : `Type "${action.name}" to confirm`) }}
+                    validators={{
+                        onChange: ({ value }) => (value === action.name ? undefined : `Type "${action.name}" to confirm`)
+                    }}
                 >
                     {#snippet children(field)}
                         <Field.Field data-invalid={ariaInvalid(field)}>
@@ -227,7 +231,9 @@
                     {#snippet children(isDisabled)}
                         <AlertDialog.Action
                             type="submit"
-                            class={buttonVariants({ variant: action.dangerous ? 'destructive' : 'default' })}
+                            class={buttonVariants({
+                                variant: action.dangerous ? 'destructive' : 'default'
+                            })}
                             disabled={isDisabled}
                         >
                             {isDisabled && form.state.isSubmitting ? 'Running...' : 'Run Job'}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/backups-options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/backups-options.svelte.ts
@@ -27,13 +27,19 @@ export function getColumns(): ColumnDef<StockFeatures, ElasticsearchSnapshot, un
         },
         {
             accessorKey: 'status',
-            cell: (info) => renderComponent(SnapshotStatusCell, { value: info.getValue() as string | undefined }),
+            cell: (info) =>
+                renderComponent(SnapshotStatusCell, {
+                    value: info.getValue() as string | undefined
+                }),
             enableSorting: true,
             header: 'Status'
         },
         {
             accessorKey: 'start_time',
-            cell: (info) => renderComponent(DateTime, { value: (info.getValue() as null | string) ?? undefined }),
+            cell: (info) =>
+                renderComponent(DateTime, {
+                    value: (info.getValue() as null | string) ?? undefined
+                }),
             enableSorting: true,
             header: 'Started'
         },
@@ -48,7 +54,10 @@ export function getColumns(): ColumnDef<StockFeatures, ElasticsearchSnapshot, un
         },
         {
             accessorKey: 'indices_count',
-            cell: (info) => renderComponent(Number, { value: info.getValue() as null | number }),
+            cell: (info) =>
+                renderComponent(Number, {
+                    value: info.getValue() as null | number
+                }),
             enableSorting: true,
             header: 'Indices',
             meta: {
@@ -82,7 +91,14 @@ export function getTableOptions(queryParameters: TableMemoryPagingParameters, ge
             return {
                 ...withClientSortedRowModel(options),
                 getRowId: (row) => row.repository + '/' + row.name,
-                initialState: { sorting: [{ desc: true, id: 'start_time' }] },
+                initialState: {
+                    sorting: [
+                        {
+                            desc: true,
+                            id: 'start_time'
+                        }
+                    ]
+                },
                 manualSorting: false
             };
         },

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/indices-options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/indices-options.svelte.ts
@@ -21,7 +21,10 @@ export function getColumns(): ColumnDef<StockFeatures, ElasticsearchIndexDetail,
         },
         {
             accessorKey: 'health',
-            cell: (info) => renderComponent(HealthBadgeCell, { value: info.getValue() as null | string | undefined }),
+            cell: (info) =>
+                renderComponent(HealthBadgeCell, {
+                    value: info.getValue() as null | string | undefined
+                }),
             enableSorting: true,
             header: 'Health'
         },
@@ -33,7 +36,10 @@ export function getColumns(): ColumnDef<StockFeatures, ElasticsearchIndexDetail,
         },
         {
             accessorKey: 'primary',
-            cell: (info) => renderComponent(Number, { value: info.getValue() as null | number }),
+            cell: (info) =>
+                renderComponent(Number, {
+                    value: info.getValue() as null | number
+                }),
             enableSorting: true,
             header: 'Primary',
             meta: {
@@ -42,7 +48,10 @@ export function getColumns(): ColumnDef<StockFeatures, ElasticsearchIndexDetail,
         },
         {
             accessorKey: 'replica',
-            cell: (info) => renderComponent(Number, { value: info.getValue() as null | number }),
+            cell: (info) =>
+                renderComponent(Number, {
+                    value: info.getValue() as null | number
+                }),
             enableSorting: true,
             header: 'Replica',
             meta: {
@@ -51,7 +60,10 @@ export function getColumns(): ColumnDef<StockFeatures, ElasticsearchIndexDetail,
         },
         {
             accessorKey: 'unassigned_shards',
-            cell: (info) => renderComponent(UnassignedShardsCell, { value: info.getValue() as number }),
+            cell: (info) =>
+                renderComponent(UnassignedShardsCell, {
+                    value: info.getValue() as number
+                }),
             enableSorting: true,
             header: 'Unassigned',
             meta: {
@@ -60,7 +72,10 @@ export function getColumns(): ColumnDef<StockFeatures, ElasticsearchIndexDetail,
         },
         {
             accessorKey: 'docs_count',
-            cell: (info) => renderComponent(Number, { value: info.getValue() as null | number }),
+            cell: (info) =>
+                renderComponent(Number, {
+                    value: info.getValue() as null | number
+                }),
             enableSorting: true,
             header: 'Documents',
             meta: {
@@ -69,7 +84,10 @@ export function getColumns(): ColumnDef<StockFeatures, ElasticsearchIndexDetail,
         },
         {
             accessorKey: 'store_size_in_bytes',
-            cell: (info) => renderComponent(Bytes, { value: info.getValue() as null | number }),
+            cell: (info) =>
+                renderComponent(Bytes, {
+                    value: info.getValue() as null | number
+                }),
             enableSorting: true,
             header: 'Size',
             meta: {
@@ -88,7 +106,14 @@ export function getTableOptions(queryParameters: TableMemoryPagingParameters, ge
         configureOptions: (options) => {
             return {
                 ...withClientSortedRowModel(options),
-                initialState: { sorting: [{ desc: true, id: 'store_size_in_bytes' }] },
+                initialState: {
+                    sorting: [
+                        {
+                            desc: true,
+                            id: 'store_size_in_bytes'
+                        }
+                    ]
+                },
                 manualSorting: false
             };
         },

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/migration-status-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/migration-status-cell.svelte
@@ -13,10 +13,22 @@
     let { status }: Props = $props();
 
     const styles = {
-        Completed: { colorClass: 'text-muted-foreground', icon: CheckCircle2 },
-        Failed: { colorClass: 'text-destructive', icon: XCircle },
-        Pending: { colorClass: 'text-amber-500', icon: Clock },
-        Running: { colorClass: 'text-blue-500', icon: Loader }
+        Completed: {
+            colorClass: 'text-muted-foreground',
+            icon: CheckCircle2
+        },
+        Failed: {
+            colorClass: 'text-destructive',
+            icon: XCircle
+        },
+        Pending: {
+            colorClass: 'text-amber-500',
+            icon: Clock
+        },
+        Running: {
+            colorClass: 'text-blue-500',
+            icon: Loader
+        }
     } as const;
 
     const style = $derived(styles[status]);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/migrations-options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/migrations-options.svelte.ts
@@ -33,25 +33,37 @@ export function getColumns(): ColumnDef<StockFeatures, MigrationStateRow, unknow
         },
         {
             accessorKey: 'migration_type',
-            cell: (info) => renderComponent(MigrationTypeCell, { value: info.getValue() as number }),
+            cell: (info) =>
+                renderComponent(MigrationTypeCell, {
+                    value: info.getValue() as number
+                }),
             enableSorting: true,
             header: 'Type'
         },
         {
             accessorKey: 'status',
-            cell: (info) => renderComponent(MigrationStatusCell, { status: info.getValue() as MigrationStatus }),
+            cell: (info) =>
+                renderComponent(MigrationStatusCell, {
+                    status: info.getValue() as MigrationStatus
+                }),
             enableSorting: true,
             header: 'Status'
         },
         {
             accessorKey: 'started_utc',
-            cell: (info) => renderComponent(DateTime, { value: (info.getValue() as null | string) ?? undefined }),
+            cell: (info) =>
+                renderComponent(DateTime, {
+                    value: (info.getValue() as null | string) ?? undefined
+                }),
             enableSorting: true,
             header: 'Started'
         },
         {
             accessorKey: 'completed_utc',
-            cell: (info) => renderComponent(DateTime, { value: (info.getValue() as null | string) ?? undefined }),
+            cell: (info) =>
+                renderComponent(DateTime, {
+                    value: (info.getValue() as null | string) ?? undefined
+                }),
             enableSorting: true,
             header: 'Completed'
         },
@@ -67,7 +79,10 @@ export function getColumns(): ColumnDef<StockFeatures, MigrationStateRow, unknow
         },
         {
             accessorKey: 'error_message',
-            cell: (info) => renderComponent(MigrationErrorCell, { value: info.getValue() as null | string | undefined }),
+            cell: (info) =>
+                renderComponent(MigrationErrorCell, {
+                    value: info.getValue() as null | string | undefined
+                }),
             enableSorting: false,
             header: 'Error',
             meta: {
@@ -88,7 +103,12 @@ export function getTableOptions(queryParameters: TableMemoryPagingParameters, ge
                 ...withClientSortedRowModel(options),
                 getRowId: (row) => row.id,
                 initialState: {
-                    sorting: [{ desc: true, id: 'version' }]
+                    sorting: [
+                        {
+                            desc: true,
+                            id: 'version'
+                        }
+                    ]
                 },
                 manualSorting: false
             };

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/api.svelte.ts
@@ -23,7 +23,9 @@ export function getAssistantAccessQuery(request: GetAssistantAccessRequest) {
         queryFn: async ({ signal }: { signal: AbortSignal }) => {
             const client = useFetchClient();
             const response = await client.getJSON<AssistantAccess>('assistant/access', {
-                params: { organization_id: request.route.organizationId },
+                params: {
+                    organization_id: request.route.organizationId
+                },
                 signal
             });
 
@@ -35,5 +37,7 @@ export function getAssistantAccessQuery(request: GetAssistantAccessRequest) {
 }
 
 export async function invalidateAssistantAccessQueries(queryClient: QueryClient): Promise<void> {
-    await queryClient.invalidateQueries({ queryKey: queryKeys.type });
+    await queryClient.invalidateQueries({
+        queryKey: queryKeys.type
+    });
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-message-actions.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-message-actions.svelte
@@ -21,7 +21,9 @@
     }
 
     let { align = 'start', content, feedback, onFeedback, onRegenerate, showFeedback = false }: Props = $props();
-    const clipboard = new UseClipboard({ delay: 1500 });
+    const clipboard = new UseClipboard({
+        delay: 1500
+    });
 
     async function updateFeedback(value: AssistantFeedback): Promise<void> {
         const updatedFeedback = feedback === value ? undefined : value;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-panel.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-panel.svelte
@@ -107,7 +107,12 @@
             suggestedActionPath,
             tools: []
         };
-        const assistantMessage: AssistantChatMessage = { content: '', id: crypto.randomUUID(), role: 'assistant', tools: [] };
+        const assistantMessage: AssistantChatMessage = {
+            content: '',
+            id: crypto.randomUUID(),
+            role: 'assistant',
+            tools: []
+        };
         const history = [...messages, userMessage];
         messages = [...history, assistantMessage];
         await streamResponse(history, assistantMessage);
@@ -130,7 +135,12 @@
 
         errorMessage = undefined;
         const history = messages.slice(0, userMessageIndex + 1);
-        const replacement: AssistantChatMessage = { content: '', id: crypto.randomUUID(), role: 'assistant', tools: [] };
+        const replacement: AssistantChatMessage = {
+            content: '',
+            id: crypto.randomUUID(),
+            role: 'assistant',
+            tools: []
+        };
         messages = [...history, replacement];
         conversationId = crypto.randomUUID();
         await streamResponse(history, replacement);
@@ -186,7 +196,10 @@
             }
 
             if (event.type === 'text_delta') {
-                return { ...message, content: message.content + (event.text ?? '') };
+                return {
+                    ...message,
+                    content: message.content + (event.text ?? '')
+                };
             }
 
             if (event.type === 'tool_call' && event.tool_call_id && event.tool_name) {
@@ -208,14 +221,25 @@
                 const status = assistantToolResultFailed(event.result) ? ('failed' as const) : ('complete' as const);
                 return {
                     ...message,
-                    tools: message.tools.map((tool) => (tool.id === event.tool_call_id ? { ...tool, result: event.result, status } : tool))
+                    tools: message.tools.map((tool) =>
+                        tool.id === event.tool_call_id
+                            ? {
+                                  ...tool,
+                                  result: event.result,
+                                  status
+                              }
+                            : tool
+                    )
                 };
             }
 
             if (event.type === 'suggested_actions') {
                 return {
                     ...message,
-                    suggestedActions: (event.suggested_actions ?? []).map((action) => ({ ...action, sourcePath: requestPath }))
+                    suggestedActions: (event.suggested_actions ?? []).map((action) => ({
+                        ...action,
+                        sourcePath: requestPath
+                    }))
                 };
             }
 
@@ -237,7 +261,14 @@
         abortController?.abort();
         messages = messages.map((message) => ({
             ...message,
-            tools: message.tools.map((tool) => (tool.status === 'running' ? { ...tool, status: 'cancelled' as const } : tool))
+            tools: message.tools.map((tool) =>
+                tool.status === 'running'
+                    ? {
+                          ...tool,
+                          status: 'cancelled' as const
+                      }
+                    : tool
+            )
         }));
     }
 
@@ -262,7 +293,14 @@
     }
 
     function setMessageFeedback(messageId: string, feedback: AssistantFeedback | undefined): void {
-        messages = messages.map((message) => (message.id === messageId ? { ...message, feedback } : message));
+        messages = messages.map((message) =>
+            message.id === messageId
+                ? {
+                      ...message,
+                      feedback
+                  }
+                : message
+        );
     }
 
     async function scrollToLatest(behavior: 'auto' | 'smooth' = 'smooth', force = false): Promise<void> {
@@ -272,7 +310,10 @@
         }
 
         await tick();
-        conversationElement?.scrollTo({ behavior, top: conversationElement.scrollHeight });
+        conversationElement?.scrollTo({
+            behavior,
+            top: conversationElement.scrollHeight
+        });
         isNearBottom = true;
         showScrollToBottom = false;
     }
@@ -283,7 +324,9 @@
         data-assistant-panel
         class="bg-background top-16! bottom-0! h-auto! w-full gap-0 sm:max-w-120!"
         onInteractOutside={handleInteractOutside}
-        overlayProps={{ class: 'top-16! bg-black/5 dark:bg-black/30 supports-backdrop-filter:backdrop-blur-[0.5px]' }}
+        overlayProps={{
+            class: 'top-16! bg-black/5 dark:bg-black/30 supports-backdrop-filter:backdrop-blur-[0.5px]'
+        }}
         preventScroll={false}
     >
         <Sheet.Header class="border-b pr-14">

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-tool-activity.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-tool-activity.svelte
@@ -20,8 +20,12 @@
     let { tool }: Props = $props();
     let open = $state(false);
 
-    const argumentsClipboard = new UseClipboard({ delay: 1500 });
-    const resultClipboard = new UseClipboard({ delay: 1500 });
+    const argumentsClipboard = new UseClipboard({
+        delay: 1500
+    });
+    const resultClipboard = new UseClipboard({
+        delay: 1500
+    });
 
     const toolLabels: Record<string, string> = {
         add_stack_reference_link: 'Added stack reference link',

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/api.svelte.ts
@@ -81,7 +81,10 @@ export async function isEmailAddressTaken(email: string) {
 }
 
 export async function login(email: string, password: string) {
-    const data: Login = { email, password };
+    const data: Login = {
+        email,
+        password
+    };
     const client = useFetchClient();
     const response = await client.postJSON<TokenResult>('auth/login', data, {
         expectedStatusCodes: [401, 422]
@@ -97,7 +100,9 @@ export async function login(email: string, password: string) {
 }
 
 export async function logout(queryClient?: QueryClient, client = useFetchClient()) {
-    await client.get('auth/logout', { expectedStatusCodes: [200, 401, 403] });
+    await client.get('auth/logout', {
+        expectedStatusCodes: [200, 401, 403]
+    });
     await endSession();
 
     await queryClient?.cancelQueries();

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/index.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/index.svelte.ts
@@ -78,7 +78,10 @@ export async function githubLogin(redirectUrl?: string) {
     await oauthLogin({
         authUrl: 'https://github.com/login/oauth/authorize',
         clientId: gitHubClientId,
-        popupOptions: { height: 618, width: 1020 },
+        popupOptions: {
+            height: 618,
+            width: 1020
+        },
         provider: 'github',
         redirectUrl,
         scope: 'user:email'
@@ -110,7 +113,9 @@ export async function gotoLogin() {
     const url = page.url;
     const isAuthPath = url.pathname.startsWith('/next/login');
     const redirect = url.pathname === resolve('/') || isAuthPath ? resolve('/(auth)/login') : `${resolve('/(auth)/login')}?redirect=${url.pathname}`;
-    await goto(redirect, { replaceState: true });
+    await goto(redirect, {
+        replaceState: true
+    });
 }
 
 export async function liveLogin(redirectUrl?: string) {
@@ -141,7 +146,10 @@ export async function slackOAuthLogin(): Promise<string> {
         extraParams: {
             state: encodeURIComponent(Math.random().toString(36).substring(2))
         },
-        popupOptions: { height: 630, width: 580 },
+        popupOptions: {
+            height: 630,
+            width: 580
+        },
         provider: 'slack',
         scope: 'incoming-webhook'
     });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/auth/state.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/auth/state.svelte.ts
@@ -9,4 +9,6 @@ const authSerializer = {
     }
 };
 
-export const accessToken = new CachedPersistedState<null | string>('satellizer_token', null, { serializer: authSerializer });
+export const accessToken = new CachedPersistedState<null | string>('satellizer_token', null, {
+    serializer: authSerializer
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/billing/components/change-plan-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/billing/components/change-plan-dialog.svelte
@@ -208,12 +208,16 @@
 
                     if (needsPayment && isPaidPlan) {
                         if (!stripe || !stripeElements) {
-                            return { form: 'Payment system not loaded. Please try again.' };
+                            return {
+                                form: 'Payment system not loaded. Please try again.'
+                            };
                         }
 
                         const { error: submitError } = await stripeElements.submit();
                         if (submitError) {
-                            return { form: submitError.message ?? 'Payment validation failed' };
+                            return {
+                                form: submitError.message ?? 'Payment validation failed'
+                            };
                         }
 
                         const { error: pmError, paymentMethod } = await stripe.createPaymentMethod({
@@ -221,7 +225,9 @@
                         });
 
                         if (pmError) {
-                            return { form: pmError.message ?? 'Failed to process payment method' };
+                            return {
+                                form: pmError.message ?? 'Failed to process payment method'
+                            };
                         }
 
                         stripeToken = paymentMethod.id;
@@ -247,13 +253,18 @@
                             couponError = message;
                             // Scroll coupon into view and focus the input after DOM updates
                             requestAnimationFrame(() => {
-                                couponSectionEl?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+                                couponSectionEl?.scrollIntoView({
+                                    behavior: 'smooth',
+                                    block: 'nearest'
+                                });
                                 couponInputEl?.focus();
                             });
                         }
 
                         toast.error(message);
-                        return { form: message };
+                        return {
+                            form: message
+                        };
                     }
 
                     toast.success(result.message ?? 'Your billing plan has been successfully changed.');
@@ -279,7 +290,9 @@
 
                     const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred';
                     toast.error(errorMessage);
-                    return { form: errorMessage };
+                    return {
+                        form: errorMessage
+                    };
                 }
             }
         }
@@ -336,7 +349,12 @@
 
     function onUseDifferentCard() {
         paymentExpanded = true;
-        requestAnimationFrame(() => paymentSectionEl?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }));
+        requestAnimationFrame(() =>
+            paymentSectionEl?.scrollIntoView({
+                behavior: 'smooth',
+                block: 'nearest'
+            })
+        );
     }
 
     function onKeepCurrentCard() {
@@ -347,7 +365,10 @@
         couponOpen = true;
         couponError = null;
         requestAnimationFrame(() => {
-            couponSectionEl?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+            couponSectionEl?.scrollIntoView({
+                behavior: 'smooth',
+                block: 'nearest'
+            });
             couponInputEl?.focus();
         });
     }
@@ -403,10 +424,20 @@
 
         const plan = tier.monthly ?? tier.yearly;
         if (!plan) {
-            return { amount: 0, period: '', subAmount: null, subPeriod: '' };
+            return {
+                amount: 0,
+                period: '',
+                subAmount: null,
+                subPeriod: ''
+            };
         }
 
-        return { amount: plan.price, period: '/mo', subAmount: null, subPeriod: '' };
+        return {
+            amount: plan.price,
+            period: '/mo',
+            subAmount: null,
+            subPeriod: ''
+        };
     }
 
     const yearlySavingsLabel = $derived.by(() => {
@@ -452,14 +483,25 @@
 
     const currentPlanInfo = $derived.by(() => {
         if (organization.plan_id === FREE_PLAN_ID) {
-            return { isFree: true as const, label: 'Free plan', period: '', price: 0 };
+            return {
+                isFree: true as const,
+                label: 'Free plan',
+                period: '',
+                price: 0
+            };
         }
 
         const plan = plansQuery.data?.find((p: BillingPlan) => p.id === organization.plan_id);
         const price = organization.billing_price > 0 ? organization.billing_price : (plan?.price ?? 0);
         const name = tiers.find((t) => t.id === currentTierId)?.name ?? organization.plan_name;
         const period = currentInterval === 'year' ? '/yr' : '/mo';
-        return { billedLabel: `billed ${intervalWord(currentInterval)}`, isFree: false as const, name, period, price };
+        return {
+            billedLabel: `billed ${intervalWord(currentInterval)}`,
+            isFree: false as const,
+            name,
+            period,
+            price
+        };
     });
 
     const ctaLabel = $derived.by(() => {
@@ -472,15 +514,21 @@
         }
 
         if (planDirty && organization.plan_id === FREE_PLAN_ID) {
-            return `Start ${planLabel(selectedPlanId, { includeInterval: true })}`;
+            return `Start ${planLabel(selectedPlanId, {
+                includeInterval: true
+            })}`;
         }
 
         if (planDirty) {
             const intervalChanged = intervalOf(organization.plan_id) !== intervalOf(selectedPlanId);
 
             return isDowngrade
-                ? `Downgrade to ${planLabel(selectedPlanId, { includeInterval: intervalChanged })}`
-                : `Switch to ${planLabel(selectedPlanId, { includeInterval: intervalChanged })}`;
+                ? `Downgrade to ${planLabel(selectedPlanId, {
+                      includeInterval: intervalChanged
+                  })}`
+                : `Switch to ${planLabel(selectedPlanId, {
+                      includeInterval: intervalChanged
+                  })}`;
         }
 
         if (paymentDirty && !couponDirty) {
@@ -788,17 +836,33 @@
                                 <Muted class="min-w-16 text-[10px] font-semibold tracking-wider uppercase">Plan</Muted>
                                 <Muted class="text-xs">
                                     {#if isFreeSelected}
-                                        <Small class="text-foreground text-xs">{planLabel(organization.plan_id, { includeInterval: true })}</Small>
+                                        <Small class="text-foreground text-xs"
+                                            >{planLabel(organization.plan_id, {
+                                                includeInterval: true
+                                            })}</Small
+                                        >
                                         <span class="text-muted-foreground/60 mx-1">→</span>
                                         <Small class="text-foreground text-xs">Free</Small>
                                         · immediate, prorated credit
                                     {:else if organization.plan_id === FREE_PLAN_ID}
-                                        Start <Small class="text-foreground text-xs">{planLabel(selectedPlanId, { includeInterval: true })}</Small>
+                                        Start <Small class="text-foreground text-xs"
+                                            >{planLabel(selectedPlanId, {
+                                                includeInterval: true
+                                            })}</Small
+                                        >
                                         {#if selectedPlan}· <Currency value={selectedPlan.price} />{interval === 'year' ? '/yr' : '/mo'}{/if}
                                     {:else}
-                                        <Small class="text-foreground text-xs">{planLabel(organization.plan_id, { includeInterval: includeInt })}</Small>
+                                        <Small class="text-foreground text-xs"
+                                            >{planLabel(organization.plan_id, {
+                                                includeInterval: includeInt
+                                            })}</Small
+                                        >
                                         <span class="text-muted-foreground/60 mx-1">→</span>
-                                        <Small class="text-foreground text-xs">{planLabel(selectedPlanId, { includeInterval: includeInt })}</Small>
+                                        <Small class="text-foreground text-xs"
+                                            >{planLabel(selectedPlanId, {
+                                                includeInterval: includeInt
+                                            })}</Small
+                                        >
                                         {#if selectedPlan}· <Currency value={selectedPlan.price} />{interval === 'year' ? '/yr' : '/mo'} · prorated today{/if}
                                     {/if}
                                 </Muted>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/billing/components/stripe-provider.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/billing/components/stripe-provider.svelte
@@ -39,7 +39,10 @@
 
                 stripeInstance = stripe;
                 elementsInstance = clientSecret
-                    ? stripe.elements({ appearance, clientSecret })
+                    ? stripe.elements({
+                          appearance,
+                          clientSecret
+                      })
                     : stripe.elements({
                           appearance,
                           currency: currency ?? 'usd',

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
@@ -61,19 +61,30 @@ export function createOrganizationEventNotificationRefresher(queryClient: QueryC
 export async function invalidatePersistentEventQueries(queryClient: QueryClient, message: WebSocketMessageValue<'PersistentEventChanged'>) {
     const { id, organization_id, project_id, stack_id } = message;
     if (id) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.id(id) });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.id(id)
+        });
     }
 
     if (stack_id) {
-        await queryClient.invalidateQueries({ exact: true, queryKey: queryKeys.stacks(stack_id) });
+        await queryClient.invalidateQueries({
+            exact: true,
+            queryKey: queryKeys.stacks(stack_id)
+        });
     }
 
     if (project_id) {
-        await queryClient.invalidateQueries({ exact: true, queryKey: queryKeys.projects(project_id) });
+        await queryClient.invalidateQueries({
+            exact: true,
+            queryKey: queryKeys.projects(project_id)
+        });
     }
 
     if (organization_id) {
-        await queryClient.invalidateQueries({ exact: true, queryKey: queryKeys.organizations(organization_id) });
+        await queryClient.invalidateQueries({
+            exact: true,
+            queryKey: queryKeys.organizations(organization_id)
+        });
     }
 
     if (!id && !stack_id) {
@@ -263,7 +274,11 @@ export interface GetStackEventsRequest {
 
 export function createEventWithNavigationQueryOptions(request: GetEventRequest, queryClient: QueryClient) {
     const eventId = request.route.id;
-    const params = request.params ? { ...request.params } : undefined;
+    const params = request.params
+        ? {
+              ...request.params
+          }
+        : undefined;
 
     return {
         enabled: () => !!accessToken.current && !!eventId,
@@ -272,7 +287,11 @@ export function createEventWithNavigationQueryOptions(request: GetEventRequest, 
             const client = useFetchClient();
             const response = await client.getJSON<PersistentEvent>(`events/${eventId}`, {
                 params: {
-                    ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
+                    ...(DEFAULT_OFFSET
+                        ? {
+                              offset: DEFAULT_OFFSET
+                          }
+                        : {}),
                     ...params
                 }
             });
@@ -307,10 +326,18 @@ export function deleteEvent(request: DeleteEventsRequest) {
         },
         mutationKey: queryKeys.deleteEvent(request.route.ids),
         onError: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         },
         onSuccess: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
             schedulePersistentEventDeleteReconciliation(queryClient);
         }
     }));
@@ -324,7 +351,11 @@ export function getEventQuery(request: GetEventRequest) {
             const client = useFetchClient();
             const response = await client.getJSON<PersistentEvent>(`events/${request.route.id}`, {
                 params: {
-                    ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
+                    ...(DEFAULT_OFFSET
+                        ? {
+                              offset: DEFAULT_OFFSET
+                          }
+                        : {}),
                     ...request.params
                 }
             });
@@ -345,7 +376,11 @@ export function getEventsByReferenceQuery(request: GetEventsByReferenceRequest) 
                 : `events/by-ref/${encodeURIComponent(request.route.referenceId ?? '')}`;
             const response = await client.getJSON<EventSummaryModel<SummaryTemplateKeys>[]>(path, {
                 params: {
-                    ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
+                    ...(DEFAULT_OFFSET
+                        ? {
+                              offset: DEFAULT_OFFSET
+                          }
+                        : {}),
                     limit: 20,
                     mode: 'summary',
                     page: 1,
@@ -369,7 +404,11 @@ export function getOrganizationCountQuery(request: GetOrganizationCountRequest) 
 
     return createQuery<CountResult, ProblemDetails>(() => {
         const organizationId = request.route.organizationId;
-        const params = request.params ? { ...request.params } : undefined;
+        const params = request.params
+            ? {
+                  ...request.params
+              }
+            : undefined;
 
         return {
             enabled: () => !!accessToken.current && !!organizationId && (request.enabled?.() ?? true),
@@ -378,7 +417,11 @@ export function getOrganizationCountQuery(request: GetOrganizationCountRequest) 
                 const client = useFetchClient();
                 const response = await client.getJSON<CountResult>(`/organizations/${organizationId}/events/count`, {
                     params: {
-                        ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
+                        ...(DEFAULT_OFFSET
+                            ? {
+                                  offset: DEFAULT_OFFSET
+                              }
+                            : {}),
                         ...params
                     }
                 });
@@ -394,7 +437,11 @@ export function getOrganizationCountQuery(request: GetOrganizationCountRequest) 
 export function getOrganizationEventsQuery(request: GetOrganizationEventsRequest) {
     return createQuery<FetchClientResponse<EventSummaryModel<SummaryTemplateKeys>[]>, ProblemDetails>(() => {
         const organizationId = request.route.organizationId;
-        const params = request.params ? { ...request.params } : undefined;
+        const params = request.params
+            ? {
+                  ...request.params
+              }
+            : undefined;
 
         return {
             enabled: () => !!accessToken.current && !!organizationId && (request.enabled?.() ?? true),
@@ -425,7 +472,11 @@ export function getOrganizationSessionsCountQuery(request: GetOrganizationSessio
             const client = useFetchClient();
             const response = await client.getJSON<CountResult>(`/organizations/${request.route.organizationId}/events/count`, {
                 params: {
-                    ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
+                    ...(DEFAULT_OFFSET
+                        ? {
+                              offset: DEFAULT_OFFSET
+                          }
+                        : {}),
                     ...request.params
                 }
             });
@@ -441,7 +492,11 @@ export function getProjectCountQuery(request: GetProjectCountRequest) {
 
     return createQuery<CountResult, ProblemDetails>(() => {
         const projectId = request.route.projectId;
-        const params = request.params ? { ...request.params } : undefined;
+        const params = request.params
+            ? {
+                  ...request.params
+              }
+            : undefined;
 
         return {
             enabled: () => !!accessToken.current && !!projectId,
@@ -450,7 +505,11 @@ export function getProjectCountQuery(request: GetProjectCountRequest) {
                 const client = useFetchClient();
                 const response = await client.getJSON<CountResult>(`/projects/${projectId}/events/count`, {
                     params: {
-                        ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
+                        ...(DEFAULT_OFFSET
+                            ? {
+                                  offset: DEFAULT_OFFSET
+                              }
+                            : {}),
                         ...params
                     }
                 });
@@ -476,7 +535,11 @@ export function getSessionEventsQuery(request: GetSessionEventsRequest) {
                 : `events/sessions/${request.route.sessionId}`;
             const response = await client.getJSON<EventSummaryModel<SummaryTemplateKeys>[]>(path, {
                 params: {
-                    ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
+                    ...(DEFAULT_OFFSET
+                        ? {
+                              offset: DEFAULT_OFFSET
+                          }
+                        : {}),
                     mode: 'summary',
                     ...request.params
                 }
@@ -498,7 +561,11 @@ export function getStackCountQuery(request: GetStackCountRequest) {
             const client = useFetchClient();
             const response = await client.getJSON<CountResult>('events/count', {
                 params: {
-                    ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
+                    ...(DEFAULT_OFFSET
+                        ? {
+                              offset: DEFAULT_OFFSET
+                          }
+                        : {}),
                     ...request.params,
                     filter: request.params?.filter?.includes(`stack:${request.route.stackId}`)
                         ? request.params.filter
@@ -527,7 +594,11 @@ export function getStackEventsQuery(request: GetStackEventsRequest) {
             const client = useFetchClient();
             const response = await client.getJSON<PersistentEvent[]>(`stacks/${request.route.stackId}/events`, {
                 params: {
-                    ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
+                    ...(DEFAULT_OFFSET
+                        ? {
+                              offset: DEFAULT_OFFSET
+                          }
+                        : {}),
                     ...request.params
                 }
             });
@@ -546,15 +617,21 @@ export function schedulePersistentEventDeleteReconciliation(queryClient: QueryCl
         });
 
     eventTarget.dispatchEvent(new Event(PERSISTENT_EVENT_DELETE_RECONCILE_EVENT));
-    void queryClient.invalidateQueries({ queryKey: stackQueryKeys.type });
+    void queryClient.invalidateQueries({
+        queryKey: stackQueryKeys.type
+    });
     setTimeout(() => {
         void invalidateQueryBackedDetails();
-        void queryClient.invalidateQueries({ queryKey: stackQueryKeys.type });
+        void queryClient.invalidateQueries({
+            queryKey: stackQueryKeys.type
+        });
     }, PERSISTENT_EVENT_DELETE_RECONCILE_DELAY);
     setTimeout(() => {
         eventTarget.dispatchEvent(new Event(PERSISTENT_EVENT_DELETE_RECONCILE_EVENT));
         void invalidateQueryBackedDetails();
-        void queryClient.invalidateQueries({ queryKey: stackQueryKeys.type });
+        void queryClient.invalidateQueries({
+            queryKey: stackQueryKeys.type
+        });
     }, PERSISTENT_EVENT_DELETE_RECONCILE_RETRY_DELAY);
 }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/dialogs/remove-event-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/dialogs/remove-event-dialog.svelte
@@ -39,7 +39,12 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={onSubmit}>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={onSubmit}
+            >
                 Delete
                 {#if count === 1}
                     Event

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/event-detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/event-detail-sheet.svelte
@@ -30,7 +30,10 @@
     );
 
     function handleEventLoaded(event: PersistentEvent): void {
-        currentEventDetails = { eventId: event.id, stackId: event.stack_id };
+        currentEventDetails = {
+            eventId: event.id,
+            stackId: event.stack_id
+        };
         assistantPageContext.setOverlayEvent(assistantContextOwner, event);
     }
 
@@ -44,7 +47,9 @@
             lastEventId = eventId;
             currentEventDetails = undefined;
             if (eventId) {
-                assistantPageContext.setOverlay(assistantContextOwner, { eventId });
+                assistantPageContext.setOverlay(assistantContextOwner, {
+                    eventId
+                });
             } else {
                 assistantPageContext.clearOverlay(assistantContextOwner);
             }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
@@ -182,7 +182,10 @@
             return;
         }
 
-        tabsListRef.scrollBy({ behavior: 'smooth', left: direction === 'left' ? -tabsListRef.clientWidth / 2 : tabsListRef.clientWidth / 2 });
+        tabsListRef.scrollBy({
+            behavior: 'smooth',
+            left: direction === 'left' ? -tabsListRef.clientWidth / 2 : tabsListRef.clientWidth / 2
+        });
     }
 
     function onPromoted(title: string): void {
@@ -247,7 +250,9 @@
         }
 
         try {
-            await updateProjectMutation.mutateAsync({ promoted_tabs: promotedTabs } as UpdateProject);
+            await updateProjectMutation.mutateAsync({
+                promoted_tabs: promotedTabs
+            } as UpdateProject);
         } catch {
             toast.error('An error occurred reordering tabs.');
         }
@@ -459,6 +464,7 @@
         <Skeleton class="mt-4 h-7.5 w-full rounded-full" />
         <Table.Root class="mt-4">
             <Table.Body>
+                <!-- eslint-disable-next-line @stylistic/object-curly-newline -->
                 {#each { length: 5 } as name, index (`${name}-${index}`)}
                     <Table.Row class="group">
                         <Table.Head class="w-40 font-semibold whitespace-nowrap"><Skeleton class="h-6 w-full rounded-full" /></Table.Head>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-stats-dashboard.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-stats-dashboard.svelte
@@ -130,7 +130,12 @@
                 <Skeleton class="h-5 w-16" />
             {:else}
                 <div class={metricValueClass}>
-                    <Number value={eventsPerHour} formatOptions={{ maximumFractionDigits: 1 }} />
+                    <Number
+                        value={eventsPerHour}
+                        formatOptions={{
+                            maximumFractionDigits: 1
+                        }}
+                    />
                 </div>
             {/if}
         </Card.Content>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/helpers.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/helpers.svelte.ts
@@ -142,7 +142,9 @@ export function quoteIfSpecialCharacters(value?: null | string): null | string |
 
 export function serializeFilters(filters: IFilter[]): string {
     const serialized: SerializedFilter[] = filters.map((filter) => {
-        const entry: SerializedFilter = { type: filter.type };
+        const entry: SerializedFilter = {
+            type: filter.type
+        };
 
         if ('term' in filter && (filter as { term?: string }).term !== undefined) {
             entry.term = (filter as { term?: string }).term;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/organization-defaults-faceted-filter-builder.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/organization-defaults-faceted-filter-builder.svelte
@@ -13,60 +13,197 @@
     };
 
     const eventsBooleanFilters: KnownTermsFilterConfig[] = [
-        { term: 'first', title: 'First Occurrence' },
-        { term: 'bot', title: 'Is Bot' }
+        {
+            term: 'first',
+            title: 'First Occurrence'
+        },
+        {
+            term: 'bot',
+            title: 'Is Bot'
+        }
     ];
 
-    const eventsDateFilters: KnownTermsFilterConfig[] = [{ priority: 50, term: 'date', title: 'Date' }];
+    const eventsDateFilters: KnownTermsFilterConfig[] = [
+        {
+            priority: 50,
+            term: 'date',
+            title: 'Date'
+        }
+    ];
 
-    const eventsGeoFilters: KnownTermsFilterConfig[] = [{ term: 'geo', title: 'Location' }];
+    const eventsGeoFilters: KnownTermsFilterConfig[] = [
+        {
+            term: 'geo',
+            title: 'Location'
+        }
+    ];
 
     const eventsNumberFilters: KnownTermsFilterConfig[] = [
-        { term: 'value', title: 'Value' },
-        { term: 'count', title: 'Count' },
-        { term: 'data.@request.port', title: 'Http Port' } // TODO: verify
+        {
+            term: 'value',
+            title: 'Value'
+        },
+        {
+            term: 'count',
+            title: 'Count'
+        },
+        {
+            term: 'data.@request.port',
+            title: 'Http Port'
+        } // TODO: verify
     ];
 
     const eventsStringFilters: KnownTermsFilterConfig[] = [
-        { term: 'stack', title: 'Stack Id' }, // TODO: Think about if this needed
-        { term: 'id', title: 'Id' }, // TODO: Think about if this needed
-        { term: 'source', title: 'Source' },
-        { priority: 80, term: 'message', title: 'Message' },
-        { term: 'submission', title: 'Submission Method' },
-        { term: 'ip', title: 'Ip Address' },
-        { term: 'useragent', title: 'User Agent' },
-        { priority: 40, term: 'path', title: 'Http Path' },
-        { term: 'data.@request.host', title: 'Http Host' }, // TODO: verify
-        { term: 'data.@request.http_method', title: 'Http Method' }, // TODO: verify
-        { term: 'browser', title: 'Browser' },
-        { term: 'client.useragent', title: 'Client User Agent' },
-        { term: 'device', title: 'Device' },
-        { term: 'os', title: 'OS' },
-        { term: 'cmd', title: 'Command Line' },
-        { term: 'machine', title: 'Machine Name' },
-        { term: 'architecture', title: 'Machine Architecture' },
-        { priority: 50, term: 'user', title: 'User' },
-        { term: 'user.name', title: 'User Name' },
-        { term: 'user.email', title: 'User Email' },
-        { term: 'user.description', title: 'User Description' },
-        { term: 'country', title: 'Country' },
-        { term: 'level1', title: 'Region' },
-        { term: 'level2', title: 'City' },
-        { term: 'locality', title: 'Locality' },
-        { term: 'error.code', title: 'Error Code' },
-        { term: 'error.type', title: 'Error Type' },
-        { term: 'error.message', title: 'Error Message' },
-        { term: 'error.targettype', title: 'Error Target Type' },
-        { term: 'error.targetmethod', title: 'Error Target Method' }
+        {
+            term: 'stack',
+            title: 'Stack Id'
+        }, // TODO: Think about if this needed
+        {
+            term: 'id',
+            title: 'Id'
+        }, // TODO: Think about if this needed
+        {
+            term: 'source',
+            title: 'Source'
+        },
+        {
+            priority: 80,
+            term: 'message',
+            title: 'Message'
+        },
+        {
+            term: 'submission',
+            title: 'Submission Method'
+        },
+        {
+            term: 'ip',
+            title: 'Ip Address'
+        },
+        {
+            term: 'useragent',
+            title: 'User Agent'
+        },
+        {
+            priority: 40,
+            term: 'path',
+            title: 'Http Path'
+        },
+        {
+            term: 'data.@request.host',
+            title: 'Http Host'
+        }, // TODO: verify
+        {
+            term: 'data.@request.http_method',
+            title: 'Http Method'
+        }, // TODO: verify
+        {
+            term: 'browser',
+            title: 'Browser'
+        },
+        {
+            term: 'client.useragent',
+            title: 'Client User Agent'
+        },
+        {
+            term: 'device',
+            title: 'Device'
+        },
+        {
+            term: 'os',
+            title: 'OS'
+        },
+        {
+            term: 'cmd',
+            title: 'Command Line'
+        },
+        {
+            term: 'machine',
+            title: 'Machine Name'
+        },
+        {
+            term: 'architecture',
+            title: 'Machine Architecture'
+        },
+        {
+            priority: 50,
+            term: 'user',
+            title: 'User'
+        },
+        {
+            term: 'user.name',
+            title: 'User Name'
+        },
+        {
+            term: 'user.email',
+            title: 'User Email'
+        },
+        {
+            term: 'user.description',
+            title: 'User Description'
+        },
+        {
+            term: 'country',
+            title: 'Country'
+        },
+        {
+            term: 'level1',
+            title: 'Region'
+        },
+        {
+            term: 'level2',
+            title: 'City'
+        },
+        {
+            term: 'locality',
+            title: 'Locality'
+        },
+        {
+            term: 'error.code',
+            title: 'Error Code'
+        },
+        {
+            term: 'error.type',
+            title: 'Error Type'
+        },
+        {
+            term: 'error.message',
+            title: 'Error Message'
+        },
+        {
+            term: 'error.targettype',
+            title: 'Error Target Type'
+        },
+        {
+            term: 'error.targetmethod',
+            title: 'Error Target Method'
+        }
     ];
 
     const eventsVersionFilters: KnownTermsFilterConfig[] = [
-        { term: 'version', title: 'Version' },
-        { term: 'browser.version', title: 'Browser Version' },
-        { term: 'browser.major', title: 'Browser Major Version' },
-        { term: 'client.version', title: 'Client Version' },
-        { term: 'os.version', title: 'OS Version' },
-        { term: 'os.major', title: 'OS Major Version' }
+        {
+            term: 'version',
+            title: 'Version'
+        },
+        {
+            term: 'browser.version',
+            title: 'Browser Version'
+        },
+        {
+            term: 'browser.major',
+            title: 'Browser Major Version'
+        },
+        {
+            term: 'client.version',
+            title: 'Client Version'
+        },
+        {
+            term: 'os.version',
+            title: 'OS Version'
+        },
+        {
+            term: 'os.major',
+            title: 'OS Major Version'
+        }
     ];
 </script>
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/simple-stack-trace/simple-stack-trace.stories.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/simple-stack-trace/simple-stack-trace.stories.svelte
@@ -32,6 +32,21 @@
     };
 </script>
 
-<Story name="Default" args={{ error: error }} />
-<Story name="Nested Errors" args={{ error: nestedErrors }} />
-<Story name="Empty" args={{ error: undefined }} />
+<Story
+    name="Default"
+    args={{
+        error: error
+    }}
+/>
+<Story
+    name="Nested Errors"
+    args={{
+        error: nestedErrors
+    }}
+/>
+<Story
+    name="Empty"
+    args={{
+        error: undefined
+    }}
+/>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace.stories.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace.stories.svelte
@@ -442,6 +442,21 @@
     };
 </script>
 
-<Story name="Default" args={{ error: error }} />
-<Story name="Nested Errors" args={{ error: nestedErrors }} />
-<Story name="Empty" args={{ error: undefined }} />
+<Story
+    name="Default"
+    args={{
+        error: error
+    }}
+/>
+<Story
+    name="Nested Errors"
+    args={{
+        error: nestedErrors
+    }}
+/>
+<Story
+    name="Empty"
+    args={{
+        error: undefined
+    }}
+/>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/options.svelte.ts
@@ -47,7 +47,12 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
                     class: 'translate-y-[2px]',
                     disabled: !props.row.getCanSelect(),
                     indeterminate: props.row.getIsSomeSelected(),
-                    onCheckedChange: (checked: 'indeterminate' | boolean) => props.row.getToggleSelectedHandler()({ target: { checked } })
+                    onCheckedChange: (checked: 'indeterminate' | boolean) =>
+                        props.row.getToggleSelectedHandler()({
+                            target: {
+                                checked
+                            }
+                        })
                 }),
             enableHiding: false,
             enableResizing: false,
@@ -56,7 +61,12 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
                 renderComponent(Checkbox, {
                     checked: table.getIsAllRowsSelected(),
                     indeterminate: table.getIsSomeRowsSelected(),
-                    onCheckedChange: (checked: 'indeterminate' | boolean) => table.getToggleAllRowsSelectedHandler()({ target: { checked } })
+                    onCheckedChange: (checked: 'indeterminate' | boolean) =>
+                        table.getToggleAllRowsSelectedHandler()({
+                            target: {
+                                checked
+                            }
+                        })
                 }),
             id: 'select',
             meta: {
@@ -64,7 +74,12 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
             }
         },
         {
-            cell: (prop) => renderComponent(Summary, { showStatus: false, showType, summary: prop.row.original }),
+            cell: (prop) =>
+                renderComponent(Summary, {
+                    showStatus: false,
+                    showType,
+                    summary: prop.row.original
+                }),
             enableResizing: true,
             header: 'Summary',
             id: 'summary',
@@ -94,7 +109,10 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
     if (isEventSummary) {
         columns.push(
             {
-                cell: (prop) => renderComponent(EventsUserIdentitySummaryCell, { summary: prop.row.original }),
+                cell: (prop) =>
+                    renderComponent(EventsUserIdentitySummaryCell, {
+                        summary: prop.row.original
+                    }),
                 header: 'User',
                 id: 'user',
                 maxSize: 480,
@@ -106,7 +124,10 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
             },
             {
                 accessorKey: nameof<EventSummaryModel<SummaryTemplateKeys>>('date'),
-                cell: (prop) => renderComponent(TimeAgo, { value: prop.getValue<string>() }),
+                cell: (prop) =>
+                    renderComponent(TimeAgo, {
+                        value: prop.getValue<string>()
+                    }),
                 header: 'Date',
                 id: 'date',
                 maxSize: 480,
@@ -118,7 +139,11 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
             },
             {
                 accessorKey: nameof<EventSummaryModel<SummaryTemplateKeys>>('tags'),
-                cell: (prop) => renderComponent(EventTagsSummaryCell, { onTagClick: options?.onTagClick, tags: prop.getValue<string[]>() }),
+                cell: (prop) =>
+                    renderComponent(EventTagsSummaryCell, {
+                        onTagClick: options?.onTagClick,
+                        tags: prop.getValue<string[]>()
+                    }),
                 enableSorting: false,
                 header: 'Tags',
                 id: 'tags',
@@ -206,7 +231,10 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
             },
             {
                 accessorFn: (row) => getSummaryDataValue(row, 'Level'),
-                cell: (prop) => renderComponent(LogLevel, { level: prop.getValue<string | undefined>() }),
+                cell: (prop) =>
+                    renderComponent(LogLevel, {
+                        level: prop.getValue<string | undefined>()
+                    }),
                 header: 'Level',
                 id: 'level',
                 maxSize: 240,
@@ -221,7 +249,11 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
         columns.push(
             {
                 accessorKey: nameof<StackSummaryModel<SummaryTemplateKeys>>('tags'),
-                cell: (prop) => renderComponent(EventTagsSummaryCell, { onTagClick: options?.onTagClick, tags: prop.getValue<string[]>() }),
+                cell: (prop) =>
+                    renderComponent(EventTagsSummaryCell, {
+                        onTagClick: options?.onTagClick,
+                        tags: prop.getValue<string[]>()
+                    }),
                 enableSorting: false,
                 header: 'Tags',
                 id: 'tags',
@@ -234,7 +266,10 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
             },
             {
                 accessorKey: nameof<StackSummaryModel<SummaryTemplateKeys>>('status'),
-                cell: (prop) => renderComponent(StackStatusCell, { value: prop.getValue<StackStatus>() }),
+                cell: (prop) =>
+                    renderComponent(StackStatusCell, {
+                        value: prop.getValue<StackStatus>()
+                    }),
                 enableSorting: false,
                 header: 'Status',
                 id: 'status',
@@ -246,7 +281,10 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
                 size: 144
             },
             {
-                cell: (prop) => renderComponent(StackUsersSummaryCell, { summary: prop.row.original }),
+                cell: (prop) =>
+                    renderComponent(StackUsersSummaryCell, {
+                        summary: prop.row.original
+                    }),
                 enableSorting: false,
                 header: 'Users',
                 id: 'users',
@@ -259,7 +297,10 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
             },
             {
                 accessorKey: nameof<StackSummaryModel<SummaryTemplateKeys>>('total'),
-                cell: (prop) => renderComponent(NumberFormatter, { value: prop.getValue<number>() }),
+                cell: (prop) =>
+                    renderComponent(NumberFormatter, {
+                        value: prop.getValue<number>()
+                    }),
                 enableSorting: false,
                 header: 'Events',
                 id: 'events',
@@ -272,7 +313,10 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
             },
             {
                 accessorKey: nameof<StackSummaryModel<SummaryTemplateKeys>>('first_occurrence'),
-                cell: (prop) => renderComponent(TimeAgo, { value: prop.getValue<string>() }),
+                cell: (prop) =>
+                    renderComponent(TimeAgo, {
+                        value: prop.getValue<string>()
+                    }),
                 enableSorting: false,
                 header: 'First',
                 id: 'first',
@@ -285,7 +329,10 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
             },
             {
                 accessorKey: nameof<StackSummaryModel<SummaryTemplateKeys>>('last_occurrence'),
-                cell: (prop) => renderComponent(TimeAgo, { value: prop.getValue<string>() }),
+                cell: (prop) =>
+                    renderComponent(TimeAgo, {
+                        value: prop.getValue<string>()
+                    }),
                 enableSorting: false,
                 header: 'Last',
                 id: 'last',

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/extended-data.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/extended-data.svelte
@@ -27,7 +27,9 @@
     });
 
     async function onPromote(title: string): Promise<void> {
-        const wasPromoted = await promoteTab.mutateAsync({ name: title });
+        const wasPromoted = await promoteTab.mutateAsync({
+            name: title
+        });
         if (wasPromoted) {
             promoted(title);
         } else {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/overview.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/overview.svelte
@@ -46,7 +46,10 @@
         let refs: { id: string; name: string }[] = [];
         Object.entries(event.data || {}).forEach(([key, value]) => {
             if (key.startsWith(referencePrefix)) {
-                refs.push({ id: value as string, name: key.slice(5) });
+                refs.push({
+                    id: value as string,
+                    name: key.slice(5)
+                });
             }
         });
         return refs;
@@ -87,7 +90,13 @@
                     <Table.Head class="w-40 font-semibold whitespace-nowrap">Reference</Table.Head>
                     <Table.Cell class="w-4 pr-0"><EventsFacetedFilter.ReferenceTrigger changed={filterChanged} value={event.reference_id} /></Table.Cell>
                 {/if}
-                <Table.Cell><A href={resolve('/(app)/event/by-ref/[referenceId]', { referenceId: event.reference_id })}>{event.reference_id}</A></Table.Cell>
+                <Table.Cell
+                    ><A
+                        href={resolve('/(app)/event/by-ref/[referenceId]', {
+                            referenceId: event.reference_id
+                        })}>{event.reference_id}</A
+                    ></Table.Cell
+                >
             </Table.Row>
         {/if}
         {#each references as reference (reference.id)}
@@ -99,7 +108,13 @@
                     <Table.Head class="w-40 font-semibold whitespace-nowrap">{reference.name}</Table.Head>
                     <Table.Cell class="w-4 pr-0"><EventsFacetedFilter.ReferenceTrigger changed={filterChanged} value={reference.id} /></Table.Cell>
                 {/if}
-                <Table.Cell><A href={resolve('/(app)/event/by-ref/[referenceId]', { referenceId: reference.id })}>{reference.id}</A></Table.Cell>
+                <Table.Cell
+                    ><A
+                        href={resolve('/(app)/event/by-ref/[referenceId]', {
+                            referenceId: reference.id
+                        })}>{reference.id}</A
+                    ></Table.Cell
+                >
             </Table.Row>
         {/each}
         {#if level}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/promoted-extended-data.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/promoted-extended-data.svelte
@@ -23,7 +23,9 @@
     });
 
     async function onDemote(title: string): Promise<void> {
-        const wasDemoted = await demoteTab.mutateAsync({ name: title });
+        const wasDemoted = await demoteTab.mutateAsync({
+            name: title
+        });
         if (wasDemoted) {
             demoted(title);
         } else {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
@@ -37,7 +37,10 @@
             return undefined;
         }
 
-        const query = new URLSearchParams({ filter: filter.toFilter(), time: 'all' });
+        const query = new URLSearchParams({
+            filter: filter.toFilter(),
+            time: 'all'
+        });
         return `${eventsPath}?${query.toString()}`;
     });
 
@@ -48,7 +51,11 @@
     const queryParams = $derived({
         filter: '-type:heartbeat' as const,
         limit: 10 as const,
-        ...(time ? { time } : {})
+        ...(time
+            ? {
+                  time
+              }
+            : {})
     });
 
     const sessionEventsQuery = getSessionEventsQuery({
@@ -142,6 +149,7 @@
 
     {#if sessionEventsQuery.isPending}
         <div class="space-y-2">
+            <!-- eslint-disable-next-line @stylistic/object-curly-newline -->
             {#each Array.from({ length: 5 }, (_, i) => i) as i (i)}
                 <Skeleton class="h-10 w-full" />
             {/each}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/notifications/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/notifications/api.svelte.ts
@@ -15,7 +15,9 @@ export function clearSystemNotificationMutation() {
             await client.delete('notifications/system');
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.current });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.current
+            });
         }
     }));
 }
@@ -24,7 +26,9 @@ export function getCurrentSystemNotificationQuery() {
     return createQuery<null | SystemNotification, ProblemDetails>(() => ({
         queryFn: async ({ signal }: { signal: AbortSignal }) => {
             const client = useFetchClient();
-            const response = await client.getJSON<SystemNotification>('notifications/system', { signal });
+            const response = await client.getJSON<SystemNotification>('notifications/system', {
+                signal
+            });
 
             return response.data ?? null;
         },
@@ -48,7 +52,9 @@ export function setSystemNotificationMutation() {
                 return response.data!;
             },
             onSuccess: () => {
-                queryClient.invalidateQueries({ queryKey: queryKeys.current });
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.current
+                });
             }
         })
     );

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/api.svelte.ts
@@ -13,21 +13,43 @@ import type { Invoice, InvoiceGridModel, NewOrganization, SuspensionCode, ViewOr
 export async function invalidateOrganizationQueries(queryClient: QueryClient, message: WebSocketMessageValue<'OrganizationChanged'>) {
     const { id } = message;
     if (id) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.id(id, undefined) });
-        await queryClient.invalidateQueries({ queryKey: queryKeys.id(id, 'stats') });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.id(id, undefined)
+        });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.id(id, 'stats')
+        });
 
         // Invalidate regardless of mode
-        await queryClient.invalidateQueries({ queryKey: queryKeys.list(undefined) });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.list(undefined)
+        });
     } else {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.type });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.type
+        });
     }
 }
 
 export async function invalidateOrganizationUsageQueries(queryClient: QueryClient, organizationId?: string) {
-    const invalidations = [queryClient.invalidateQueries({ queryKey: queryKeys.list(undefined) })];
+    const invalidations = [
+        queryClient.invalidateQueries({
+            queryKey: queryKeys.list(undefined)
+        })
+    ];
     if (organizationId) {
-        invalidations.push(queryClient.invalidateQueries({ exact: true, queryKey: queryKeys.id(organizationId, undefined) }));
-        invalidations.push(queryClient.invalidateQueries({ exact: true, queryKey: queryKeys.id(organizationId, 'stats') }));
+        invalidations.push(
+            queryClient.invalidateQueries({
+                exact: true,
+                queryKey: queryKeys.id(organizationId, undefined)
+            })
+        );
+        invalidations.push(
+            queryClient.invalidateQueries({
+                exact: true,
+                queryKey: queryKeys.id(organizationId, 'stats')
+            })
+        );
     }
 
     await Promise.all(invalidations);
@@ -38,15 +60,40 @@ export async function invalidatePlanOverageQueries(queryClient: QueryClient, mes
 }
 
 export const queryKeys = {
-    adminSearch: (params: GetAdminSearchOrganizationsParams) => [...queryKeys.list(params.mode), 'admin', { ...params }] as const,
+    adminSearch: (params: GetAdminSearchOrganizationsParams) =>
+        [
+            ...queryKeys.list(params.mode),
+            'admin',
+            {
+                ...params
+            }
+        ] as const,
     changePlan: (id: string | undefined) => [...queryKeys.type, id, 'change-plan'] as const,
     deleteOrganization: (ids: string[] | undefined) => [...queryKeys.ids(ids), 'delete'] as const,
     icon: (id: string | undefined) => [...queryKeys.id(id, undefined), 'icon'] as const,
-    id: (id: string | undefined, mode: 'stats' | undefined) => (mode ? ([...queryKeys.type, id, { mode }] as const) : ([...queryKeys.type, id] as const)),
+    id: (id: string | undefined, mode: 'stats' | undefined) =>
+        mode
+            ? ([
+                  ...queryKeys.type,
+                  id,
+                  {
+                      mode
+                  }
+              ] as const)
+            : ([...queryKeys.type, id] as const),
     ids: (ids: string[] | undefined) => [...queryKeys.type, ...(ids ?? [])] as const,
     invoice: (id: string | undefined) => [...queryKeys.type, 'invoice', id] as const,
     invoices: (id: string | undefined) => [...queryKeys.type, id, 'invoices'] as const,
-    list: (mode: 'stats' | undefined) => (mode ? ([...queryKeys.type, 'list', { mode }] as const) : ([...queryKeys.type, 'list'] as const)),
+    list: (mode: 'stats' | undefined) =>
+        mode
+            ? ([
+                  ...queryKeys.type,
+                  'list',
+                  {
+                      mode
+                  }
+              ] as const)
+            : ([...queryKeys.type, 'list'] as const),
     plans: (id: string | undefined) => [...queryKeys.type, id, 'plans'] as const,
     postOrganization: () => [...queryKeys.type, 'post-organization'] as const,
     setBonusOrganization: (id: string | undefined) => [...queryKeys.type, id, 'set-bonus'] as const,
@@ -193,9 +240,13 @@ export function addOrganizationUser(request: AddOrganizationUserRequest) {
             return response.data!;
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.organizationId, undefined) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.organizationId, undefined)
+            });
             // Also invalidate the user list for this org (different query namespace from Organization)
-            queryClient.invalidateQueries({ queryKey: ['User', 'organization', request.route.organizationId] });
+            queryClient.invalidateQueries({
+                queryKey: ['User', 'organization', request.route.organizationId]
+            });
         }
     }));
 }
@@ -211,9 +262,15 @@ export function changePlanMutation(request: ChangePlanMutationRequest) {
         },
         mutationKey: queryKeys.changePlan(request.route.organizationId),
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.organizationId, undefined) });
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.organizationId, 'stats') });
-            queryClient.invalidateQueries({ queryKey: queryKeys.plans(request.route.organizationId) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.organizationId, undefined)
+            });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.organizationId, 'stats')
+            });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.plans(request.route.organizationId)
+            });
         }
     }));
 }
@@ -233,10 +290,18 @@ export function deleteOrganization(request: DeleteOrganizationRequest) {
         },
         mutationKey: queryKeys.deleteOrganization(request.route.ids),
         onError: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id, undefined) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id, undefined)
+                })
+            );
         },
         onSuccess: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id, undefined) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id, undefined)
+                })
+            );
         }
     }));
 }
@@ -265,9 +330,13 @@ export function deleteOrganizationUser(request: DeleteOrganizationUserRequest) {
             await client.deleteJSON<void>(`organizations/${request.route.organizationId}/users/${encodeURIComponent(request.route.email)}`);
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.organizationId, undefined) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.organizationId, undefined)
+            });
             // Also invalidate the user list for this org (different query namespace from Organization)
-            queryClient.invalidateQueries({ queryKey: ['User', 'organization', request.route.organizationId] });
+            queryClient.invalidateQueries({
+                queryKey: ['User', 'organization', request.route.organizationId]
+            });
         }
     }));
 }
@@ -284,12 +353,20 @@ export function deleteSuspendOrganization(request: DeleteSuspendOrganizationRequ
         },
         mutationKey: queryKeys.unsuspendOrganization(request.route.id),
         onError: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id, undefined) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id, undefined)
+            });
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id, undefined) });
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id, 'stats') });
-            queryClient.invalidateQueries({ queryKey: queryKeys.list(undefined) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id, undefined)
+            });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id, 'stats')
+            });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.list(undefined)
+            });
         }
     }));
 }
@@ -345,7 +422,9 @@ export function getInvoicesQuery(request: GetInvoicesRequest) {
             const client = useFetchClient();
             const response = await client.getJSON<InvoiceGridModel[]>(`organizations/${request.route.organizationId}/invoices`, {
                 expectedStatusCodes: [200, 404],
-                params: { ...request.params },
+                params: {
+                    ...request.params
+                },
                 signal
             });
 
@@ -404,13 +483,22 @@ export function getOrganizationsQuery(request: GetOrganizationsRequest) {
         queryFn: async ({ signal }: { signal: AbortSignal }) => {
             const client = useFetchClient();
             const response = await client.getJSON<ViewOrganization[]>('organizations', {
-                params: { ...request.params },
+                params: {
+                    ...request.params
+                },
                 signal
             });
 
             return response;
         },
-        queryKey: [...queryKeys.list(request.params?.mode ?? undefined), { params: { ...request.params } }],
+        queryKey: [
+            ...queryKeys.list(request.params?.mode ?? undefined),
+            {
+                params: {
+                    ...request.params
+                }
+            }
+        ],
         refetchInterval: request.refetchInterval
     }));
 }
@@ -444,7 +532,9 @@ export function patchOrganization(request: PatchOrganizationRequest) {
             return response.data!;
         },
         onError: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id, undefined) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id, undefined)
+            });
         },
         onSuccess: (organization: ViewOrganization) => updateOrganizationCache(queryClient, request.route.id, organization)
     }));
@@ -452,7 +542,12 @@ export function patchOrganization(request: PatchOrganizationRequest) {
 
 export function postOrganization() {
     const queryClient = useQueryClient();
-    const defaultOrganizationsQueryKey = [...queryKeys.list(undefined), { params: {} }] as const;
+    const defaultOrganizationsQueryKey = [
+        ...queryKeys.list(undefined),
+        {
+            params: {}
+        }
+    ] as const;
 
     return createMutation<ViewOrganization, ProblemDetails, NewOrganization>(() => ({
         enabled: () => !!accessToken.current,
@@ -478,8 +573,12 @@ export function postOrganization() {
             });
 
             await Promise.all([
-                queryClient.invalidateQueries({ queryKey: queryKeys.list(undefined) }),
-                queryClient.invalidateQueries({ queryKey: userQueryKeys.me() })
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.list(undefined)
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: userQueryKeys.me()
+                })
             ]);
         }
     }));
@@ -503,13 +602,21 @@ export function postSetBonusOrganization() {
         },
         mutationKey: queryKeys.setBonusOrganization(undefined),
         onError: (error, params) => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(params.organizationId, undefined) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(params.organizationId, undefined)
+            });
         },
         onSuccess: (data, params) => {
             // TODO: Normalize all this invalidation.
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(params.organizationId, undefined) });
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(params.organizationId, 'stats') });
-            queryClient.invalidateQueries({ queryKey: queryKeys.list(undefined) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(params.organizationId, undefined)
+            });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(params.organizationId, 'stats')
+            });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.list(undefined)
+            });
         }
     }));
 }
@@ -526,13 +633,21 @@ export function postSuspendOrganization(request: PostSuspendOrganizationRequest)
         },
         mutationKey: queryKeys.suspendOrganization(request.route.id),
         onError: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id, undefined) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id, undefined)
+            });
         },
         onSuccess: () => {
             // TODO: Normalize all this invalidation.
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id, undefined) });
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id, 'stats') });
-            queryClient.invalidateQueries({ queryKey: queryKeys.list(undefined) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id, undefined)
+            });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id, 'stats')
+            });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.list(undefined)
+            });
         }
     }));
 }
@@ -551,11 +666,17 @@ export function removeOrganizationFeature(request: SetOrganizationFeatureRequest
         },
         mutationKey: queryKeys.setFeature(request.route.id),
         onError: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id, undefined) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id, undefined)
+            });
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id, undefined) });
-            queryClient.invalidateQueries({ queryKey: queryKeys.list(undefined) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id, undefined)
+            });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.list(undefined)
+            });
         }
     }));
 }
@@ -574,11 +695,17 @@ export function setOrganizationFeature(request: SetOrganizationFeatureRequest) {
         },
         mutationKey: queryKeys.setFeature(request.route.id),
         onError: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id, undefined) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id, undefined)
+            });
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id, undefined) });
-            queryClient.invalidateQueries({ queryKey: queryKeys.list(undefined) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id, undefined)
+            });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.list(undefined)
+            });
         }
     }));
 }
@@ -604,16 +731,21 @@ export function uploadOrganizationIcon(request: OrganizationIconRequest) {
 function updateOrganizationCache(queryClient: QueryClient, id: string | undefined, organization: ViewOrganization) {
     queryClient.setQueryData(queryKeys.id(id, 'stats'), organization);
     queryClient.setQueryData(queryKeys.id(id, undefined), organization);
-    queryClient.setQueriesData<FetchClientResponse<ViewOrganization[]> | undefined>({ queryKey: queryKeys.type }, (response) => {
-        if (!Array.isArray(response?.data) || !response.data.some((existingOrganization) => existingOrganization.id === organization.id)) {
-            return response;
-        }
+    queryClient.setQueriesData<FetchClientResponse<ViewOrganization[]> | undefined>(
+        {
+            queryKey: queryKeys.type
+        },
+        (response) => {
+            if (!Array.isArray(response?.data) || !response.data.some((existingOrganization) => existingOrganization.id === organization.id)) {
+                return response;
+            }
 
-        return {
-            ...response,
-            data: response.data.map((existingOrganization) => {
-                return existingOrganization.id === organization.id ? organization : existingOrganization;
-            })
-        };
-    });
+            return {
+                ...response,
+                data: response.data.map((existingOrganization) => {
+                    return existingOrganization.id === organization.id ? organization : existingOrganization;
+                })
+            };
+        }
+    );
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/impersonate-organization-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/impersonate-organization-dialog.svelte
@@ -465,10 +465,22 @@
                                 <PaginationFirstButton {currentPage} />
                             </PaginationItem>
                             <PaginationItem>
-                                <PaginationPrevious page={{ type: 'page', value: Math.max(1, currentPage - 1) }} isActive={false} />
+                                <PaginationPrevious
+                                    page={{
+                                        type: 'page',
+                                        value: Math.max(1, currentPage - 1)
+                                    }}
+                                    isActive={false}
+                                />
                             </PaginationItem>
                             <PaginationItem>
-                                <PaginationNext page={{ type: 'page', value: Math.min(totalPages, currentPage + 1) }} isActive={false} />
+                                <PaginationNext
+                                    page={{
+                                        type: 'page',
+                                        value: Math.min(totalPages, currentPage + 1)
+                                    }}
+                                    isActive={false}
+                                />
                             </PaginationItem>
                         </PaginationContent>
                     </Pagination>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/leave-organization-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/leave-organization-dialog.svelte
@@ -26,7 +26,12 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={onSubmit}>Leave Organization</AlertDialog.Action>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={onSubmit}>Leave Organization</AlertDialog.Action
+            >
         </AlertDialog.Footer>
     </AlertDialog.Content>
 </AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/remove-organization-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/remove-organization-dialog.svelte
@@ -26,7 +26,12 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={onSubmit}>Delete Organization</AlertDialog.Action>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={onSubmit}>Delete Organization</AlertDialog.Action
+            >
         </AlertDialog.Footer>
     </AlertDialog.Content>
 </AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/set-event-bonus-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/set-event-bonus-dialog.svelte
@@ -79,7 +79,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred, please try again.' };
+                    return {
+                        form: 'An unexpected error occurred, please try again.'
+                    };
                 }
             }
         }
@@ -189,7 +191,12 @@
 
             <AlertDialog.Footer>
                 <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-                <AlertDialog.Action type="submit" class={buttonVariants({ variant: 'default' })}>Set Bonus</AlertDialog.Action>
+                <AlertDialog.Action
+                    type="submit"
+                    class={buttonVariants({
+                        variant: 'default'
+                    })}>Set Bonus</AlertDialog.Action
+                >
             </AlertDialog.Footer>
         </form>
     </AlertDialog.Content>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/suspend-organization-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/dialogs/suspend-organization-dialog.svelte
@@ -49,7 +49,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred, please try again.' };
+                    return {
+                        form: 'An unexpected error occurred, please try again.'
+                    };
                 }
             }
         }
@@ -136,7 +138,12 @@
 
             <AlertDialog.Footer>
                 <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-                <AlertDialog.Action type="submit" class={buttonVariants({ variant: 'destructive' })}>Suspend Organization</AlertDialog.Action>
+                <AlertDialog.Action
+                    type="submit"
+                    class={buttonVariants({
+                        variant: 'destructive'
+                    })}>Suspend Organization</AlertDialog.Action
+                >
             </AlertDialog.Footer>
         </form>
     </AlertDialog.Content>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/notifications/project-configuration-notification.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/notifications/project-configuration-notification.svelte
@@ -16,7 +16,9 @@
         const project = projects[0];
 
         if (projects.length === 1 && project) {
-            return resolve('/(app)/project/[projectId]/configure', { projectId: project.id });
+            return resolve('/(app)/project/[projectId]/configure', {
+                projectId: project.id
+            });
         }
 
         return resolve('/(app)/project/list');

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/notifications/suspended-organization-notification.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/notifications/suspended-organization-notification.svelte
@@ -16,7 +16,11 @@
 
     let { isChatEnabled, name, openChat, organizationId, suspensionCode, ...restProps }: Props = $props();
 
-    const changePlanHref = $derived(`${resolve('/(app)/organization/[organizationId]/billing', { organizationId })}?changePlan=true`);
+    const changePlanHref = $derived(
+        `${resolve('/(app)/organization/[organizationId]/billing', {
+            organizationId
+        })}?changePlan=true`
+    );
 </script>
 
 <Notification variant="destructive" {...restProps}>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/over-limit-indicator.stories.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/over-limit-indicator.stories.svelte
@@ -6,7 +6,9 @@
     const { Story } = defineMeta({
         argTypes: {
             isOverLimit: {
-                control: { type: 'boolean' },
+                control: {
+                    type: 'boolean'
+                },
                 defaultValue: true
             }
         },
@@ -16,5 +18,15 @@
     });
 </script>
 
-<Story name="Over Limit" args={{ isOverLimit: true }} />
-<Story name="Not Over Limit" args={{ isOverLimit: false }} />
+<Story
+    name="Over Limit"
+    args={{
+        isOverLimit: true
+    }}
+/>
+<Story
+    name="Not Over Limit"
+    args={{
+        isOverLimit: false
+    }}
+/>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/suspension-indicator.stories.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/suspension-indicator.stories.svelte
@@ -6,11 +6,15 @@
     const { Story } = defineMeta({
         argTypes: {
             code: {
-                control: { type: 'select' },
+                control: {
+                    type: 'select'
+                },
                 options: ['Billing', 'Overage', 'Abuse', 'Other', undefined]
             },
             notes: {
-                control: { type: 'text' }
+                control: {
+                    type: 'text'
+                }
             }
         },
         component: SuspensionIndicator,
@@ -19,9 +23,40 @@
     });
 </script>
 
-<Story name="Billing" args={{ code: 'Billing' }} />
-<Story name="Overage" args={{ code: 'Overage' }} />
-<Story name="Abuse" args={{ code: 'Abuse' }} />
-<Story name="Other" args={{ code: 'Other' }} />
-<Story name="Unknown" args={{ code: undefined }} />
-<Story name="With Notes" args={{ code: 'Billing', notes: 'Account payment failed on 2024-01-15. Customer contacted.' }} />
+<Story
+    name="Billing"
+    args={{
+        code: 'Billing'
+    }}
+/>
+<Story
+    name="Overage"
+    args={{
+        code: 'Overage'
+    }}
+/>
+<Story
+    name="Abuse"
+    args={{
+        code: 'Abuse'
+    }}
+/>
+<Story
+    name="Other"
+    args={{
+        code: 'Other'
+    }}
+/>
+<Story
+    name="Unknown"
+    args={{
+        code: undefined
+    }}
+/>
+<Story
+    name="With Notes"
+    args={{
+        code: 'Billing',
+        notes: 'Account payment failed on 2024-01-15. Customer contacted.'
+    }}
+/>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/table/options.svelte.ts
@@ -36,7 +36,10 @@ export function getColumns<TOrganizations extends ViewOrganization>(mode: GetOrg
         },
         {
             accessorFn: (row) => row.is_over_monthly_limit,
-            cell: (info) => renderComponent(OrganizationOverLimitCell, { isOverLimit: info.getValue<boolean>() }),
+            cell: (info) =>
+                renderComponent(OrganizationOverLimitCell, {
+                    isOverLimit: info.getValue<boolean>()
+                }),
             enableSorting: false,
             header: 'Over Limit',
             id: 'is_over_monthly_limit',
@@ -47,7 +50,10 @@ export function getColumns<TOrganizations extends ViewOrganization>(mode: GetOrg
         },
         {
             accessorKey: 'retention_days',
-            cell: (info) => renderComponent(OrganizationRetentionDaysCell, { value: info.getValue<number>() }),
+            cell: (info) =>
+                renderComponent(OrganizationRetentionDaysCell, {
+                    value: info.getValue<number>()
+                }),
             enableSorting: false,
             header: 'Retention',
             meta: {
@@ -79,7 +85,10 @@ export function getColumns<TOrganizations extends ViewOrganization>(mode: GetOrg
         columns.push(
             {
                 accessorKey: 'project_count',
-                cell: (info) => renderComponent(NumberFormatter, { value: info.getValue<number>() }),
+                cell: (info) =>
+                    renderComponent(NumberFormatter, {
+                        value: info.getValue<number>()
+                    }),
                 enableSorting: false,
                 header: 'Projects',
                 meta: {
@@ -88,7 +97,10 @@ export function getColumns<TOrganizations extends ViewOrganization>(mode: GetOrg
             },
             {
                 accessorKey: 'stack_count',
-                cell: (info) => renderComponent(NumberFormatter, { value: info.getValue<number>() }),
+                cell: (info) =>
+                    renderComponent(NumberFormatter, {
+                        value: info.getValue<number>()
+                    }),
                 enableSorting: false,
                 header: 'Stacks',
                 meta: {
@@ -97,7 +109,10 @@ export function getColumns<TOrganizations extends ViewOrganization>(mode: GetOrg
             },
             {
                 accessorKey: 'event_count',
-                cell: (info) => renderComponent(NumberFormatter, { value: info.getValue<number>() }),
+                cell: (info) =>
+                    renderComponent(NumberFormatter, {
+                        value: info.getValue<number>()
+                    }),
                 enableSorting: false,
                 header: 'Events',
                 meta: {
@@ -108,7 +123,10 @@ export function getColumns<TOrganizations extends ViewOrganization>(mode: GetOrg
     }
 
     columns.push({
-        cell: (info) => renderComponent(OrganizationsActionsCell, { organization: info.row.original }),
+        cell: (info) =>
+            renderComponent(OrganizationsActionsCell, {
+                organization: info.row.original
+            }),
         enableHiding: false,
         enableSorting: false,
         header: '',

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/table/organization-actions-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/table/organization-actions-cell.svelte
@@ -82,15 +82,36 @@
         {/snippet}
     </DropdownMenu.Trigger>
     <DropdownMenu.Content align="end">
-        <DropdownMenu.Item onclick={() => goto(resolve('/(app)/organization/[organizationId]/manage', { organizationId: org.id }))}>
+        <DropdownMenu.Item
+            onclick={() =>
+                goto(
+                    resolve('/(app)/organization/[organizationId]/manage', {
+                        organizationId: org.id
+                    })
+                )}
+        >
             <Edit />
             Edit
         </DropdownMenu.Item>
-        <DropdownMenu.Item onclick={() => goto(resolve('/(app)/organization/[organizationId]/billing', { organizationId: org.id }))}>
+        <DropdownMenu.Item
+            onclick={() =>
+                goto(
+                    resolve('/(app)/organization/[organizationId]/billing', {
+                        organizationId: org.id
+                    })
+                )}
+        >
             <ChangePlan />
             Change Plan
         </DropdownMenu.Item>
-        <DropdownMenu.Item onclick={() => goto(resolve('/(app)/organization/[organizationId]/billing', { organizationId: org.id }))}>
+        <DropdownMenu.Item
+            onclick={() =>
+                goto(
+                    resolve('/(app)/organization/[organizationId]/billing', {
+                        organizationId: org.id
+                    })
+                )}
+        >
             <ViewInvoices />
             View Invoices
         </DropdownMenu.Item>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/api.svelte.ts
@@ -10,17 +10,25 @@ import { createMutation, createQuery, QueryClient, useQueryClient } from '@tanst
 export async function invalidateProjectQueries(queryClient: QueryClient, message: WebSocketMessageValue<'ProjectChanged'>) {
     const { id, organization_id } = message;
     if (id) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.id(id) });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.id(id)
+        });
     }
 
     if (organization_id) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.organization(organization_id) });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.organization(organization_id)
+        });
     }
 
     if (!id && !organization_id) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.type });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.type
+        });
     } else {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.projects() });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.projects()
+        });
     }
 }
 
@@ -224,10 +232,18 @@ export function deleteProject(request: DeleteProjectRequest) {
         },
         mutationKey: queryKeys.deleteProject(request.route.ids),
         onError: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         },
         onSuccess: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         }
     }));
 }
@@ -240,14 +256,18 @@ export function deleteProjectConfig(request: DeleteConfigRequest) {
         mutationFn: async (params: DeleteConfigParams) => {
             const client = useFetchClient();
             const response = await client.delete(`projects/${request.route.id}/config`, {
-                params: { key: params.key }
+                params: {
+                    key: params.key
+                }
             });
 
             return response.ok;
         },
         mutationKey: queryKeys.deleteConfig(request.route.id),
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.config(request.route.id) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.config(request.route.id)
+            });
         }
     }));
 }
@@ -258,14 +278,18 @@ export function deletePromotedTab(request: DeletePromotedTabRequest) {
         mutationFn: async (params: DeletePromotedTabParams) => {
             const client = useFetchClient();
             const response = await client.delete(`projects/${request.route.id}/promotedtabs`, {
-                params: { ...params }
+                params: {
+                    ...params
+                }
             });
 
             return response.ok;
         },
         mutationKey: queryKeys.deletePromotedTab(request.route.id),
         onError: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id)
+            });
         },
         onSuccess: (_: boolean, variables: { name: string }) => {
             // Update the project to reflect the demoted tab until it's updated from the server
@@ -293,7 +317,9 @@ export function deleteSlack(request: DeleteSlackRequest) {
         },
         mutationKey: queryKeys.deleteSlack(request.route.id),
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id)
+            });
         }
     }));
 }
@@ -310,7 +336,9 @@ export function deleteSourceMapMutation(request: SourceMapRequest) {
         },
         mutationKey: [...queryKeys.sourceMaps(request.route.id), 'delete'],
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.sourceMaps(request.route.id) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.sourceMaps(request.route.id)
+            });
         }
     }));
 }
@@ -353,7 +381,12 @@ export function getOrganizationProjectsQuery(request: GetOrganizationProjectsReq
 
             return response;
         },
-        queryKey: [...queryKeys.organization(request.route.organizationId), { params: request.params }]
+        queryKey: [
+            ...queryKeys.organization(request.route.organizationId),
+            {
+                params: request.params
+            }
+        ]
     }));
 }
 
@@ -430,7 +463,12 @@ export function getProjectsQuery(request: GetProjectsRequest) {
 
             return response;
         },
-        queryKey: [queryKeys.projects(), { params: request.params }],
+        queryKey: [
+            queryKeys.projects(),
+            {
+                params: request.params
+            }
+        ],
         refetchInterval: request.refetchInterval
     }));
 }
@@ -455,7 +493,9 @@ export function getSourceMapsQuery(request: SourceMapRequest) {
         enabled: () => !!accessToken.current && !!request.route.id,
         queryFn: async ({ signal }: { signal: AbortSignal }) => {
             const client = useFetchClient();
-            const response = await client.getJSON<SourceMapArtifact[]>(`projects/${request.route.id}/source-maps`, { signal });
+            const response = await client.getJSON<SourceMapArtifact[]>(`projects/${request.route.id}/source-maps`, {
+                signal
+            });
             return response.data!;
         },
         queryKey: queryKeys.sourceMaps(request.route.id)
@@ -476,7 +516,12 @@ export function postProject() {
         onSuccess: async (project: ViewProject) => {
             queryClient.setQueryData(queryKeys.id(project.id), project);
 
-            const organizationProjectsQueryKey = [...queryKeys.organization(project.organization_id), { params: undefined }] as const;
+            const organizationProjectsQueryKey = [
+                ...queryKeys.organization(project.organization_id),
+                {
+                    params: undefined
+                }
+            ] as const;
             queryClient.setQueryData<FetchClientResponse<ViewProject[]> | undefined>(organizationProjectsQueryKey, (response) => {
                 if (!response || response.data?.some((existingProject) => existingProject.id === project.id)) {
                     return response;
@@ -488,7 +533,9 @@ export function postProject() {
                 };
             });
 
-            await queryClient.invalidateQueries({ queryKey: queryKeys.type });
+            await queryClient.invalidateQueries({
+                queryKey: queryKeys.type
+            });
         }
     }));
 }
@@ -500,15 +547,25 @@ export function postProjectConfig(request: PostConfigRequest) {
         enabled: () => !!accessToken.current,
         mutationFn: async (params: PostConfigParams) => {
             const client = useFetchClient();
-            const response = await client.post(`projects/${request.route.id}/config`, <StringValueFromBody>{ value: params.value }, {
-                params: { key: params.key }
-            });
+            const response = await client.post(
+                `projects/${request.route.id}/config`,
+                <StringValueFromBody>{
+                    value: params.value
+                },
+                {
+                    params: {
+                        key: params.key
+                    }
+                }
+            );
 
             return response.ok;
         },
         mutationKey: queryKeys.postConfig(request.route.id),
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.config(request.route.id) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.config(request.route.id)
+            });
         }
     }));
 }
@@ -539,7 +596,9 @@ export function postPromotedTab(request: PostPromotedTabRequest) {
                 `projects/${request.route.id}/promotedtabs`,
                 {},
                 {
-                    params: { ...params }
+                    params: {
+                        ...params
+                    }
                 }
             );
 
@@ -547,7 +606,9 @@ export function postPromotedTab(request: PostPromotedTabRequest) {
         },
         mutationKey: queryKeys.postPromotedTab(request.route.id),
         onError: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id)
+            });
         },
         onSuccess: (_: boolean, variables: { name: string }) => {
             // Update the project to reflect the new promoted tab until it's updated from the server
@@ -569,13 +630,19 @@ export function postSlack(request: PostSlackRequest) {
         enabled: () => !!accessToken.current && !!request.route.id,
         mutationFn: async (code: string) => {
             const client = useFetchClient();
-            const response = await client.post(`projects/${request.route.id}/slack`, undefined, { params: { code } });
+            const response = await client.post(`projects/${request.route.id}/slack`, undefined, {
+                params: {
+                    code
+                }
+            });
 
             return response.ok;
         },
         mutationKey: queryKeys.postSlack(request.route.id),
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.integrationNotificationSettings(request.route.id, 'slack') });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.integrationNotificationSettings(request.route.id, 'slack')
+            });
         }
     }));
 }
@@ -596,7 +663,9 @@ export function postSourceMapMutation(request: SourceMapRequest) {
         },
         mutationKey: [...queryKeys.sourceMaps(request.route.id), 'post'],
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.sourceMaps(request.route.id) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.sourceMaps(request.route.id)
+            });
         }
     }));
 }
@@ -644,7 +713,9 @@ export function updateProject(request: UpdateProjectRequest) {
             return response.data!;
         },
         onError: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id)
+            });
         },
         onSuccess: (project: ViewProject) => {
             queryClient.setQueryData(queryKeys.id(request.route.id), project);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/add-project-config-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/add-project-config-dialog.svelte
@@ -38,7 +38,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred, please try again.' };
+                    return {
+                        form: 'An unexpected error occurred, please try again.'
+                    };
                 }
             }
         }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/remove-project-config-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/remove-project-config-dialog.svelte
@@ -26,7 +26,12 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={onSubmit}>Delete Configuration Value</AlertDialog.Action>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={onSubmit}>Delete Configuration Value</AlertDialog.Action
+            >
         </AlertDialog.Footer>
     </AlertDialog.Content>
 </AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/remove-project-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/remove-project-dialog.svelte
@@ -26,7 +26,12 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={onSubmit}>Delete Project</AlertDialog.Action>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={onSubmit}>Delete Project</AlertDialog.Action
+            >
         </AlertDialog.Footer>
     </AlertDialog.Content>
 </AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/remove-slack-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/remove-slack-dialog.svelte
@@ -25,7 +25,12 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={onSubmit}>Remove Slack</AlertDialog.Action>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={onSubmit}>Remove Slack</AlertDialog.Action
+            >
         </AlertDialog.Footer>
     </AlertDialog.Content>
 </AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/reset-project-data-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/reset-project-data-dialog.svelte
@@ -27,7 +27,12 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={onSubmit}>Reset Project Data</AlertDialog.Action>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={onSubmit}>Reset Project Data</AlertDialog.Action
+            >
         </AlertDialog.Footer>
     </AlertDialog.Content>
 </AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/update-project-config-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/dialogs/update-project-config-dialog.svelte
@@ -35,7 +35,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred' };
+                    return {
+                        form: 'An unexpected error occurred'
+                    };
                 }
             }
         }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/integration-notification-settings-form.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/integration-notification-settings-form.svelte
@@ -112,6 +112,7 @@
     </div>
 {:else}
     <div class="space-y-3">
+        <!-- eslint-disable-next-line @stylistic/object-curly-newline -->
         {#each { length: 5 } as name, index (`${name}-${index}`)}
             <div class="rounded-lg border p-4">
                 <div class="flex items-center justify-between">

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/project-command-actions.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/project-command-actions.svelte
@@ -39,12 +39,42 @@
     let { onReset, onSearchReset, onSelect, open, resetPending, selectedActionId = $bindable(), selectingProject = $bindable() }: Props = $props();
 
     const projectActions: ProjectAction[] = [
-        { icon: FolderOpen, id: 'open', keywords: ['edit', 'manage', 'settings'], label: 'Open Project' },
-        { icon: Stacks, id: 'stacks', keywords: ['errors', 'exceptions', 'issues'], label: 'Project Stacks' },
-        { icon: Bell, id: 'notifications', keywords: ['alerts', 'email'], label: 'Project Notifications' },
-        { icon: CloudDownload, id: 'client-setup', keywords: ['SDK', 'configure client', 'instrumentation'], label: 'Client Setup' },
-        { icon: Database, id: 'generate-sample-data', keywords: ['seed', 'demo events'], label: 'Generate Sample Data' },
-        { icon: AlertTriangle, id: 'reset-data', keywords: ['clear', 'delete events'], label: 'Reset Project Data' }
+        {
+            icon: FolderOpen,
+            id: 'open',
+            keywords: ['edit', 'manage', 'settings'],
+            label: 'Open Project'
+        },
+        {
+            icon: Stacks,
+            id: 'stacks',
+            keywords: ['errors', 'exceptions', 'issues'],
+            label: 'Project Stacks'
+        },
+        {
+            icon: Bell,
+            id: 'notifications',
+            keywords: ['alerts', 'email'],
+            label: 'Project Notifications'
+        },
+        {
+            icon: CloudDownload,
+            id: 'client-setup',
+            keywords: ['SDK', 'configure client', 'instrumentation'],
+            label: 'Client Setup'
+        },
+        {
+            icon: Database,
+            id: 'generate-sample-data',
+            keywords: ['seed', 'demo events'],
+            label: 'Generate Sample Data'
+        },
+        {
+            icon: AlertTriangle,
+            id: 'reset-data',
+            keywords: ['clear', 'delete events'],
+            label: 'Reset Project Data'
+        }
     ];
 
     const selectedAction = $derived(projectActions.find((action) => action.id === selectedActionId));
@@ -83,11 +113,15 @@
     function getProjectHref(action: ProjectActionId, project: ViewProject): string | undefined {
         switch (action) {
             case 'client-setup':
-                return resolve('/(app)/project/[projectId]/configure', { projectId: project.id });
+                return resolve('/(app)/project/[projectId]/configure', {
+                    projectId: project.id
+                });
             case 'notifications':
                 return `${resolve('/(app)/account/notifications')}?project=${project.id}`;
             case 'open':
-                return resolve('/(app)/project/[projectId]/manage', { projectId: project.id });
+                return resolve('/(app)/project/[projectId]/manage', {
+                    projectId: project.id
+                });
             case 'stacks':
                 return `${resolve('/(app)/stack')}?filter=project:${project.id}`;
             default:

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/config-options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/config-options.svelte.ts
@@ -33,7 +33,11 @@ export function getColumns<TClientConfigurationSetting extends ClientConfigurati
             }
         },
         {
-            cell: (info) => renderComponent(ProjectConfigActionsCell, { projectId: params.projectId, setting: info.row.original }),
+            cell: (info) =>
+                renderComponent(ProjectConfigActionsCell, {
+                    projectId: params.projectId,
+                    setting: info.row.original
+                }),
             enableHiding: false,
             enableSorting: false,
             header: '',
@@ -56,7 +60,10 @@ export function getTableOptions<TClientConfigurationSetting extends ClientConfig
     const queryData = $derived(
         Object.entries(queryResponse.data?.settings ?? {})
             .map(([key, value]) => {
-                return { key, value } as TClientConfigurationSetting;
+                return {
+                    key,
+                    value
+                } as TClientConfigurationSetting;
             })
             .filter((setting) => !knownSettingsToHide.includes(setting.key))
     );

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/options.svelte.ts
@@ -46,7 +46,10 @@ export function getColumns<TProject extends ViewProject>(
         columns.push(
             {
                 accessorKey: 'stack_count',
-                cell: (info) => renderComponent(NumberFormatter, { value: info.getValue<number>() }),
+                cell: (info) =>
+                    renderComponent(NumberFormatter, {
+                        value: info.getValue<number>()
+                    }),
                 enableSorting: false,
                 header: 'Stacks',
                 meta: {
@@ -55,7 +58,10 @@ export function getColumns<TProject extends ViewProject>(
             },
             {
                 accessorKey: 'event_count',
-                cell: (info) => renderComponent(NumberFormatter, { value: info.getValue<number>() }),
+                cell: (info) =>
+                    renderComponent(NumberFormatter, {
+                        value: info.getValue<number>()
+                    }),
                 enableSorting: false,
                 header: 'Events',
                 meta: {
@@ -66,7 +72,10 @@ export function getColumns<TProject extends ViewProject>(
     }
 
     columns.push({
-        cell: (info) => renderComponent(ProjectActionsCell, { project: info.row.original }),
+        cell: (info) =>
+            renderComponent(ProjectActionsCell, {
+                project: info.row.original
+            }),
         enableHiding: false,
         enableSorting: false,
         header: '',

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/project-actions-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/project-actions-cell.svelte
@@ -51,11 +51,25 @@
             <Stacks />
             Stacks
         </DropdownMenu.Item>
-        <DropdownMenu.Item onclick={() => goto(resolve('/(app)/project/[projectId]/manage', { projectId: project.id }))}>
+        <DropdownMenu.Item
+            onclick={() =>
+                goto(
+                    resolve('/(app)/project/[projectId]/manage', {
+                        projectId: project.id
+                    })
+                )}
+        >
             <Edit />
             Edit
         </DropdownMenu.Item>
-        <DropdownMenu.Item onclick={() => goto(resolve('/(app)/project/[projectId]/configure', { projectId: project.id }))}>
+        <DropdownMenu.Item
+            onclick={() =>
+                goto(
+                    resolve('/(app)/project/[projectId]/configure', {
+                        projectId: project.id
+                    })
+                )}
+        >
             <Configure />
             Client Setup
         </DropdownMenu.Item>
@@ -64,7 +78,14 @@
             Delete
         </DropdownMenu.Item>
         <DropdownMenu.Separator />
-        <DropdownMenu.Item onclick={() => goto(resolve('/(app)/organization/[organizationId]/manage', { organizationId: project.organization_id }))}>
+        <DropdownMenu.Item
+            onclick={() =>
+                goto(
+                    resolve('/(app)/organization/[organizationId]/manage', {
+                        organizationId: project.organization_id
+                    })
+                )}
+        >
             <Organization />
             View Organization
         </DropdownMenu.Item>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/project-config-actions-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/project-config-actions-cell.svelte
@@ -43,7 +43,10 @@
         toast.dismiss(toastId);
 
         try {
-            await updateProjectConfig.mutateAsync({ key: setting.key, value });
+            await updateProjectConfig.mutateAsync({
+                key: setting.key,
+                value
+            });
             toastId = toast.success(`Successfully updated ${setting.key} setting.`);
         } catch (error) {
             toastId = toast.error(`Error updating ${setting.key}'s setting. Please try again.`);
@@ -55,7 +58,9 @@
         toast.dismiss(toastId);
 
         try {
-            await removeProjectConfig.mutateAsync({ key: setting.key });
+            await removeProjectConfig.mutateAsync({
+                key: setting.key
+            });
             toastId = toast.success(`Successfully removed ${setting.key} setting.`);
         } catch (error) {
             toastId = toast.error(`Error removing ${setting.key}'s setting. Please try again.`);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/user-notification-settings-form.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/user-notification-settings-form.svelte
@@ -180,6 +180,7 @@
         <div class="space-y-4">
             <Skeleton class="h-6 w-40 rounded" />
             <div class="space-y-3">
+                <!-- eslint-disable-next-line @stylistic/object-curly-newline -->
                 {#each { length: 5 } as name, index (`${name}-${index}`)}
                     <div class="rounded-lg border p-4 opacity-60">
                         <div class="flex items-center justify-between">

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.svelte.ts
@@ -55,9 +55,13 @@ function cancelScheduledSavedViewInvalidation(queryClient: QueryClient, organiza
 
 async function invalidateSavedViewCache(queryClient: QueryClient, organizationId: string | undefined) {
     if (organizationId) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.organization(organizationId) });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.organization(organizationId)
+        });
     } else {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.type });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.type
+        });
     }
 }
 
@@ -115,7 +119,9 @@ export function deleteSavedView(request: { route: { organizationId: string | und
             removeSavedViewFromCaches(queryClient, savedView, request.route.organizationId);
         },
         onSettled: () => {
-            void queryClient.invalidateQueries({ queryKey: queryKeys.type });
+            void queryClient.invalidateQueries({
+                queryKey: queryKeys.type
+            });
         },
         onSuccess: (_data: WorkInProgressResult, savedView: SavedView) => {
             removeSavedViewFromCaches(queryClient, savedView, request.route.organizationId);
@@ -204,10 +210,14 @@ export function postPredefinedSavedViews(request: { route: { organizationId: str
                 syncSavedViewCaches(queryClient, savedView, request.route.organizationId);
             }
 
-            void queryClient.invalidateQueries({ queryKey: queryKeys.organization(request.route.organizationId) });
+            void queryClient.invalidateQueries({
+                queryKey: queryKeys.organization(request.route.organizationId)
+            });
             const viewTypes = savedViews.map((savedView) => savedView.view_type).filter((view, index, views) => views.indexOf(view) === index);
             for (const view of viewTypes) {
-                void queryClient.invalidateQueries({ queryKey: queryKeys.view(request.route.organizationId, view) });
+                void queryClient.invalidateQueries({
+                    queryKey: queryKeys.view(request.route.organizationId, view)
+                });
             }
         }
     }));
@@ -233,7 +243,12 @@ export function removeSavedViewFromCaches(queryClient: QueryClient, savedView: S
     const evict = (cachedViews: SavedView[] | undefined) => cachedViews?.filter((v) => v.id !== savedView.id);
     queryClient.setQueryData(queryKeys.view(organizationId, savedView.view_type), evict);
     queryClient.setQueryData(queryKeys.organization(organizationId), evict);
-    queryClient.setQueriesData<SavedView[]>({ queryKey: queryKeys.type }, evict);
+    queryClient.setQueriesData<SavedView[]>(
+        {
+            queryKey: queryKeys.type
+        },
+        evict
+    );
 }
 
 export function restoreDeletedSavedView(savedView: SavedView): void {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
@@ -214,7 +214,10 @@
         }
 
         try {
-            const result = await updateMutation.mutateAsync({ name, slug });
+            const result = await updateMutation.mutateAsync({
+                name,
+                slug
+            });
             isRenameDialogOpen = false;
             toast.success(`View renamed to "${result.name}".`);
         } catch (error) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -116,7 +116,12 @@ export function savedViewColumnsEqual(
     defaultColumnVisibility: ColumnVisibilityState = {}
 ): boolean {
     const normalize = (value: ColumnVisibilityState | null | undefined) =>
-        Object.fromEntries(Object.entries({ ...defaultColumnVisibility, ...(value ?? {}) }).filter(([, isVisible]) => !isVisible));
+        Object.fromEntries(
+            Object.entries({
+                ...defaultColumnVisibility,
+                ...(value ?? {})
+            }).filter(([, isVisible]) => !isVisible)
+        );
     const aEntries = Object.entries(normalize(a)).sort(([k1], [k2]) => k1.localeCompare(k2));
     const bEntries = Object.entries(normalize(b)).sort(([k1], [k2]) => k1.localeCompare(k2));
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/sessions/components/sessions-stats-dashboard.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/sessions/components/sessions-stats-dashboard.svelte
@@ -28,8 +28,22 @@
     const metricIconClass = 'size-3.5 shrink-0 text-[var(--chart-2)]';
     const metricValueClass = 'truncate text-lg leading-none font-bold text-[var(--chart-2)] tabular-nums sm:text-xl';
 
-    const compactAverageDuration = $derived(avgDuration > 0 ? prettyMilliseconds(avgDuration * 1000, { compact: true, secondsDecimalDigits: 0 }) : '—');
-    const preciseAverageDuration = $derived(avgDuration > 0 ? prettyMilliseconds(avgDuration * 1000, { secondsDecimalDigits: 0, unitCount: 2 }) : '—');
+    const compactAverageDuration = $derived(
+        avgDuration > 0
+            ? prettyMilliseconds(avgDuration * 1000, {
+                  compact: true,
+                  secondsDecimalDigits: 0
+              })
+            : '—'
+    );
+    const preciseAverageDuration = $derived(
+        avgDuration > 0
+            ? prettyMilliseconds(avgDuration * 1000, {
+                  secondsDecimalDigits: 0,
+                  unitCount: 2
+              })
+            : '—'
+    );
 </script>
 
 <div class="grid grid-cols-2 gap-2 sm:grid-cols-4">
@@ -81,7 +95,12 @@
                 <Skeleton class="h-6 w-16" />
             {:else}
                 <div class={metricValueClass}>
-                    <Number value={avgPerHour} formatOptions={{ maximumFractionDigits: 1 }} />
+                    <Number
+                        value={avgPerHour}
+                        formatOptions={{
+                            maximumFractionDigits: 1
+                        }}
+                    />
                 </div>
             {/if}
         </Card.Content>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ai-elements/response/response.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ai-elements/response/response.svelte
@@ -17,7 +17,9 @@
     let currentTheme = $derived(mode.current === 'dark' ? 'github-dark-default' : 'github-light-default');
 
     const assistantTheme = {
-        blockquote: { base: 'border-muted-foreground/30 text-muted-foreground my-3 border-l-3 pl-3' },
+        blockquote: {
+            base: 'border-muted-foreground/30 text-muted-foreground my-3 border-l-3 pl-3'
+        },
         code: {
             actions: 'pointer-events-none sticky top-2 z-10 -mt-9 flex h-7 items-center justify-end',
             base: 'my-3 flex w-full flex-col gap-1.5 rounded-lg border border-border bg-sidebar p-1.5',
@@ -29,17 +31,31 @@
         components: {
             button: 'disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer p-1 text-muted-foreground transition-colors hover:text-foreground rounded hover:bg-border flex items-center justify-center size-7'
         },
-        h1: { base: 'mt-5 mb-2 text-xl font-semibold text-foreground' },
-        h2: { base: 'mt-5 mb-2 text-lg font-semibold text-foreground' },
-        h3: { base: 'mt-4 mb-1.5 text-base font-semibold text-foreground' },
-        h4: { base: 'mt-3 mb-1 text-sm font-semibold text-foreground' },
-        li: { base: 'py-0.5' },
+        h1: {
+            base: 'mt-5 mb-2 text-xl font-semibold text-foreground'
+        },
+        h2: {
+            base: 'mt-5 mb-2 text-lg font-semibold text-foreground'
+        },
+        h3: {
+            base: 'mt-4 mb-1.5 text-base font-semibold text-foreground'
+        },
+        h4: {
+            base: 'mt-3 mb-1 text-sm font-semibold text-foreground'
+        },
+        li: {
+            base: 'py-0.5'
+        },
         link: {
             base: 'font-medium text-foreground underline decoration-muted-foreground/60 underline-offset-2 wrap-anywhere transition-colors hover:text-primary hover:decoration-primary',
             blocked: 'text-muted-foreground'
         },
-        ol: { base: 'my-2 ml-5 list-outside list-decimal whitespace-normal text-foreground' },
-        paragraph: { base: 'my-2 leading-relaxed text-foreground' },
+        ol: {
+            base: 'my-2 ml-5 list-outside list-decimal whitespace-normal text-foreground'
+        },
+        paragraph: {
+            base: 'my-2 leading-relaxed text-foreground'
+        },
         table: {
             container: 'max-w-full overflow-x-auto rounded-md border border-border bg-background',
             table: 'w-full table-auto border-collapse',
@@ -53,7 +69,9 @@
         th: {
             base: 'w-px min-w-0 px-2 py-1.5 text-left align-bottom text-[0.6875rem] leading-tight font-semibold text-foreground whitespace-normal'
         },
-        ul: { base: 'my-2 ml-5 list-outside list-disc whitespace-normal text-foreground' }
+        ul: {
+            base: 'my-2 ml-5 list-outside list-disc whitespace-normal text-foreground'
+        }
     } satisfies NonNullable<StreamdownProps['theme']>;
 </script>
 
@@ -62,7 +80,13 @@
         {content}
         {components}
         baseTheme="shadcn"
-        controls={{ code: { copy: true, download: false }, table: false }}
+        controls={{
+            code: {
+                copy: true,
+                download: false
+            },
+            table: false
+        }}
         mergeTheme={true}
         shikiTheme={currentTheme}
         shikiThemes={{

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
@@ -70,7 +70,11 @@
                     id: 'select'
                 },
                 {
-                    cell: (props) => renderComponent(Summary, { showStatus: false, summary: props.row.original }),
+                    cell: (props) =>
+                        renderComponent(Summary, {
+                            showStatus: false,
+                            summary: props.row.original
+                        }),
                     header: 'Summary',
                     id: 'summary',
                     meta: {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
@@ -49,14 +49,24 @@
         users: 1
     };
     const summary: TestSummary = $derived(kind === 'event' ? eventSummary : stackSummary);
-    const queryParameters = { limit: 20, page: 1 };
+    const queryParameters = {
+        limit: 20,
+        page: 1
+    };
 
     function getDefaultColumnSizing(): ColumnSizingState | undefined {
         if (allColumnsSized) {
-            return { date: 130, summary: 140 };
+            return {
+                date: 130,
+                summary: 140
+            };
         }
 
-        return sizedFullWidthSummary ? { summary: 180 } : undefined;
+        return sizedFullWidthSummary
+            ? {
+                  summary: 180
+              }
+            : undefined;
     }
 
     const table = createTable(

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
@@ -16,12 +16,30 @@
 
     type Item = { label: string; value: string };
     const items: Item[] = [
-        { label: '5', value: '5' },
-        { label: '10', value: '10' },
-        { label: '20', value: '20' },
-        { label: '30', value: '30' },
-        { label: '40', value: '40' },
-        { label: '50', value: '50' }
+        {
+            label: '5',
+            value: '5'
+        },
+        {
+            label: '10',
+            value: '10'
+        },
+        {
+            label: '20',
+            value: '20'
+        },
+        {
+            label: '30',
+            value: '30'
+        },
+        {
+            label: '40',
+            value: '40'
+        },
+        {
+            label: '50',
+            value: '50'
+        }
     ];
 
     let valueString = $derived(value + '');

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/date-range-picker/custom-range-form.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/date-range-picker/custom-range-form.svelte
@@ -22,7 +22,10 @@
     let previousRange: CustomDateRange | null | undefined;
 
     const form = createForm(() => ({
-        defaultValues: structuredCloneState(range) ?? { end: '', start: '' },
+        defaultValues: structuredCloneState(range) ?? {
+            end: '',
+            start: ''
+        },
         validators: {
             onSubmit: CustomDateRangeSchema,
             onSubmitAsync: async ({ value }) => {
@@ -40,7 +43,10 @@
     // Initialize values on mount and reset when range prop changes
     $effect(() => {
         if (range !== previousRange) {
-            const clonedRange = structuredCloneState(range) ?? { end: '', start: '' };
+            const clonedRange = structuredCloneState(range) ?? {
+                end: '',
+                start: ''
+            };
             form.reset();
             form.setFieldValue('start', clonedRange.start ?? '');
             form.setFieldValue('end', clonedRange.end ?? '');
@@ -63,7 +69,10 @@
 
         const endTime = validateAndResolveTime(endValue);
         if (startResolved && endTime && startResolved > endTime) {
-            return { error: 'End date must be after start date', valid: false };
+            return {
+                error: 'End date must be after start date',
+                valid: false
+            };
         }
 
         return basicValidation;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/date-range-picker/date-range-picker.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/date-range-picker/date-range-picker.svelte
@@ -17,13 +17,34 @@
 
     // Simplified quick ranges — just the most commonly used
     const commonRanges = [
-        { label: 'Last 15 minutes', value: '[now-15m TO now]' },
-        { label: 'Last 1 hour', value: '[now-1h TO now]' },
-        { label: 'Last 4 hours', value: '[now-4h TO now]' },
-        { label: 'Last 24 hours', value: '[now-1d TO now]' },
-        { label: 'Last 7 days', value: '[now-7d TO now]' },
-        { label: 'Last 30 days', value: '[now-30d TO now]' },
-        { label: 'Last 90 days', value: '[now-90d TO now]' }
+        {
+            label: 'Last 15 minutes',
+            value: '[now-15m TO now]'
+        },
+        {
+            label: 'Last 1 hour',
+            value: '[now-1h TO now]'
+        },
+        {
+            label: 'Last 4 hours',
+            value: '[now-4h TO now]'
+        },
+        {
+            label: 'Last 24 hours',
+            value: '[now-1d TO now]'
+        },
+        {
+            label: 'Last 7 days',
+            value: '[now-7d TO now]'
+        },
+        {
+            label: 'Last 30 days',
+            value: '[now-30d TO now]'
+        },
+        {
+            label: 'Last 90 days',
+            value: '[now-90d TO now]'
+        }
     ];
 
     let showCustom = $state(false);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/detail-sheet.svelte
@@ -89,7 +89,12 @@
     function createHistoryState(value?: string): Record<string, unknown> {
         return {
             ...page.state,
-            [detailSheetHistoryStateKey]: value ? { key: historyKey, value } : undefined
+            [detailSheetHistoryStateKey]: value
+                ? {
+                      key: historyKey,
+                      value
+                  }
+                : undefined
         };
     }
 
@@ -139,7 +144,10 @@
             return;
         }
 
-        pendingNavigation = { options: type === 'link' ? selectedLinkNavigationOptions : undefined, url: to.url };
+        pendingNavigation = {
+            options: type === 'link' ? selectedLinkNavigationOptions : undefined,
+            url: to.url
+        };
         cancel();
         clearOwnedHistoryEntry();
         window.history.back();
@@ -247,7 +255,9 @@
     <Sheet.Content
         class="bg-background top-15.25! bottom-0! z-40 h-auto! w-full scrollbar-gutter-stable gap-0 overflow-y-auto rounded-l-lg border-l text-base shadow-2xl duration-150 ease-out will-change-transform sm:max-w-full! md:w-5/6!"
         onInteractOutside={preserveDetailSheetForAssistant}
-        overlayProps={{ class: 'top-15.25! z-40 bg-black/5 dark:bg-black/40 supports-backdrop-filter:backdrop-blur-[0.5px]' }}
+        overlayProps={{
+            class: 'top-15.25! z-40 bg-black/5 dark:bg-black/40 supports-backdrop-filter:backdrop-blur-[0.5px]'
+        }}
         preventScroll={false}
     >
         <div class="absolute top-3 right-12 z-10 flex items-center gap-1">

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/formatters/bytes.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/formatters/bytes.svelte
@@ -7,11 +7,26 @@
 
     const parsedValue = $derived(typeof value === 'number' ? value : parseFloat(value ?? ''));
     const byteUnits: { divisor: number; unit: Intl.NumberFormatOptions['unit'] }[] = [
-        { divisor: 1e12, unit: 'terabyte' },
-        { divisor: 1e9, unit: 'gigabyte' },
-        { divisor: 1e6, unit: 'megabyte' },
-        { divisor: 1e3, unit: 'kilobyte' },
-        { divisor: 1, unit: 'byte' }
+        {
+            divisor: 1e12,
+            unit: 'terabyte'
+        },
+        {
+            divisor: 1e9,
+            unit: 'gigabyte'
+        },
+        {
+            divisor: 1e6,
+            unit: 'megabyte'
+        },
+        {
+            divisor: 1e3,
+            unit: 'kilobyte'
+        },
+        {
+            divisor: 1,
+            unit: 'byte'
+        }
     ];
     const byteUnit = $derived(byteUnits.find(({ divisor }) => Math.abs(parsedValue) >= divisor) ?? byteUnits.at(-1)!);
     const byteValueNumberFormatter = $derived(

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/formatters/number-compact.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/formatters/number-compact.svelte
@@ -8,5 +8,8 @@
 </script>
 
 {#if value !== null && !isNaN(value) && isFinite(value)}
-    {new Intl.NumberFormat(locale, { maximumFractionDigits: 1, notation: 'compact' }).format(value)}
+    {new Intl.NumberFormat(locale, {
+        maximumFractionDigits: 1,
+        notation: 'compact'
+    }).format(value)}
 {/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/navigation/nav-item.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/navigation/nav-item.svelte
@@ -21,7 +21,15 @@
 
 <Button class={[!isActive && 'hover:underline', 'relative justify-start hover:bg-transparent', className]} data-sveltekit-noscroll {href} variant="ghost">
     {#if isActive}
-        <div class="bg-muted absolute inset-0 rounded-md" in:send={{ key: 'active-sidebar-tab' }} out:receive={{ key: 'active-sidebar-tab' }}></div>
+        <div
+            class="bg-muted absolute inset-0 rounded-md"
+            in:send={{
+                key: 'active-sidebar-tab'
+            }}
+            out:receive={{
+                key: 'active-sidebar-tab'
+            }}
+        ></div>
     {/if}
     <div class="relative">
         {title}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/notification/notification.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/notification/notification.svelte
@@ -40,7 +40,18 @@
     let { action, children, class: className, icon, ref = $bindable(null), variant = 'default', ...restProps }: NotificationProps = $props();
 </script>
 
-<div bind:this={ref} data-slot="notification" class={[notificationVariants({ variant }), className]} {...restProps} role="alert">
+<div
+    bind:this={ref}
+    data-slot="notification"
+    class={[
+        notificationVariants({
+            variant
+        }),
+        className
+    ]}
+    {...restProps}
+    role="alert"
+>
     {#if icon || action}
         <div class="flex w-full flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
             <div class="flex items-center gap-3">

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.stories.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.stories.svelte
@@ -13,8 +13,44 @@
     const extremeLongTags = ['environment:production', 'service:checkout-api', 'component:customer-profile-image-processing-worker-with-azure-storage'];
 </script>
 
-<Story name="Long Tags" args={{ class: 'w-64 p-4', tags: longTags }} />
-<Story name="Long Tags in a Summary Cell" args={{ class: 'w-48 flex-nowrap p-4', maxVisible: 2, tags: longTags }} />
-<Story name="Clickable Long Tags in a Summary Cell" args={{ class: 'w-48 flex-nowrap p-4', maxVisible: 2, onTagClick: () => {}, tags: longTags }} />
-<Story name="Extreme Long Tag in Overflow Popover" args={{ class: 'w-48 flex-nowrap p-4', maxVisible: 2, onTagClick: () => {}, tags: extremeLongTags }} />
-<Story name="Clickable Long Tags" args={{ class: 'w-64 p-4', onTagClick: () => {}, tags: longTags }} />
+<Story
+    name="Long Tags"
+    args={{
+        class: 'w-64 p-4',
+        tags: longTags
+    }}
+/>
+<Story
+    name="Long Tags in a Summary Cell"
+    args={{
+        class: 'w-48 flex-nowrap p-4',
+        maxVisible: 2,
+        tags: longTags
+    }}
+/>
+<Story
+    name="Clickable Long Tags in a Summary Cell"
+    args={{
+        class: 'w-48 flex-nowrap p-4',
+        maxVisible: 2,
+        onTagClick: () => {},
+        tags: longTags
+    }}
+/>
+<Story
+    name="Extreme Long Tag in Overflow Popover"
+    args={{
+        class: 'w-48 flex-nowrap p-4',
+        maxVisible: 2,
+        onTagClick: () => {},
+        tags: extremeLongTags
+    }}
+/>
+<Story
+    name="Clickable Long Tags"
+    args={{
+        class: 'w-64 p-4',
+        onTagClick: () => {},
+        tags: longTags
+    }}
+/>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/typography/a.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/typography/a.svelte
@@ -6,7 +6,15 @@
     let { children, class: className, variant = 'default', ...props }: Props = $props();
 </script>
 
-<a class={cn(variants({ variant }), className)} {...props}>
+<a
+    class={cn(
+        variants({
+            variant
+        }),
+        className
+    )}
+    {...props}
+>
     {#if children}
         {@render children()}
     {/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/query-params.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/query-params.svelte.ts
@@ -45,7 +45,14 @@ export function createQueryParameters<T extends QueryParameterSchema>({
     const getCurrentHistoryEntryId = () => (window.history.state as null | SvelteKitHistoryState)?.[svelteKitPageStateKey]?.[queryHistoryEntryIdKey];
 
     const createHistoryState = (entryId: string | undefined, state: App.PageState = page.state) =>
-        ({ ...state, ...(entryId ? { [queryHistoryEntryIdKey]: entryId } : {}) }) as App.PageState;
+        ({
+            ...state,
+            ...(entryId
+                ? {
+                      [queryHistoryEntryIdKey]: entryId
+                  }
+                : {})
+        }) as App.PageState;
 
     const getPendingReplacementStorageKey = (entryId: string) => `${pendingReplacementStoragePrefix}${entryId}`;
     const getStoredPendingReplacement = (entryId: string) => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/query-params.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/query-params.svelte.ts
@@ -249,5 +249,7 @@ export function createQueryParameters<T extends QueryParameterSchema>({
         }
     });
 
-    return createQueryParameterProxy(current, schema, { update });
+    return createQueryParameterProxy(current, schema, {
+        update
+    });
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/query-params.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/query-params.test-harness.svelte
@@ -9,7 +9,9 @@
     const queryParameters = createQueryParameters({
         debounceMilliseconds: 200,
         history: untrack(() => history),
-        schema: { filter: 'string' }
+        schema: {
+            filter: 'string'
+        }
     });
 </script>
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
@@ -101,7 +101,10 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
         visibilityKey,
         configuration.defaultColumnVisibility ?? <ColumnVisibilityState>{}
     );
-    const columnVisibility = () => ({ ...configuration.defaultColumnVisibility, ...persistedColumnVisibility() });
+    const columnVisibility = () => ({
+        ...configuration.defaultColumnVisibility,
+        ...persistedColumnVisibility()
+    });
 
     const orderKey = configuration.columnPersistenceKey ? `${configuration.columnPersistenceKey}-column-order` : 'events-column-order';
     const [persistedColumnOrder, setPersistedColumnOrder] = createPersistedTableState(orderKey, configuration.defaultColumnOrder ?? <ColumnOrderState>[]);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/api.svelte.ts
@@ -57,7 +57,9 @@ export function createProjectStackNotificationRefresher(queryClient: QueryClient
 export async function invalidateStackQueries(queryClient: QueryClient, message: WebSocketMessageValue<'StackChanged'>) {
     const { id } = message;
     if (id) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.id(id) });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.id(id)
+        });
     } else {
         await queryClient.invalidateQueries({
             predicate: (query) => !isProjectStacksQueryKey(query.queryKey),
@@ -81,7 +83,13 @@ export const queryKeys = {
     postMarkSnoozed: (ids: string[] | undefined) => [...queryKeys.ids(ids), 'mark-snoozed'] as const,
     postPromote: (ids: string[] | undefined) => [...queryKeys.ids(ids), 'promote'] as const,
     postRemoveLink: (id: string | undefined) => [...queryKeys.id(id), 'remove-link'] as const,
-    project: (projectId: string | undefined, params?: GetProjectStacksParams) => [...queryKeys.projects(projectId), { params }] as const,
+    project: (projectId: string | undefined, params?: GetProjectStacksParams) =>
+        [
+            ...queryKeys.projects(projectId),
+            {
+                params
+            }
+        ] as const,
     projects: (projectId: string | undefined) => [...queryKeys.type, 'project', projectId] as const,
     type: ['Stack'] as const
 };
@@ -164,10 +172,18 @@ export function deleteMarkCritical(request: PostMarkCriticalRequest) {
         },
         mutationKey: queryKeys.deleteMarkCritical(request.route.ids),
         onError: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         },
         onSuccess: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         }
     }));
 }
@@ -184,10 +200,18 @@ export function deleteStack(request: DeleteStackRequest) {
         },
         mutationKey: queryKeys.deleteStack(request.route.ids),
         onError: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         },
         onSuccess: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         }
     }));
 }
@@ -236,14 +260,20 @@ export function postAddLink(request: PostAddLinkRequest) {
         enabled: () => !!accessToken.current && !!request.route.id,
         mutationFn: async (url: string) => {
             const client = useFetchClient();
-            await client.post(`stacks/${request.route.id}/add-link`, { value: url });
+            await client.post(`stacks/${request.route.id}/add-link`, {
+                value: url
+            });
         },
         mutationKey: queryKeys.postAddLink(request.route.id),
         onError: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id)
+            });
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id)
+            });
         }
     }));
 }
@@ -254,14 +284,26 @@ export function postChangeStatus(request: PostChangeStatusRequest) {
         enabled: () => !!accessToken.current && !!request.route.ids?.length,
         mutationFn: async (status: StackStatus) => {
             const client = useFetchClient();
-            await client.post(`stacks/${request.route.ids?.join(',')}/change-status`, undefined, { params: { status } });
+            await client.post(`stacks/${request.route.ids?.join(',')}/change-status`, undefined, {
+                params: {
+                    status
+                }
+            });
         },
         mutationKey: queryKeys.postChangeStatus(request.route.ids),
         onError: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         },
         onSuccess: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         }
     }));
 }
@@ -276,10 +318,18 @@ export function postMarkCritical(request: PostMarkCriticalRequest) {
         },
         mutationKey: queryKeys.postMarkCritical(request.route.ids),
         onError: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         },
         onSuccess: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         }
     }));
 }
@@ -290,14 +340,26 @@ export function postMarkFixed(request: PostMarkFixedRequest) {
         enabled: () => !!accessToken.current && !!request.route.ids?.length,
         mutationFn: async (version?: string) => {
             const client = useFetchClient();
-            await client.post(`stacks/${request.route.ids?.join(',')}/mark-fixed`, undefined, { params: { version } });
+            await client.post(`stacks/${request.route.ids?.join(',')}/mark-fixed`, undefined, {
+                params: {
+                    version
+                }
+            });
         },
         mutationKey: queryKeys.postMarkFixed(request.route.ids),
         onError: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         },
         onSuccess: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         }
     }));
 }
@@ -308,14 +370,26 @@ export function postMarkSnoozed(request: PostMarkSnoozedRequest) {
         enabled: () => !!accessToken.current && !!request.route.ids?.length,
         mutationFn: async (snoozeUntilUtc: Date) => {
             const client = useFetchClient();
-            await client.post(`stacks/${request.route.ids?.join(',')}/mark-snoozed`, undefined, { params: { snoozeUntilUtc: snoozeUntilUtc.toISOString() } });
+            await client.post(`stacks/${request.route.ids?.join(',')}/mark-snoozed`, undefined, {
+                params: {
+                    snoozeUntilUtc: snoozeUntilUtc.toISOString()
+                }
+            });
         },
         mutationKey: queryKeys.postMarkSnoozed(request.route.ids),
         onError: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         },
         onSuccess: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         }
     }));
 }
@@ -334,10 +408,18 @@ export function postPromote(request: PostPromoteRequest) {
         },
         mutationKey: queryKeys.postPromote(request.route.ids),
         onError: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         },
         onSuccess: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         }
     }));
 }
@@ -348,14 +430,20 @@ export function postRemoveLink(request: PostRemoveLinkRequest) {
         enabled: () => !!accessToken.current && !!request.route.id,
         mutationFn: async (url: string) => {
             const client = useFetchClient();
-            await client.post(`stacks/${request.route.id}/remove-link`, { value: url });
+            await client.post(`stacks/${request.route.id}/remove-link`, {
+                value: url
+            });
         },
         mutationKey: queryKeys.postRemoveLink(request.route.id),
         onError: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id)
+            });
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id)
+            });
         }
     }));
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/add-stack-reference-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/add-stack-reference-dialog.svelte
@@ -32,7 +32,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred' };
+                    return {
+                        form: 'An unexpected error occurred'
+                    };
                 }
             }
         }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/mark-stack-discarded-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/mark-stack-discarded-dialog.svelte
@@ -47,7 +47,13 @@
         All future occurrences will be discarded and will not count against your event limit.
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <button type="button" class={buttonVariants({ variant: 'destructive' })} onclick={onSubmit}>
+            <button
+                type="button"
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={onSubmit}
+            >
                 Discard
                 {#if count === 1}
                     Stack

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/mark-stack-fixed-in-version-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/mark-stack-fixed-in-version-dialog.svelte
@@ -38,7 +38,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred, please try again.' };
+                    return {
+                        form: 'An unexpected error occurred, please try again.'
+                    };
                 }
             }
         }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/remove-stack-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/remove-stack-dialog.svelte
@@ -40,7 +40,12 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={onSubmit}>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={onSubmit}
+            >
                 Delete
                 {#if count === 1}
                     Stack

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/remove-stack-reference-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/remove-stack-reference-dialog.svelte
@@ -26,7 +26,12 @@
         <Code>{reference}</Code>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={onSubmit}>Delete Reference Link</AlertDialog.Action>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={onSubmit}>Delete Reference Link</AlertDialog.Action
+            >
         </AlertDialog.Footer>
     </AlertDialog.Content>
 </AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
@@ -375,6 +375,7 @@
         </Card.Header>
         <Card.Content class="space-y-2">
             <div class="grid grid-cols-2 gap-2 lg:grid-cols-4">
+                <!-- eslint-disable-next-line @stylistic/object-curly-newline -->
                 {#each { length: 4 } as name, index (`${name}-${index}`)}
                     <Card.Root size="sm" class={metricCardClass}>
                         <Card.Header class={metricHeaderClass}>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-detail-sheet.svelte
@@ -37,7 +37,10 @@
     );
 
     function handleEventLoaded(event: PersistentEvent): void {
-        currentEventDetails = { eventId: event.id, stackId: event.stack_id };
+        currentEventDetails = {
+            eventId: event.id,
+            stackId: event.stack_id
+        };
         assistantPageContext.setOverlayEvent(assistantContextOwner, event);
     }
 
@@ -50,7 +53,9 @@
         if (currentStack) {
             assistantPageContext.setOverlayStack(assistantContextOwner, currentStack);
         } else if (stackId) {
-            assistantPageContext.setOverlay(assistantContextOwner, { stackId });
+            assistantPageContext.setOverlay(assistantContextOwner, {
+                stackId
+            });
         }
     }
 
@@ -65,7 +70,9 @@
             currentEventDetails = undefined;
             currentStack = undefined;
             if (stackId) {
-                assistantPageContext.setOverlay(assistantContextOwner, { stackId });
+                assistantPageContext.setOverlay(assistantContextOwner, {
+                    stackId
+                });
             } else {
                 assistantPageContext.clearOverlay(assistantContextOwner);
             }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-detail-sheet.svelte
@@ -30,7 +30,9 @@
         currentEventDetails
             ? buildEventDetailsHref(currentEventDetails.eventId, currentEventDetails.stackId)
             : stackId
-              ? resolve('/(app)/stack/[stackId=objectid]', { stackId })
+              ? resolve('/(app)/stack/[stackId=objectid]', {
+                    stackId
+                })
               : '#'
     );
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-options-dropdown-menu.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-options-dropdown-menu.svelte
@@ -91,7 +91,11 @@
     }
 
     async function navigateToProjectIntegrations() {
-        await goto(resolve('/(app)/project/[projectId]/manage', { projectId: stack.project_id }));
+        await goto(
+            resolve('/(app)/project/[projectId]/manage', {
+                projectId: stack.project_id
+            })
+        );
     }
 
     async function updateCritical() {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-status-badge.stories.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-status-badge.stories.svelte
@@ -7,7 +7,9 @@
     const { Story } = defineMeta({
         argTypes: {
             status: {
-                control: { type: 'select' },
+                control: {
+                    type: 'select'
+                },
                 options: [StackStatus.Open, StackStatus.Fixed, StackStatus.Regressed, StackStatus.Snoozed, StackStatus.Ignored, StackStatus.Discarded]
             }
         },
@@ -17,9 +19,39 @@
     });
 </script>
 
-<Story name="Open" args={{ status: StackStatus.Open }} />
-<Story name="Fixed" args={{ status: StackStatus.Fixed }} />
-<Story name="Regressed" args={{ status: StackStatus.Regressed }} />
-<Story name="Snoozed" args={{ status: StackStatus.Snoozed }} />
-<Story name="Ignored" args={{ status: StackStatus.Ignored }} />
-<Story name="Discarded" args={{ status: StackStatus.Discarded }} />
+<Story
+    name="Open"
+    args={{
+        status: StackStatus.Open
+    }}
+/>
+<Story
+    name="Fixed"
+    args={{
+        status: StackStatus.Fixed
+    }}
+/>
+<Story
+    name="Regressed"
+    args={{
+        status: StackStatus.Regressed
+    }}
+/>
+<Story
+    name="Snoozed"
+    args={{
+        status: StackStatus.Snoozed
+    }}
+/>
+<Story
+    name="Ignored"
+    args={{
+        status: StackStatus.Ignored
+    }}
+/>
+<Story
+    name="Discarded"
+    args={{
+        status: StackStatus.Discarded
+    }}
+/>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/table/options.svelte.ts
@@ -38,7 +38,12 @@ export function getColumns(onTagClick?: (tag: string) => void): ColumnDef<StockF
                     class: 'translate-y-[2px]',
                     disabled: !props.row.getCanSelect(),
                     indeterminate: props.row.getIsSomeSelected(),
-                    onCheckedChange: (checked: 'indeterminate' | boolean) => props.row.getToggleSelectedHandler()({ target: { checked } })
+                    onCheckedChange: (checked: 'indeterminate' | boolean) =>
+                        props.row.getToggleSelectedHandler()({
+                            target: {
+                                checked
+                            }
+                        })
                 }),
             enableHiding: false,
             enableSorting: false,
@@ -46,7 +51,12 @@ export function getColumns(onTagClick?: (tag: string) => void): ColumnDef<StockF
                 renderComponent(Checkbox, {
                     checked: table.getIsAllRowsSelected(),
                     indeterminate: table.getIsSomeRowsSelected(),
-                    onCheckedChange: (checked: 'indeterminate' | boolean) => table.getToggleAllRowsSelectedHandler()({ target: { checked } })
+                    onCheckedChange: (checked: 'indeterminate' | boolean) =>
+                        table.getToggleAllRowsSelectedHandler()({
+                            target: {
+                                checked
+                            }
+                        })
                 }),
             id: 'select',
             meta: {
@@ -61,7 +71,10 @@ export function getColumns(onTagClick?: (tag: string) => void): ColumnDef<StockF
         },
         {
             accessorKey: nameof<Stack>('status'),
-            cell: (prop) => renderComponent(StackStatusCell, { value: prop.getValue<Stack['status']>() }),
+            cell: (prop) =>
+                renderComponent(StackStatusCell, {
+                    value: prop.getValue<Stack['status']>()
+                }),
             header: 'Status',
             id: 'status',
             meta: {
@@ -70,7 +83,10 @@ export function getColumns(onTagClick?: (tag: string) => void): ColumnDef<StockF
         },
         {
             accessorKey: nameof<Stack>('type'),
-            cell: (prop) => renderComponent(StackTypeBadge, { value: prop.getValue<string>() }),
+            cell: (prop) =>
+                renderComponent(StackTypeBadge, {
+                    value: prop.getValue<string>()
+                }),
             header: 'Type',
             id: 'type',
             meta: {
@@ -79,7 +95,10 @@ export function getColumns(onTagClick?: (tag: string) => void): ColumnDef<StockF
         },
         {
             accessorKey: nameof<Stack>('occurrences_are_critical'),
-            cell: (prop) => renderComponent(StackCriticalCell, { isCritical: prop.getValue<boolean>() }),
+            cell: (prop) =>
+                renderComponent(StackCriticalCell, {
+                    isCritical: prop.getValue<boolean>()
+                }),
             header: 'Critical',
             id: 'critical',
             meta: {
@@ -88,7 +107,11 @@ export function getColumns(onTagClick?: (tag: string) => void): ColumnDef<StockF
         },
         {
             accessorKey: nameof<Stack>('tags'),
-            cell: (prop) => renderComponent(StackTagsCell, { onTagClick, tags: prop.getValue<string[]>() }),
+            cell: (prop) =>
+                renderComponent(StackTagsCell, {
+                    onTagClick,
+                    tags: prop.getValue<string[]>()
+                }),
             header: 'Tags',
             id: 'tags',
             meta: {
@@ -97,7 +120,10 @@ export function getColumns(onTagClick?: (tag: string) => void): ColumnDef<StockF
         },
         {
             accessorKey: nameof<Stack>('total_occurrences'),
-            cell: (prop) => renderComponent(NumberFormatter, { value: prop.getValue<number>() }),
+            cell: (prop) =>
+                renderComponent(NumberFormatter, {
+                    value: prop.getValue<number>()
+                }),
             header: 'Events',
             id: 'events',
             meta: {
@@ -106,7 +132,10 @@ export function getColumns(onTagClick?: (tag: string) => void): ColumnDef<StockF
         },
         {
             accessorKey: nameof<Stack>('first_occurrence'),
-            cell: (prop) => renderComponent(TimeAgo, { value: prop.getValue<string>() }),
+            cell: (prop) =>
+                renderComponent(TimeAgo, {
+                    value: prop.getValue<string>()
+                }),
             header: 'First',
             id: 'first',
             meta: {
@@ -115,7 +144,10 @@ export function getColumns(onTagClick?: (tag: string) => void): ColumnDef<StockF
         },
         {
             accessorKey: nameof<Stack>('last_occurrence'),
-            cell: (prop) => renderComponent(TimeAgo, { value: prop.getValue<string>() }),
+            cell: (prop) =>
+                renderComponent(TimeAgo, {
+                    value: prop.getValue<string>()
+                }),
             header: 'Last',
             id: 'last',
             meta: {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/status/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/status/api.svelte.ts
@@ -26,7 +26,9 @@ export function getAboutQuery() {
 export function getHealthQuery() {
     return createQuery<string, ProblemDetails>(() => ({
         queryFn: async ({ signal }: { signal: AbortSignal }) => {
-            const client = useFetchClient({ baseUrl: '' });
+            const client = useFetchClient({
+                baseUrl: ''
+            });
             const response = await client.get('health', {
                 signal
             });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/api.svelte.ts
@@ -9,7 +9,9 @@ import { createMutation, createQuery, QueryClient, useQueryClient } from '@tanst
 export async function invalidateTokenQueries(queryClient: QueryClient, message: WebSocketMessageValue<'TokenChanged'>) {
     const { id, organization_id, project_id } = message;
     if (id) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.id(id) });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.id(id)
+        });
     }
 
     //     if (organization_id) {
@@ -17,11 +19,15 @@ export async function invalidateTokenQueries(queryClient: QueryClient, message: 
     //     }
 
     if (project_id) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.project(project_id) });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.project(project_id)
+        });
     }
 
     if (!id && !organization_id && !project_id) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.type });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.type
+        });
     }
 }
 
@@ -87,10 +93,18 @@ export function deleteToken(request: DeleteTokenRequest) {
         },
         mutationKey: queryKeys.deleteToken(request.route.ids),
         onError: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         },
         onSuccess: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         }
     }));
 }
@@ -139,7 +153,12 @@ export function getProjectTokensQuery(request: GetProjectTokensRequest) {
 
             return response;
         },
-        queryKey: [...queryKeys.project(request.route.projectId), { params: request.params }]
+        queryKey: [
+            ...queryKeys.project(request.route.projectId),
+            {
+                params: request.params
+            }
+        ]
     }));
 }
 
@@ -154,7 +173,9 @@ export function patchToken(request: PatchTokenRequest) {
         },
         mutationKey: queryKeys.id(request.route.id),
         onError: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id)
+            });
         },
         onSuccess: (token: ViewToken) => {
             queryClient.setQueryData(queryKeys.id(request.route.id), token);
@@ -174,7 +195,9 @@ export function postProjectToken(request: PostProjectTokenRequest) {
         },
         mutationKey: queryKeys.postProjectToken(request.route.projectId),
         onSuccess: (token: ViewToken) => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.type });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.type
+            });
             queryClient.setQueryData(queryKeys.id(token.id), token);
         }
     }));

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/dialogs/disable-token-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/dialogs/disable-token-dialog.svelte
@@ -27,7 +27,12 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={onSubmit}>Disable Token</AlertDialog.Action>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={onSubmit}>Disable Token</AlertDialog.Action
+            >
         </AlertDialog.Footer>
     </AlertDialog.Content>
 </AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/dialogs/remove-token-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/dialogs/remove-token-dialog.svelte
@@ -27,7 +27,12 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={onSubmit}>Delete Token</AlertDialog.Action>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={onSubmit}>Delete Token</AlertDialog.Action
+            >
         </AlertDialog.Footer>
     </AlertDialog.Content>
 </AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/dialogs/update-token-notes-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/dialogs/update-token-notes-dialog.svelte
@@ -33,7 +33,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred' };
+                    return {
+                        form: 'An unexpected error occurred'
+                    };
                 }
             }
         }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/table/options.svelte.ts
@@ -14,7 +14,10 @@ export function getColumns<TToken extends ViewToken>(): ColumnDef<StockFeatures,
     const columns: ColumnDef<StockFeatures, TToken, unknown>[] = [
         {
             accessorKey: 'id',
-            cell: (info) => renderComponent(TokenIdCell, { token: info.row.original }),
+            cell: (info) =>
+                renderComponent(TokenIdCell, {
+                    token: info.row.original
+                }),
             enableHiding: false,
             enableSorting: false,
             header: 'Token',
@@ -24,7 +27,10 @@ export function getColumns<TToken extends ViewToken>(): ColumnDef<StockFeatures,
         },
         {
             accessorKey: 'scopes',
-            cell: (info) => renderComponent(TokenScopesCell, { scopes: info.getValue<string[]>() }),
+            cell: (info) =>
+                renderComponent(TokenScopesCell, {
+                    scopes: info.getValue<string[]>()
+                }),
             enableHiding: true,
             enableSorting: false,
             header: 'Scope',
@@ -43,7 +49,10 @@ export function getColumns<TToken extends ViewToken>(): ColumnDef<StockFeatures,
             }
         },
         {
-            cell: (info) => renderComponent(TokenActionsCell, { token: info.row.original }),
+            cell: (info) =>
+                renderComponent(TokenActionsCell, {
+                    token: info.row.original
+                }),
             enableHiding: false,
             enableSorting: false,
             header: '',

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/table/token-actions-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/table/token-actions-cell.svelte
@@ -48,7 +48,10 @@
     });
 
     async function updateDisabled(is_disabled: boolean) {
-        await updateToken.mutateAsync({ is_disabled, notes: token.notes });
+        await updateToken.mutateAsync({
+            is_disabled,
+            notes: token.notes
+        });
         toast.success(`Successfully ${is_disabled ? 'disabled' : 'enabled'} token`);
     }
 
@@ -61,7 +64,10 @@
     }
 
     async function updateNotes(notes?: string) {
-        await updateToken.mutateAsync({ is_disabled: token.is_disabled, notes });
+        await updateToken.mutateAsync({
+            is_disabled: token.is_disabled,
+            notes
+        });
         toast.success('Successfully updated notes');
     }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.svelte.ts
@@ -12,14 +12,20 @@ import type { OAuthGrant, UpdateEmailAddressResult, UpdateUser, UpdateUserEmailA
 export async function invalidateUserQueries(queryClient: QueryClient, message: WebSocketMessageValue<'UserChanged'>) {
     const { id } = message;
     if (id) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.id(id) });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.id(id)
+        });
 
         const currentUser = queryClient.getQueryData<ViewCurrentUser>(queryKeys.me());
         if (currentUser?.id === id) {
-            queryClient.invalidateQueries({ queryKey: queryKeys.me() });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.me()
+            });
         }
     } else {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.type });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.type
+        });
     }
 }
 
@@ -96,7 +102,9 @@ export function deleteOAuthGrantMutation() {
         },
         mutationKey: queryKeys.deleteOAuthGrant(undefined),
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.oauthGrants() });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.oauthGrants()
+            });
         }
     }));
 }
@@ -182,7 +190,12 @@ export function getOrganizationUsersQuery(request: GetOrganizationUsersRequest) 
 
             return response;
         },
-        queryKey: [...queryKeys.organization(request.route.organizationId), { params: request.params }]
+        queryKey: [
+            ...queryKeys.organization(request.route.organizationId),
+            {
+                params: request.params
+            }
+        ]
     }));
 }
 
@@ -197,7 +210,9 @@ export function patchUser(request: PatchUserRequest) {
         },
         mutationKey: queryKeys.patchUser(request.route.id),
         onError: () => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.id(request.route.id) });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.id(request.route.id)
+            });
         },
         onSuccess: (data) => {
             queryClient.setQueryData(queryKeys.id(request.route.id), data);
@@ -221,16 +236,25 @@ export function postEmailAddress(request: PostEmailAddressRequest) {
         },
         mutationKey: queryKeys.postEmailAddress(request.route.id),
         onSuccess: (data, variables) => {
-            const partialUserData: Partial<ViewCurrentUser> = { email_address: variables.email_address, is_email_address_verified: data.is_verified };
+            const partialUserData: Partial<ViewCurrentUser> = {
+                email_address: variables.email_address,
+                is_email_address_verified: data.is_verified
+            };
 
             const user = queryClient.getQueryData<ViewCurrentUser>(queryKeys.id(request.route.id));
             if (user) {
-                queryClient.setQueryData(queryKeys.id(request.route.id), <ViewCurrentUser>{ ...user, ...partialUserData });
+                queryClient.setQueryData(queryKeys.id(request.route.id), <ViewCurrentUser>{
+                    ...user,
+                    ...partialUserData
+                });
             }
 
             const currentUser = queryClient.getQueryData<ViewCurrentUser>(queryKeys.me());
             if (currentUser?.id === request.route.id) {
-                queryClient.setQueryData(queryKeys.me(), <ViewCurrentUser>{ ...currentUser, ...partialUserData });
+                queryClient.setQueryData(queryKeys.me(), <ViewCurrentUser>{
+                    ...currentUser,
+                    ...partialUserData
+                });
             }
         }
     }));

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/dialogs/delete-current-user-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/dialogs/delete-current-user-dialog.svelte
@@ -25,7 +25,12 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={onSubmit}>Delete Account</AlertDialog.Action>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={onSubmit}>Delete Account</AlertDialog.Action
+            >
         </AlertDialog.Footer>
     </AlertDialog.Content>
 </AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/dialogs/remove-user-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/dialogs/remove-user-dialog.svelte
@@ -26,7 +26,12 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={onSubmit}>Remove User</AlertDialog.Action>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={onSubmit}>Remove User</AlertDialog.Action
+            >
         </AlertDialog.Footer>
     </AlertDialog.Content>
 </AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/invite-user-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/invite-user-dialog.svelte
@@ -33,7 +33,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred, please try again.' };
+                    return {
+                        form: 'An unexpected error occurred, please try again.'
+                    };
                 }
             }
         }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/oauth-grants/table/oauth-grant-actions-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/oauth-grants/table/oauth-grant-actions-cell.svelte
@@ -59,7 +59,13 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} disabled={revokeGrant.isPending} onclick={() => void revokeAccess()}>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                disabled={revokeGrant.isPending}
+                onclick={() => void revokeAccess()}
+            >
                 Revoke Access
             </AlertDialog.Action>
         </AlertDialog.Footer>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/oauth-grants/table/oauth-grant-organizations-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/oauth-grants/table/oauth-grant-organizations-cell.svelte
@@ -11,7 +11,12 @@
 
     let { grant, organizationNamesById }: Props = $props();
 
-    const organizations = $derived(grant.organization_ids.map((id) => ({ id, name: formatOrganization(id) })));
+    const organizations = $derived(
+        grant.organization_ids.map((id) => ({
+            id,
+            name: formatOrganization(id)
+        }))
+    );
 
     function formatOrganization(id: string) {
         return organizationNamesById.get(id) ?? id;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/oauth-grants/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/oauth-grants/table/options.svelte.ts
@@ -13,7 +13,10 @@ export function getColumns(organizationNamesById: ReadonlyMap<string, string>): 
     const columns: ColumnDef<StockFeatures, OAuthGrant, unknown>[] = [
         {
             accessorKey: 'application_name',
-            cell: (info) => renderComponent(OAuthGrantApplicationCell, { grant: info.row.original }),
+            cell: (info) =>
+                renderComponent(OAuthGrantApplicationCell, {
+                    grant: info.row.original
+                }),
             enableHiding: false,
             enableSorting: false,
             header: 'Application',
@@ -23,7 +26,10 @@ export function getColumns(organizationNamesById: ReadonlyMap<string, string>): 
         },
         {
             accessorKey: 'resources',
-            cell: (info) => renderComponent(OAuthGrantAccessCell, { grant: info.row.original }),
+            cell: (info) =>
+                renderComponent(OAuthGrantAccessCell, {
+                    grant: info.row.original
+                }),
             enableHiding: false,
             enableSorting: false,
             header: 'Access',
@@ -33,7 +39,11 @@ export function getColumns(organizationNamesById: ReadonlyMap<string, string>): 
         },
         {
             accessorKey: 'organization_ids',
-            cell: (info) => renderComponent(OAuthGrantOrganizationsCell, { grant: info.row.original, organizationNamesById }),
+            cell: (info) =>
+                renderComponent(OAuthGrantOrganizationsCell, {
+                    grant: info.row.original,
+                    organizationNamesById
+                }),
             enableHiding: false,
             enableSorting: false,
             header: 'Organizations',
@@ -42,7 +52,10 @@ export function getColumns(organizationNamesById: ReadonlyMap<string, string>): 
             }
         },
         {
-            cell: (info) => renderComponent(OAuthGrantActionsCell, { grant: info.row.original }),
+            cell: (info) =>
+                renderComponent(OAuthGrantActionsCell, {
+                    grant: info.row.original
+                }),
             enableHiding: false,
             enableSorting: false,
             header: '',

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/table/options.svelte.ts
@@ -33,7 +33,10 @@ export function getColumns<TUser extends ViewUser>(organizationId: string): Colu
         },
         {
             accessorKey: 'is_invite',
-            cell: (info) => renderComponent(BooleanFormatter, { value: info.getValue() as boolean }),
+            cell: (info) =>
+                renderComponent(BooleanFormatter, {
+                    value: info.getValue() as boolean
+                }),
             enableHiding: true,
             enableSorting: false,
             header: 'Invited',
@@ -44,7 +47,11 @@ export function getColumns<TUser extends ViewUser>(organizationId: string): Colu
     ];
 
     columns.push({
-        cell: (info) => renderComponent(UserActionsCell, { organizationId, user: info.row.original }),
+        cell: (info) =>
+            renderComponent(UserActionsCell, {
+                organizationId,
+                user: info.row.original
+            }),
         enableHiding: false,
         enableSorting: false,
         header: '',

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/api.svelte.ts
@@ -9,7 +9,9 @@ import { createMutation, createQuery, QueryClient, useQueryClient } from '@tanst
 export async function invalidateWebhookQueries(queryClient: QueryClient, message: WebSocketMessageValue<'WebhookChanged'>) {
     const { id, organization_id, project_id } = message;
     if (id) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.id(id) });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.id(id)
+        });
     }
 
     //     if (organization_id) {
@@ -17,11 +19,15 @@ export async function invalidateWebhookQueries(queryClient: QueryClient, message
     //     }
 
     if (project_id) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.project(project_id) });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.project(project_id)
+        });
     }
 
     if (!id && !organization_id && !project_id) {
-        await queryClient.invalidateQueries({ queryKey: queryKeys.type });
+        await queryClient.invalidateQueries({
+            queryKey: queryKeys.type
+        });
     }
 }
 
@@ -68,10 +74,18 @@ export function deleteWebhook(request: DeleteWebhookRequest) {
         },
         mutationKey: queryKeys.deleteWebhook(request.route.ids),
         onError: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         },
         onSuccess: () => {
-            request.route.ids?.forEach((id) => queryClient.invalidateQueries({ queryKey: queryKeys.id(id) }));
+            request.route.ids?.forEach((id) =>
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.id(id)
+                })
+            );
         }
     }));
 }
@@ -99,7 +113,12 @@ export function getProjectWebhooksQuery(request: GetProjectWebhooksRequest) {
 
             return response;
         },
-        queryKey: [...queryKeys.project(request.route.projectId), { params: request.params }]
+        queryKey: [
+            ...queryKeys.project(request.route.projectId),
+            {
+                params: request.params
+            }
+        ]
     }));
 }
 
@@ -115,7 +134,9 @@ export function postWebhook() {
         },
         mutationKey: queryKeys.postWebhook(),
         onSuccess: (webhook: Webhook) => {
-            queryClient.invalidateQueries({ queryKey: queryKeys.type });
+            queryClient.invalidateQueries({
+                queryKey: queryKeys.type
+            });
             queryClient.setQueryData(queryKeys.id(webhook.id), webhook);
         }
     }));

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/components/dialogs/add-webhook-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/components/dialogs/add-webhook-dialog.svelte
@@ -41,7 +41,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred, please try again.' };
+                    return {
+                        form: 'An unexpected error occurred, please try again.'
+                    };
                 }
             }
         }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/components/dialogs/remove-webhook-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/components/dialogs/remove-webhook-dialog.svelte
@@ -26,7 +26,12 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={onSubmit}>Delete Webhook</AlertDialog.Action>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={onSubmit}>Delete Webhook</AlertDialog.Action
+            >
         </AlertDialog.Footer>
     </AlertDialog.Content>
 </AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/components/table/options.svelte.ts
@@ -31,7 +31,10 @@ export function getColumns<TWebhook extends Webhook>(): ColumnDef<StockFeatures,
             }
         },
         {
-            cell: (info) => renderComponent(WebhookActionsCell, { webhook: info.row.original }),
+            cell: (info) =>
+                renderComponent(WebhookActionsCell, {
+                    webhook: info.row.original
+                }),
             enableHiding: false,
             enableSorting: false,
             header: '',

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/keyboard-shortcuts-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/keyboard-shortcuts-dialog.svelte
@@ -23,32 +23,65 @@
     const shortcutSections: ShortcutSection[] = [
         {
             rows: [
-                { action: 'Go to Stacks', shortcuts: [appKeyboardShortcuts.stacks.keys] },
-                { action: 'Go to All Events', shortcuts: [appKeyboardShortcuts.allEvents.keys] },
-                { action: 'Show Keyboard Shortcuts', shortcuts: [appKeyboardShortcuts.keyboardShortcuts.keys] }
+                {
+                    action: 'Go to Stacks',
+                    shortcuts: [appKeyboardShortcuts.stacks.keys]
+                },
+                {
+                    action: 'Go to All Events',
+                    shortcuts: [appKeyboardShortcuts.allEvents.keys]
+                },
+                {
+                    action: 'Show Keyboard Shortcuts',
+                    shortcuts: [appKeyboardShortcuts.keyboardShortcuts.keys]
+                }
             ],
             title: 'Navigation'
         },
         {
             rows: [
-                { action: 'Open Organization Switcher', shortcuts: [appKeyboardShortcuts.switchOrganization.keys] },
-                { action: 'Open User Menu', shortcuts: [appKeyboardShortcuts.userMenu.keys] }
+                {
+                    action: 'Open Organization Switcher',
+                    shortcuts: [appKeyboardShortcuts.switchOrganization.keys]
+                },
+                {
+                    action: 'Open User Menu',
+                    shortcuts: [appKeyboardShortcuts.userMenu.keys]
+                }
             ],
             title: 'Menus'
         },
         {
             rows: [
-                { action: 'Open Command Palette', shortcuts: [appKeyboardShortcuts.commandPalette.keys] },
-                { action: 'Open Selected Command', shortcuts: [['Enter']] },
-                { action: 'Close Command Palette', shortcuts: [['Esc']] }
+                {
+                    action: 'Open Command Palette',
+                    shortcuts: [appKeyboardShortcuts.commandPalette.keys]
+                },
+                {
+                    action: 'Open Selected Command',
+                    shortcuts: [['Enter']]
+                },
+                {
+                    action: 'Close Command Palette',
+                    shortcuts: [['Esc']]
+                }
             ],
             title: 'Command Palette'
         },
         {
             rows: [
-                { action: 'Open Selected Row', shortcuts: [['Enter']] },
-                { action: 'Toggle Selected Row', shortcuts: [['Space']] },
-                { action: 'Close Menus and Popovers', shortcuts: [['Esc']] }
+                {
+                    action: 'Open Selected Row',
+                    shortcuts: [['Enter']]
+                },
+                {
+                    action: 'Toggle Selected Row',
+                    shortcuts: [['Space']]
+                },
+                {
+                    action: 'Close Menus and Popovers',
+                    shortcuts: [['Esc']]
+                }
             ],
             title: 'Lists and Tables'
         }

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar-organization-switcher.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar-organization-switcher.svelte
@@ -98,7 +98,12 @@
                 <Sidebar.MenuButton
                     size="lg"
                     class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
-                    onclick={() => void navigateTo(resolve('/(app)/organization/[organizationId]/manage', { organizationId: activeOrganization.id }))}
+                    onclick={() =>
+                        void navigateTo(
+                            resolve('/(app)/organization/[organizationId]/manage', {
+                                organizationId: activeOrganization.id
+                            })
+                        )}
                 >
                     <Avatar.Root class="size-8" shape="square" title="Organization Icon">
                         {#if activeOrganization.icon_url}
@@ -184,7 +189,11 @@
                         {#if activeOrganization?.id}
                             <DropdownMenu.Item
                                 onSelect={() =>
-                                    void navigateTo(resolve('/(app)/organization/[organizationId]/manage', { organizationId: activeOrganization.id }))}
+                                    void navigateTo(
+                                        resolve('/(app)/organization/[organizationId]/manage', {
+                                            organizationId: activeOrganization.id
+                                        })
+                                    )}
                             >
                                 <div class="bg-background flex size-6 items-center justify-center rounded-md border">
                                     <Settings class="size-4" aria-hidden="true" />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar-user.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar-user.svelte
@@ -191,13 +191,23 @@
                         </DropdownMenu.Item>
                         {#if currentOrganizationId}
                             <DropdownMenu.Item
-                                onSelect={() => navigateTo(resolve('/(app)/organization/[organizationId]/manage', { organizationId: currentOrganizationId }))}
+                                onSelect={() =>
+                                    navigateTo(
+                                        resolve('/(app)/organization/[organizationId]/manage', {
+                                            organizationId: currentOrganizationId
+                                        })
+                                    )}
                             >
                                 <Settings />
                                 <span class="w-full">Manage Organization</span>
                             </DropdownMenu.Item>
                             <DropdownMenu.Item
-                                onSelect={() => navigateTo(resolve('/(app)/organization/[organizationId]/billing', { organizationId: currentOrganizationId }))}
+                                onSelect={() =>
+                                    navigateTo(
+                                        resolve('/(app)/organization/[organizationId]/billing', {
+                                            organizationId: currentOrganizationId
+                                        })
+                                    )}
                             >
                                 <CreditCard />
                                 <span class="w-full">Billing</span>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar.svelte
@@ -190,7 +190,9 @@
             }
 
             if (!hasExpandedRouteChanges) {
-                nextExpandedRouteHrefs = { ...nextExpandedRouteHrefs };
+                nextExpandedRouteHrefs = {
+                    ...nextExpandedRouteHrefs
+                };
                 hasExpandedRouteChanges = true;
             }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
@@ -116,7 +116,11 @@
         queryFn: async ({ signal }: { signal: AbortSignal }) => {
             return client.getJSON<EventSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organization.current}/events`, {
                 params: {
-                    ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
+                    ...(DEFAULT_OFFSET
+                        ? {
+                              offset: DEFAULT_OFFSET
+                          }
+                        : {}),
                     filter: debouncedSearchText,
                     limit: COMMAND_SEARCH_REQUEST_LIMIT,
                     mode: 'summary',
@@ -133,7 +137,11 @@
         queryFn: async ({ signal }: { signal: AbortSignal }) => {
             return client.getJSON<StackSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organization.current}/events`, {
                 params: {
-                    ...(DEFAULT_OFFSET ? { offset: DEFAULT_OFFSET } : {}),
+                    ...(DEFAULT_OFFSET
+                        ? {
+                              offset: DEFAULT_OFFSET
+                          }
+                        : {}),
                     filter: debouncedSearchText,
                     limit: COMMAND_SEARCH_REQUEST_LIMIT,
                     mode: 'stack_frequent',
@@ -224,7 +232,9 @@
     }
 
     function getStackHref(result: CommandSearchResult): string {
-        return resolve('/(app)/stack/[stackId=objectid]', { stackId: result.id });
+        return resolve('/(app)/stack/[stackId=objectid]', {
+            stackId: result.id
+        });
     }
 
     const eventSearchHref = $derived(buildSearchHref(resolve('/(app)/event'), debouncedSearchText));
@@ -357,10 +367,17 @@
     async function refreshCurrentView(): Promise<void> {
         closeCommandWindow();
         isRefreshing = true;
-        document.dispatchEvent(new CustomEvent('refresh', { bubbles: true, detail: 'Command Palette' }));
+        document.dispatchEvent(
+            new CustomEvent('refresh', {
+                bubbles: true,
+                detail: 'Command Palette'
+            })
+        );
 
         try {
-            await queryClient.refetchQueries({ type: 'active' });
+            await queryClient.refetchQueries({
+                type: 'active'
+            });
             toast.success('Refreshed the current view.');
         } finally {
             isRefreshing = false;
@@ -410,7 +427,9 @@
         const targetValue = visibleItems[targetIndex]?.getAttribute('data-value');
         if (targetValue) {
             commandValue = targetValue;
-            visibleItems[targetIndex]?.scrollIntoView({ block: 'nearest' });
+            visibleItems[targetIndex]?.scrollIntoView({
+                block: 'nearest'
+            });
         }
     }
 </script>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
@@ -122,7 +122,11 @@
         isKeyboardShortcutsOpen = false;
         isUserMenuOpen = false;
         if (singleOrganization?.id) {
-            await goto(resolve('/(app)/organization/[organizationId]/manage', { organizationId: singleOrganization.id }));
+            await goto(
+                resolve('/(app)/organization/[organizationId]/manage', {
+                    organizationId: singleOrganization.id
+                })
+            );
             return;
         }
 
@@ -261,7 +265,9 @@
                     await invalidateWebhookQueries(queryClient, data.message);
                     break;
                 default:
-                    await queryClient.invalidateQueries({ queryKey: [data.message.type] });
+                    await queryClient.invalidateQueries({
+                        queryKey: [data.message.type]
+                    });
                     break;
             }
         }
@@ -358,7 +364,9 @@
             return;
         }
 
-        document.addEventListener('keydown', handleKeydown, { capture: true });
+        document.addEventListener('keydown', handleKeydown, {
+            capture: true
+        });
 
         const organizationEventRefresher = createOrganizationEventNotificationRefresher(queryClient);
         const projectStackRefresher = createProjectStackNotificationRefresher(queryClient);
@@ -377,7 +385,9 @@
         };
 
         return () => {
-            document.removeEventListener('keydown', handleKeydown, { capture: true });
+            document.removeEventListener('keydown', handleKeydown, {
+                capture: true
+            });
             organizationEventRefresher.cancel();
             projectStackRefresher.cancel();
             ws?.close();
@@ -486,10 +496,16 @@
     }
 
     const filteredRoutes = $derived.by(() => {
-        const context: NavigationItemContext = { authenticated: isAuthenticated, impersonating: isImpersonating, user: meQuery.data };
+        const context: NavigationItemContext = {
+            authenticated: isAuthenticated,
+            impersonating: isImpersonating,
+            user: meQuery.data
+        };
         const allRoutes = routes().filter((route) => (route.show ? route.show(context) : true));
         const organizationSettingsHref = singleOrganization?.id
-            ? resolve('/(app)/organization/[organizationId]/manage', { organizationId: singleOrganization.id })
+            ? resolve('/(app)/organization/[organizationId]/manage', {
+                  organizationId: singleOrganization.id
+              })
             : undefined;
 
         const savedViews = (savedViewsQuery.data ?? []).filter((savedView) => !isSavedViewDeleted(savedView));
@@ -562,7 +578,15 @@
 {#snippet setupShell()}
     <div class="flex h-screen w-full items-center justify-center px-4">
         <main class="w-full">
-            <div in:fade={{ delay: 150, duration: 150 }} out:fade={{ duration: 150 }}>
+            <div
+                in:fade={{
+                    delay: 150,
+                    duration: 150
+                }}
+                out:fade={{
+                    duration: 150
+                }}
+            >
                 {@render children()}
             </div>
         </main>
@@ -636,7 +660,15 @@
                     <OrganizationNotifications {isChatEnabled} {openChat} {requiresPremium} premiumFeatureName={premiumPage.current} class="mb-4" />
                 {/if}
 
-                <div in:fade={{ delay: 150, duration: 150 }} out:fade={{ duration: 150 }}>
+                <div
+                    in:fade={{
+                        delay: 150,
+                        duration: 150
+                    }}
+                    out:fade={{
+                        duration: 150
+                    }}
+                >
                     {@render children()}
                 </div>
             </main>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
@@ -103,7 +103,10 @@
     async function askAssistant(prompt: string): Promise<void> {
         AssistantPanel ??= (await import('$features/assistant/components/assistant-panel.svelte')).default;
         isAssistantOpen = true;
-        assistantPromptRequest = { id: crypto.randomUUID(), prompt };
+        assistantPromptRequest = {
+            id: crypto.randomUUID(),
+            prompt
+        };
     }
 
     function getAssistantPath(context: AssistantResourceContext | undefined, fallback: string): string {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+page.svelte
@@ -3,6 +3,8 @@
     import { resolve } from '$app/paths';
 
     $effect(() => {
-        goto(resolve('/(app)/stack'), { replaceState: true });
+        goto(resolve('/(app)/stack'), {
+            replaceState: true
+        });
     });
 </script>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/account/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/account/+layout.svelte
@@ -14,7 +14,10 @@
     const meQuery = getMeQuery();
     let isAuthenticated = $derived(accessToken.current !== null);
     const filteredRoutes = $derived.by(() => {
-        const context: NavigationItemContext = { authenticated: isAuthenticated, user: meQuery.data };
+        const context: NavigationItemContext = {
+            authenticated: isAuthenticated,
+            user: meQuery.data
+        };
         return routes().filter((route) => (route.show ? route.show(context) : true));
     });
     const currentPath = $derived(page.url.pathname);

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/account/manage/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/account/manage/+page.svelte
@@ -99,7 +99,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred, please try again.' };
+                    return {
+                        form: 'An unexpected error occurred, please try again.'
+                    };
                 }
             }
         }
@@ -123,7 +125,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred, please try again.' };
+                    return {
+                        form: 'An unexpected error occurred, please try again.'
+                    };
                 }
             }
         }
@@ -187,7 +191,9 @@
             await deleteAccountMutation.mutateAsync();
             toastId = toast.success('Successfully queued your account for deletion.');
             await logout(queryClient, client);
-            await goto(resolve('/(auth)/login'), { replaceState: true });
+            await goto(resolve('/(auth)/login'), {
+                replaceState: true
+            });
         } catch (error: unknown) {
             const message = error instanceof ProblemDetails ? error.title : 'Please try again.';
             toastId = toast.error(`An error occurred while trying to delete your account: ${message}`);
@@ -308,7 +314,10 @@
             </updateEmailAddressForm.Subscribe>
             <updateEmailAddressForm.Field
                 name="email_address"
-                validators={{ onChangeAsync: ({ value }) => validateEmailAvailability(value ?? ''), onChangeAsyncDebounceMs: 1000 }}
+                validators={{
+                    onChangeAsync: ({ value }) => validateEmailAvailability(value ?? ''),
+                    onChangeAsyncDebounceMs: 1000
+                }}
             >
                 {#snippet children(field)}
                     <Field.Field data-invalid={ariaInvalid(field)}>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/account/notifications/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/account/notifications/+page.svelte
@@ -22,9 +22,13 @@
 
     const meQuery = getMeQuery();
     const queryParams = createQueryParameters({
-        defaults: { project: '' },
+        defaults: {
+            project: ''
+        },
         history: 'push',
-        schema: { project: 'string' }
+        schema: {
+            project: 'string'
+        }
     });
 
     const updateUser = patchUser({
@@ -76,7 +80,9 @@
         toast.dismiss(toastId);
 
         try {
-            await updateUser.mutateAsync({ email_notifications_enabled: checked });
+            await updateUser.mutateAsync({
+                email_notifications_enabled: checked
+            });
             toastId = toast.success('Email notification preference saved.');
         } catch {
             toastId = toast.error('An error occurred while saving your email notification preferences.');

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/account/verify/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/account/verify/+page.svelte
@@ -12,7 +12,9 @@
         if (token) {
             try {
                 await client.post('/users/verify-email-address', undefined, {
-                    params: { token }
+                    params: {
+                        token
+                    }
                 });
                 toast.success('Your account has been successfully verified.');
             } catch {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -302,7 +302,9 @@
             queryParams.update(DEFAULT_PARAMS);
             reset();
         },
-        { lazy: true }
+        {
+            lazy: true
+        }
     );
 
     function getCurrentFilters(params: ListFilterQueryParams = queryParams): FacetedFilter.IFilter[] {
@@ -421,7 +423,9 @@
             isInternalFilterUpdate = false;
             filters = getCurrentFilters(currentQueryParams);
         },
-        { lazy: true }
+        {
+            lazy: true
+        }
     );
 
     function handleResetToSaved(): void {
@@ -524,7 +528,9 @@
         }
 
         untrack(() => {
-            updateFilters(getCurrentFilters(getListFilterQueryParams(queryParams)), { clearPagination: false });
+            updateFilters(getCurrentFilters(getListFilterQueryParams(queryParams)), {
+                clearPagination: false
+            });
         });
         normalizedSavedViewId = activeSavedViewId;
     });
@@ -738,7 +744,9 @@
         }
 
         const organizationId = organization.current;
-        const requestParameters = { ...eventsQueryParameters };
+        const requestParameters = {
+            ...eventsQueryParameters
+        };
         const requestIdentity = JSON.stringify([organizationId, requestParameters]);
         if (!requestParameters.after && !requestParameters.before) {
             return;
@@ -756,7 +764,15 @@
         const totalResponse = await client.getJSON<EventSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organizationId}/events`, {
             params: totalParams
         });
-        if (requestIdentity !== JSON.stringify([organization.current, { ...eventsQueryParameters }])) {
+        if (
+            requestIdentity !==
+            JSON.stringify([
+                organization.current,
+                {
+                    ...eventsQueryParameters
+                }
+            ])
+        ) {
             return;
         }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
@@ -22,7 +22,9 @@
         () => {
             goto(resolve('/(app)/event'));
         },
-        { lazy: true }
+        {
+            lazy: true
+        }
     );
 
     async function filterChanged(addedOrUpdated: FacetedFilter.IFilter) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
@@ -42,7 +42,9 @@
 
     async function handleEventLoaded(event: PersistentEvent) {
         assistantPageContext.setPageEvent(event);
-        await goto(buildEventDetailsHref(event.id, event.stack_id), { replaceState: true });
+        await goto(buildEventDetailsHref(event.id, event.stack_id), {
+            replaceState: true
+        });
     }
 
     $effect(() => {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/by-ref/[referenceId]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/by-ref/[referenceId]/+page.svelte
@@ -24,7 +24,9 @@
         const event = eventsQuery.data?.length === 1 ? eventsQuery.data[0] : undefined;
         if (event?.id && event.id !== redirectedEventId) {
             redirectedEventId = event.id;
-            void goto(buildEventDetailsHref(event.id), { replaceState: true });
+            void goto(buildEventDetailsHref(event.id), {
+                replaceState: true
+            });
         }
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/routes.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/routes.svelte.ts
@@ -12,7 +12,9 @@ export function routes(): NavigationItem[] {
     return [
         {
             group: 'Event',
-            href: resolve('/(app)/event/[eventId=objectid]', { eventId: page.params.eventId }),
+            href: resolve('/(app)/event/[eventId=objectid]', {
+                eventId: page.params.eventId
+            }),
             icon: Events,
             show: () => false,
             title: 'Event Details'

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/+layout.svelte
@@ -29,7 +29,10 @@
     });
 
     const filteredRoutes = $derived.by(() => {
-        const context: NavigationItemContext = { authenticated: isAuthenticated, user: meQuery.data };
+        const context: NavigationItemContext = {
+            authenticated: isAuthenticated,
+            user: meQuery.data
+        };
         return routes().filter((route) => route.group === 'Organization Settings' && (route.show ? route.show(context) : true));
     });
     const currentPath = $derived(page.url.pathname);

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/billing/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/billing/+page.svelte
@@ -38,9 +38,13 @@
     const canChangePlan = $derived(organizationQuery.isSuccess && !!env.PUBLIC_STRIPE_PUBLISHABLE_KEY);
 
     const params = createQueryParameters({
-        defaults: { changePlan: false },
+        defaults: {
+            changePlan: false
+        },
         history: 'push',
-        schema: { changePlan: 'boolean' }
+        schema: {
+            changePlan: 'boolean'
+        }
     });
 
     let changePlanDialogOpen = $state(!!params.changePlan);
@@ -56,7 +60,12 @@
     }
 
     function handleOpenInvoice(invoiceId: string) {
-        window.open(resolve('/(app)/payment/[id]', { id: invoiceId }), '_blank');
+        window.open(
+            resolve('/(app)/payment/[id]', {
+                id: invoiceId
+            }),
+            '_blank'
+        );
     }
 
     function handleViewStripeInvoice(invoiceId: string) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/features/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/features/+page.svelte
@@ -128,6 +128,7 @@
             </div>
 
             {#if organizationQuery.isLoading}
+                <!-- eslint-disable-next-line @stylistic/object-curly-newline -->
                 {#each Array.from({ length: KNOWN_FEATURES.length }, (_, index) => index) as i (`skeleton-${i}`)}
                     <div class="rounded-lg border p-4">
                         <div class="flex items-center justify-between">

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/manage/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/manage/+page.svelte
@@ -104,7 +104,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred.' };
+                    return {
+                        form: 'An unexpected error occurred.'
+                    };
                 }
             }
         }
@@ -248,13 +250,22 @@
             <Button variant="secondary" href={resolve('/(app)/event')}>
                 <Events class="mr-2 size-4" /> View Events
             </Button>
-            <Button variant="secondary" href={resolve('/(app)/organization/[organizationId]/projects', { organizationId })}>
+            <Button
+                variant="secondary"
+                href={resolve('/(app)/organization/[organizationId]/projects', {
+                    organizationId
+                })}
+            >
                 <Projects class="mr-2 size-4" /> View Projects
             </Button>
         </div>
 
         <DropdownMenu.Root>
-            <DropdownMenu.Trigger class={buttonVariants({ variant: 'destructive' })}>
+            <DropdownMenu.Trigger
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+            >
                 <X class="mr-2 size-4" />
                 <span>Delete</span>
             </DropdownMenu.Trigger>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/projects/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/projects/+page.svelte
@@ -3,6 +3,8 @@
     import { resolve } from '$app/paths';
 
     $effect(() => {
-        goto(resolve('/(app)/project/list'), { replaceState: true });
+        goto(resolve('/(app)/project/list'), {
+            replaceState: true
+        });
     });
 </script>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/routes.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/routes.svelte.ts
@@ -19,33 +19,43 @@ export function routes(): NavigationItem[] {
     return [
         {
             group: 'Organization Settings',
-            href: resolve('/(app)/organization/[organizationId]/manage', { organizationId }),
+            href: resolve('/(app)/organization/[organizationId]/manage', {
+                organizationId
+            }),
             icon: Settings,
             title: 'General'
         },
         {
             group: 'Organization Settings',
-            href: resolve('/(app)/organization/[organizationId]/users', { organizationId }),
+            href: resolve('/(app)/organization/[organizationId]/users', {
+                organizationId
+            }),
             icon: Users,
             keywords: ['members', 'team', 'invite'],
             title: 'Users'
         },
         {
             group: 'Organization Settings',
-            href: resolve('/(app)/organization/[organizationId]/billing', { organizationId }),
+            href: resolve('/(app)/organization/[organizationId]/billing', {
+                organizationId
+            }),
             icon: Billing,
             title: 'Billing'
         },
         {
             group: 'Organization Settings',
-            href: resolve('/(app)/organization/[organizationId]/features', { organizationId }),
+            href: resolve('/(app)/organization/[organizationId]/features', {
+                organizationId
+            }),
             icon: Zap,
             show: (ctx) => !!ctx.user?.roles?.includes('global'),
             title: 'Features'
         },
         {
             group: 'Organization Settings',
-            href: resolve('/(app)/organization/[organizationId]/usage', { organizationId }),
+            href: resolve('/(app)/organization/[organizationId]/usage', {
+                organizationId
+            }),
             icon: Usage,
             title: 'Usage'
         }

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/usage/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/usage/+page.svelte
@@ -33,12 +33,30 @@
     let changePlanDialogOpen = $state(false);
 
     const chartConfig = {
-        blocked: { color: 'var(--chart-2)', label: 'Blocked' },
-        deleted: { color: 'var(--chart-7)', label: 'Deleted' },
-        discarded: { color: 'var(--chart-3)', label: 'Discarded' },
-        limit: { color: 'var(--chart-6)', label: 'Limit' },
-        too_big: { color: 'var(--chart-4)', label: 'Too Big' },
-        total: { color: 'var(--chart-1)', label: 'Total' }
+        blocked: {
+            color: 'var(--chart-2)',
+            label: 'Blocked'
+        },
+        deleted: {
+            color: 'var(--chart-7)',
+            label: 'Deleted'
+        },
+        discarded: {
+            color: 'var(--chart-3)',
+            label: 'Discarded'
+        },
+        limit: {
+            color: 'var(--chart-6)',
+            label: 'Limit'
+        },
+        too_big: {
+            color: 'var(--chart-4)',
+            label: 'Too Big'
+        },
+        total: {
+            color: 'var(--chart-1)',
+            label: 'Total'
+        }
     } satisfies Chart.ChartConfig;
 
     const chartData = $derived.by(() => {
@@ -57,17 +75,34 @@
     });
 
     const series = [
-        { key: 'total', ...chartConfig.total },
-        { key: 'discarded', ...chartConfig.discarded },
-        { key: 'blocked', ...chartConfig.blocked },
-        { key: 'too_big', ...chartConfig.too_big },
-        { key: 'deleted', ...chartConfig.deleted },
+        {
+            key: 'total',
+            ...chartConfig.total
+        },
+        {
+            key: 'discarded',
+            ...chartConfig.discarded
+        },
+        {
+            key: 'blocked',
+            ...chartConfig.blocked
+        },
+        {
+            key: 'too_big',
+            ...chartConfig.too_big
+        },
+        {
+            key: 'deleted',
+            ...chartConfig.deleted
+        },
         {
             key: 'limit',
             ...chartConfig.limit,
             props: {
                 class: 'fill-none',
-                line: { class: '[stroke-dasharray:4]' }
+                line: {
+                    class: '[stroke-dasharray:4]'
+                }
             }
         }
     ];
@@ -126,7 +161,9 @@
                         area: {
                             curve: curveNatural
                         },
-                        yAxis: { format: 'metric' }
+                        yAxis: {
+                            format: 'metric'
+                        }
                     }}
                 >
                     {#snippet tooltip()}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/add/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/add/+page.svelte
@@ -46,7 +46,9 @@
             onSubmitAsync: async ({ value }) => {
                 toast.dismiss(toastId);
                 try {
-                    const createdOrganization = await createOrganization.mutateAsync({ name: value.organization_name });
+                    const createdOrganization = await createOrganization.mutateAsync({
+                        name: value.organization_name
+                    });
                     organization.current = createdOrganization.id;
 
                     const createdProject = await createProject.mutateAsync({
@@ -56,7 +58,11 @@
                     } as NewProject);
 
                     toastId = toast.success('Project added successfully');
-                    await goto(resolve('/(app)/project/[projectId]/configure', { projectId: createdProject.id }) + '?redirect=true');
+                    await goto(
+                        resolve('/(app)/project/[projectId]/configure', {
+                            projectId: createdProject.id
+                        }) + '?redirect=true'
+                    );
                     return null;
                 } catch (error: unknown) {
                     if (showBillingDialogOnUpgradeProblem(error, organization.current, () => form.handleSubmit())) {
@@ -69,7 +75,9 @@
                     }
 
                     toastId = toast.error(CREATE_ERROR_MESSAGE);
-                    return { form: 'An unexpected error occurred, please try again.' };
+                    return {
+                        form: 'An unexpected error occurred, please try again.'
+                    };
                 }
             }
         }

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/list/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/list/+page.svelte
@@ -52,12 +52,18 @@
     async function rowClick(org: ViewOrganization) {
         if (org.id) {
             organization.current = org.id;
-            await goto(resolve('/(app)/organization/[organizationId]/manage', { organizationId: org.id }));
+            await goto(
+                resolve('/(app)/organization/[organizationId]/manage', {
+                    organizationId: org.id
+                })
+            );
         }
     }
 
     function rowHref(org: ViewOrganization): string {
-        return resolve('/(app)/organization/[organizationId]/manage', { organizationId: org.id });
+        return resolve('/(app)/organization/[organizationId]/manage', {
+            organizationId: org.id
+        });
     }
 
     async function addOrganization() {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/+layout.svelte
@@ -31,9 +31,21 @@
         }
     });
     const currentPath = $derived(page.url.pathname);
-    const configurePath = $derived(resolve('/(app)/project/[projectId]/configure', { projectId }));
-    const settingsPath = $derived(resolve('/(app)/project/[projectId]/settings', { projectId }));
-    const sourceMapsPath = $derived(resolve('/(app)/project/[projectId]/source-maps', { projectId }));
+    const configurePath = $derived(
+        resolve('/(app)/project/[projectId]/configure', {
+            projectId
+        })
+    );
+    const settingsPath = $derived(
+        resolve('/(app)/project/[projectId]/settings', {
+            projectId
+        })
+    );
+    const sourceMapsPath = $derived(
+        resolve('/(app)/project/[projectId]/source-maps', {
+            projectId
+        })
+    );
     const isConfigurePage = $derived(currentPath === configurePath || currentPath.startsWith(configurePath + '/'));
     const navigationRoutes = $derived(routes().filter((route) => route.href !== sourceMapsPath));
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/api-keys/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/api-keys/+page.svelte
@@ -93,7 +93,11 @@
         <Muted>Create and manage client API keys and project-scoped deployment tokens.</Muted>
         <Muted>
             To install an SDK and start sending events, open
-            <A href={resolve('/(app)/project/[projectId]/configure', { projectId })}>Client setup</A>.
+            <A
+                href={resolve('/(app)/project/[projectId]/configure', {
+                    projectId
+                })}>Client setup</A
+            >.
         </Muted>
     </div>
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/configure/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/configure/+page.svelte
@@ -61,7 +61,9 @@
         toast.dismiss(toastId);
 
         try {
-            await enableTokenMutation.mutateAsync({ is_disabled: false });
+            await enableTokenMutation.mutateAsync({
+                is_disabled: false
+            });
             toastId = toast.success(`Successfully enabled API key`);
         } catch (error) {
             toastId = toast.error('Failed to enable API key. Please try again.');
@@ -95,25 +97,110 @@
     }
 
     const projectTypes: ProjectType[] = [
-        { id: 'bash', label: 'Bash Shell', platform: 'Command Line' },
-        { id: 'powershell', label: 'PowerShell', platform: 'Command Line' },
+        {
+            id: 'bash',
+            label: 'Bash Shell',
+            platform: 'Command Line'
+        },
+        {
+            id: 'powershell',
+            label: 'PowerShell',
+            platform: 'Command Line'
+        },
 
-        { id: 'dotnet-console', label: 'Console and Service applications', package: 'Exceptionless', platform: '.NET' },
-        { id: 'dotnet-aspnetcore', label: 'ASP.NET Core', package: 'Exceptionless.AspNetCore', platform: '.NET' },
-        { config: 'app.config', id: 'dotnet-wpf', label: 'Windows Presentation Foundation (WPF)', package: 'Exceptionless.Wpf', platform: '.NET' },
-        { config: 'app.config', id: 'dotnet-winforms', label: 'Windows Forms', package: 'Exceptionless.Windows', platform: '.NET' },
+        {
+            id: 'dotnet-console',
+            label: 'Console and Service applications',
+            package: 'Exceptionless',
+            platform: '.NET'
+        },
+        {
+            id: 'dotnet-aspnetcore',
+            label: 'ASP.NET Core',
+            package: 'Exceptionless.AspNetCore',
+            platform: '.NET'
+        },
+        {
+            config: 'app.config',
+            id: 'dotnet-wpf',
+            label: 'Windows Presentation Foundation (WPF)',
+            package: 'Exceptionless.Wpf',
+            platform: '.NET'
+        },
+        {
+            config: 'app.config',
+            id: 'dotnet-winforms',
+            label: 'Windows Forms',
+            package: 'Exceptionless.Windows',
+            platform: '.NET'
+        },
 
-        { id: 'javascript-browser', label: 'Browser applications', package: 'Exceptionless.JavaScript', platform: 'JavaScript' },
-        { id: 'javascript-nodejs', label: 'Node.js', package: 'Exceptionless.Node', platform: 'JavaScript' },
-        { id: 'javascript-react-native', label: 'React Native', package: '@exceptionless/react-native', platform: 'JavaScript' },
-        { id: 'javascript-expo', label: 'Expo', package: '@exceptionless/react-native', platform: 'JavaScript' },
+        {
+            id: 'javascript-browser',
+            label: 'Browser applications',
+            package: 'Exceptionless.JavaScript',
+            platform: 'JavaScript'
+        },
+        {
+            id: 'javascript-nodejs',
+            label: 'Node.js',
+            package: 'Exceptionless.Node',
+            platform: 'JavaScript'
+        },
+        {
+            id: 'javascript-react-native',
+            label: 'React Native',
+            package: '@exceptionless/react-native',
+            platform: 'JavaScript'
+        },
+        {
+            id: 'javascript-expo',
+            label: 'Expo',
+            package: '@exceptionless/react-native',
+            platform: 'JavaScript'
+        },
 
-        { id: 'dotnet-legacy-console', label: 'Console and Service applications', package: 'Exceptionless', platform: '.NET Legacy' },
-        { config: 'web.config', id: 'dotnet-legacy-mvc', label: 'ASP.NET MVC', package: 'Exceptionless.Mvc', platform: '.NET Legacy' },
-        { config: 'web.config', id: 'dotnet-legacy-webapi', label: 'ASP.NET Web API', package: 'Exceptionless.WebApi', platform: '.NET Legacy' },
-        { config: 'web.config', id: 'dotnet-legacy-webforms', label: 'ASP.NET Web Forms', package: 'Exceptionless.Web', platform: '.NET Legacy' },
-        { config: 'app.config', id: 'dotnet-legacy-winforms', label: 'Windows Forms', package: 'Exceptionless.Windows', platform: '.NET Legacy' },
-        { config: 'app.config', id: 'dotnet-legacy-wpf', label: 'Windows Presentation Foundation (WPF)', package: 'Exceptionless.Wpf', platform: '.NET Legacy' }
+        {
+            id: 'dotnet-legacy-console',
+            label: 'Console and Service applications',
+            package: 'Exceptionless',
+            platform: '.NET Legacy'
+        },
+        {
+            config: 'web.config',
+            id: 'dotnet-legacy-mvc',
+            label: 'ASP.NET MVC',
+            package: 'Exceptionless.Mvc',
+            platform: '.NET Legacy'
+        },
+        {
+            config: 'web.config',
+            id: 'dotnet-legacy-webapi',
+            label: 'ASP.NET Web API',
+            package: 'Exceptionless.WebApi',
+            platform: '.NET Legacy'
+        },
+        {
+            config: 'web.config',
+            id: 'dotnet-legacy-webforms',
+            label: 'ASP.NET Web Forms',
+            package: 'Exceptionless.Web',
+            platform: '.NET Legacy'
+        },
+        {
+            config: 'app.config',
+            id: 'dotnet-legacy-winforms',
+            label: 'Windows Forms',
+            package: 'Exceptionless.Windows',
+            platform: '.NET Legacy'
+        },
+        {
+            config: 'app.config',
+            id: 'dotnet-legacy-wpf',
+            label: 'Windows Presentation Foundation (WPF)',
+            package: 'Exceptionless.Wpf',
+            platform: '.NET Legacy'
+        }
     ];
 
     const projectTypesGroupedByPlatform = Object.groupBy(projectTypes, (p) => p.platform);
@@ -708,8 +795,11 @@ public partial class App : Application {
                 <NotificationDescription>
                     <P>
                         Exceptionless automatically discovers public source maps. If your source maps are private or are not published with your generated
-                        JavaScript, <A href={resolve('/(app)/project/[projectId]/source-maps', { projectId })}>upload and manage them</A> to restore the original
-                        function names and source locations.
+                        JavaScript, <A
+                            href={resolve('/(app)/project/[projectId]/source-maps', {
+                                projectId
+                            })}>upload and manage them</A
+                        > to restore the original function names and source locations.
                     </P>
                 </NotificationDescription>
             </Notification>
@@ -741,7 +831,12 @@ public partial class App : Application {
     {/if}
 
     <div class="border-border flex flex-col-reverse gap-2 border-t pt-4 sm:flex-row sm:justify-end">
-        <Button variant="secondary" href={resolve('/(app)/project/[projectId]/manage', { projectId })}>
+        <Button
+            variant="secondary"
+            href={resolve('/(app)/project/[projectId]/manage', {
+                projectId
+            })}
+        >
             <ArrowLeft class="mr-2 size-4" aria-hidden="true" /> Back to Project Settings
         </Button>
         <Button variant="secondary" href={`${resolve('/(app)/account/notifications')}?project=${projectId}`}>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/manage/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/manage/+page.svelte
@@ -118,7 +118,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred.' };
+                    return {
+                        form: 'An unexpected error occurred.'
+                    };
                 }
             }
         }
@@ -172,7 +174,12 @@
             <Button variant="secondary" href={`${resolve('/(app)/stack')}?filter=project:${projectId}`}>
                 <Stacks class="mr-2 size-4" /> Go To Stacks
             </Button>
-            <Button variant="secondary" href={resolve('/(app)/project/[projectId]/configure', { projectId })}>
+            <Button
+                variant="secondary"
+                href={resolve('/(app)/project/[projectId]/configure', {
+                    projectId
+                })}
+            >
                 <CloudDownload class="mr-2 size-4" /> Client Setup
             </Button>
             <Button variant="secondary" href={`${resolve('/(app)/account/notifications')}?project=${projectId}`}>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/routes.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/routes.svelte.ts
@@ -18,49 +18,65 @@ export function routes(): NavigationItem[] {
     return [
         {
             group: 'Project Settings',
-            href: resolve('/(app)/project/[projectId]/manage', { projectId: page.params.projectId }),
+            href: resolve('/(app)/project/[projectId]/manage', {
+                projectId: page.params.projectId
+            }),
             icon: Settings,
             title: 'General'
         },
         {
             group: 'Project Settings',
-            href: resolve('/(app)/project/[projectId]/api-keys', { projectId: page.params.projectId }),
+            href: resolve('/(app)/project/[projectId]/api-keys', {
+                projectId: page.params.projectId
+            }),
             icon: ApiKey,
             title: 'API Keys'
         },
         {
             group: 'Project Settings',
-            href: resolve('/(app)/project/[projectId]/settings', { projectId: page.params.projectId }),
+            href: resolve('/(app)/project/[projectId]/settings', {
+                projectId: page.params.projectId
+            }),
             icon: Settings,
             title: 'Settings'
         },
         {
             group: 'Project Settings',
-            href: resolve('/(app)/project/[projectId]/configuration-values', { projectId: page.params.projectId }),
+            href: resolve('/(app)/project/[projectId]/configuration-values', {
+                projectId: page.params.projectId
+            }),
             icon: ClientConfig,
             title: 'Configuration'
         },
         {
             group: 'Project Settings',
-            href: resolve('/(app)/project/[projectId]/source-maps', { projectId: page.params.projectId }),
+            href: resolve('/(app)/project/[projectId]/source-maps', {
+                projectId: page.params.projectId
+            }),
             icon: SourceMaps,
             title: 'Source Maps'
         },
         {
             group: 'Project Settings',
-            href: resolve('/(app)/project/[projectId]/integrations', { projectId: page.params.projectId }),
+            href: resolve('/(app)/project/[projectId]/integrations', {
+                projectId: page.params.projectId
+            }),
             icon: Integration,
             title: 'Integrations'
         },
         {
             group: 'Project Settings',
-            href: resolve('/(app)/project/[projectId]/stacks', { projectId: page.params.projectId }),
+            href: resolve('/(app)/project/[projectId]/stacks', {
+                projectId: page.params.projectId
+            }),
             icon: Stacks,
             title: 'Stack Management'
         },
         {
             group: 'Project Settings',
-            href: resolve('/(app)/project/[projectId]/usage', { projectId: page.params.projectId }),
+            href: resolve('/(app)/project/[projectId]/usage', {
+                projectId: page.params.projectId
+            }),
             icon: Usage,
             title: 'Usage'
         }

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/settings/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/settings/+page.svelte
@@ -75,9 +75,14 @@
 
         try {
             if (value) {
-                await updateProjectConfig.mutateAsync({ key, value });
+                await updateProjectConfig.mutateAsync({
+                    key,
+                    value
+                });
             } else {
-                await removeProjectConfig.mutateAsync({ key });
+                await removeProjectConfig.mutateAsync({
+                    key
+                });
             }
 
             toastId = toast.success(`Successfully updated ${displayName} setting.`);
@@ -223,7 +228,12 @@
                     Exceptionless automatically discovers public source maps. Upload and manage maps when they are private or are not published with your
                     generated JavaScript.
                 </Muted>
-                <Button href={resolve('/(app)/project/[projectId]/source-maps', { projectId })} variant="outline">Manage source maps</Button>
+                <Button
+                    href={resolve('/(app)/project/[projectId]/source-maps', {
+                        projectId
+                    })}
+                    variant="outline">Manage source maps</Button
+                >
             </div>
         </div>
     </section>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/source-maps/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/source-maps/+page.svelte
@@ -49,7 +49,10 @@
             onSubmit: SourceMapUploadSchema,
             onSubmitAsync: async ({ value }) => {
                 try {
-                    await uploadSourceMap.mutateAsync({ file: value.file!, generated_file_url: value.generated_file_url });
+                    await uploadSourceMap.mutateAsync({
+                        file: value.file!,
+                        generated_file_url: value.generated_file_url
+                    });
                     toast.success('Source map uploaded. New events will be symbolicated before stacking.');
                     form.reset();
                     if (fileInput) {
@@ -63,7 +66,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred.' };
+                    return {
+                        form: 'An unexpected error occurred.'
+                    };
                 }
             }
         }
@@ -108,7 +113,11 @@
         <H4>Upload Source Map</H4>
         <Muted>
             Automating uploads from CI/CD? Create a project-scoped
-            <A href={resolve('/(app)/project/[projectId]/api-keys', { projectId })}>source map upload token</A> and use it with the source map API.
+            <A
+                href={resolve('/(app)/project/[projectId]/api-keys', {
+                    projectId
+                })}>source map upload token</A
+            > and use it with the source map API.
         </Muted>
         <form
             class="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(16rem,0.5fr)_auto] lg:items-end"
@@ -240,7 +249,12 @@
     </section>
 
     <div class="border-border flex border-t pt-4 sm:justify-end">
-        <Button variant="secondary" href={resolve('/(app)/project/[projectId]/settings', { projectId })}>
+        <Button
+            variant="secondary"
+            href={resolve('/(app)/project/[projectId]/settings', {
+                projectId
+            })}
+        >
             <ArrowLeft class="mr-2 size-4" aria-hidden="true" /> Back to Settings
         </Button>
     </div>
@@ -257,7 +271,12 @@
         </AlertDialog.Header>
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-            <AlertDialog.Action class={buttonVariants({ variant: 'destructive' })} onclick={removeSourceMap}>Delete Source Map</AlertDialog.Action>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                onclick={removeSourceMap}>Delete Source Map</AlertDialog.Action
+            >
         </AlertDialog.Footer>
     </AlertDialog.Content>
 </AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
@@ -75,7 +75,9 @@
             queryParams.update(DEFAULT_PARAMS);
             reset();
         },
-        { lazy: true }
+        {
+            lazy: true
+        }
     );
 
     function normalizeStackKeywordFilters(nextFilters: FacetedFilter.IFilter[]): FacetedFilter.IFilter[] {
@@ -125,7 +127,9 @@
         ([filter]) => {
             filters = sanitizeStackFilters(getFiltersFromCache(filterCacheKey(filter), filter), true);
         },
-        { lazy: true }
+        {
+            lazy: true
+        }
     );
 
     $effect(() => {
@@ -211,7 +215,10 @@
     });
 
     function rowHref(row: Stack): string {
-        return resolve('/(app)/project/[projectId]/stacks/[stackId]', { projectId: projectId ?? '', stackId: row.id });
+        return resolve('/(app)/project/[projectId]/stacks/[stackId]', {
+            projectId: projectId ?? '',
+            stackId: row.id
+        });
     }
 
     function rowClick(row: Stack): void {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/[stackId]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/[stackId]/+page.svelte
@@ -18,9 +18,15 @@
     watch(
         () => organization.current,
         () => {
-            goto(resolve('/(app)/project/[projectId]/stacks', { projectId: page.params.projectId || '' }));
+            goto(
+                resolve('/(app)/project/[projectId]/stacks', {
+                    projectId: page.params.projectId || ''
+                })
+            );
         },
-        { lazy: true }
+        {
+            lazy: true
+        }
     );
 
     async function filterChanged(addedOrUpdated: IFilter) {
@@ -36,7 +42,11 @@
     }
 
     async function handleDeleted() {
-        await goto(resolve('/(app)/project/[projectId]/stacks', { projectId: page.params.projectId || '' }));
+        await goto(
+            resolve('/(app)/project/[projectId]/stacks', {
+                projectId: page.params.projectId || ''
+            })
+        );
     }
 
     $effect(() => {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/usage/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/usage/+page.svelte
@@ -47,13 +47,34 @@
     let changePlanDialogOpen = $state(false);
 
     const chartConfig = {
-        blocked: { color: 'var(--chart-2)', label: 'Blocked' },
-        deleted: { color: 'var(--chart-7)', label: 'Deleted' },
-        discarded: { color: 'var(--chart-3)', label: 'Discarded' },
-        limit: { color: 'var(--chart-6)', label: 'Limit' },
-        org_total: { color: 'var(--chart-5)', label: 'Total in Organization' },
-        too_big: { color: 'var(--chart-4)', label: 'Too Big' },
-        total: { color: 'var(--chart-1)', label: 'Total' }
+        blocked: {
+            color: 'var(--chart-2)',
+            label: 'Blocked'
+        },
+        deleted: {
+            color: 'var(--chart-7)',
+            label: 'Deleted'
+        },
+        discarded: {
+            color: 'var(--chart-3)',
+            label: 'Discarded'
+        },
+        limit: {
+            color: 'var(--chart-6)',
+            label: 'Limit'
+        },
+        org_total: {
+            color: 'var(--chart-5)',
+            label: 'Total in Organization'
+        },
+        too_big: {
+            color: 'var(--chart-4)',
+            label: 'Too Big'
+        },
+        total: {
+            color: 'var(--chart-1)',
+            label: 'Total'
+        }
     } satisfies Chart.ChartConfig;
 
     const chartData = $derived.by(() => {
@@ -87,18 +108,38 @@
     });
 
     const series = [
-        { key: 'org_total', ...chartConfig.org_total },
-        { key: 'total', ...chartConfig.total },
-        { key: 'discarded', ...chartConfig.discarded },
-        { key: 'blocked', ...chartConfig.blocked },
-        { key: 'too_big', ...chartConfig.too_big },
-        { key: 'deleted', ...chartConfig.deleted },
+        {
+            key: 'org_total',
+            ...chartConfig.org_total
+        },
+        {
+            key: 'total',
+            ...chartConfig.total
+        },
+        {
+            key: 'discarded',
+            ...chartConfig.discarded
+        },
+        {
+            key: 'blocked',
+            ...chartConfig.blocked
+        },
+        {
+            key: 'too_big',
+            ...chartConfig.too_big
+        },
+        {
+            key: 'deleted',
+            ...chartConfig.deleted
+        },
         {
             key: 'limit',
             ...chartConfig.limit,
             props: {
                 class: 'fill-none',
-                line: { class: '[stroke-dasharray:4]' }
+                line: {
+                    class: '[stroke-dasharray:4]'
+                }
             }
         }
     ];
@@ -156,7 +197,9 @@
                         area: {
                             curve: curveNatural
                         },
-                        yAxis: { format: 'metric' }
+                        yAxis: {
+                            format: 'metric'
+                        }
                     }}
                 >
                     {#snippet tooltip()}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/add/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/add/+page.svelte
@@ -33,9 +33,16 @@
             onSubmitAsync: async ({ value }) => {
                 toast.dismiss(toastId);
                 try {
-                    const { id } = await createProject.mutateAsync({ ...value, organization_id: organization.current ?? value.organization_id } as NewProject);
+                    const { id } = await createProject.mutateAsync({
+                        ...value,
+                        organization_id: organization.current ?? value.organization_id
+                    } as NewProject);
                     toastId = toast.success('Project added successfully');
-                    await goto(resolve('/(app)/project/[projectId]/configure', { projectId: id }) + '?redirect=true');
+                    await goto(
+                        resolve('/(app)/project/[projectId]/configure', {
+                            projectId: id
+                        }) + '?redirect=true'
+                    );
                     return null;
                 } catch (error: unknown) {
                     if (showBillingDialogOnUpgradeProblem(error, organization.current, () => form.handleSubmit())) {
@@ -48,7 +55,9 @@
                     }
 
                     toastId = toast.error('Error creating project. Please try again.');
-                    return { form: 'An unexpected error occurred, please try again.' };
+                    return {
+                        form: 'An unexpected error occurred, please try again.'
+                    };
                 }
             }
         }

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/list/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/list/+page.svelte
@@ -55,17 +55,27 @@
         refetchInterval: ORGANIZATION_USAGE_REFETCH_INTERVAL_MS
     });
 
-    const table = createTable(getTableOptions<ViewProject>(projectsQueryParameters, projectsQuery, { includeOrganizationColumn: true }));
+    const table = createTable(
+        getTableOptions<ViewProject>(projectsQueryParameters, projectsQuery, {
+            includeOrganizationColumn: true
+        })
+    );
 
     async function rowClick(project: ViewProject) {
         if (project.id) {
             organization.current = project.organization_id;
-            await goto(resolve('/(app)/project/[projectId]/manage', { projectId: project.id }));
+            await goto(
+                resolve('/(app)/project/[projectId]/manage', {
+                    projectId: project.id
+                })
+            );
         }
     }
 
     function rowHref(project: ViewProject): string {
-        return resolve('/(app)/project/[projectId]/manage', { projectId: project.id });
+        return resolve('/(app)/project/[projectId]/manage', {
+            projectId: project.id
+        });
     }
 
     async function addProject() {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/redirect-to-events.svelte.ts
@@ -90,7 +90,9 @@ export function deserializeTimeQueryParam(time: string): string {
  */
 export function getEventsNavigationOptionsForFilter(filter: IFilter): ListNavigationOptions | undefined {
     if (filter.type === 'string' && filter.key === 'string-stack') {
-        return { time: null };
+        return {
+            time: null
+        };
     }
 
     return undefined;

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
@@ -101,7 +101,9 @@
             queryParams.update(DEFAULT_PARAMS);
             reset();
         },
-        { lazy: true }
+        {
+            lazy: true
+        }
     );
 
     let filters = $state(applyTimeFilter(getFiltersFromCache(filterCacheKey(queryParams.filter), queryParams.filter), queryParams.time));
@@ -110,7 +112,9 @@
         ([filter, time]) => {
             filters = applyTimeFilter(getFiltersFromCache(filterCacheKey(filter), filter), time);
         },
-        { lazy: true }
+        {
+            lazy: true
+        }
     );
 
     $effect(() => {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -91,7 +91,9 @@
     }
 
     function rowHref(row: EventSummaryModel<SummaryTemplateKeys>): string {
-        return resolve('/(app)/stack/[stackId=objectid]', { stackId: row.id });
+        return resolve('/(app)/stack/[stackId=objectid]', {
+            stackId: row.id
+        });
     }
 
     const DEFAULT_TIME_RANGE = '[now-7d TO now]';
@@ -291,7 +293,9 @@
             queryParams.update(DEFAULT_PARAMS);
             reset();
         },
-        { lazy: true }
+        {
+            lazy: true
+        }
     );
 
     function getCurrentFilters(params: ListFilterQueryParams = queryParams): FacetedFilter.IFilter[] {
@@ -413,7 +417,9 @@
                 filters = updatedFilters;
             }
         },
-        { lazy: true }
+        {
+            lazy: true
+        }
     );
 
     function handleResetToSaved(): void {
@@ -516,7 +522,9 @@
         }
 
         untrack(() => {
-            updateFilters(getCurrentFilters(getListFilterQueryParams(queryParams)), { clearPagination: false });
+            updateFilters(getCurrentFilters(getListFilterQueryParams(queryParams)), {
+                clearPagination: false
+            });
         });
         normalizedSavedViewId = activeSavedViewId;
     });

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/+page.svelte
@@ -24,7 +24,9 @@
         () => {
             goto(resolve('/(app)/stack'));
         },
-        { lazy: true }
+        {
+            lazy: true
+        }
     );
 
     async function filterChanged(addedOrUpdated: IFilter) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/+page.svelte
@@ -47,7 +47,9 @@
 
     async function handleEventLoaded(event: PersistentEvent) {
         assistantPageContext.setPageEvent(event);
-        await goto(buildEventDetailsHref(event.id, event.stack_id), { replaceState: true });
+        await goto(buildEventDetailsHref(event.id, event.stack_id), {
+            replaceState: true
+        });
     }
 
     function handleStackLoaded(stack: Stack) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/event/[eventId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/event/[eventId=objectid]/+page.svelte
@@ -24,7 +24,9 @@
         () => {
             goto(resolve('/(app)/stack'));
         },
-        { lazy: true }
+        {
+            lazy: true
+        }
     );
 
     async function filterChanged(addedOrUpdated: IFilter) {
@@ -47,7 +49,9 @@
         assistantPageContext.setPageEvent(event);
 
         if (event.id !== eventId || event.stack_id !== stackId) {
-            await goto(buildEventDetailsHref(event.id, event.stack_id), { replaceState: true });
+            await goto(buildEventDetailsHref(event.id, event.stack_id), {
+                replaceState: true
+            });
         }
     }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -108,7 +108,9 @@
             queryParams.update(DEFAULT_PARAMS);
             paused = false;
         },
-        { lazy: true }
+        {
+            lazy: true
+        }
     );
 
     let filters = $state(getFiltersFromCache(filterCacheKey(queryParams.filter), queryParams.filter));
@@ -117,7 +119,9 @@
         ([filter]) => {
             filters = getFiltersFromCache(filterCacheKey(filter), filter);
         },
-        { lazy: true }
+        {
+            lazy: true
+        }
     );
 
     async function onFilterChanged(addedOrUpdated: FacetedFilter.IFilter) {
@@ -184,7 +188,10 @@
                     showType: !hasSingleTypeFilter(eventsQueryParameters.filter)
                 })
                     .filter((c) => c.id !== 'select')
-                    .map((c) => ({ ...c, enableSorting: false }));
+                    .map((c) => ({
+                        ...c,
+                        enableSorting: false
+                    }));
             },
             configureOptions: (options) => {
                 options.enableMultiRowSelection = false;

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/+layout.svelte
@@ -14,7 +14,10 @@
     const meQuery = getMeQuery();
     let isAuthenticated = $derived(accessToken.current !== null);
     const filteredRoutes = $derived.by(() => {
-        const context: NavigationItemContext = { authenticated: isAuthenticated, user: meQuery.data };
+        const context: NavigationItemContext = {
+            authenticated: isAuthenticated,
+            user: meQuery.data
+        };
         return routes().filter((route) => (route.show ? route.show(context) : true));
     });
     const currentPath = $derived(page.url.pathname);

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/+page.svelte
@@ -4,6 +4,8 @@
     import { onMount } from 'svelte';
 
     onMount(() => {
-        goto(resolve('/(app)/system/overview'), { replaceState: true });
+        goto(resolve('/(app)/system/overview'), {
+            replaceState: true
+        });
     });
 </script>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/actions/[[category]]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/actions/[[category]]/+page.svelte
@@ -37,7 +37,11 @@
                 url.searchParams.delete('q');
             }
 
-            goto(url.pathname + url.search, { keepFocus: true, noScroll: true, replaceState: true });
+            goto(url.pathname + url.search, {
+                keepFocus: true,
+                noScroll: true,
+                replaceState: true
+            });
         }
     });
 
@@ -47,11 +51,15 @@
         const base = category === 'All' ? actionsBase : `${actionsBase}/${category}`;
 
         if (query) {
-            goto(`${base}?q=${encodeURIComponent(query)}`, { noScroll: true });
+            goto(`${base}?q=${encodeURIComponent(query)}`, {
+                noScroll: true
+            });
             return;
         }
 
-        goto(base, { noScroll: true });
+        goto(base, {
+            noScroll: true
+        });
     }
 
     const filteredActions = $derived(

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/elasticsearch/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/elasticsearch/+layout.svelte
@@ -6,9 +6,18 @@
     let { children } = $props();
 
     const tabs = [
-        { href: resolve('/(app)/system/elasticsearch/overview'), label: 'Overview' },
-        { href: resolve('/(app)/system/elasticsearch/indices'), label: 'Indices' },
-        { href: resolve('/(app)/system/elasticsearch/backups'), label: 'Backups' }
+        {
+            href: resolve('/(app)/system/elasticsearch/overview'),
+            label: 'Overview'
+        },
+        {
+            href: resolve('/(app)/system/elasticsearch/indices'),
+            label: 'Indices'
+        },
+        {
+            href: resolve('/(app)/system/elasticsearch/backups'),
+            label: 'Backups'
+        }
     ];
 
     const currentPath = $derived(page.url.pathname);

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/elasticsearch/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/elasticsearch/+page.svelte
@@ -4,6 +4,8 @@
     import { onMount } from 'svelte';
 
     onMount(() => {
-        goto(resolve('/(app)/system/elasticsearch/overview'), { replaceState: true });
+        goto(resolve('/(app)/system/elasticsearch/overview'), {
+            replaceState: true
+        });
     });
 </script>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/elasticsearch/overview/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/elasticsearch/overview/+page.svelte
@@ -26,15 +26,33 @@
     const shardMetrics = $derived<ShardMetric[]>(
         data
             ? [
-                  { id: 'active_primary', label: 'Active Primary Shards', value: data.health.active_primary_shards },
-                  { id: 'active_total', label: 'Active Shards (Total)', value: data.health.active_shards },
-                  { id: 'relocating', label: 'Relocating Shards', value: data.health.relocating_shards },
-                  { id: 'unassigned', label: 'Unassigned Shards', value: data.health.unassigned_shards }
+                  {
+                      id: 'active_primary',
+                      label: 'Active Primary Shards',
+                      value: data.health.active_primary_shards
+                  },
+                  {
+                      id: 'active_total',
+                      label: 'Active Shards (Total)',
+                      value: data.health.active_shards
+                  },
+                  {
+                      id: 'relocating',
+                      label: 'Relocating Shards',
+                      value: data.health.relocating_shards
+                  },
+                  {
+                      id: 'unassigned',
+                      label: 'Unassigned Shards',
+                      value: data.health.unassigned_shards
+                  }
               ]
             : []
     );
 
-    const queryParameters: TableMemoryPagingParameters = $state({ limit: 10 });
+    const queryParameters: TableMemoryPagingParameters = $state({
+        limit: 10
+    });
     const shardTable = createTable(getTableOptions(queryParameters, () => shardMetrics));
 
     function shardRowClick(metric: ShardMetric) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/exie/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/exie/+page.svelte
@@ -40,12 +40,44 @@
     const tokensPerTurn = $derived(usage && usage.turns > 0 ? totalTokens / usage.turns : 0);
 
     const statCards = $derived([
-        { icon: Building2, label: 'Active Organizations', value: usage?.active_organizations, valueType: 'number' },
-        { icon: MessagesSquare, label: 'Turns', value: usage?.turns, valueType: 'number' },
-        { icon: Bot, label: 'Tokens', value: totalTokens, valueType: 'compact' },
-        { icon: Coins, label: 'Total Provider Cost', sub: 'across all organizations', value: usage?.cost_usd, valueType: 'currency' },
-        { icon: Gauge, label: 'Tokens per Turn', value: tokensPerTurn, valueType: 'number' },
-        { icon: Wrench, label: 'Average Cost', sub: 'per active organization', value: averageCost, valueType: 'currency' }
+        {
+            icon: Building2,
+            label: 'Active Organizations',
+            value: usage?.active_organizations,
+            valueType: 'number'
+        },
+        {
+            icon: MessagesSquare,
+            label: 'Turns',
+            value: usage?.turns,
+            valueType: 'number'
+        },
+        {
+            icon: Bot,
+            label: 'Tokens',
+            value: totalTokens,
+            valueType: 'compact'
+        },
+        {
+            icon: Coins,
+            label: 'Total Provider Cost',
+            sub: 'across all organizations',
+            value: usage?.cost_usd,
+            valueType: 'currency'
+        },
+        {
+            icon: Gauge,
+            label: 'Tokens per Turn',
+            value: tokensPerTurn,
+            valueType: 'number'
+        },
+        {
+            icon: Wrench,
+            label: 'Average Cost',
+            sub: 'per active organization',
+            value: averageCost,
+            valueType: 'currency'
+        }
     ]);
 </script>
 
@@ -136,7 +168,9 @@
                                     <Table.Cell class="max-w-64 pl-4 whitespace-normal">
                                         <a
                                             class="text-primary font-medium underline-offset-4 hover:underline"
-                                            href={resolve('/(app)/organization/[organizationId]/manage', { organizationId: organization.organization_id })}
+                                            href={resolve('/(app)/organization/[organizationId]/manage', {
+                                                organizationId: organization.organization_id
+                                            })}
                                         >
                                             {organization.organization_name}
                                         </a>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/migrations/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/migrations/+page.svelte
@@ -40,7 +40,12 @@
         return 'Pending';
     }
 
-    const allStates = $derived((data?.states ?? []).map((s) => ({ ...s, status: getStatus(s) })));
+    const allStates = $derived(
+        (data?.states ?? []).map((s) => ({
+            ...s,
+            status: getStatus(s)
+        }))
+    );
     const failedCount = $derived(allStates.filter((s) => s.status === 'Failed').length);
     const runningCount = $derived(allStates.filter((s) => s.status === 'Running').length);
 
@@ -57,7 +62,9 @@
         })
     );
 
-    const queryParameters: TableMemoryPagingParameters = $state({ limit: DEFAULT_LIMIT });
+    const queryParameters: TableMemoryPagingParameters = $state({
+        limit: DEFAULT_LIMIT
+    });
     const table = createTable(getTableOptions(queryParameters, () => filteredStates));
 </script>
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/notifications/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/notifications/+page.svelte
@@ -83,7 +83,11 @@
 
     async function handleSetSystemNotification() {
         try {
-            await setSystemNotification.mutateAsync({ level: systemLevel, message: systemMessage, target: systemTarget });
+            await setSystemNotification.mutateAsync({
+                level: systemLevel,
+                message: systemMessage,
+                target: systemTarget
+            });
             toast.success('System notification set successfully.');
         } catch {
             toast.error('Failed to set system notification.');

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/oauth-applications/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/oauth-applications/+page.svelte
@@ -33,12 +33,36 @@
     import { toast } from 'svelte-sonner';
 
     const supportedScopes = [
-        { description: 'Allows connecting to the MCP endpoint.', label: 'MCP', value: 'mcp:read' },
-        { description: 'Allows reading project metadata.', label: 'Projects', value: 'projects:read' },
-        { description: 'Allows reading stack data.', label: 'Stacks', value: 'stacks:read' },
-        { description: 'Allows changing stack status, snooze, and critical settings.', label: 'Stacks Write', value: 'stacks:write' },
-        { description: 'Allows reading event details.', label: 'Events', value: 'events:read' },
-        { description: 'Allows refresh token issuance.', label: 'Offline Access', value: 'offline_access' }
+        {
+            description: 'Allows connecting to the MCP endpoint.',
+            label: 'MCP',
+            value: 'mcp:read'
+        },
+        {
+            description: 'Allows reading project metadata.',
+            label: 'Projects',
+            value: 'projects:read'
+        },
+        {
+            description: 'Allows reading stack data.',
+            label: 'Stacks',
+            value: 'stacks:read'
+        },
+        {
+            description: 'Allows changing stack status, snooze, and critical settings.',
+            label: 'Stacks Write',
+            value: 'stacks:write'
+        },
+        {
+            description: 'Allows reading event details.',
+            label: 'Events',
+            value: 'events:read'
+        },
+        {
+            description: 'Allows refresh token issuance.',
+            label: 'Offline Access',
+            value: 'offline_access'
+        }
     ] as const;
 
     const applicationsQuery = getOAuthApplicationsQuery();
@@ -61,7 +85,10 @@
 
                 try {
                     const saved = selectedApplication
-                        ? await updateApplication.mutateAsync({ id: selectedApplication.id, request })
+                        ? await updateApplication.mutateAsync({
+                              id: selectedApplication.id,
+                              request
+                          })
                         : await createApplication.mutateAsync(request);
 
                     selectedApplication = saved;
@@ -74,7 +101,9 @@
                         return problemDetailsToFormErrors(error);
                     }
 
-                    return { form: 'An unexpected error occurred, please try again.' };
+                    return {
+                        form: 'An unexpected error occurred, please try again.'
+                    };
                 }
             }
         }

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/overview/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/overview/+page.svelte
@@ -75,10 +75,19 @@
     ]);
 
     const eventsAllTimeChartConfig = {
-        count: { color: 'var(--chart-1)', label: 'Events' }
+        count: {
+            color: 'var(--chart-1)',
+            label: 'Events'
+        }
     } satisfies Chart.ChartConfig;
 
-    const eventsAllTimeChartSeries = [{ color: eventsAllTimeChartConfig.count.color, key: 'count', label: 'Events' }];
+    const eventsAllTimeChartSeries = [
+        {
+            color: eventsAllTimeChartConfig.count.color,
+            key: 'count',
+            label: 'Events'
+        }
+    ];
 
     const eventsAllTimeChartData = $derived(
         (dateHistogram(stats?.events.aggregations, 'date_date')?.buckets ?? []).map((b) => ({
@@ -88,10 +97,19 @@
     );
 
     const organizationGrowthChartConfig = {
-        count: { color: 'var(--chart-2)', label: 'New Organizations' }
+        count: {
+            color: 'var(--chart-2)',
+            label: 'New Organizations'
+        }
     } satisfies Chart.ChartConfig;
 
-    const organizationGrowthChartSeries = [{ color: organizationGrowthChartConfig.count.color, key: 'count', label: 'New Organizations' }];
+    const organizationGrowthChartSeries = [
+        {
+            color: organizationGrowthChartConfig.count.color,
+            key: 'count',
+            label: 'New Organizations'
+        }
+    ];
 
     const organizationGrowthChartData = $derived(
         (dateHistogram(stats?.organizations.aggregations, 'date_created_utc')?.buckets ?? []).map((b) => ({
@@ -102,7 +120,10 @@
 
     function formatMonthLabel(v: unknown): string {
         if (v instanceof Date) {
-            return v.toLocaleDateString(undefined, { month: 'short', year: 'numeric' });
+            return v.toLocaleDateString(undefined, {
+                month: 'short',
+                year: 'numeric'
+            });
         }
 
         return String(v);
@@ -120,7 +141,9 @@
     const typeStatusChartData = $derived(
         stackTypeStatusBuckets.map((typeBucket) => {
             const statusBuckets = terms(typeBucket.aggregations, 'terms_status')?.buckets ?? [];
-            const row: Record<string, number | string> = { type: (typeBucket.key as string) || '(none)' };
+            const row: Record<string, number | string> = {
+                type: (typeBucket.key as string) || '(none)'
+            };
             for (const s of statusBuckets) {
                 row[s.key as string] = s.total ?? 0;
             }
@@ -145,14 +168,23 @@
     });
 
     const typeStatusChartConfig = $derived(
-        Object.fromEntries(allStatuses.map((status: string) => [status, { color: statusColorMap[status] ?? 'var(--chart-1)', label: status }])) as Record<
-            string,
-            { color: string; label: string }
-        >
+        Object.fromEntries(
+            allStatuses.map((status: string) => [
+                status,
+                {
+                    color: statusColorMap[status] ?? 'var(--chart-1)',
+                    label: status
+                }
+            ])
+        ) as Record<string, { color: string; label: string }>
     );
 
     const typeStatusChartSeries = $derived(
-        allStatuses.map((status: string) => ({ color: statusColorMap[status] ?? 'var(--chart-1)', key: status, label: status }))
+        allStatuses.map((status: string) => ({
+            color: statusColorMap[status] ?? 'var(--chart-1)',
+            key: status,
+            label: status
+        }))
     );
 </script>
 
@@ -213,7 +245,11 @@
                                 xScale={scaleUtc()}
                                 yDomain={[0, Math.max(1, ...eventsAllTimeChartData.map((d) => d.count))]}
                                 series={eventsAllTimeChartSeries}
-                                props={{ area: { curve: curveLinear } }}
+                                props={{
+                                    area: {
+                                        curve: curveLinear
+                                    }
+                                }}
                             >
                                 {#snippet tooltip()}
                                     <Chart.Tooltip indicator="line" labelFormatter={(v) => formatMonthLabel(v)} />
@@ -242,7 +278,11 @@
                                 xScale={scaleUtc()}
                                 yDomain={[0, Math.max(1, ...organizationGrowthChartData.map((d) => d.count))]}
                                 series={organizationGrowthChartSeries}
-                                props={{ area: { curve: curveLinear } }}
+                                props={{
+                                    area: {
+                                        curve: curveLinear
+                                    }
+                                }}
                             >
                                 {#snippet tooltip()}
                                     <Chart.Tooltip indicator="line" labelFormatter={(v) => formatMonthLabel(v)} />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/saved-views/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/saved-views/+page.svelte
@@ -154,7 +154,9 @@
         <AlertDialog.Footer>
             <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
             <AlertDialog.Action
-                class={buttonVariants({ variant: 'destructive' })}
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
                 disabled={forceUpdatePredefined.isPending}
                 onclick={handleForceUpdatePredefined}
             >

--- a/src/Exceptionless.Web/ClientApp/src/routes/(auth)/oauth/authorize/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(auth)/oauth/authorize/+page.svelte
@@ -61,7 +61,11 @@
     const selectedScopes = new SvelteSet<string>();
 
     const meQuery = getMeQuery();
-    const organizationsQuery = getOrganizationsQuery({ params: { mode: null } });
+    const organizationsQuery = getOrganizationsQuery({
+        params: {
+            mode: null
+        }
+    });
 
     const clientId = $derived(page.url.searchParams.get('client_id') ?? 'Unknown application');
     const redirectUri = $derived(page.url.searchParams.get('redirect_uri') ?? 'Unknown redirect URI');
@@ -90,7 +94,9 @@
 
         const returnUrl = `${page.url.pathname}${page.url.search}`;
         const loginUrl = `${resolve('/(auth)/login')}?redirect=${encodeURIComponent(returnUrl)}`;
-        void goto(loginUrl, { replaceState: true });
+        void goto(loginUrl, {
+            replaceState: true
+        });
     });
 
     $effect(() => {
@@ -153,7 +159,9 @@
         const response = await client.postJSON<OAuthAuthorizeConsentResponse>(
             'oauth/authorize/consent',
             getAuthorizationRequestBody([], page.url.searchParams.get('scope')),
-            { expectedStatusCodes: [400, 401] }
+            {
+                expectedStatusCodes: [400, 401]
+            }
         );
 
         isLoadingConsent = false;
@@ -202,7 +210,9 @@
         const response = await client.postJSON<OAuthAuthorizeResponse>(
             'oauth/authorize',
             getAuthorizationRequestBody([...selectedOrganizationIds], selectedScopeValues.join(' ')),
-            { expectedStatusCodes: [400, 401] }
+            {
+                expectedStatusCodes: [400, 401]
+            }
         );
 
         if (response.ok && response.data?.redirect_uri) {
@@ -228,7 +238,9 @@
         clearAuthenticationSession();
         const returnUrl = `${page.url.pathname}${page.url.search}`;
         const loginUrl = `${resolve('/(auth)/login')}?redirect=${encodeURIComponent(returnUrl)}`;
-        await goto(loginUrl, { replaceState: true });
+        await goto(loginUrl, {
+            replaceState: true
+        });
     }
 
     function getAuthorizationRequestBody(organizationIds: string[], scope: null | string): OAuthAuthorizeRequestBody {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(auth)/signup/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(auth)/signup/+page.svelte
@@ -129,7 +129,13 @@
                         </Field.Field>
                     {/snippet}
                 </form.Field>
-                <form.Field name="email" validators={{ onChangeAsync: ({ value }) => validateEmailAvailability(value), onChangeAsyncDebounceMs: 1000 }}>
+                <form.Field
+                    name="email"
+                    validators={{
+                        onChangeAsync: ({ value }) => validateEmailAvailability(value),
+                        onChangeAsyncDebounceMs: 1000
+                    }}
+                >
                     {#snippet children(field)}
                         <Field.Field data-invalid={ariaInvalid(field)}>
                             <Field.Label for={field.name}>Email</Field.Label>

--- a/src/Exceptionless.Web/ClientApp/src/routes/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/+layout.svelte
@@ -49,7 +49,9 @@
                 return;
             }
 
-            await goto(buildServiceStatusUrl(resolve('/status'), url), { replaceState: true });
+            await goto(buildServiceStatusUrl(resolve('/status'), url), {
+                replaceState: true
+            });
         }
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/status/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/status/+page.svelte
@@ -14,7 +14,9 @@
     const healthQuery = getHealthQuery();
     $effect(() => {
         if (healthQuery.isSuccess && redirect) {
-            goto(redirect, { replaceState: true });
+            goto(redirect, {
+                replaceState: true
+            });
         }
     });
 </script>


### PR DESCRIPTION
## What changed

- Added `@stylistic/eslint-plugin` to the Svelte ClientApp.
- Enforced curly braces, 1TBS brace style, multiline object literals, and blank lines before consecutive control-flow blocks for `.svelte` and `.svelte.ts` files.
- Formatted existing Svelte sources to satisfy the new error-level rules.
- Added targeted disables only for six Svelte `{#each}` expressions that Prettier must keep inline.

## Verification

- `npm run lint` — passed after rebasing
- `npm run validate` — passed before rebasing
- `npm run test:unit` — 47 test files / 485 tests passed; 1 unrelated existing `time-ago.svelte.test.ts` failure remains with `effect_update_depth_exceeded`
- `npm run build` — passed before rebasing
- Rebased onto `origin/main` at `3306e65fcbcabf979eb51f705b6ae179f2ecede5`
- Pushed head: `e2490f779ec0041de837751c2b1fe85c06bb78fd`

No Angular files were changed.