### PR TITLE
Align project filter with event details

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
@@ -290,17 +290,13 @@
                     {#if projectQuery.isSuccess || stack.project_id}
                         <Table.Row class="group">
                             {#if projectQuery.isSuccess}
-                                <Table.Head class="w-36 font-semibold whitespace-nowrap">Project</Table.Head>
-                                <Table.Cell class="relative w-4 pr-0">
-                                    <EventsFacetedFilter.ProjectTrigger
-                                        changed={filterChanged}
-                                        class="absolute top-1/2 left-0 -translate-y-1/2"
-                                        value={[projectQuery.data.id!]}
-                                    />
+                                <Table.Head class="w-40 font-semibold whitespace-nowrap">Project</Table.Head>
+                                <Table.Cell class="w-4 pr-0">
+                                    <EventsFacetedFilter.ProjectTrigger changed={filterChanged} value={[projectQuery.data.id!]} />
                                 </Table.Cell>
                                 <Table.Cell>{projectQuery.data.name}</Table.Cell>
                             {:else}
-                                <Table.Head class="w-36 font-semibold whitespace-nowrap"><Skeleton class="h-6 w-full rounded-full" /></Table.Head>
+                                <Table.Head class="w-40 font-semibold whitespace-nowrap"><Skeleton class="h-6 w-full rounded-full" /></Table.Head>
                                 <Table.Cell class="w-4 pr-0"></Table.Cell>
                                 <Table.Cell class="flex items-center"><Skeleton class="h-6 w-full rounded-full" /></Table.Cell>
                             {/if}


### PR DESCRIPTION
## Summary

- align the stack card Project label and filter columns with the event detail rows
- remove custom absolute positioning from the Project filter trigger
- keep the loading state on the same column width

## Why

The Project filter used a narrower label column and custom positioning, so its filter icon did not line up consistently with the filters in the event details below.

## Validation

- `npm run validate`
- visually verified in the local Aspire Svelte app

## Breaking changes

None.