### PR TITLE
Add configurable auto-fill columns to saved views

### DIFF
--- a/src/Exceptionless.Core/Models/SavedViewColumnSettings.cs
+++ b/src/Exceptionless.Core/Models/SavedViewColumnSettings.cs
@@ -15,6 +15,9 @@ public sealed record SavedViewColumnSettings
     /// <summary>Whether the column is visible. Null means use the table default.</summary>
     public bool? Visible { get; set; }
 
+    /// <summary>Whether the column fills the table's remaining width. Null or false means use fixed-width behavior.</summary>
+    public bool? AutoFill { get; set; }
+
     /// <summary>Zero-based display position. Null means use the table default order.</summary>
     [Range(0, MaxPosition)]
     public int? Position { get; set; }

--- a/src/Exceptionless.Core/Seed/predefined-saved-views.json
+++ b/src/Exceptionless.Core/Seed/predefined-saved-views.json
@@ -21,6 +21,7 @@
             "message": { "visible": false },
             "name": { "visible": false },
             "source": { "visible": false },
+            "summary": { "autoFill": true },
             "type": { "visible": false }
         },
         "showStats": true,
@@ -61,6 +62,7 @@
             "message": { "visible": false },
             "name": { "visible": false },
             "source": { "visible": false },
+            "summary": { "autoFill": true },
             "type": { "visible": false }
         },
         "showStats": true,
@@ -101,6 +103,7 @@
             "message": { "visible": false },
             "name": { "visible": false },
             "source": { "visible": false },
+            "summary": { "autoFill": true },
             "type": { "visible": false }
         },
         "showStats": true,
@@ -125,6 +128,9 @@
                 "value": "[now-7d TO now]"
             }
         ],
+        "columns": {
+            "summary": { "autoFill": true }
+        },
         "showStats": true,
         "showChart": true
     },
@@ -156,6 +162,9 @@
                 "hidden": true
             }
         ],
+        "columns": {
+            "summary": { "autoFill": true }
+        },
         "showStats": true,
         "showChart": true
     },
@@ -187,6 +196,9 @@
                 "hidden": true
             }
         ],
+        "columns": {
+            "summary": { "autoFill": true }
+        },
         "showStats": true,
         "showChart": true
     },
@@ -219,6 +231,9 @@
                 "hidden": true
             }
         ],
