### PR TITLE
Expand command palette actions

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/project-command-actions.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/project-command-actions.svelte
@@ -1,5 +1,6 @@
 <script module lang="ts">
-    export type ProjectActionId = 'client-setup' | 'generate-sample-data' | 'notifications' | 'open' | 'reset-data' | 'stacks';
+    export type ProjectActionId =
+        'api-keys' | 'client-setup' | 'events' | 'generate-sample-data' | 'integrations' | 'notifications' | 'open' | 'reset-data' | 'source-maps' | 'stacks';
 </script>
 
 <script lang="ts">
@@ -13,10 +14,14 @@
     import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
     import ArrowLeft from '@lucide/svelte/icons/arrow-left';
     import Bell from '@lucide/svelte/icons/bell';
+    import Events from '@lucide/svelte/icons/calendar-days';
     import CloudDownload from '@lucide/svelte/icons/cloud-download';
     import Database from '@lucide/svelte/icons/database';
+    import SourceMaps from '@lucide/svelte/icons/file-code-2';
     import FolderOpen from '@lucide/svelte/icons/folder-open';
+    import ApiKey from '@lucide/svelte/icons/key';
     import Stacks from '@lucide/svelte/icons/layers';
+    import Integration from '@lucide/svelte/icons/plug-2';
     import { toast } from 'svelte-sonner';
 
     type ProjectAction = {
@@ -50,6 +55,30 @@
             id: 'stacks',
             keywords: ['errors', 'exceptions', 'issues'],
             label: 'Project Stacks'
+        },
+        {
+            icon: Events,
+            id: 'events',
+            keywords: ['errors', 'logs', 'sessions', 'events'],
+            label: 'Project Events'
+        },
+        {
+            icon: ApiKey,
+            id: 'api-keys',
+            keywords: ['tokens', 'access keys', 'client keys'],
+            label: 'Project API Keys'
+        },
+        {
+            icon: Integration,
+            id: 'integrations',
+            keywords: ['webhooks', 'Slack', 'Zapier'],
+            label: 'Project Webhooks & Integrations'
+        },
+        {
+            icon: SourceMaps,
+            id: 'source-maps',
+            keywords: ['JavaScript', 'minified', 'symbols'],
+            label: 'Project Source Maps'
         },
         {
             icon: Bell,
@@ -112,14 +141,28 @@
 
     function getProjectHref(action: ProjectActionId, project: ViewProject): string | undefined {
         switch (action) {
+            case 'api-keys':
+                return resolve('/(app)/project/[projectId]/api-keys', {
+                    projectId: project.id
+                });
             case 'client-setup':
                 return resolve('/(app)/project/[projectId]/configure', {
+                    projectId: project.id
+                });
+            case 'events':
+                return `${resolve('/(app)/event')}?project=${project.id}`;
+            case 'integrations':
+                return resolve('/(app)/project/[projectId]/integrations', {
                     projectId: project.id
                 });
             case 'notifications':
                 return `${resolve('/(app)/account/notifications')}?project=${project.id}`;
             case 'open':
                 return resolve('/(app)/project/[projectId]/manage', {
+                    projectId: project.id
+                });
+            case 'source-maps':
+                return resolve('/(app)/project/[projectId]/source-maps', {
                     projectId: project.id
                 });
             case 'stacks':

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte
@@ -1,22 +1,26 @@
 <script lang="ts">
     import type { ViewOrganization } from '$features/organizations/models';
     import type { ViewProject } from '$features/projects/models';
-    import type { FetchClientResponse, ProblemDetails } from '@foundatiofx/fetchclient';
+    import type { FetchClientResponse } from '@foundatiofx/fetchclient';
 
     import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';
     import * as Command from '$comp/ui/command';
     import { logout } from '$features/auth/api.svelte';
     import { accessToken } from '$features/auth/index.svelte';
+    import { showBillingDialogOnUpgradeProblem } from '$features/billing';
     import { buildEventDetailsHref, type EventSummaryModel, type StackSummaryModel, type SummaryTemplateKeys } from '$features/events/components/summary/index';
+    import { addOrganizationUser } from '$features/organizations/api.svelte';
     import { organization } from '$features/organizations/context.svelte';
     import { resetData } from '$features/projects/api.svelte';
     import ResetProjectDataDialog from '$features/projects/components/dialogs/reset-project-data-dialog.svelte';
     import ProjectCommandActions, { type ProjectActionId } from '$features/projects/components/project-command-actions.svelte';
     import { appKeyboardShortcuts, formatKeyboardShortcut, type ShortcutKey } from '$features/shared/keyboard-shortcuts';
+    import InviteUserDialog from '$features/users/components/invite-user-dialog.svelte';
     import { DEFAULT_OFFSET } from '$shared/api/api.svelte';
-    import { useFetchClient } from '@foundatiofx/fetchclient';
+    import { ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
     import Activity from '@lucide/svelte/icons/activity';
+    import Bot from '@lucide/svelte/icons/bot';
     import Building2 from '@lucide/svelte/icons/building-2';
     import CircleHelp from '@lucide/svelte/icons/circle-help';
     import CircleUserRound from '@lucide/svelte/icons/circle-user-round';
@@ -29,8 +33,11 @@
     import RefreshCw from '@lucide/svelte/icons/refresh-cw';
     import Search from '@lucide/svelte/icons/search';
     import SunMoon from '@lucide/svelte/icons/sun-moon';
+    import UserPlus from '@lucide/svelte/icons/user-plus';
+    import Users from '@lucide/svelte/icons/users';
     import { createQuery, useQueryClient } from '@tanstack/svelte-query';
     import { toggleMode } from 'mode-watcher';
+    import { tick } from 'svelte';
     import { toast } from 'svelte-sonner';
 
     import type { NavigationItem } from '../../routes.svelte';
@@ -48,11 +55,14 @@
     };
 
     type Props = {
+        askExie: (prompt: string) => Promise<void> | void;
         isChatEnabled: boolean;
+        isExieEnabled: boolean;
         isGlobalAdmin: boolean;
         isImpersonating: boolean;
         open: boolean;
         openChat: () => void;
+        openExie: () => Promise<void> | void;
         openImpersonateOrganization: () => Promise<void> | void;
         openKeyboardShortcuts: () => Promise<void> | void;
         openOrganizationSwitcher: () => Promise<void> | void;
@@ -65,17 +75,24 @@
 
     type CommandSearchResult = EventSummaryModel<SummaryTemplateKeys> | StackSummaryModel<SummaryTemplateKeys>;
 
+    const EXIE_ERROR_TRENDS_PROMPT =
+        'Analyze error trends in the current context over the last 7 days. Highlight spikes, regressions, and the issues that deserve attention first.';
+    const EXIE_TRIAGE_PROMPT =
+        'Triage the most important recent errors in the current context. Summarize their impact, likely causes, and the next investigation steps.';
     const COMMAND_SEARCH_RESULT_LIMIT = 3;
     const COMMAND_SEARCH_REQUEST_LIMIT = COMMAND_SEARCH_RESULT_LIMIT + 1;
     const COMMAND_SEARCH_MIN_LENGTH = 2;
     const COMMAND_SEARCH_TIME_RANGE = '[now-7d TO now]';
 
     let {
+        askExie,
         isChatEnabled,
+        isExieEnabled,
         isGlobalAdmin,
         isImpersonating,
         open = $bindable(),
         openChat,
+        openExie,
         openImpersonateOrganization,
         openKeyboardShortcuts,
         openOrganizationSwitcher,
@@ -327,6 +344,46 @@
         await openOrganizationSwitcher();
     }
 
+    async function openExieAssistant(): Promise<void> {
+        closeCommandWindow();
+        await openExie();
+    }
+
+    async function askExieAssistant(prompt: string): Promise<void> {
+        closeCommandWindow();
+        await askExie(prompt);
+    }
+
+    let showInviteUserDialog = $state(false);
+    const addOrganizationUserMutation = addOrganizationUser({
+        route: {
+            get organizationId() {
+                return organization.current ?? '';
+            }
+        }
+    });
+
+    async function openInviteUserDialog(): Promise<void> {
+        closeCommandWindow();
+        await tick();
+        showInviteUserDialog = true;
+    }
+
+    async function inviteUser(email: string): Promise<void> {
+        try {
+            await addOrganizationUserMutation.mutateAsync(email);
+            toast.success('User invited successfully');
+        } catch (error: unknown) {
+            if (showBillingDialogOnUpgradeProblem(error, organization.current, () => inviteUser(email))) {
+                return;
+            }
+
+            const message = error instanceof ProblemDetails ? error.title : 'Please try again.';
+            toast.error(`An error occurred while trying to invite the user: ${message}`);
+            throw error;
+        }
+    }
+
     async function openCurrentUserMenu(): Promise<void> {
         closeCommandWindow();
         await openUserMenu();
@@ -499,6 +556,26 @@
                 bind:selectedActionId={selectedProjectActionId}
             />
             {#if !selectingProject}
+                {#if isExieEnabled}
+                    <Command.Group heading="Exie" value="Exie Assistant">
+                        <Command.Item value="Ask Exie open assistant AI chat" onSelect={() => void openExieAssistant()}>
+                            <Bot />
+                            <span>Ask Exie</span>
+                        </Command.Item>
+                        <Command.Item value="Exie Triage Recent Errors investigate issues stacks" onSelect={() => void askExieAssistant(EXIE_TRIAGE_PROMPT)}>
+                            <Activity />
+                            <span>Triage Recent Errors</span>
+                        </Command.Item>
+                        <Command.Item
+                            value="Exie Analyze Error Trends seven days spikes regressions"
+                            onSelect={() => void askExieAssistant(EXIE_ERROR_TRENDS_PROMPT)}
+                        >
+                            <Stacks />
+                            <span>Analyze Error Trends</span>
+                        </Command.Item>
+                    </Command.Group>
+                    <Command.Separator />
+                {/if}
                 {#each Object.entries(groupedRoutes) as [group, items], index (group)}
                     <Command.Group heading={group}>
                         {#each items as route (route.href)}
@@ -543,6 +620,22 @@
                                 <span>Switch Organization</span>
                                 <Command.Shortcut>{formatKeyboardShortcut(appKeyboardShortcuts.switchOrganization.keys)}</Command.Shortcut>
                             </Command.Item>
+                            {#if organization.current}
+                                <Command.LinkItem
+                                    href={resolve('/(app)/organization/[organizationId]/users', {
+                                        organizationId: organization.current
+                                    })}
+                                    onclick={closeCommandWindow}
+                                    value="View Organization Users manage members team user list"
+                                >
+                                    <Users />
+                                    <span>View Organization Users</span>
+                                </Command.LinkItem>
+                                <Command.Item value="Invite User add member organization team" onSelect={() => void openInviteUserDialog()}>
+                                    <UserPlus />
+                                    <span>Invite User</span>
+                                </Command.Item>
+                            {/if}
                             <Command.LinkItem
                                 href={resolve('/(app)/organization/add')}
                                 onclick={closeCommandWindow}
@@ -609,3 +702,5 @@
 {#if resetProjectTarget}
     <ResetProjectDataDialog bind:open={showResetProjectDataDialog} name={resetProjectTarget.name} reset={resetProjectData} />
 {/if}
+
+<InviteUserDialog bind:open={showInviteUserDialog} {inviteUser} />

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/navigation-command.svelte.test.ts
@@ -5,6 +5,7 @@ import type { NavigationItem } from '../../routes.svelte';
 
 const generateSampleDataMutateAsync = vi.hoisted(() => vi.fn());
 const goto = vi.hoisted(() => vi.fn());
+const inviteUserMutateAsync = vi.hoisted(() => vi.fn());
 const logout = vi.hoisted(() => vi.fn());
 const organizationState = vi.hoisted(() => ({ current: 'organization-id' as string | undefined }));
 const refetchQueries = vi.hoisted(() => vi.fn());
@@ -22,13 +23,20 @@ vi.mock('$app/navigation', () => ({ goto }));
 vi.mock('$features/auth/api.svelte', () => ({ logout }));
 vi.mock('$features/auth/index.svelte', () => ({ accessToken: { current: 'access-token' } }));
 vi.mock('$features/events/components/summary/index', () => ({ buildEventDetailsHref: vi.fn() }));
+vi.mock('$features/billing', () => ({ showBillingDialogOnUpgradeProblem: vi.fn(() => false) }));
+vi.mock('$features/organizations/api.svelte', () => ({
+    addOrganizationUser: () => ({ isPending: false, mutateAsync: inviteUserMutateAsync })
+}));
 vi.mock('$features/organizations/context.svelte', () => ({ organization: organizationState }));
 vi.mock('$features/projects/api.svelte', () => ({
     generateSampleData: () => ({ isPending: false, mutateAsync: generateSampleDataMutateAsync }),
     getOrganizationProjectsQuery: () => ({ data: { data: [project] }, isError: false, isLoading: false }),
     resetData: () => ({ isPending: false, mutateAsync: resetDataMutateAsync })
 }));
-vi.mock('@foundatiofx/fetchclient', () => ({ useFetchClient: () => ({ getJSON: vi.fn() }) }));
+vi.mock('@foundatiofx/fetchclient', () => ({
+    ProblemDetails: class ProblemDetails extends Error {},
+    useFetchClient: () => ({ getJSON: vi.fn() })
+}));
 vi.mock('@tanstack/svelte-query', () => ({
     createQuery: () => ({
         data: undefined,
@@ -44,10 +52,13 @@ vi.mock('svelte-sonner', () => ({ toast }));
 import NavigationCommand from './navigation-command.svelte';
 
 type RenderOptions = {
+    askExie?: (prompt: string) => Promise<void> | void;
     isChatEnabled?: boolean;
+    isExieEnabled?: boolean;
     isGlobalAdmin?: boolean;
     isImpersonating?: boolean;
     openChat?: () => void;
+    openExie?: () => Promise<void> | void;
     openImpersonateOrganization?: () => Promise<void> | void;
     organizations?: Array<{ id: string; name: string }>;
     stopImpersonating?: () => Promise<void> | void;
@@ -62,11 +73,14 @@ const sessionsRoute: NavigationItem = {
 
 function renderCommandPalette(routes: NavigationItem[] = [], options: RenderOptions = {}) {
     return render(NavigationCommand, {
+        askExie: options.askExie ?? vi.fn(),
         isChatEnabled: options.isChatEnabled ?? false,
+        isExieEnabled: options.isExieEnabled ?? true,
         isGlobalAdmin: options.isGlobalAdmin ?? false,
         isImpersonating: options.isImpersonating ?? false,
         open: true,
         openChat: options.openChat ?? vi.fn(),
+        openExie: options.openExie ?? vi.fn(),
         openImpersonateOrganization: options.openImpersonateOrganization ?? vi.fn(),
         openKeyboardShortcuts: vi.fn(),
         openOrganizationSwitcher: vi.fn(),
@@ -86,6 +100,7 @@ describe('NavigationCommand project actions', () => {
     beforeEach(() => {
         generateSampleDataMutateAsync.mockResolvedValue(undefined);
         goto.mockResolvedValue(undefined);
+        inviteUserMutateAsync.mockResolvedValue(undefined);
         logout.mockResolvedValue(undefined);
         organizationState.current = 'organization-id';
         refetchQueries.mockResolvedValue(undefined);
@@ -96,6 +111,10 @@ describe('NavigationCommand project actions', () => {
     it.each([
         ['Open Project', `/next/project/${project.id}/manage`],
         ['Project Stacks', `/next/stack?filter=project:${project.id}`],
+        ['Project Events', `/next/event?project=${project.id}`],
+        ['Project API Keys', `/next/project/${project.id}/api-keys`],
+        ['Project Webhooks & Integrations', `/next/project/${project.id}/integrations`],
+        ['Project Source Maps', `/next/project/${project.id}/source-maps`],
         ['Project Notifications', `/next/account/notifications?project=${project.id}`],
         ['Client Setup', `/next/project/${project.id}/configure`]
     ])('links %s to the selected project', async (action, expectedHref) => {
@@ -123,6 +142,15 @@ describe('NavigationCommand project actions', () => {
 
         const aiToolsGroup = screen.getByText('AI Tools').closest('[data-command-group]');
         await waitFor(() => expect(aiToolsGroup?.hasAttribute('hidden')).toBe(false));
+    });
+
+    it('finds project integrations by the webhook keyword', async () => {
+        renderCommandPalette();
+
+        await fireEvent.input(screen.getByPlaceholderText('Search or jump to...'), { target: { value: 'webhook' } });
+
+        const integrationsCommand = screen.getByText('Project Webhooks & Integrations').closest('[data-command-item]');
+        await waitFor(() => expect(integrationsCommand?.hasAttribute('data-selected')).toBe(true));
     });
 
     it('does not mount remote result groups while a search is pending', async () => {
@@ -174,9 +202,70 @@ describe('NavigationCommand project actions', () => {
     it('offers the approved app actions', () => {
         renderCommandPalette([], { isChatEnabled: true, isGlobalAdmin: true });
 
-        for (const action of ['Add Organization', 'Chat with Support', 'Toggle Theme', 'Refresh Current View', 'Impersonate Organization', 'Log Out']) {
+        for (const action of [
+            'Add Organization',
+            'View Organization Users',
+            'Invite User',
+            'Ask Exie',
+            'Triage Recent Errors',
+            'Analyze Error Trends',
+            'Chat with Support',
+            'Toggle Theme',
+            'Refresh Current View',
+            'Impersonate Organization',
+            'Log Out'
+        ]) {
             expect(screen.getByText(action)).toBeTruthy();
         }
+    });
+
+    it('links to the current organization users list', () => {
+        renderCommandPalette();
+
+        const usersLink = screen.getByText('View Organization Users').closest('a');
+
+        expect(usersLink?.getAttribute('href')).toBe('/next/organization/organization-id/users');
+    });
+
+    it('opens Exie from the command palette', async () => {
+        const openExie = vi.fn();
+        renderCommandPalette([], { openExie });
+
+        await fireEvent.click(screen.getByText('Ask Exie'));
+
+        expect(openExie).toHaveBeenCalledOnce();
+    });
+
+    it.each([
+        ['Triage Recent Errors', 'Triage the most important recent errors'],
+        ['Analyze Error Trends', 'Analyze error trends in the current context over the last 7 days']
+    ])('sends the %s prompt to Exie', async (command, expectedPrompt) => {
+        const askExie = vi.fn();
+        renderCommandPalette([], { askExie });
+
+        await fireEvent.click(screen.getByText(command));
+
+        expect(askExie).toHaveBeenCalledWith(expect.stringContaining(expectedPrompt));
+    });
+
+    it('hides Exie commands when Exie is disabled', () => {
+        renderCommandPalette([], { isExieEnabled: false });
+
+        expect(screen.queryByText('Ask Exie')).toBeNull();
+        expect(screen.queryByText('Triage Recent Errors')).toBeNull();
+        expect(screen.queryByText('Analyze Error Trends')).toBeNull();
+    });
+
+    it('invites a user to the current organization', async () => {
+        renderCommandPalette();
+
+        await fireEvent.click(screen.getByText('Invite User'));
+        const emailInput = await screen.findByLabelText('Email Address');
+        await fireEvent.input(emailInput, { target: { value: 'new.user@example.com' } });
+        await fireEvent.click(screen.getByRole('button', { name: 'Invite User' }));
+
+        await waitFor(() => expect(inviteUserMutateAsync).toHaveBeenCalledWith('new.user@example.com'));
+        expect(toast.success).toHaveBeenCalledWith('User invited successfully');
     });
 
     it('switches directly to a named organization', async () => {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
@@ -109,12 +109,11 @@
             return;
         }
 
-        if (isAssistantOpen) {
-            isAssistantOpen = false;
-            return;
+        if (!isAssistantOpen) {
+            await loadAssistantPanel();
         }
 
-        await openAssistantPanel();
+        isAssistantOpen = !isAssistantOpen;
     }
 
     async function openAssistantPanel(): Promise<void> {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
@@ -109,8 +109,17 @@
             return;
         }
 
+        if (isAssistantOpen) {
+            isAssistantOpen = false;
+            return;
+        }
+
+        await openAssistantPanel();
+    }
+
+    async function openAssistantPanel(): Promise<void> {
         await loadAssistantPanel();
-        isAssistantOpen = !isAssistantOpen;
+        isAssistantOpen = true;
     }
 
     async function askAssistant(prompt: string): Promise<void> {
@@ -710,11 +719,14 @@
         >
             <main class={isAssistantPage ? 'flex min-h-0 flex-1 flex-col' : 'flex-1 px-4 pt-4'}>
                 <NavigationCommand
+                    askExie={askAssistant}
                     bind:open={isCommandOpen}
                     {isChatEnabled}
+                    isExieEnabled={isAssistantEnabled}
                     {isGlobalAdmin}
                     {isImpersonating}
                     {openChat}
+                    openExie={openAssistantPanel}
                     {openImpersonateOrganization}
                     {openKeyboardShortcuts}
                     {openOrganizationSwitcher}


### PR DESCRIPTION
## Summary

- add direct organization user-list and invite-user commands
- add Exie commands to open the shared assistant, triage recent errors, and analyze error trends
- expand the staged project picker with Events, API Keys, Webhooks & Integrations, and Source Maps
- preserve Exie access gating, billing upgrade handling, and project/organization context

## Impact

The command palette now exposes common organization and project workflows from anywhere in the app. Webhooks, Slack, Zapier, and integrations use one searchable command because they share the same project page. Exie quick actions are read-only investigation prompts; consequential stack mutations remain explicit inside the assistant flow.

No API contracts or breaking behaviors changed.

## Validation

- `npm run validate`
- `npm run test:unit -- --run src/routes/(app)/(components)/navigation-command.svelte.test.ts src/lib/features/assistant/components/assistant-panel.svelte.test.ts src/lib/features/assistant/assistant-links.test.ts` (54 tests)
- `npm run build`
