### PR TITLE
Prevent usage charts from overshooting between monthly values

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/usage/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/usage/+page.svelte
@@ -13,7 +13,7 @@
     import { getNextBillingDateUtc, getRemainingEventLimit, ORGANIZATION_USAGE_REFETCH_INTERVAL_MS } from '$features/organizations/utils';
     import { formatDateLabel, formatLongDate } from '$shared/dates';
     import { scaleUtc } from 'd3-scale';
-    import { curveNatural } from 'd3-shape';
+    import { curveMonotoneX } from 'd3-shape';
     import { AreaChart } from 'layerchart';
 
     const organizationQuery = getOrganizationQuery({
@@ -159,7 +159,7 @@
                     {series}
                     props={{
                         area: {
-                            curve: curveNatural
+                            curve: curveMonotoneX
                         },
                         yAxis: {
                             format: 'metric'

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/usage/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/usage/+page.svelte
@@ -15,7 +15,7 @@
     import { getProjectQuery } from '$features/projects/api.svelte';
     import { formatDateLabel, formatLongDate } from '$shared/dates';
     import { scaleUtc } from 'd3-scale';
-    import { curveNatural } from 'd3-shape';
+    import { curveMonotoneX } from 'd3-shape';
     import { AreaChart } from 'layerchart';
 
     const organizationQuery = getOrganizationQuery({
@@ -195,7 +195,7 @@
                     {series}
                     props={{
                         area: {
-                            curve: curveNatural
+                            curve: curveMonotoneX
                         },
                         yAxis: {
                             format: 'metric'


### PR DESCRIPTION
## Summary

- replace `curveNatural` with `curveMonotoneX` in organization and project usage charts
- preserve rounded curves while preventing interpolated values from crossing below the actual monthly range
- cover every Svelte usage chart that previously used `curveNatural`

## Root cause

`curveNatural` can overshoot sharply changing monthly limits, creating a visual dip below zero even when all data points are non-negative. `curveMonotoneX` preserves the rounded appearance without inventing values outside neighboring points.

## Verification

- `npm run validate`
- `npm run test:unit -- --run` — 560 tests passed
- `npm run build`
- `git diff --check`

## Breaking changes

None.

<img width="1280" height="607" alt="image" src="https://github.com/user-attachments/assets/6ebe25d2-9387-4711-8b68-a2b892c36014" />
