### PR TITLE
Use latest DeepSeek Flash and recover malformed tool calls

### DIFF
--- a/src/Exceptionless.Core/Configuration/AssistantOptions.cs
+++ b/src/Exceptionless.Core/Configuration/AssistantOptions.cs
@@ -5,7 +5,7 @@ namespace Exceptionless.Core.Configuration;
 public sealed class AssistantOptions
 {
     public const string DefaultEndpoint = "https://openrouter.ai/api/v1/chat/completions";
-    public const string DefaultModel = "deepseek/deepseek-v4-flash";
+    public const string DefaultModel = "~deepseek/deepseek-v4-flash-latest";
 
     public bool Enabled { get; internal set; }
     public bool IsConfigured => !String.IsNullOrWhiteSpace(ApiKey);

--- a/src/Exceptionless.Web/Assistant/AssistantLimits.cs
+++ b/src/Exceptionless.Web/Assistant/AssistantLimits.cs
@@ -5,6 +5,7 @@ internal static class AssistantLimits
     public const int MaximumInputMessages = 20;
     public const int MaximumInputCharacters = 48_000;
     public const int MaximumOutputTokens = 2048;
+    public const int MaximumMalformedResponseRetries = 1;
     public const int MaximumToolRounds = 3;
     public const int MaximumToolCallsPerTurn = 12;
     public const int MaximumProjectsPerTurn = 5;

--- a/src/Exceptionless.Web/Assistant/AssistantService.cs
+++ b/src/Exceptionless.Web/Assistant/AssistantService.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Exceptionless.Core;
 using Exceptionless.Core.Configuration;
 using Exceptionless.Core.Models.Billing;
@@ -32,6 +33,7 @@ public sealed class AssistantService(
     private const string SnoozeStackTool = "snooze_stack";
     private const string UpdateStackStatusTool = "update_stack_status";
     private static readonly JsonSerializerOptions s_jsonOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web).ConfigureExceptionlessApiDefaults();
+    private static readonly Regex s_rawDsmlPattern = new(@"<\s*/?\s*[|｜]\s*DSML\s*[|｜]", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, TimeSpan.FromSeconds(1));
 
     public async IAsyncEnumerable<AssistantStreamEvent> StreamAsync(
         AssistantChatRequest request,
@@ -60,6 +62,8 @@ public sealed class AssistantService(
         IReadOnlyCollection<AssistantSuggestedAction> pendingSuggestedActions = [];
         string? configureHref = String.IsNullOrWhiteSpace(request.ProjectId) ? null : AssistantRoutes.ProjectConfigure(request.ProjectId);
         bool requireFinalAnswer = false;
+        int malformedResponseRetries = 0;
+        object? malformedResponseCorrection = null;
 
         while (true)
         {
@@ -95,6 +99,9 @@ public sealed class AssistantService(
 
             var toolCalls = new Dictionary<int, PendingToolCall>();
             var assistantContent = new StringBuilder();
+            // A streamed response cannot be retracted after malformed provider markup reaches the
+            // browser, so hold this provider round until its content is known to be safe.
+            var assistantContentChunks = new List<string>();
             bool usageRecorded = false;
 
             int providerInputCharacters = JsonSerializer.Serialize(messages, s_jsonOptions).Length;
@@ -148,7 +155,7 @@ public sealed class AssistantService(
                     if (!String.IsNullOrEmpty(text))
                     {
                         assistantContent.Append(text);
-                        yield return AssistantStreamEvent.TextDelta(text);
+                        assistantContentChunks.Add(text);
                     }
                 }
 
@@ -175,6 +182,42 @@ public sealed class AssistantService(
                     if (function.TryGetProperty("arguments", out var arguments) && arguments.ValueKind == JsonValueKind.String)
                         pending.Arguments.Append(arguments.GetString());
                 }
+            }
+
+            if (s_rawDsmlPattern.IsMatch(assistantContent.ToString()))
+            {
+                if (malformedResponseRetries < AssistantLimits.MaximumMalformedResponseRetries)
+                {
+                    malformedResponseRetries++;
+                    logger.LogWarning(
+                        "Assistant provider returned raw DSML content for organization {OrganizationId}; retrying response",
+                        request.OrganizationId);
+                    malformedResponseCorrection = new
+                    {
+                        role = "system",
+                        content = "The previous provider response exposed internal DSML tool-call markup as text. Retry the response from the beginning. Return normal answer text and use only the structured tool_calls field for tools. Never include DSML markup in content."
+                    };
+                    messages.Add(malformedResponseCorrection);
+                    continue;
+                }
+
+                logger.LogWarning(
+                    "Assistant provider returned raw DSML content again for organization {OrganizationId}",
+                    request.OrganizationId);
+                yield return AssistantStreamEvent.Error("Exie received a malformed response from the AI provider. Please try again.");
+                yield return AssistantStreamEvent.Done();
+                yield break;
+            }
+
+            if (malformedResponseCorrection is not null)
+            {
+                messages.Remove(malformedResponseCorrection);
+                malformedResponseCorrection = null;
+            }
+
+            foreach (string text in assistantContentChunks)
+            {
+                yield return AssistantStreamEvent.TextDelta(text);
             }
 
             if (toolCalls.Count == 0)

--- a/src/Exceptionless.Web/appsettings.yml
+++ b/src/Exceptionless.Web/appsettings.yml
@@ -31,7 +31,7 @@ Serilog:
 
 Assistant:
   Endpoint: https://openrouter.ai/api/v1/chat/completions
-  Model: deepseek/deepseek-v4-flash
+  Model: "~deepseek/deepseek-v4-flash-latest"
   ApiKey:
 
 Apm:

--- a/tests/Exceptionless.Tests/Assistant/AssistantQualityEvaluationTests.cs
+++ b/tests/Exceptionless.Tests/Assistant/AssistantQualityEvaluationTests.cs
@@ -141,6 +141,7 @@ public sealed class AssistantQualityEvaluationTests : IntegrationTestsBase
         Assert.Contains(turn.Events, item => item.Type == "done");
         Assert.False(String.IsNullOrWhiteSpace(turn.Text));
         Assert.NotEmpty(turn.ToolCalls);
+        Assert.DoesNotContain("DSML", turn.Text, StringComparison.OrdinalIgnoreCase);
     }
 
     private sealed record EvaluationTurn(

--- a/tests/Exceptionless.Tests/Assistant/AssistantServiceTests.cs
+++ b/tests/Exceptionless.Tests/Assistant/AssistantServiceTests.cs
@@ -107,7 +107,8 @@ public sealed class AssistantServiceTests
             item => Assert.Equal(" world", item.Text),
             item => Assert.Equal("done", item.Type));
         Assert.Equal("Bearer", handler.AuthorizationScheme);
-        Assert.Contains("deepseek/deepseek-v4-flash", handler.RequestBody);
+        using var providerRequest = JsonDocument.Parse(handler.RequestBody);
+        Assert.Equal("~deepseek/deepseek-v4-flash-latest", providerRequest.RootElement.GetProperty("model").GetString());
         Assert.Contains($"\"max_tokens\":{AssistantLimits.MaximumOutputTokens}", handler.RequestBody);
         Assert.Contains("get_event", handler.RequestBody);
         Assert.Contains("get_stack", handler.RequestBody);
@@ -152,8 +153,7 @@ public sealed class AssistantServiceTests
         Assert.Contains("Call this whenever the answer asks what the user wants to investigate or do next", handler.RequestBody);
         Assert.Contains("If there is no genuinely useful next step, end the answer directly and omit the tool", handler.RequestBody);
 
-        using var requestBody = JsonDocument.Parse(handler.RequestBody);
-        JsonElement getStackEvents = requestBody.RootElement.GetProperty("tools").EnumerateArray()
+        JsonElement getStackEvents = providerRequest.RootElement.GetProperty("tools").EnumerateArray()
             .Single(tool => tool.GetProperty("function").GetProperty("name").GetString() == "get_stack_events")
             .GetProperty("function");
         JsonElement getStackEventsParameters = getStackEvents.GetProperty("parameters");
@@ -945,6 +945,126 @@ public sealed class AssistantServiceTests
                 Assert.Equal("Exie stopped before providing an answer. Please try again.", item.Message);
             },
             item => Assert.Equal("done", item.Type));
+    }
+
+    [Fact]
+    public async Task StreamAsync_RawDsmlResponse_RetriesWithoutEmittingMarkup()
+    {
+        string recoveredPayload = JsonSerializer.Serialize(new
+        {
+            choices = new[]
+            {
+                new
+                {
+                    delta = new
+                    {
+                        content = "I found no errors in the selected time range.",
+                        tool_calls = new[]
+                        {
+                            new
+                            {
+                                index = 0,
+                                id = "suggestions-1",
+                                function = new
+                                {
+                                    name = "suggest_followups",
+                                    arguments = JsonSerializer.Serialize(new
+                                    {
+                                        actions = new[]
+                                        {
+                                            new { label = "Search seven days", prompt = "Search for errors in the last 7 days." }
+                                        }
+                                    })
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        var handler = new StubHttpMessageHandler(
+            """
+            data: {"choices":[{"delta":{"content":"I found no errors. "}}]}
+
+            data: {"choices":[{"delta":{"content":"<｜DS"}}]}
+
+            data: {"choices":[{"delta":{"content":"ML｜tool_calls><｜DSML｜invoke name=\"suggest_followups\">"}}]}
+
+            data: [DONE]
+
+            """,
+            $"data: {recoveredPayload}\n\ndata: [DONE]\n");
+        var appOptions = AppOptions.ReadFromConfiguration(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["BaseURL"] = "https://localhost",
+                ["Assistant:ApiKey"] = "test-key"
+            })
+            .Build());
+        var service = CreateAssistantService(handler, appOptions);
+        var events = new List<AssistantStreamEvent>();
+
+        await foreach (var item in service.StreamAsync(
+            new AssistantChatRequest([new AssistantChatMessage("user", "Find recent errors")]),
+            "user-id",
+            CreatePlanOptions(),
+            TestContext.Current.CancellationToken))
+        {
+            events.Add(item);
+        }
+
+        Assert.Equal(2, handler.RequestBodies.Count);
+        Assert.Contains("The previous provider response exposed internal DSML tool-call markup as text", handler.RequestBodies[1]);
+        Assert.Collection(events,
+            item => Assert.Equal("I found no errors in the selected time range.", item.Text),
+            item =>
+            {
+                Assert.Equal("suggested_actions", item.Type);
+                Assert.Equal("Search seven days", Assert.Single(item.SuggestedActions!).Label);
+            },
+            item => Assert.Equal("done", item.Type));
+        Assert.DoesNotContain("DSML", String.Concat(events.Select(item => item.Text)), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("I found no errors. ", String.Concat(events.Select(item => item.Text)), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task StreamAsync_RepeatedRawDsmlResponse_EmitsClearErrorAndCompletion()
+    {
+        const string malformedResponse = """
+            data: {"choices":[{"delta":{"content":"<|DSML|tool_calls>"}}]}
+
+            data: [DONE]
+
+            """;
+        var handler = new StubHttpMessageHandler(malformedResponse, malformedResponse);
+        var appOptions = AppOptions.ReadFromConfiguration(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["BaseURL"] = "https://localhost",
+                ["Assistant:ApiKey"] = "test-key"
+            })
+            .Build());
+        var service = CreateAssistantService(handler, appOptions);
+        var events = new List<AssistantStreamEvent>();
+
+        await foreach (var item in service.StreamAsync(
+            new AssistantChatRequest([new AssistantChatMessage("user", "Find recent errors")]),
+            "user-id",
+            CreatePlanOptions(),
+            TestContext.Current.CancellationToken))
+        {
+            events.Add(item);
+        }
+
+        Assert.Equal(2, handler.RequestBodies.Count);
+        Assert.Collection(events,
+            item =>
+            {
+                Assert.Equal("error", item.Type);
+                Assert.Equal("Exie received a malformed response from the AI provider. Please try again.", item.Message);
+            },
+            item => Assert.Equal("done", item.Type));
+        Assert.DoesNotContain(events, item => item.Type == "text_delta");
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Assistant/README.md
+++ b/tests/Exceptionless.Tests/Assistant/README.md
@@ -5,7 +5,7 @@ The assistant quality gate is an opt-in integration test that calls the configur
 - a current event is fetched directly without rediscovering its project or stack;
 - a project-scoped top-errors question uses one stack search and returns navigable links;
 - an organization-wide question lists projects once, stays within the server's project-search limit, and returns navigable links;
-- every scenario finishes with non-empty answer text and no streamed error.
+- every scenario finishes with non-empty answer text, no streamed error, and no raw DSML tool markup.
 
 The gate makes billable provider requests, so it is skipped by default. Run it before changing the assistant model, system prompt, tool schemas, or tool-selection behavior:
 


### PR DESCRIPTION
## Summary

- route Exie through OpenRouter's unpinned DeepSeek V4 Flash latest-family alias
- detect raw DSML tool-call markup before it reaches the browser and retry the provider once
- return a clear error if the retry is also malformed
- extend unit and provider-backed quality coverage for DSML leakage

## Why

OpenRouter could return DeepSeek's internal DSML representation as ordinary assistant text, exposing broken tool-call markup in the conversation. The previous undated model slug also remained on the older Flash release instead of following the latest family revision.

## Behavior

- no public API contract changes
- clean provider responses retain their original text-delta boundaries, but each provider round is validated before those deltas are emitted
- malformed responses consume at most one additional provider request
- existing usage, token, tool, time, and provider-price limits remain in place

## Verification

`dotnet test --project tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-restore --no-progress -- --filter-namespace Exceptionless.Tests.Assistant`

- 76 passed
- 1 skipped: opt-in billable provider evaluation