+        "columns": {
+            "summary": { "autoFill": true }
+        },
         "showStats": true,
         "showChart": true
     }

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-view-auto-fill.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-view-auto-fill.e2e.ts
@@ -1,0 +1,123 @@
+import { expect, test } from '../fixtures/e2e-test';
+import { ExceptionlessE2EJourney } from '../support/exceptionless-journey';
+import { getVisibleText } from '../support/page-helpers';
+
+test('saved views choose which event or stack column auto-fills', async ({ e2eApi, e2eScenario, page, request }) => {
+    const journey = ExceptionlessE2EJourney.fromScenario(page, e2eApi, e2eScenario);
+    await journey.submitRepresentativeEvent();
+
+    await test.step('a user can choose and save a non-default auto-fill column', async () => {
+        const slugSuffix = journey.run
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-|-$/g, '')
+            .slice(-40)
+            .replace(/^-|-$/g, '');
+        const viewSlug = `e2e-auto-fill-${slugSuffix}`;
+        const response = await request.post(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views`, {
+            data: {
+                columns: {
+                    date: { position: 1, visible: true, width: 140 },
+                    exception_type: { visible: false },
+                    level: { visible: false },
+                    message: { visible: false },
+                    name: { visible: false },
+                    project: { visible: false },
+                    source: { visible: false },
+                    summary: { position: 0, visible: true, width: 320 },
+                    tags: { visible: false },
+                    type: { visible: false },
+                    user: { visible: false },
+                    version: { visible: false }
+                },
+                name: `E2E Auto-Fill ${slugSuffix}`,
+                organization_id: e2eScenario.organizationId,
+                slug: viewSlug,
+                view_type: 'events'
+            },
+            headers: { Authorization: `Bearer ${e2eScenario.userToken}` }
+        });
+        expect(response.status(), await response.text()).toBe(201);
+
+        await page.setViewportSize({ height: 900, width: 1600 });
+        await page.goto(`/next/event/${viewSlug}`);
+        await expect(getVisibleText(page, journey.message)).toBeVisible({ timeout: 30_000 });
+
+        await page.getByRole('button', { name: /^View/ }).filter({ visible: true }).first().click();
+        await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
+
+        const columnDialog = page.getByRole('dialog', { name: 'Column Picker' });
+        const dateAutoFill = columnDialog.getByRole('radio', { name: 'Date auto fill' });
+        const summaryAutoFill = columnDialog.getByRole('radio', { name: 'Summary auto fill' });
+        await expect(columnDialog).toBeVisible();
+        await expect(dateAutoFill).not.toBeChecked();
+        await dateAutoFill.click();
+        await expect(dateAutoFill).toBeChecked();
+        await summaryAutoFill.click();
+        await expect(summaryAutoFill).toBeChecked();
+        await columnDialog.getByRole('button', { name: 'Reset to default' }).click();
+        await expect(summaryAutoFill).toBeChecked();
+        await dateAutoFill.click();
+        await expect(dateAutoFill).toBeChecked();
+        await columnDialog.getByRole('button', { name: 'Done' }).click();
+
+        await page.getByRole('button', { name: /^View/ }).filter({ visible: true }).first().click();
+        const saveResponse = page.waitForResponse((candidate) => candidate.request().method() === 'PATCH' && candidate.url().includes(`/api/v2/saved-views/`));
+        await page.getByRole('menuitem', { exact: true, name: 'Save' }).click();
+        const savedResponse = await saveResponse;
+        expect(savedResponse.status()).toBe(200);
+        expect(savedResponse.request().postDataJSON().columns.date.auto_fill).toBe(true);
+        expect((await savedResponse.json()).columns.date.auto_fill).toBe(true);
+
+        await page.reload();
+        await expect(getVisibleText(page, journey.message)).toBeVisible({ timeout: 30_000 });
+        await page.getByRole('button', { name: /^View/ }).filter({ visible: true }).first().click();
+        await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
+        await expect(page.getByRole('dialog', { name: 'Column Picker' }).getByRole('radio', { name: 'Date auto fill' })).toBeChecked();
+        await page.getByRole('dialog', { name: 'Column Picker' }).getByRole('button', { name: 'Done' }).click();
+
+        const table = page.locator('table:has(thead [role="checkbox"])').first();
+        const dateHeader = table.getByRole('columnheader', { name: 'Date' });
+        const summaryHeader = table.getByRole('columnheader', { name: 'Summary' });
+        const initialTableWidth = (await table.boundingBox())!.width;
+        const initialDateWidth = (await dateHeader.boundingBox())!.width;
+        const initialSummaryWidth = (await summaryHeader.boundingBox())!.width;
+
+        await page.setViewportSize({ height: 900, width: 2000 });
+        await expect.poll(async () => (await table.boundingBox())!.width).toBeGreaterThan(initialTableWidth + 300);
+
+        const widerTableWidth = (await table.boundingBox())!.width;
+        const widerDateWidth = (await dateHeader.boundingBox())!.width;
+        const widerSummaryWidth = (await summaryHeader.boundingBox())!.width;
+
+        expect(widerSummaryWidth).toBeCloseTo(initialSummaryWidth, 1);
+        expect(widerDateWidth - initialDateWidth).toBeCloseTo(widerTableWidth - initialTableWidth, 1);
+    });
+
+    for (const route of ['/next/event/all', '/next/stack/all']) {
+        await test.step(`${route} predefined view auto-fills Summary`, async () => {
+            await page.setViewportSize({ height: 900, width: 1600 });
+            await page.goto(route);
+            await expect(getVisibleText(page, journey.message)).toBeVisible({ timeout: 30_000 });
+
+            const table = page.locator('table:has(thead [role="checkbox"])').first();
+            const border = table.locator('xpath=ancestor::div[contains(@class, "rounded-md") and contains(@class, "border")][1]');
+            const summaryHeader = table.getByRole('columnheader', { name: 'Summary' });
+            const narrowTableWidth = (await table.boundingBox())!.width;
+            const narrowBorderWidth = (await border.boundingBox())!.width;
+            const narrowSummaryWidth = (await summaryHeader.boundingBox())!.width;
+
+            expect(Math.abs(narrowTableWidth - narrowBorderWidth)).toBeLessThanOrEqual(2);
+
+            await page.setViewportSize({ height: 900, width: 2000 });
+            await expect.poll(async () => (await table.boundingBox())!.width).toBeGreaterThan(narrowTableWidth + 300);
+
+            const wideTableWidth = (await table.boundingBox())!.width;
+            const wideBorderWidth = (await border.boundingBox())!.width;
+            const wideSummaryWidth = (await summaryHeader.boundingBox())!.width;
+
+            expect(Math.abs(wideTableWidth - wideBorderWidth)).toBeLessThanOrEqual(2);
+            expect(wideSummaryWidth - narrowSummaryWidth).toBeCloseTo(wideTableWidth - narrowTableWidth, 1);
+        });
+    }
+});

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-view-auto-fill.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-view-auto-fill.e2e.ts
@@ -48,9 +48,15 @@ test('saved views choose which event or stack column auto-fills', async ({ e2eAp
 
         const columnDialog = page.getByRole('dialog', { name: 'Column Picker' });
         const dateAutoFill = columnDialog.getByRole('radio', { name: 'Date auto fill' });
+        const noAutoFill = columnDialog.getByRole('radio', { name: 'No auto-fill column' });
         const summaryAutoFill = columnDialog.getByRole('radio', { name: 'Summary auto fill' });
         await expect(columnDialog).toBeVisible();
+        await expect(noAutoFill).toBeChecked();
         await expect(dateAutoFill).not.toBeChecked();
+        await dateAutoFill.click();
+        await expect(dateAutoFill).toBeChecked();
+        await noAutoFill.click();
+        await expect(noAutoFill).toBeChecked();
         await dateAutoFill.click();
         await expect(dateAutoFill).toBeChecked();
         await summaryAutoFill.click();
@@ -92,6 +98,29 @@ test('saved views choose which event or stack column auto-fills', async ({ e2eAp
 
         expect(widerSummaryWidth).toBeCloseTo(initialSummaryWidth, 1);
         expect(widerDateWidth - initialDateWidth).toBeCloseTo(widerTableWidth - initialTableWidth, 1);
+
+        await table.getByRole('button', { name: 'Resize date column' }).press('ArrowRight');
+        await page.getByRole('button', { name: /^View/ }).filter({ visible: true }).first().click();
+        await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
+        await expect(page.getByRole('dialog', { name: 'Column Picker' }).getByRole('radio', { name: 'No auto-fill column' })).toBeChecked();
+        await page.getByRole('dialog', { name: 'Column Picker' }).getByRole('button', { name: 'Done' }).click();
+
+        await page.getByRole('button', { name: /^View/ }).filter({ visible: true }).first().click();
+        const fixedWidthSaveResponse = page.waitForResponse(
+            (candidate) => candidate.request().method() === 'PATCH' && candidate.url().includes(`/api/v2/saved-views/`)
+        );
+        await page.getByRole('menuitem', { exact: true, name: 'Save' }).click();
+        const fixedWidthSavedResponse = await fixedWidthSaveResponse;
+        expect(fixedWidthSavedResponse.status()).toBe(200);
+        expect(fixedWidthSavedResponse.request().postDataJSON().columns.summary.auto_fill).toBe(false);
+        expect((await fixedWidthSavedResponse.json()).columns.summary.auto_fill).toBe(false);
+
+        await page.reload();
+        await expect(getVisibleText(page, journey.message)).toBeVisible({ timeout: 30_000 });
+        await page.getByRole('button', { name: /^View/ }).filter({ visible: true }).first().click();
+        await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
+        await expect(page.getByRole('dialog', { name: 'Column Picker' }).getByRole('radio', { name: 'No auto-fill column' })).toBeChecked();
+        await page.getByRole('dialog', { name: 'Column Picker' }).getByRole('button', { name: 'Done' }).click();
     });
 
     for (const route of ['/next/event/all', '/next/stack/all']) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-data-table.svelte
@@ -8,6 +8,7 @@
     import type { EventSummaryModel, SummaryTemplateKeys } from '../summary/index';
 
     interface Props {
+        autoFillColumnId?: string;
         bodyChildren?: Snippet;
         footerChildren?: Snippet;
         isLoading: boolean;
@@ -18,7 +19,7 @@
         toolbarChildren?: Snippet;
     }
 
-    let { bodyChildren, footerChildren, isLoading, limit = $bindable(), rowClick, rowHref, table, toolbarChildren }: Props = $props();
+    let { autoFillColumnId, bodyChildren, footerChildren, isLoading, limit = $bindable(), rowClick, rowHref, table, toolbarChildren }: Props = $props();
 </script>
 
 <DataTable.Root>
@@ -27,7 +28,7 @@
             {@render toolbarChildren()}
         </DataTable.Toolbar>
     {/if}
-    <DataTable.Body {rowClick} {rowHref} {table}>
+    <DataTable.Body {autoFillColumnId} {rowClick} {rowHref} {table}>
         {#if isLoading}
             <DelayedRender>
                 <DataTable.Loading {table} />

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-data-table.svelte
@@ -8,18 +8,30 @@
     import type { EventSummaryModel, SummaryTemplateKeys } from '../summary/index';
 
     interface Props {
-        autoFillColumnId?: string;
+        autoFillColumnId?: null | string;
         bodyChildren?: Snippet;
         footerChildren?: Snippet;
         isLoading: boolean;
         limit: number;
+        onAutoFillColumnResized?: (columnId: string) => void;
         rowClick?: (row: EventSummaryModel<SummaryTemplateKeys>) => void;
         rowHref?: (row: EventSummaryModel<SummaryTemplateKeys>) => string;
         table: Table<StockFeatures, EventSummaryModel<SummaryTemplateKeys>>;
         toolbarChildren?: Snippet;
     }
 
-    let { autoFillColumnId, bodyChildren, footerChildren, isLoading, limit = $bindable(), rowClick, rowHref, table, toolbarChildren }: Props = $props();
+    let {
+        autoFillColumnId,
+        bodyChildren,
+        footerChildren,
+        isLoading,
+        limit = $bindable(),
+        onAutoFillColumnResized,
+        rowClick,
+        rowHref,
+        table,
+        toolbarChildren
+    }: Props = $props();
 </script>
 
 <DataTable.Root>
@@ -28,7 +40,7 @@
             {@render toolbarChildren()}
         </DataTable.Toolbar>
     {/if}
-    <DataTable.Body {autoFillColumnId} {rowClick} {rowHref} {table}>
+    <DataTable.Body {autoFillColumnId} {onAutoFillColumnResized} {rowClick} {rowHref} {table}>
         {#if isLoading}
             <DelayedRender>
                 <DataTable.Loading {table} />

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
@@ -5,6 +5,7 @@ import type { SavedView } from './models';
 import {
     buildColumnSettings,
     getSavedAutoFillColumnId,
+    getSavedAutoFillColumnSelection,
     getSavedColumnOrder,
     getSavedColumnSizing,
     getSavedColumnVisibility,
@@ -28,13 +29,33 @@ describe('saved view column settings', () => {
         });
     });
 
-    it('does not preserve auto-fill after that column is resized or hidden', () => {
-        expect(buildColumnSettings(['summary'], [], {}, { summary: 480 }, 'summary')).toEqual({
-            summary: { position: 0, visible: true, width: 480 }
+    it('persists an explicit choice to keep every column fixed width', () => {
+        expect(buildColumnSettings(['summary', 'date'], [], {}, { date: 480 }, null, 'summary')).toEqual({
+            date: { position: 1, visible: true, width: 480 },
+            summary: { auto_fill: false, position: 0, visible: true }
         });
-        expect(buildColumnSettings(['summary'], [], { summary: false }, {}, 'summary')).toEqual({
-            summary: { position: 0, visible: false }
-        });
+    });
+
+    it('distinguishes explicit None from legacy default auto-fill behavior', () => {
+        const explicitNone = {
+            columns: {
+                summary: { auto_fill: false }
+            }
+        } as Pick<SavedView, 'columns'>;
+        const legacyDefault = {
+            columns: {
+                summary: { visible: true }
+            }
+        } as Pick<SavedView, 'columns'>;
+        const legacyFixedDefault = {
+            columns: {
+                summary: { visible: true, width: 480 }
+            }
+        } as Pick<SavedView, 'columns'>;
+
+        expect(getSavedAutoFillColumnSelection(explicitNone, 'summary')).toBeNull();
+        expect(getSavedAutoFillColumnSelection(legacyDefault, 'summary')).toBe('summary');
+        expect(getSavedAutoFillColumnSelection(legacyFixedDefault, 'summary')).toBeNull();
     });
 
     it('reads order, visibility, and width from structured columns', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
@@ -4,6 +4,7 @@ import type { SavedView } from './models';
 
 import {
     buildColumnSettings,
+    getSavedAutoFillColumnId,
     getSavedColumnOrder,
     getSavedColumnSizing,
     getSavedColumnVisibility,
@@ -17,12 +18,22 @@ describe('saved view column settings', () => {
             ['select', 'summary', 'project'],
             ['select', 'project', 'summary'],
             { project: true, summary: true },
-            { project: 360 }
+            { project: 360 },
+            'summary'
         );
 
         expect(result).toEqual({
             project: { position: 0, visible: true, width: 360 },
-            summary: { position: 1, visible: true }
+            summary: { auto_fill: true, position: 1, visible: true }
+        });
+    });
+
+    it('does not preserve auto-fill after that column is resized or hidden', () => {
+        expect(buildColumnSettings(['summary'], [], {}, { summary: 480 }, 'summary')).toEqual({
+            summary: { position: 0, visible: true, width: 480 }
+        });
+        expect(buildColumnSettings(['summary'], [], { summary: false }, {}, 'summary')).toEqual({
+            summary: { position: 0, visible: false }
         });
     });
 
@@ -30,13 +41,14 @@ describe('saved view column settings', () => {
         const view = {
             columns: {
                 project: { position: 0, visible: true, width: 360 },
-                summary: { position: 1, visible: false }
+                summary: { auto_fill: true, position: 1, visible: false }
             }
         } as Pick<SavedView, 'columns'>;
 
         expect(getSavedColumnOrder(view)).toEqual(['project', 'summary']);
         expect(getSavedColumnVisibility(view)).toEqual({ project: true, summary: false });
         expect(getSavedColumnSizing(view)).toEqual({ project: 360 });
+        expect(getSavedAutoFillColumnId(view)).toBe('summary');
     });
 
     it('detects changed and reset column widths', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
@@ -2,6 +2,8 @@ import type { ColumnOrderState, ColumnSizingState, ColumnVisibilityState } from 
 
 import type { SavedView, SavedViewColumnSettings } from './models';
 
+export type AutoFillColumnSelection = null | string;
+
 type SavedColumnState = Pick<SavedView, 'columns'>;
 
 export function buildColumnSettings(
@@ -9,7 +11,8 @@ export function buildColumnSettings(
     columnOrder: ColumnOrderState,
     columnVisibility: ColumnVisibilityState,
     columnSizing: ColumnSizingState,
-    autoFillColumnId?: string
+    autoFillColumnId?: AutoFillColumnSelection,
+    defaultAutoFillColumnId?: string
 ): Record<string, SavedViewColumnSettings> {
     const availableColumnIds = columnIds.filter((columnId) => columnId !== 'select');
     const availableColumnIdSet = new Set(availableColumnIds);
@@ -17,6 +20,8 @@ export function buildColumnSettings(
         ...columnOrder.filter((columnId, index) => columnId !== 'select' && availableColumnIdSet.has(columnId) && columnOrder.indexOf(columnId) === index),
         ...availableColumnIds.filter((columnId) => !columnOrder.includes(columnId))
     ];
+    const explicitNoneMarkerColumnId =
+        autoFillColumnId === null ? (availableColumnIdSet.has(defaultAutoFillColumnId ?? '') ? defaultAutoFillColumnId : availableColumnIds[0]) : undefined;
 
     return Object.fromEntries(
         orderedColumnIds.map((columnId, position) => [
@@ -25,6 +30,7 @@ export function buildColumnSettings(
                 position,
                 visible: columnVisibility[columnId] ?? true,
                 ...(columnId === autoFillColumnId && columnVisibility[columnId] !== false && columnSizing[columnId] === undefined ? { auto_fill: true } : {}),
+                ...(columnId === explicitNoneMarkerColumnId ? { auto_fill: false } : {}),
                 ...(columnSizing[columnId] !== undefined ? { width: Math.round(columnSizing[columnId]) } : {})
             }
         ])
@@ -33,6 +39,25 @@ export function buildColumnSettings(
 
 export function getSavedAutoFillColumnId(view: SavedColumnState | undefined): string | undefined {
     return Object.entries(view?.columns ?? {}).find(([, settings]) => settings.auto_fill === true)?.[0];
+}
+
+export function getSavedAutoFillColumnSelection(view: SavedColumnState | undefined, defaultAutoFillColumnId?: string): AutoFillColumnSelection {
+    const savedAutoFillColumnId = getSavedAutoFillColumnId(view);
+    if (savedAutoFillColumnId) {
+        return savedAutoFillColumnId;
+    }
+
+    const settings = Object.values(view?.columns ?? {});
+    if (settings.some((column) => column.auto_fill === false)) {
+        return null;
+    }
+
+    if (!defaultAutoFillColumnId) {
+        return null;
+    }
+
+    const defaultSettings = view?.columns?.[defaultAutoFillColumnId];
+    return defaultSettings?.visible === false || defaultSettings?.width != null ? null : defaultAutoFillColumnId;
 }
 
 export function getSavedColumnOrder(view: SavedColumnState | undefined): ColumnOrderState {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
@@ -8,7 +8,8 @@ export function buildColumnSettings(
     columnIds: string[],
     columnOrder: ColumnOrderState,
     columnVisibility: ColumnVisibilityState,
-    columnSizing: ColumnSizingState
+    columnSizing: ColumnSizingState,
+    autoFillColumnId?: string
 ): Record<string, SavedViewColumnSettings> {
     const availableColumnIds = columnIds.filter((columnId) => columnId !== 'select');
     const availableColumnIdSet = new Set(availableColumnIds);
@@ -23,10 +24,15 @@ export function buildColumnSettings(
             {
                 position,
                 visible: columnVisibility[columnId] ?? true,
+                ...(columnId === autoFillColumnId && columnVisibility[columnId] !== false && columnSizing[columnId] === undefined ? { auto_fill: true } : {}),
                 ...(columnSizing[columnId] !== undefined ? { width: Math.round(columnSizing[columnId]) } : {})
             }
         ])
     );
+}
+
+export function getSavedAutoFillColumnId(view: SavedColumnState | undefined): string | undefined {
+    return Object.entries(view?.columns ?? {}).find(([, settings]) => settings.auto_fill === true)?.[0];
 }
 
 export function getSavedColumnOrder(view: SavedColumnState | undefined): ColumnOrderState {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/column-management-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/column-management-dialog.svelte
@@ -11,6 +11,8 @@
     import { Button } from '$comp/ui/button';
     import * as Dialog from '$comp/ui/dialog';
     import * as InputGroup from '$comp/ui/input-group';
+    import { Label } from '$comp/ui/label';
+    import * as RadioGroup from '$comp/ui/radio-group';
     import { Separator } from '$comp/ui/separator';
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
     import ChevronUp from '@lucide/svelte/icons/chevron-up';
@@ -21,11 +23,14 @@
     import X from '@lucide/svelte/icons/x';
 
     interface Props {
+        autoFillColumnId?: string;
+        defaultAutoFillColumnId?: string;
         open: boolean;
+        setAutoFillColumnId: (columnId: string) => void;
         table: Table<StockFeatures, TData>;
     }
 
-    let { open = $bindable(), table }: Props = $props();
+    let { autoFillColumnId, defaultAutoFillColumnId, open = $bindable(), setAutoFillColumnId, table }: Props = $props();
 
     let draggedColumnId = $state<null | string>(null);
     let search = $state('');
@@ -52,8 +57,27 @@
 
     function removeColumn(column: (typeof allColumns)[number]): void {
         if (visibleColumns.length > 1) {
+            if (column.id === autoFillColumnId) {
+                const remainingColumns = visibleColumns.filter((visibleColumn) => visibleColumn.id !== column.id);
+                const replacement = remainingColumns.find((visibleColumn) => visibleColumn.id === defaultAutoFillColumnId) ?? remainingColumns[0];
+                if (replacement) {
+                    selectAutoFillColumn(replacement.id);
+                }
+            }
+
             column.toggleVisibility(false);
         }
+    }
+
+    function selectAutoFillColumn(columnId: string): void {
+        table.setColumnSizing((current) => {
+            const next = {
+                ...current
+            };
+            delete next[columnId];
+            return next;
+        });
+        setAutoFillColumnId(columnId);
     }
 
     function canRemoveColumn(column: (typeof allColumns)[number]): boolean {
@@ -95,6 +119,9 @@
         table.resetColumnVisibility();
         table.resetColumnOrder();
         table.resetColumnSizing();
+        if (defaultAutoFillColumnId) {
+            setAutoFillColumnId(defaultAutoFillColumnId);
+        }
         search = '';
     }
 
@@ -141,7 +168,7 @@
     >
         <Dialog.Header class="border-b px-6 py-5 pr-14">
             <Dialog.Title>Column Picker</Dialog.Title>
-            <Dialog.Description>Select and reorder the columns displayed in this table.</Dialog.Description>
+            <Dialog.Description>Select, reorder, and choose which column fills the available table width.</Dialog.Description>
         </Dialog.Header>
 
         <div class="grid min-h-0 gap-0 lg:grid-cols-[minmax(0,1fr)_5rem_minmax(0,1fr)]">
@@ -208,12 +235,17 @@
                             <h3 id="selected-columns-heading" class="text-sm font-semibold">Selected Columns</h3>
                             <Badge variant="secondary">{visibleColumns.length}</Badge>
                         </div>
-                        <p class="text-muted-foreground text-sm">Drag to reorder. The first item appears on the far left.</p>
+                        <p class="text-muted-foreground text-sm">Drag to reorder, or mark one column to auto fill the available width.</p>
                     </div>
                 </div>
 
                 <div class="border-input bg-muted/20 rounded-lg border p-2">
-                    <div class="flex max-h-[22.75rem] flex-col gap-1.5 overflow-y-auto pr-1" role="list" aria-label="Selected columns">
+                    <RadioGroup.Root
+                        aria-label="Auto-fill column"
+                        class="flex max-h-[22.75rem] flex-col gap-1.5 overflow-y-auto pr-1"
+                        onValueChange={selectAutoFillColumn}
+                        value={autoFillColumnId ?? ''}
+                    >
                         {#each visibleColumns as column, index (column.id)}
                             <div
                                 class={[
@@ -228,16 +260,26 @@
                             >
                                 <Button
                                     variant="ghost"
-                                    class="hover:bg-muted/70 h-auto min-w-0 flex-1 justify-start gap-3 rounded-l-lg rounded-r-none px-3 font-normal"
+                                    size="icon-sm"
+                                    class="hover:bg-muted/70 my-1 ml-1 shrink-0"
                                     disabled={!canRemoveColumn(column)}
                                     onclick={() => removeColumn(column)}
                                     aria-label={`Remove ${getColumnLabel(column)} column`}
                                 >
-                                    <span class="min-w-0 flex-1 truncate text-left font-medium">{getColumnLabel(column)}</span>
-                                    {#if canRemoveColumn(column)}
-                                        <X class="shrink-0" aria-hidden="true" />
-                                    {/if}
+                                    <X class="shrink-0" aria-hidden="true" />
                                 </Button>
+                                <span class="min-w-0 flex-1 self-center truncate px-2 text-left font-medium">{getColumnLabel(column)}</span>
+                                <Label
+                                    class="hover:bg-muted/70 mr-1 flex shrink-0 cursor-pointer items-center gap-2 rounded-md px-2 text-xs font-normal"
+                                    for={`auto-fill-column-${column.id}`}
+                                >
+                                    <RadioGroup.Item
+                                        aria-label={`${getColumnLabel(column)} auto fill`}
+                                        id={`auto-fill-column-${column.id}`}
+                                        value={column.id}
+                                    />
+                                    Auto fill
+                                </Label>
                                 <div class="flex shrink-0 items-center gap-1">
                                     <Button variant="ghost" size="icon-sm" onclick={() => moveColumnUp(column.id)} disabled={index === 0} title="Move up">
                                         <ChevronUp />
@@ -257,7 +299,7 @@
                                 </div>
                             </div>
                         {/each}
-                    </div>
+                    </RadioGroup.Root>
                 </div>
             </section>
         </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/column-management-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/column-management-dialog.svelte
@@ -22,11 +22,13 @@
     import Search from '@lucide/svelte/icons/search';
     import X from '@lucide/svelte/icons/x';
 
+    import type { AutoFillColumnSelection } from '../column-settings';
+
     interface Props {
-        autoFillColumnId?: string;
+        autoFillColumnId: AutoFillColumnSelection;
         defaultAutoFillColumnId?: string;
         open: boolean;
-        setAutoFillColumnId: (columnId: string) => void;
+        setAutoFillColumnId: (columnId: AutoFillColumnSelection) => void;
         table: Table<StockFeatures, TData>;
     }
 
@@ -34,6 +36,8 @@
 
     let draggedColumnId = $state<null | string>(null);
     let search = $state('');
+
+    const AUTO_FILL_NONE_VALUE = '__none__';
 
     const allColumns = $derived(table.getAllLeafColumns().filter((column) => column.id !== 'select'));
     const visibleColumns = $derived(allColumns.filter((column) => column.getIsVisible()));
@@ -58,25 +62,28 @@
     function removeColumn(column: (typeof allColumns)[number]): void {
         if (visibleColumns.length > 1) {
             if (column.id === autoFillColumnId) {
-                const remainingColumns = visibleColumns.filter((visibleColumn) => visibleColumn.id !== column.id);
-                const replacement = remainingColumns.find((visibleColumn) => visibleColumn.id === defaultAutoFillColumnId) ?? remainingColumns[0];
-                if (replacement) {
-                    selectAutoFillColumn(replacement.id);
-                }
+                selectAutoFillColumn(null);
             }
 
             column.toggleVisibility(false);
         }
     }
 
-    function selectAutoFillColumn(columnId: string): void {
-        table.setColumnSizing((current) => {
-            const next = {
-                ...current
-            };
-            delete next[columnId];
-            return next;
-        });
+    function handleAutoFillValueChange(value: string): void {
+        selectAutoFillColumn(value === AUTO_FILL_NONE_VALUE ? null : value);
+    }
+
+    function selectAutoFillColumn(columnId: AutoFillColumnSelection): void {
+        if (columnId) {
+            table.setColumnSizing((current) => {
+                const next = {
+                    ...current
+                };
+                delete next[columnId];
+                return next;
+            });
+        }
+
         setAutoFillColumnId(columnId);
     }
 
@@ -121,6 +128,8 @@
         table.resetColumnSizing();
         if (defaultAutoFillColumnId) {
             setAutoFillColumnId(defaultAutoFillColumnId);
+        } else {
+            setAutoFillColumnId(null);
         }
         search = '';
     }
@@ -243,9 +252,17 @@
                     <RadioGroup.Root
                         aria-label="Auto-fill column"
                         class="flex max-h-[22.75rem] flex-col gap-1.5 overflow-y-auto pr-1"
-                        onValueChange={selectAutoFillColumn}
-                        value={autoFillColumnId ?? ''}
+                        onValueChange={handleAutoFillValueChange}
+                        value={autoFillColumnId ?? AUTO_FILL_NONE_VALUE}
                     >
+                        <Label
+                            class="bg-background hover:bg-muted/70 flex min-h-11 cursor-pointer items-center gap-3 rounded-lg border px-3 text-sm font-normal shadow-xs transition-colors"
+                            for="auto-fill-column-none"
+                        >
+                            <RadioGroup.Item aria-label="No auto-fill column" id="auto-fill-column-none" value={AUTO_FILL_NONE_VALUE} />
+                            <span class="font-medium">None</span>
+                            <span class="text-muted-foreground ml-auto text-xs">Keep every column fixed width</span>
+                        </Label>
                         {#each visibleColumns as column, index (column.id)}
                             <div
                                 class={[

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
@@ -45,15 +45,18 @@
 
     interface Props {
         activeSavedView?: SavedView;
+        autoFillColumnId?: string;
         columnOrder?: string[];
         columnSizing?: Record<string, number>;
         columnVisibility?: Record<string, boolean>;
+        defaultAutoFillColumnId?: string;
         filters: IFilter[];
         isModified: boolean;
         onClearSavedView: () => void;
         onLoadView: (view: SavedView) => void;
         onResetToSaved: () => void;
         savedViews: SavedView[];
+        setAutoFillColumnId: (columnId: string) => void;
         setShowChart?: (show: boolean) => void;
         setShowStats?: (show: boolean) => void;
         showChart?: boolean;
@@ -66,15 +69,18 @@
 
     let {
         activeSavedView,
+        autoFillColumnId,
         columnOrder,
         columnSizing,
         columnVisibility,
+        defaultAutoFillColumnId,
         filters,
         isModified,
         onClearSavedView,
         onLoadView,
         onResetToSaved,
         savedViews,
+        setAutoFillColumnId,
         setShowChart,
         setShowStats,
         showChart = true,
@@ -117,6 +123,7 @@
     });
 
     const saving = $derived(createMutation.isPending || updateMutation.isPending || removeMutation.isPending);
+    const effectiveAutoFillColumnId = $derived(autoFillColumnId && columnSizing?.[autoFillColumnId] === undefined ? autoFillColumnId : undefined);
 
     const currentFilterString = $derived(toFilter(filters.filter((f) => f.type !== 'date')));
 
@@ -162,7 +169,8 @@
             table.getAllLeafColumns().map((column) => column.id),
             columnOrder ?? [],
             columnVisibility ?? {},
-            columnSizing ?? {}
+            columnSizing ?? {},
+            effectiveAutoFillColumnId
         );
     }
 
@@ -393,5 +401,11 @@
 {/if}
 
 {#if isColumnDialogOpen}
-    <ColumnManagementDialog bind:open={isColumnDialogOpen} {table} />
+    <ColumnManagementDialog
+        bind:open={isColumnDialogOpen}
+        autoFillColumnId={effectiveAutoFillColumnId}
+        {defaultAutoFillColumnId}
+        {setAutoFillColumnId}
+        {table}
+    />
 {/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
@@ -24,6 +24,7 @@
     import { tick } from 'svelte';
     import { toast } from 'svelte-sonner';
 
+    import type { AutoFillColumnSelection } from '../column-settings';
     import type { NewSavedView, SavedView, UpdateSavedView } from '../models';
 
     import { deleteSavedView, markSavedViewDeleted, patchSavedView, postSavedView, restoreDeletedSavedView } from '../api.svelte';
@@ -45,7 +46,7 @@
 
     interface Props {
         activeSavedView?: SavedView;
-        autoFillColumnId?: string;
+        autoFillColumnId: AutoFillColumnSelection;
         columnOrder?: string[];
         columnSizing?: Record<string, number>;
         columnVisibility?: Record<string, boolean>;
@@ -56,7 +57,7 @@
         onLoadView: (view: SavedView) => void;
         onResetToSaved: () => void;
         savedViews: SavedView[];
-        setAutoFillColumnId: (columnId: string) => void;
+        setAutoFillColumnId: (columnId: AutoFillColumnSelection) => void;
         setShowChart?: (show: boolean) => void;
         setShowStats?: (show: boolean) => void;
         showChart?: boolean;
@@ -123,8 +124,6 @@
     });
 
     const saving = $derived(createMutation.isPending || updateMutation.isPending || removeMutation.isPending);
-    const effectiveAutoFillColumnId = $derived(autoFillColumnId && columnSizing?.[autoFillColumnId] === undefined ? autoFillColumnId : undefined);
-
     const currentFilterString = $derived(toFilter(filters.filter((f) => f.type !== 'date')));
 
     // Auto-detect if current filters match an existing saved view for "load existing" hint
@@ -170,7 +169,8 @@
             columnOrder ?? [],
             columnVisibility ?? {},
             columnSizing ?? {},
-            effectiveAutoFillColumnId
+            autoFillColumnId,
+            defaultAutoFillColumnId
         );
     }
 
@@ -401,11 +401,5 @@
 {/if}
 
 {#if isColumnDialogOpen}
-    <ColumnManagementDialog
-        bind:open={isColumnDialogOpen}
-        autoFillColumnId={effectiveAutoFillColumnId}
-        {defaultAutoFillColumnId}
-        {setAutoFillColumnId}
-        {table}
-    />
+    <ColumnManagementDialog bind:open={isColumnDialogOpen} {autoFillColumnId} {defaultAutoFillColumnId} {setAutoFillColumnId} {table} />
 {/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -5,11 +5,12 @@ import { goto } from '$app/navigation';
 import { buildFilterCacheKey, deserializeFilters, serializeFilters } from '$features/events/components/filters/helpers.svelte';
 import { organization } from '$features/organizations/context.svelte';
 
+import type { AutoFillColumnSelection } from './column-settings';
 import type { SavedView } from './models';
 
 import { getSavedViewsByViewQuery } from './api.svelte';
 import {
-    getSavedAutoFillColumnId,
+    getSavedAutoFillColumnSelection,
     getSavedColumnOrder,
     getSavedColumnSizing,
     getSavedColumnVisibility,
@@ -55,7 +56,7 @@ export interface UseSavedViewsOptions {
 
 export interface UseSavedViewsReturn {
     activeSavedView: SavedView | undefined;
-    autoFillColumnId: string | undefined;
+    autoFillColumnId: AutoFillColumnSelection;
     handleClearSavedView: () => void;
     handleLoadView: (view: SavedView) => void;
     handleResetToSaved: () => void;
@@ -65,7 +66,7 @@ export interface UseSavedViewsReturn {
     isMissing: boolean;
     isModified: boolean;
     savedViews: SavedView[];
-    setAutoFillColumnId: (columnId: string) => void;
+    setAutoFillColumnId: (columnId: AutoFillColumnSelection) => void;
 }
 
 export function clearSavedViewQueryParams(queryParams: SavedViewQueryParams): void {
@@ -112,8 +113,8 @@ export function hasMissingSavedViewSlug(options: {
     return !!options.slug && !options.activeSavedView && !!options.savedViews && !options.isLoading;
 }
 
-export function hasSavedViewAutoFillChange(current: string | undefined, view: Pick<SavedView, 'columns'>, defaultAutoFillColumnId?: string): boolean {
-    return current !== (getSavedAutoFillColumnId(view) ?? defaultAutoFillColumnId);
+export function hasSavedViewAutoFillChange(current: AutoFillColumnSelection, view: Pick<SavedView, 'columns'>, defaultAutoFillColumnId?: string): boolean {
+    return current !== getSavedAutoFillColumnSelection(view, defaultAutoFillColumnId);
 }
 
 export function hasSavedViewColumnChanges(
@@ -171,7 +172,7 @@ export function supportsTimeQueryParam(queryParams: SavedViewQueryParams): query
 
 export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsReturn {
     const isEnabled = $derived(!!organization.current);
-    let autoFillColumnId = $state(options.defaultAutoFillColumnId);
+    let autoFillColumnId = $state<AutoFillColumnSelection>(options.defaultAutoFillColumnId ?? null);
 
     // Some routes, such as stream, do not declare every saved-view query parameter.
     const supportsSort = supportsSortQueryParam(options.queryParams);
@@ -206,8 +207,6 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     });
 
     function applyColumnState(view: Pick<SavedView, 'columns'> | undefined): void {
-        autoFillColumnId = getSavedAutoFillColumnId(view) ?? options.defaultAutoFillColumnId;
-
         if (options.setColumnVisibility) {
             options.setColumnVisibility(getSavedColumnVisibility(view));
         }
@@ -217,6 +216,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         options.setColumnSizing?.(getSavedColumnSizing(view));
+        autoFillColumnId = getSavedAutoFillColumnSelection(view, options.defaultAutoFillColumnId);
     }
 
     function applyDisplayState(view: Pick<SavedView, 'show_chart' | 'show_stats'> | undefined): void {
@@ -415,7 +415,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         get savedViews() {
             return savedViewsListQuery.data ?? [];
         },
-        setAutoFillColumnId(columnId: string) {
+        setAutoFillColumnId(columnId: AutoFillColumnSelection) {
             autoFillColumnId = columnId;
         }
     };

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -8,7 +8,14 @@ import { organization } from '$features/organizations/context.svelte';
 import type { SavedView } from './models';
 
 import { getSavedViewsByViewQuery } from './api.svelte';
-import { getSavedColumnOrder, getSavedColumnSizing, getSavedColumnVisibility, savedViewColumnOrderEqual, savedViewColumnSizingEqual } from './column-settings';
+import {
+    getSavedAutoFillColumnId,
+    getSavedColumnOrder,
+    getSavedColumnSizing,
+    getSavedColumnVisibility,
+    savedViewColumnOrderEqual,
+    savedViewColumnSizingEqual
+} from './column-settings';
 import { savedViewHref, savedViewResolvedSlug } from './slugs';
 
 export interface SavedViewQueryParams {
@@ -21,6 +28,7 @@ export interface SavedViewQueryParams {
 
 export interface UseSavedViewsOptions {
     baseHref?: string;
+    defaultAutoFillColumnId?: string;
     defaultColumnVisibility?: ColumnVisibilityState;
     defaultFilter?: null | string;
     defaultTime?: null | string;
@@ -47,6 +55,7 @@ export interface UseSavedViewsOptions {
 
 export interface UseSavedViewsReturn {
     activeSavedView: SavedView | undefined;
+    autoFillColumnId: string | undefined;
     handleClearSavedView: () => void;
     handleLoadView: (view: SavedView) => void;
     handleResetToSaved: () => void;
@@ -56,6 +65,7 @@ export interface UseSavedViewsReturn {
     isMissing: boolean;
     isModified: boolean;
     savedViews: SavedView[];
+    setAutoFillColumnId: (columnId: string) => void;
 }
 
 export function clearSavedViewQueryParams(queryParams: SavedViewQueryParams): void {
@@ -100,6 +110,10 @@ export function hasMissingSavedViewSlug(options: {
     slug: string | undefined;
 }): boolean {
     return !!options.slug && !options.activeSavedView && !!options.savedViews && !options.isLoading;
+}
+
+export function hasSavedViewAutoFillChange(current: string | undefined, view: Pick<SavedView, 'columns'>, defaultAutoFillColumnId?: string): boolean {
+    return current !== (getSavedAutoFillColumnId(view) ?? defaultAutoFillColumnId);
 }
 
 export function hasSavedViewColumnChanges(
@@ -157,6 +171,7 @@ export function supportsTimeQueryParam(queryParams: SavedViewQueryParams): query
 
 export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsReturn {
     const isEnabled = $derived(!!organization.current);
+    let autoFillColumnId = $state(options.defaultAutoFillColumnId);
 
     // Some routes, such as stream, do not declare every saved-view query parameter.
     const supportsSort = supportsSortQueryParam(options.queryParams);
@@ -191,6 +206,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     });
 
     function applyColumnState(view: Pick<SavedView, 'columns'> | undefined): void {
+        autoFillColumnId = getSavedAutoFillColumnId(view) ?? options.defaultAutoFillColumnId;
+
         if (options.setColumnVisibility) {
             options.setColumnVisibility(getSavedColumnVisibility(view));
         }
@@ -304,6 +321,10 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return true;
         }
 
+        if (hasSavedViewAutoFillChange(autoFillColumnId, view, options.defaultAutoFillColumnId)) {
+            return true;
+        }
+
         if (options.getShowStats && options.getShowStats() !== (view.show_stats ?? true)) {
             return true;
         }
@@ -370,6 +391,9 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         get activeSavedView() {
             return activeSavedView;
         },
+        get autoFillColumnId() {
+            return autoFillColumnId;
+        },
         handleClearSavedView,
         handleLoadView,
         handleResetToSaved,
@@ -390,6 +414,9 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         },
         get savedViews() {
             return savedViewsListQuery.data ?? [];
+        },
+        setAutoFillColumnId(columnId: string) {
+            autoFillColumnId = columnId;
         }
     };
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -220,6 +220,19 @@ describe('useSavedViews', () => {
             expect(hasSavedViewAutoFillChange('date', savedView, 'summary')).toBe(true);
         });
 
+        it('treats an explicit None selection as unchanged', () => {
+            const savedView = buildSavedView({
+                columns: {
+                    summary: { auto_fill: false, visible: true }
+                },
+                id: 'view-1',
+                name: 'Fixed Width View'
+            });
+
+            expect(hasSavedViewAutoFillChange(null, savedView, 'summary')).toBe(false);
+            expect(hasSavedViewAutoFillChange('summary', savedView, 'summary')).toBe(true);
+        });
+
         it('treats visibility missing default-hidden columns as unchanged', () => {
             // Arrange
             const current = { project: false, summary: true, tags: false };

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -12,6 +12,7 @@ import {
     getComparableSavedViewFilter,
     getComparableSavedViewTime,
     hasMissingSavedViewSlug,
+    hasSavedViewAutoFillChange,
     hasSavedViewColumnChanges,
     savedViewColumnsEqual,
     type SavedViewQueryParams,
@@ -198,6 +199,27 @@ describe('useSavedViews', () => {
     });
 
     describe('column comparison', () => {
+        it('detects a changed auto-fill column', () => {
+            const savedView = buildSavedView({
+                columns: {
+                    date: { visible: true },
+                    summary: { auto_fill: true, visible: true }
+                },
+                id: 'view-1',
+                name: 'Summary View'
+            });
+
+            expect(hasSavedViewAutoFillChange('date', savedView, 'summary')).toBe(true);
+            expect(hasSavedViewAutoFillChange('summary', savedView, 'summary')).toBe(false);
+        });
+
+        it('uses the default auto-fill column for legacy saved views', () => {
+            const savedView = buildSavedView({ id: 'view-1', name: 'Legacy View' });
+
+            expect(hasSavedViewAutoFillChange('summary', savedView, 'summary')).toBe(false);
+            expect(hasSavedViewAutoFillChange('date', savedView, 'summary')).toBe(true);
+        });
+
         it('treats visibility missing default-hidden columns as unchanged', () => {
             // Arrange
             const current = { project: false, summary: true, tags: false };

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
@@ -12,13 +12,14 @@
     import DataTableColumnHeader from './data-table-column-header.svelte';
 
     interface Props {
+        autoFillColumnId?: string;
         children?: Snippet;
         rowClick?: (row: TData, event?: MouseEvent) => void;
         rowHref?: (row: TData) => string;
         table: SvelteTable<StockFeatures, TData>;
     }
 
-    let { children, rowClick, rowHref, table }: Props = $props();
+    let { autoFillColumnId, children, rowClick, rowHref, table }: Props = $props();
 
     const selectColumnClass = 'w-8 min-w-8 max-w-8';
     const selectColumnWidth = 32;
@@ -85,6 +86,11 @@
     function getFlexibleDataColumnId(): string | undefined {
         const columnSizing = table.atoms.columnSizing?.get() ?? {};
         const visibleDataColumns = getVisibleDataColumns();
+        if (autoFillColumnId !== undefined) {
+            const autoFillColumn = visibleDataColumns.find((column) => column.id === autoFillColumnId);
+            return autoFillColumn && columnSizing[autoFillColumn.id] === undefined ? autoFillColumn.id : undefined;
+        }
+
         const fullWidthColumns = visibleDataColumns.filter((column) => getMetaClass(column.columnDef.meta).split(' ').includes('w-full'));
         if (fullWidthColumns.length > 0) {
             return fullWidthColumns.find((column) => columnSizing[column.id] === undefined)?.id;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
@@ -167,9 +167,9 @@
 
         event.preventDefault();
         event.stopPropagation();
-        handleAutoFillColumnResize(header);
         const delta = event.key === 'ArrowLeft' ? -16 : 16;
         const currentSize = getResizeStartSize(event, header);
+        handleAutoFillColumnResize(header);
         table.setColumnSizing((current) => ({
             ...current,
             [header.column.id]: Math.min(

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
@@ -12,14 +12,15 @@
     import DataTableColumnHeader from './data-table-column-header.svelte';
 
     interface Props {
-        autoFillColumnId?: string;
+        autoFillColumnId?: null | string;
         children?: Snippet;
+        onAutoFillColumnResized?: (columnId: string) => void;
         rowClick?: (row: TData, event?: MouseEvent) => void;
         rowHref?: (row: TData) => string;
         table: SvelteTable<StockFeatures, TData>;
     }
 
-    let { autoFillColumnId, children, rowClick, rowHref, table }: Props = $props();
+    let { autoFillColumnId, children, onAutoFillColumnResized, rowClick, rowHref, table }: Props = $props();
 
     const selectColumnClass = 'w-8 min-w-8 max-w-8';
     const selectColumnWidth = 32;
@@ -87,6 +88,10 @@
         const columnSizing = table.atoms.columnSizing?.get() ?? {};
         const visibleDataColumns = getVisibleDataColumns();
         if (autoFillColumnId !== undefined) {
+            if (autoFillColumnId === null) {
+                return undefined;
+            }
+
             const autoFillColumn = visibleDataColumns.find((column) => column.id === autoFillColumnId);
             return autoFillColumn && columnSizing[autoFillColumn.id] === undefined ? autoFillColumn.id : undefined;
         }
@@ -162,6 +167,7 @@
 
         event.preventDefault();
         event.stopPropagation();
+        handleAutoFillColumnResize(header);
         const delta = event.key === 'ArrowLeft' ? -16 : 16;
         const currentSize = getResizeStartSize(event, header);
         table.setColumnSizing((current) => ({
@@ -202,6 +208,7 @@
             }
 
             removePendingListeners();
+            handleAutoFillColumnResize(header);
             table.setColumnSizing((current) => ({
                 ...current,
                 [header.column.id]: currentSize
@@ -228,6 +235,12 @@
         } else {
             document.addEventListener('mousemove', onMouseMove);
             document.addEventListener('mouseup', onMouseEnd);
+        }
+    }
+
+    function handleAutoFillColumnResize(header: Header<StockFeatures, TData, unknown>): void {
+        if (header.column.id === autoFillColumnId) {
+            onAutoFillColumnResized?.(header.column.id);
         }
     }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
@@ -60,6 +60,34 @@ describe('DataTableBody', () => {
         expect(dateHeader.style.cssText).toBe('width: 150px; min-width: 150px; max-width: 150px;');
     });
 
+    it('keeps every data column fixed when auto-fill is explicitly disabled', () => {
+        render(DataTableBodyTestHarness, { autoFillColumnId: null, fullWidthSummary: true, kind: 'event', onRowClick: vi.fn() });
+
+        const table = screen.getByRole('table');
+        const summaryHeader = screen.getByRole('columnheader', { name: 'Summary' });
+        const dateHeader = screen.getByRole('columnheader', { name: 'Date' });
+
+        expect(table.style.cssText).toBe('width: 342px; min-width: 342px;');
+        expect(summaryHeader.style.cssText).toBe('width: 160px; min-width: 160px; max-width: 160px;');
+        expect(dateHeader.style.cssText).toBe('width: 150px; min-width: 150px; max-width: 150px;');
+    });
+
+    it('reports when the selected auto-fill column is resized', async () => {
+        const onAutoFillColumnResized = vi.fn();
+        render(DataTableBodyTestHarness, {
+            autoFillColumnId: 'date',
+            fullWidthSummary: true,
+            kind: 'event',
+            onAutoFillColumnResized,
+            onRowClick: vi.fn()
+        });
+
+        await fireEvent.keyDown(screen.getByRole('button', { name: 'Resize date column' }), { key: 'ArrowRight' });
+
+        expect(onAutoFillColumnResized).toHaveBeenCalledOnce();
+        expect(onAutoFillColumnResized).toHaveBeenCalledWith('date');
+    });
+
     it('resizes a flexible column from its rendered width', async () => {
         render(DataTableBodyTestHarness, { fullWidthSummary: true, kind: 'event', onRowClick: vi.fn() });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
@@ -38,6 +38,16 @@ describe('DataTableBody', () => {
         expect(dateHeader.style.cssText).toBe('width: 150px; min-width: 150px; max-width: 150px;');
     });
 
+    it('uses the saved view auto-fill column instead of the column-definition default', () => {
+        render(DataTableBodyTestHarness, { autoFillColumnId: 'date', fullWidthSummary: true, kind: 'event', onRowClick: vi.fn() });
+
+        const summaryHeader = screen.getByRole('columnheader', { name: 'Summary' });
+        const dateHeader = screen.getByRole('columnheader', { name: 'Date' });
+
+        expect(summaryHeader.style.cssText).toBe('width: 160px; min-width: 160px; max-width: 160px;');
+        expect(dateHeader.style.cssText).toBe('width: 100%;');
+    });
+
     it('does not transfer flexibility after the full-width column is sized', () => {
         render(DataTableBodyTestHarness, { fullWidthSummary: true, kind: 'event', onRowClick: vi.fn(), sizedFullWidthSummary: true });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
@@ -13,13 +13,14 @@
 
     interface Props {
         allColumnsSized?: boolean;
+        autoFillColumnId?: string;
         fullWidthSummary?: boolean;
         kind: 'event' | 'stack';
         onRowClick: (row: TestSummary) => void;
         sizedFullWidthSummary?: boolean;
     }
 
-    let { allColumnsSized = false, fullWidthSummary = false, kind, onRowClick, sizedFullWidthSummary = false }: Props = $props();
+    let { allColumnsSized = false, autoFillColumnId, fullWidthSummary = false, kind, onRowClick, sizedFullWidthSummary = false }: Props = $props();
 
     const summaryData = {
         Message: 'Unexpected end of Stream, the content may have already been read by another component.',
@@ -115,6 +116,7 @@
 </script>
 
 <DataTableBody
+    {autoFillColumnId}
     rowClick={onRowClick}
     rowHref={(row: SummaryModel<SummaryTemplateKeys>) => (kind === 'event' ? buildEventDetailsHref(row.id) : buildStackDetailsHref(row.id))}
     {table}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
@@ -13,14 +13,23 @@
 
     interface Props {
         allColumnsSized?: boolean;
-        autoFillColumnId?: string;
+        autoFillColumnId?: null | string;
         fullWidthSummary?: boolean;
         kind: 'event' | 'stack';
+        onAutoFillColumnResized?: (columnId: string) => void;
         onRowClick: (row: TestSummary) => void;
         sizedFullWidthSummary?: boolean;
     }
 
-    let { allColumnsSized = false, autoFillColumnId, fullWidthSummary = false, kind, onRowClick, sizedFullWidthSummary = false }: Props = $props();
+    let {
+        allColumnsSized = false,
+        autoFillColumnId,
+        fullWidthSummary = false,
+        kind,
+        onAutoFillColumnResized,
+        onRowClick,
+        sizedFullWidthSummary = false
+    }: Props = $props();
 
     const summaryData = {
         Message: 'Unexpected end of Stream, the content may have already been read by another component.',
@@ -117,6 +126,7 @@
 
 <DataTableBody
     {autoFillColumnId}
+    {onAutoFillColumnResized}
     rowClick={onRowClick}
     rowHref={(row: SummaryModel<SummaryTemplateKeys>) => (kind === 'event' ? buildEventDetailsHref(row.id) : buildStackDetailsHref(row.id))}
     {table}

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
@@ -396,6 +396,8 @@ export interface ResetPasswordModel {
 export interface SavedViewColumnSettings {
   /** Whether the column is visible. Null means use the table default. */
   visible?: null | boolean;
+  /** Whether the column fills the table's remaining width. Null or false means use fixed-width behavior. */
+  auto_fill?: null | boolean;
   /**
    * Zero-based display position. Null means use the table default order.
    * @format int32

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
@@ -517,6 +517,7 @@ export type ResetPasswordModelFormData = Infer<typeof ResetPasswordModelSchema>;
 
 export const SavedViewColumnSettingsSchema = object({
   visible: boolean().nullable().optional(),
+  auto_fill: boolean().nullable().optional(),
   position: int32()
     .min(0, "Position must be at least 0")
     .max(49, "Position must be at most 49")

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -999,6 +999,7 @@
             autoFillColumnId={savedViewsState.autoFillColumnId}
             bind:limit={eventsQueryParameters.limit!}
             isLoading={isSavedViewRoutePending || eventsQuery.isFetching}
+            onAutoFillColumnResized={() => savedViewsState.setAutoFillColumnId(null)}
             {rowClick}
             {rowHref}
             {table}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -250,6 +250,7 @@
     let showChart = $state(true);
     const savedViewsState = useSavedViews({
         baseHref: resolve('/(app)/event'),
+        defaultAutoFillColumnId: 'summary',
         defaultColumnVisibility: defaultEventColumnVisibility,
         defaultFilter: DEFAULT_FILTER,
         defaultTime: DEFAULT_TIME_RANGE,
@@ -944,15 +945,18 @@
             {#if savedViewsState.isEnabled}
                 <SavedViewPicker
                     activeSavedView={savedViewsState.activeSavedView}
+                    autoFillColumnId={savedViewsState.autoFillColumnId}
                     columnOrder={table.store.state.columnOrder}
                     columnSizing={table.store.state.columnSizing}
                     columnVisibility={table.store.state.columnVisibility}
+                    defaultAutoFillColumnId="summary"
                     filters={filters ?? []}
                     isModified={savedViewsState.isModified}
                     onLoadView={savedViewsState.handleLoadView}
                     onClearSavedView={savedViewsState.handleClearSavedView}
                     onResetToSaved={handleResetToSaved}
                     savedViews={savedViewsState.savedViews}
+                    setAutoFillColumnId={savedViewsState.setAutoFillColumnId}
                     {showChart}
                     {showStats}
                     setShowChart={(v) => (showChart = v)}
@@ -991,7 +995,14 @@
             />
         {/if}
 
-        <EventsDataTable bind:limit={eventsQueryParameters.limit!} isLoading={isSavedViewRoutePending || eventsQuery.isFetching} {rowClick} {rowHref} {table}>
+        <EventsDataTable
+            autoFillColumnId={savedViewsState.autoFillColumnId}
+            bind:limit={eventsQueryParameters.limit!}
+            isLoading={isSavedViewRoutePending || eventsQuery.isFetching}
+            {rowClick}
+            {rowHref}
+            {table}
+        >
             {#snippet footerChildren()}
                 <div class="h-9 min-w-35">
                     {#if table.getSelectedRowModel().flatRows.length}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -243,6 +243,7 @@
     let showChart = $state(true);
     const savedViewsState = useSavedViews({
         baseHref: resolve('/(app)/stack'),
+        defaultAutoFillColumnId: 'summary',
         defaultColumnVisibility: defaultStackColumnVisibility,
         defaultFilter: DEFAULT_FILTER,
         defaultTime: DEFAULT_TIME_RANGE,
@@ -847,15 +848,18 @@
             {#if savedViewsState.isEnabled}
                 <SavedViewPicker
                     activeSavedView={savedViewsState.activeSavedView}
+                    autoFillColumnId={savedViewsState.autoFillColumnId}
                     columnOrder={table.store.state.columnOrder}
                     columnSizing={table.store.state.columnSizing}
                     columnVisibility={table.store.state.columnVisibility}
+                    defaultAutoFillColumnId="summary"
                     filters={filters ?? []}
                     isModified={savedViewsState.isModified}
                     onLoadView={savedViewsState.handleLoadView}
                     onClearSavedView={savedViewsState.handleClearSavedView}
                     onResetToSaved={handleResetToSaved}
                     savedViews={savedViewsState.savedViews}
+                    setAutoFillColumnId={savedViewsState.setAutoFillColumnId}
                     {showChart}
                     {showStats}
                     setShowChart={(v) => (showChart = v)}
@@ -893,7 +897,14 @@
             />
         {/if}
 
-        <EventsDataTable bind:limit={eventsQueryParameters.limit!} isLoading={isSavedViewRoutePending || eventsQuery.isFetching} {rowClick} {rowHref} {table}>
+        <EventsDataTable
+            autoFillColumnId={savedViewsState.autoFillColumnId}
+            bind:limit={eventsQueryParameters.limit!}
+            isLoading={isSavedViewRoutePending || eventsQuery.isFetching}
+            {rowClick}
+            {rowHref}
+            {table}
+        >
             {#snippet footerChildren()}
                 <div class="h-9 min-w-35">
                     <TableStacksBulkActionsDropdownMenu {table} />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -901,6 +901,7 @@
             autoFillColumnId={savedViewsState.autoFillColumnId}
             bind:limit={eventsQueryParameters.limit!}
             isLoading={isSavedViewRoutePending || eventsQuery.isFetching}
+            onAutoFillColumnResized={() => savedViewsState.setAutoFillColumnId(null)}
             {rowClick}
             {rowHref}
             {table}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -81,6 +81,7 @@
 
     const VIEW = 'stream';
     const savedViewsState = useSavedViews({
+        defaultAutoFillColumnId: 'summary',
         defaultColumnVisibility: defaultEventColumnVisibility,
         defaultFilter: DEFAULT_PARAMS.filter,
         filterCacheKey,
@@ -330,15 +331,18 @@
             {#if savedViewsState.isEnabled}
                 <SavedViewPicker
                     activeSavedView={savedViewsState.activeSavedView}
+                    autoFillColumnId={savedViewsState.autoFillColumnId}
                     columnOrder={table.store.state.columnOrder}
                     columnSizing={table.store.state.columnSizing}
                     columnVisibility={table.store.state.columnVisibility}
+                    defaultAutoFillColumnId="summary"
                     filters={filters ?? []}
                     isModified={savedViewsState.isModified}
                     onLoadView={savedViewsState.handleLoadView}
                     onClearSavedView={savedViewsState.handleClearSavedView}
                     onResetToSaved={savedViewsState.handleResetToSaved}
                     savedViews={savedViewsState.savedViews}
+                    setAutoFillColumnId={savedViewsState.setAutoFillColumnId}
                     {table}
                     view={VIEW}
                 />
@@ -346,7 +350,7 @@
             <StreamingIndicatorButton onToggle={handleToggle} {paused} size="icon-lg" />
         </div>
     </div>
-    <DataTable.Body rowClick={rowclick} {rowHref} {table}>
+    <DataTable.Body autoFillColumnId={savedViewsState.autoFillColumnId} rowClick={rowclick} {rowHref} {table}>
         {#if clientStatus.isLoading}
             <DelayedRender>
                 <DataTable.Loading {table} />

--- a/src/Exceptionless.Web/Models/SavedView/NewSavedView.cs
+++ b/src/Exceptionless.Web/Models/SavedView/NewSavedView.cs
@@ -145,6 +145,30 @@ public record NewSavedView : IOwnedByOrganization, IValidatableObject
                     [nameof(Columns)]
                 );
             }
+
+            if (settings.AutoFill == true && settings.Width is not null)
+            {
+                yield return new ValidationResult(
+                    $"Auto-fill column '{key}' cannot also have a fixed width.",
+                    [nameof(Columns)]
+                );
+            }
+
+            if (settings.AutoFill == true && settings.Visible == false)
+            {
+                yield return new ValidationResult(
+                    $"Auto-fill column '{key}' cannot be hidden.",
+                    [nameof(Columns)]
+                );
+            }
+        }
+
+        if (columns.Count(entry => entry.Value?.AutoFill == true) > 1)
+        {
+            yield return new ValidationResult(
+                "Only one column can auto-fill the remaining table width.",
+                [nameof(Columns)]
+            );
         }
 
         foreach (var duplicatePosition in columns

--- a/tests/Exceptionless.Tests/Api/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Api/Data/openapi.json
@@ -12754,6 +12754,13 @@
             ],
             "description": "Whether the column is visible. Null means use the table default."
           },
+          "auto_fill": {
+            "type": [
+              "null",
+              "boolean"
+            ],
+            "description": "Whether the column fills the table\u0027s remaining width. Null or false means use fixed-width behavior."
+          },
           "position": {
             "maximum": 49,
             "minimum": 0,

--- a/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
@@ -123,6 +123,7 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         Assert.DoesNotContain("\"filter_definitions\"", json);
         Assert.NotNull(definitions);
         Assert.Equal(await GetDefaultPredefinedSavedViewCountAsync(), definitions.Count);
+        Assert.All(definitions, definition => Assert.True(definition.Columns?["summary"].AutoFill));
 
         var logs = definitions.FirstOrDefault(view => String.Equals(view.Key, "events:logs", StringComparison.OrdinalIgnoreCase));
         Assert.NotNull(logs);
@@ -407,7 +408,7 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         // Arrange
         var columnSettings = new Dictionary<string, SavedViewColumnSettings>
         {
-            ["summary"] = new() { Position = 0, Visible = true, Width = 420 },
+            ["summary"] = new() { AutoFill = true, Position = 0, Visible = true },
             ["project"] = new() { Position = 1, Visible = true, Width = 240 }
         };
 
@@ -431,12 +432,14 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         Assert.Equal(240, result.Columns?["project"].Width);
         Assert.True(result.Columns?["project"].Visible);
         Assert.Equal(1, result.Columns?["project"].Position);
+        Assert.True(result.Columns?["summary"].AutoFill);
 
         var savedView = await _savedViewRepository.GetByIdAsync(result.Id);
         Assert.NotNull(savedView);
         Assert.Equal(240, savedView.Columns?["project"].Width);
         Assert.True(savedView.Columns?["project"].Visible);
         Assert.Equal(1, savedView.Columns?["project"].Position);
+        Assert.True(savedView.Columns?["summary"].AutoFill);
     }
 
     [Fact]
@@ -2313,6 +2316,53 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
                 {
                     ["summary"] = new() { Position = 0 },
                     ["project"] = new() { Position = 0 }
+                }
+            })
+            .StatusCodeShouldBeUnprocessableEntity()
+        );
+    }
+
+    [Fact]
+    public Task PostAsync_MultipleAutoFillColumns_ReturnsUnprocessableEntity()
+    {
+        // Arrange & Act & Assert
+        return SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views")
+            .Content(new NewSavedView
+            {
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                Name = "Multiple Auto-Fill Columns",
+                ViewType = "events",
+                Columns = new Dictionary<string, SavedViewColumnSettings>
+                {
+                    ["summary"] = new() { AutoFill = true },
+                    ["project"] = new() { AutoFill = true }
+                }
+            })
+            .StatusCodeShouldBeUnprocessableEntity()
+        );
+    }
+
+    [Theory]
+    [InlineData(false, null)]
+    [InlineData(true, 240)]
+    public Task PostAsync_AutoFillColumnWithConflictingSetting_ReturnsUnprocessableEntity(bool visible, int? width)
+    {
+        // Arrange & Act & Assert
+        return SendRequestAsync(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-views")
+            .Content(new NewSavedView
+            {
+                OrganizationId = SampleDataService.TEST_ORG_ID,
+                Name = "Invalid Auto-Fill Column",
+                ViewType = "events",
+                Columns = new Dictionary<string, SavedViewColumnSettings>
+                {
+                    ["summary"] = new() { AutoFill = true, Visible = visible, Width = width }
                 }
             })
             .StatusCodeShouldBeUnprocessableEntity()

--- a/tests/Exceptionless.Tests/Api/OpenApiSnapshotTests.cs
+++ b/tests/Exceptionless.Tests/Api/OpenApiSnapshotTests.cs
@@ -103,6 +103,7 @@ public sealed class OpenApiSnapshotTests : IClassFixture<AppWebHostFactory>
         Assert.True(schemas.TryGetProperty("ViewOrganization", out _));
 
         var savedViewColumnProperties = savedViewColumnSettings.GetProperty("properties");
+        Assert.Equal("boolean", savedViewColumnProperties.GetProperty("auto_fill").GetProperty("type")[1].GetString());
         var position = savedViewColumnProperties.GetProperty("position");
         Assert.Equal(0, position.GetProperty("minimum").GetInt32());
         Assert.Equal(SavedViewColumnSettings.MaxPosition, position.GetProperty("maximum").GetInt32());

--- a/tests/Exceptionless.Tests/Mapping/SavedViewMapperTests.cs
+++ b/tests/Exceptionless.Tests/Mapping/SavedViewMapperTests.cs
@@ -29,7 +29,7 @@ public sealed class SavedViewMapperTests
             FilterDefinitions = "[{\"type\":\"status\",\"values\":[\"open\",\"regressed\"]}]",
             Columns = new Dictionary<string, SavedViewColumnSettings>
             {
-                ["summary"] = new() { Position = 0, Visible = true },
+                ["summary"] = new() { AutoFill = true, Position = 0, Visible = true },
                 ["status"] = new() { Position = 1, Visible = true, Width = 180 },
                 ["users"] = new() { Position = 2, Visible = false }
             }
@@ -51,6 +51,7 @@ public sealed class SavedViewMapperTests
         Assert.False(result.Columns["users"].Visible);
         Assert.Equal(1, result.Columns["status"].Position);
         Assert.Equal(180, result.Columns["status"].Width);
+        Assert.True(result.Columns["summary"].AutoFill);
     }
 
     [Fact]
@@ -112,7 +113,7 @@ public sealed class SavedViewMapperTests
             FilterDefinitions = "[{\"type\":\"status\",\"values\":[\"open\"]}]",
             Columns = new Dictionary<string, SavedViewColumnSettings>
             {
-                ["summary"] = new() { Position = 0, Visible = true },
+                ["summary"] = new() { AutoFill = true, Position = 0, Visible = true },
                 ["status"] = new() { Position = 1, Visible = true, Width = 180 }
             },
             Name = "My View",
@@ -139,6 +140,7 @@ public sealed class SavedViewMapperTests
         Assert.True(result.Columns["status"].Visible);
         Assert.Equal(1, result.Columns["status"].Position);
         Assert.Equal(180, result.Columns["status"].Width);
+        Assert.True(result.Columns["summary"].AutoFill);
         Assert.Equal("My View", result.Name);
         Assert.Equal("[now-30d TO now]", result.Time);
         Assert.Equal("-last", result.Sort);

--- a/tests/Exceptionless.Tests/Serializer/Models/SavedViewSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/SavedViewSerializerTests.cs
@@ -29,7 +29,7 @@ public class SavedViewSerializerTests : TestWithServices
             FilterDefinitions = """[{"field":"status","operator":"in","values":["open","regressed"]}]""",
             Columns = new Dictionary<string, SavedViewColumnSettings>
             {
-                ["title"] = new() { Position = 0, Visible = true, Width = 420 },
+                ["title"] = new() { AutoFill = true, Position = 0, Visible = true },
                 ["date"] = new() { Position = 1, Visible = true },
                 ["status"] = new() { Position = 2, Visible = false, Width = 180 }
             },
@@ -61,7 +61,7 @@ public class SavedViewSerializerTests : TestWithServices
         Assert.Equal(3, result.Columns.Count);
         Assert.True(result.Columns["title"].Visible);
         Assert.False(result.Columns["status"].Visible);
-        Assert.Equal(420, result.Columns["title"].Width);
+        Assert.True(result.Columns["title"].AutoFill);
     }
 
     [Fact]

--- a/tests/http/saved-views.http
+++ b/tests/http/saved-views.http
@@ -57,6 +57,7 @@ Content-Type: application/json
     "view_type": "events",
     "columns": {
         "summary": {
+            "auto_fill": true,
             "visible": true,
             "position": 0
         },
@@ -88,6 +89,7 @@ Content-Type: application/json
     "view_type": "stream",
     "columns": {
         "summary": {
+            "auto_fill": true,
             "visible": true,
             "position": 0
         },
@@ -118,6 +120,7 @@ Content-Type: application/json
     "sort": "date",
     "columns": {
         "summary": {
+            "auto_fill": true,
             "visible": true,
             "position": 0
         },


### PR DESCRIPTION
## Summary

- add a persisted `auto_fill` saved-view column setting with API validation and generated client contracts
- let users choose the auto-fill column from **View → Manage Columns**, including save, reset, resize, and reload behavior
- make Summary auto-fill by default for predefined Events, Stacks, and Stream views
- update the shared table renderer and add backend, unit, and browser coverage

## Why

Saved column widths were entirely fixed, so event and stack tables could not use additional browser width. Users also had no UI for choosing which column should absorb that space.

Fixes #2464.

## Verification

- `npm run validate`
- focused frontend unit suite: 61 tests passed
- `SavedViewEndpointTests`: 113 passed
- `SavedViewSerializerTests`: 3 passed
- `SavedViewMapperTests`: 7 passed
- `OpenApiSnapshotTests`: 4 passed
- focused Playwright saved-view auto-fill workflow: 1 passed

## Breaking changes

None.