### PR TITLE
Stabilize command palette interactions

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/project-command-actions.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/project-command-actions.svelte
@@ -1,3 +1,7 @@
+<script module lang="ts">
+    export type ProjectActionId = 'client-setup' | 'generate-sample-data' | 'notifications' | 'open' | 'reset-data' | 'stacks';
+</script>
+
 <script lang="ts">
     import type { ViewProject } from '$features/projects/models';
     import type { Component } from 'svelte';
@@ -15,8 +19,6 @@
     import Stacks from '@lucide/svelte/icons/layers';
     import { toast } from 'svelte-sonner';
 
-    type ProjectActionId = 'client-setup' | 'generate-sample-data' | 'notifications' | 'open' | 'reset-data' | 'stacks';
-
     type ProjectAction = {
         icon: Component;
         id: ProjectActionId;
@@ -30,10 +32,11 @@
         onSelect: () => void;
         open: boolean;
         resetPending: boolean;
+        selectedActionId: ProjectActionId | undefined;
         selectingProject: boolean;
     }
 
-    let { onReset, onSearchReset, onSelect, open, resetPending, selectingProject = $bindable() }: Props = $props();
+    let { onReset, onSearchReset, onSelect, open, resetPending, selectedActionId = $bindable(), selectingProject = $bindable() }: Props = $props();
 
     const projectActions: ProjectAction[] = [
         { icon: FolderOpen, id: 'open', keywords: ['edit', 'manage', 'settings'], label: 'Open Project' },
@@ -44,7 +47,7 @@
         { icon: AlertTriangle, id: 'reset-data', keywords: ['clear', 'delete events'], label: 'Reset Project Data' }
     ];
 
-    let selectedAction = $state<ProjectAction>();
+    const selectedAction = $derived(projectActions.find((action) => action.id === selectedActionId));
 
     const projectsQuery = getOrganizationProjectsQuery({
         enabled: () => open,
@@ -66,13 +69,13 @@
     });
 
     function selectAction(action: ProjectAction): void {
-        selectedAction = action;
+        selectedActionId = action.id;
         selectingProject = true;
         onSearchReset();
     }
 
     function goBack(): void {
-        selectedAction = undefined;
+        selectedActionId = undefined;
         selectingProject = false;
         onSearchReset();
     }

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
@@ -12,7 +12,7 @@
     import { organization } from '$features/organizations/context.svelte';
     import { resetData } from '$features/projects/api.svelte';
     import ResetProjectDataDialog from '$features/projects/components/dialogs/reset-project-data-dialog.svelte';
-    import ProjectCommandActions from '$features/projects/components/project-command-actions.svelte';
+    import ProjectCommandActions, { type ProjectActionId } from '$features/projects/components/project-command-actions.svelte';
     import { appKeyboardShortcuts, formatKeyboardShortcut, type ShortcutKey } from '$features/shared/keyboard-shortcuts';
     import { DEFAULT_OFFSET } from '$shared/api/api.svelte';
     import { useFetchClient } from '@foundatiofx/fetchclient';
@@ -87,6 +87,7 @@
     }: Props = $props();
     let searchText = $state('');
     let debouncedSearchText = $state('');
+    let selectedProjectActionId = $state<ProjectActionId>();
     let selectingProject = $state(false);
 
     const client = useFetchClient();
@@ -148,14 +149,16 @@
     const stackMatches = $derived((stackSearchQuery.data?.data ?? []).slice(0, COMMAND_SEARCH_RESULT_LIMIT));
     const hasMoreEventMatches = $derived((eventSearchQuery.data?.data?.length ?? 0) > COMMAND_SEARCH_RESULT_LIMIT);
     const hasMoreStackMatches = $derived((stackSearchQuery.data?.data?.length ?? 0) > COMMAND_SEARCH_RESULT_LIMIT);
-    const showEventSearchResults = $derived(eventSearchQuery.isPending || eventMatches.length > 0 || hasMoreEventMatches);
-    const showStackSearchResults = $derived(stackSearchQuery.isPending || stackMatches.length > 0 || hasMoreStackMatches);
+    const isRemoteSearchPending = $derived(eventSearchQuery.isPending || stackSearchQuery.isPending);
+    const showEventSearchResults = $derived(eventMatches.length > 0 || hasMoreEventMatches);
+    const showStackSearchResults = $derived(stackMatches.length > 0 || hasMoreStackMatches);
     const showRemoteSearchResults = $derived(showEventSearchResults || showStackSearchResults);
 
     $effect(() => {
         if (resetKey >= 0) {
             searchText = '';
             debouncedSearchText = '';
+            selectedProjectActionId = undefined;
             selectingProject = false;
         }
     });
