### PR TITLE
Increase backend test parallelism

### DIFF
--- a/tests/Exceptionless.Tests/Properties/PropertyInfo.cs
+++ b/tests/Exceptionless.Tests/Properties/PropertyInfo.cs
@@ -1,3 +1,3 @@
 ﻿using Xunit.v3;
 
-[assembly: Parallelization(MaxThreads = 6)]
+[assembly: Parallelization(MaxThreads = 8)]


### PR DESCRIPTION
## What changed

- raise the backend test assembly's maximum parallel threads from six to eight

## Why

The backend test step is now the stable critical path after E2E improvements. This PR intentionally changes only the xUnit thread cap so its hosted timing and reliability are attributable. It does not enable the aggressive scheduler, which failed locally by exhausting Elasticsearch's 1,000-shard limit.

## Local experiment

| Configuration | Runtime | Result |
| --- | ---: | --- |
| Six threads, no coverage | 3m34s | 2,941 passed, 3 skipped |
| Four threads, no coverage | 4m22s | 2,941 passed, 3 skipped |
| Eight threads, no coverage | 3m18s | 2,941 passed, 3 skipped |
| Six threads, aggressive scheduler | stopped at 1m05s | 9 failures; Elasticsearch shard limit reached |

The eight-thread configuration was 16 seconds faster than six threads in the controlled matrix. A fresh eight-thread verification on current `main` also passed all 2,944 discovered cases in 2m19s of test execution.

The GitHub-hosted runner has four CPUs, so the hosted result is the acceptance gate; this PR should be rejected if the required test step does not improve over repeated runs.

## Verification

- `dotnet test --project tests/Exceptionless.Tests/Exceptionless.Tests.csproj --configuration Release`
- 2,941 passed, 3 skipped, 0 failed

## Measurement

Compare `Run .NET Tests with Coverage` against the recent 9m21s median. The experiment succeeds only if at least three hosted runs improve the median without failures, resource exhaustion, or a longer tail.

## Breaking changes

None.