@@ -416,34 +419,27 @@
     <Command.Dialog bind:open bind:value={commandValue} filter={filterCommandItem} onkeydown={handleKeydown}>
         <Command.Input bind:value={searchText} placeholder={selectingProject ? 'Select a project...' : 'Search or jump to...'} />
         <Command.List>
-            <Command.Empty>No results found.</Command.Empty>
+            <Command.Empty>{hasSearchText && isRemoteSearchPending ? 'Searching...' : 'No results found.'}</Command.Empty>
             {#if !selectingProject && hasSearchText && showRemoteSearchResults}
                 {#key debouncedSearchText}
                     {#if showEventSearchResults}
                         <Command.Group heading="Events" value="Search Events">
-                            {#if eventSearchQuery.isPending}
-                                <Command.Item disabled value={`Searching events ${debouncedSearchText}`}>
+                            {#each eventMatches as event (event.id)}
+                                <Command.LinkItem href={getEventHref(event)} onclick={closeCommandWindow} value={getResultValue('Event', event)}>
                                     <Activity />
-                                    <span>Searching events...</span>
-                                </Command.Item>
-                            {:else}
-                                {#each eventMatches as event (event.id)}
-                                    <Command.LinkItem href={getEventHref(event)} onclick={closeCommandWindow} value={getResultValue('Event', event)}>
-                                        <Activity />
-                                        <div class="flex min-w-0 flex-col">
-                                            <span class="truncate">{getResultTitle(event)}</span>
-                                            {#if getResultDescription(event)}
-                                                <span class="text-muted-foreground truncate text-xs">{getResultDescription(event)}</span>
-                                            {/if}
-                                        </div>
-                                    </Command.LinkItem>
-                                {/each}
-                                {#if hasMoreEventMatches}
-                                    <Command.LinkItem href={eventSearchHref} onclick={closeCommandWindow} value={`View all events ${debouncedSearchText}`}>
-                                        <Search />
-                                        <span>View all matching events</span>
-                                    </Command.LinkItem>
-                                {/if}
+                                    <div class="flex min-w-0 flex-col">
+                                        <span class="truncate">{getResultTitle(event)}</span>
+                                        {#if getResultDescription(event)}
+                                            <span class="text-muted-foreground truncate text-xs">{getResultDescription(event)}</span>
+                                        {/if}
+                                    </div>
+                                </Command.LinkItem>
+                            {/each}
+                            {#if hasMoreEventMatches}
+                                <Command.LinkItem href={eventSearchHref} onclick={closeCommandWindow} value={`View all events ${debouncedSearchText}`}>
+                                    <Search />
+                                    <span>View all matching events</span>
+                                </Command.LinkItem>
                             {/if}
                         </Command.Group>
                     {/if}
@@ -452,29 +448,22 @@
                     {/if}
                     {#if showStackSearchResults}
                         <Command.Group heading="Stacks" value="Search Stacks">
-                            {#if stackSearchQuery.isPending}
-                                <Command.Item disabled value={`Searching stacks ${debouncedSearchText}`}>
+                            {#each stackMatches as stack (stack.id)}
+                                <Command.LinkItem href={getStackHref(stack)} onclick={closeCommandWindow} value={getResultValue('Stack', stack)}>
                                     <Stacks />
-                                    <span>Searching stacks...</span>
-                                </Command.Item>
-                            {:else}
-                                {#each stackMatches as stack (stack.id)}
-                                    <Command.LinkItem href={getStackHref(stack)} onclick={closeCommandWindow} value={getResultValue('Stack', stack)}>
-                                        <Stacks />
-                                        <div class="flex min-w-0 flex-col">
-                                            <span class="truncate">{getResultTitle(stack)}</span>
-                                            {#if getResultDescription(stack)}
-                                                <span class="text-muted-foreground truncate text-xs">{getResultDescription(stack)}</span>
-                                            {/if}
-                                        </div>
-                                    </Command.LinkItem>
-                                {/each}
-                                {#if hasMoreStackMatches}
-                                    <Command.LinkItem href={stackSearchHref} onclick={closeCommandWindow} value={`View all stacks ${debouncedSearchText}`}>
-                                        <Search />
-                                        <span>View all matching stacks</span>
-                                    </Command.LinkItem>
-                                {/if}
+                                    <div class="flex min-w-0 flex-col">
+                                        <span class="truncate">{getResultTitle(stack)}</span>
+                                        {#if getResultDescription(stack)}
+                                            <span class="text-muted-foreground truncate text-xs">{getResultDescription(stack)}</span>
+                                        {/if}
+                                    </div>
+                                </Command.LinkItem>
+                            {/each}
+                            {#if hasMoreStackMatches}
+                                <Command.LinkItem href={stackSearchHref} onclick={closeCommandWindow} value={`View all stacks ${debouncedSearchText}`}>
+                                    <Search />
+                                    <span>View all matching stacks</span>
+                                </Command.LinkItem>
                             {/if}
                         </Command.Group>
                     {/if}
@@ -488,6 +477,7 @@
                 onSearchReset={resetCommandSearch}
                 onSelect={closeCommandWindow}
                 resetPending={resetProjectDataMutation.isPending}
+                bind:selectedActionId={selectedProjectActionId}
             />
             {#if !selectingProject}
                 {#each Object.entries(groupedRoutes) as [group, items], index (group)}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte.test.ts
@@ -8,6 +8,7 @@ const goto = vi.hoisted(() => vi.fn());
 const logout = vi.hoisted(() => vi.fn());
 const organizationState = vi.hoisted(() => ({ current: 'organization-id' as string | undefined }));
 const refetchQueries = vi.hoisted(() => vi.fn());
+const remoteSearchQueryState = vi.hoisted(() => ({ isPending: false }));
 const resetDataMutateAsync = vi.hoisted(() => vi.fn());
 const toast = vi.hoisted(() => ({ dismiss: vi.fn(), error: vi.fn(), success: vi.fn() }));
 const toggleMode = vi.hoisted(() => vi.fn());
@@ -29,7 +30,12 @@ vi.mock('$features/projects/api.svelte', () => ({
 }));
 vi.mock('@foundatiofx/fetchclient', () => ({ useFetchClient: () => ({ getJSON: vi.fn() }) }));
 vi.mock('@tanstack/svelte-query', () => ({
-    createQuery: () => ({ data: undefined, isPending: false }),
+    createQuery: () => ({
+        data: undefined,
+        get isPending() {
+            return remoteSearchQueryState.isPending;
+        }
+    }),
     useQueryClient: () => ({ refetchQueries })
 }));
 vi.mock('mode-watcher', () => ({ toggleMode }));
@@ -83,6 +89,7 @@ describe('NavigationCommand project actions', () => {
         logout.mockResolvedValue(undefined);
         organizationState.current = 'organization-id';
         refetchQueries.mockResolvedValue(undefined);
+        remoteSearchQueryState.isPending = false;
         resetDataMutateAsync.mockResolvedValue(undefined);
     });
 
@@ -118,6 +125,17 @@ describe('NavigationCommand project actions', () => {
         await waitFor(() => expect(aiToolsGroup?.hasAttribute('hidden')).toBe(false));
     });
 
+    it('does not mount remote result groups while a search is pending', async () => {
+        remoteSearchQueryState.isPending = true;
+        renderCommandPalette();
+
+        await fireEvent.input(screen.getByPlaceholderText('Search or jump to...'), { target: { value: 'no-local-match' } });
+
+        await waitFor(() => expect(screen.getByText('Searching...')).toBeTruthy());
+        expect(screen.queryByText('Searching events...')).toBeNull();
+        expect(screen.queryByText('Searching stacks...')).toBeNull();
+    });
+
     it('generates sample data for the selected project', async () => {
         renderCommandPalette();
 
@@ -126,6 +144,18 @@ describe('NavigationCommand project actions', () => {
 
         await waitFor(() => expect(generateSampleDataMutateAsync).toHaveBeenCalledOnce());
         expect(toast.success).toHaveBeenCalledWith(`Sample data generation has been queued for "${project.name}". Events will appear shortly.`);
+    });
+
+    it('opens the project picker when a filtered project action is selected with Enter', async () => {
+        renderCommandPalette();
+
+        const searchInput = screen.getByPlaceholderText('Search or jump to...');
+        await fireEvent.input(searchInput, { target: { value: 'generate' } });
+        await waitFor(() => expect(screen.getByText('Generate Sample Data').closest('[data-command-item]')?.hasAttribute('data-selected')).toBe(true));
+        await fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+        expect(screen.getByPlaceholderText('Select a project...')).toBeTruthy();
+        await waitFor(() => expect(screen.getByText(project.name)).toBeTruthy());
     });
 
     it('confirms before resetting the selected project data', async () => {


### PR DESCRIPTION
## Summary

- Preserve the selected project action while the command palette transitions to project selection.
- Keep pending remote event and stack searches in the existing empty state instead of mounting transient result groups.
- Add regression coverage for Enter-key project-action selection and pending remote searches.

## Root cause

Keyboard selection caused the command component to recreate its filtered item tree, which discarded the action stored inside the child component. Separately, each debounced remote search briefly mounted event and stack loading groups, making the palette expand and collapse while typing.

## Impact

Filtered project actions now open the correct project picker on the first Enter press. Typing in the command palette no longer produces transient remote-search layout flicker.

## Validation

- `npm run validate`
- `npm run test:unit` — 67 files, 542 tests passed
- Focused local Playwright capture against Aspire: transient height rebounds eliminated and observed DOM mutations reduced from 1,223 to 802 while typing `generate`

## Breaking changes

None.