### PR TITLE
Improve Exie tool activity display

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-composer.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-composer.svelte
@@ -15,7 +15,8 @@
 
     let { isStreaming = false, onStop, onSubmit, showToolCalls = false, value = $bindable('') }: Props = $props();
     let textareaElement = $state<HTMLTextAreaElement | null>(null);
-    let showSlashCommands = $derived(!isStreaming && value.trimStart().startsWith('/'));
+    let slashCommandQuery = $derived(value.trim().toLowerCase());
+    let showSlashCommands = $derived(!isStreaming && slashCommandQuery.startsWith('/') && '/tools'.startsWith(slashCommandQuery));
 
     $effect(() => {
         void value;
@@ -31,6 +32,11 @@
 
         if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
             event.preventDefault();
+            if (showSlashCommands) {
+                selectToolsCommand();
+                return;
+            }
+
             if (!isStreaming && value.trim()) {
                 onSubmit(value);
             }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-composer.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-composer.svelte
@@ -1,17 +1,21 @@
 <script lang="ts">
+    import * as Command from '$comp/ui/command';
     import * as InputGroup from '$comp/ui/input-group';
     import CircleStop from '@lucide/svelte/icons/circle-stop';
     import Send from '@lucide/svelte/icons/send';
+    import Wrench from '@lucide/svelte/icons/wrench';
 
     interface Props {
         isStreaming?: boolean;
         onStop: () => void;
-        onSubmit: () => void;
+        onSubmit: (value: string) => void;
+        showToolCalls?: boolean;
         value?: string;
     }
 
-    let { isStreaming = false, onStop, onSubmit, value = $bindable('') }: Props = $props();
+    let { isStreaming = false, onStop, onSubmit, showToolCalls = false, value = $bindable('') }: Props = $props();
     let textareaElement = $state<HTMLTextAreaElement | null>(null);
+    let showSlashCommands = $derived(!isStreaming && value.trimStart().startsWith('/'));
 
     $effect(() => {
         void value;
@@ -19,10 +23,16 @@
     });
 
     function handleKeydown(event: KeyboardEvent): void {
+        if (event.key === 'Escape' && showSlashCommands) {
+            event.preventDefault();
+            value = '';
+            return;
+        }
+
         if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
             event.preventDefault();
             if (!isStreaming && value.trim()) {
-                onSubmit();
+                onSubmit(value);
             }
         }
     }
@@ -35,30 +45,52 @@
         textareaElement.style.height = 'auto';
         textareaElement.style.height = `${Math.min(textareaElement.scrollHeight, 160)}px`;
     }
+
+    function selectToolsCommand(): void {
+        onSubmit('/tools');
+    }
 </script>
 
-<InputGroup.Root class="bg-background h-auto rounded-xl shadow-xs" data-disabled={false}>
-    <InputGroup.Textarea
-        aria-describedby="assistant-composer-help"
-        aria-label="Message Exie"
-        bind:ref={textareaElement}
-        bind:value
-        class="placeholder:text-muted-foreground/50 max-h-40 min-h-18 px-3 pt-3 text-sm"
-        oninput={resizeTextarea}
-        onkeydown={handleKeydown}
-        placeholder="Ask Exie…"
-        rows={1}
-    />
-    <InputGroup.Addon align="block-end" class="justify-between gap-2 px-2.5 pb-2">
-        <span class="text-muted-foreground text-[11px]" id="assistant-composer-help">Enter to send · Shift+Enter for a new line</span>
-        {#if isStreaming}
-            <InputGroup.Button aria-label="Stop generating" onclick={onStop} size="icon-sm" variant="outline">
-                <CircleStop aria-hidden="true" />
-            </InputGroup.Button>
-        {:else}
-            <InputGroup.Button aria-label="Send message" disabled={!value.trim()} onclick={onSubmit} size="icon-sm" variant="default">
-                <Send aria-hidden="true" />
-            </InputGroup.Button>
-        {/if}
-    </InputGroup.Addon>
-</InputGroup.Root>
+<div class="relative">
+    {#if showSlashCommands}
+        <Command.Root aria-label="Exie commands" class="absolute inset-x-0 bottom-full mb-2 h-auto shadow-md">
+            <Command.List>
+                <Command.Group heading="Commands">
+                    <Command.Item onSelect={selectToolsCommand} value="/tools">
+                        <Wrench aria-hidden="true" />
+                        <div class="flex min-w-0 flex-col">
+                            <code>/tools</code>
+                            <span class="text-muted-foreground text-xs">{showToolCalls ? 'Hide' : 'Show'} tool calls in the conversation</span>
+                        </div>
+                    </Command.Item>
+                </Command.Group>
+            </Command.List>
+        </Command.Root>
+    {/if}
+
+    <InputGroup.Root class="bg-background h-auto rounded-xl shadow-xs" data-disabled={false}>
+        <InputGroup.Textarea
+            aria-describedby="assistant-composer-help"
+            aria-label="Message Exie"
+            bind:ref={textareaElement}
+            bind:value
+            class="placeholder:text-muted-foreground/50 max-h-40 min-h-18 px-3 pt-3 text-sm"
+            oninput={resizeTextarea}
+            onkeydown={handleKeydown}
+            placeholder="Ask Exie…"
+            rows={1}
+        />
+        <InputGroup.Addon align="block-end" class="justify-between gap-2 px-2.5 pb-2">
+            <span class="text-muted-foreground text-[11px]" id="assistant-composer-help"> Enter to send · Shift+Enter for a new line · / for commands </span>
+            {#if isStreaming}
+                <InputGroup.Button aria-label="Stop generating" onclick={onStop} size="icon-sm" variant="outline">
+                    <CircleStop aria-hidden="true" />
+                </InputGroup.Button>
+            {:else}
+                <InputGroup.Button aria-label="Send message" disabled={!value.trim()} onclick={() => onSubmit(value)} size="icon-sm" variant="default">
+                    <Send aria-hidden="true" />
+                </InputGroup.Button>
+            {/if}
+        </InputGroup.Addon>
+    </InputGroup.Root>
+</div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-composer.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-composer.svelte.test.ts
@@ -1,9 +1,13 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AssistantComposer from './assistant-composer.svelte';
 
 describe('AssistantComposer', () => {
+    beforeEach(() => {
+        HTMLElement.prototype.scrollIntoView = vi.fn();
+    });
+
     it('submits with Enter and preserves Shift+Enter for multiline prompts', async () => {
         const onSubmit = vi.fn();
         render(AssistantComposer, { props: { onStop: vi.fn(), onSubmit, value: 'Investigate this' } });
@@ -13,6 +17,7 @@ describe('AssistantComposer', () => {
         await fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
 
         expect(onSubmit).toHaveBeenCalledOnce();
+        expect(onSubmit).toHaveBeenCalledWith('Investigate this');
     });
 
     it('shows a stop action while Exie is streaming', async () => {
@@ -22,5 +27,18 @@ describe('AssistantComposer', () => {
         await fireEvent.click(screen.getByRole('button', { name: 'Stop generating' }));
 
         expect(onStop).toHaveBeenCalledOnce();
+    });
+
+    it('shows and runs the tools command while typing a slash command', async () => {
+        const onSubmit = vi.fn();
+        render(AssistantComposer, { props: { onStop: vi.fn(), onSubmit, value: '/' } });
+
+        const commandMenu = screen.getByLabelText('Exie commands');
+        expect(commandMenu.textContent).toContain('/tools');
+        expect(commandMenu.textContent).toContain('Show tool calls in the conversation');
+
+        await fireEvent.click(screen.getByText('/tools'));
+
+        expect(onSubmit).toHaveBeenCalledWith('/tools');
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-composer.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-composer.svelte.test.ts
@@ -41,4 +41,25 @@ describe('AssistantComposer', () => {
 
         expect(onSubmit).toHaveBeenCalledWith('/tools');
     });
+
+    it('accepts the visible tools command with Enter', async () => {
+        const onSubmit = vi.fn();
+        render(AssistantComposer, { props: { onStop: vi.fn(), onSubmit, value: '/' } });
+
+        await fireEvent.keyDown(screen.getByRole('textbox', { name: 'Message Exie' }), { key: 'Enter' });
+
+        expect(onSubmit).toHaveBeenCalledOnce();
+        expect(onSubmit).toHaveBeenCalledWith('/tools');
+    });
+
+    it('submits unmatched slash text as a regular prompt', async () => {
+        const onSubmit = vi.fn();
+        render(AssistantComposer, { props: { onStop: vi.fn(), onSubmit, value: '/unknown' } });
+
+        expect(screen.queryByLabelText('Exie commands')).toBeNull();
+        await fireEvent.keyDown(screen.getByRole('textbox', { name: 'Message Exie' }), { key: 'Enter' });
+
+        expect(onSubmit).toHaveBeenCalledOnce();
+        expect(onSubmit).toHaveBeenCalledWith('/unknown');
+    });
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-message.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-message.svelte
@@ -33,6 +33,7 @@
         showToolCalls = false,
         suggestionsDisabled = false
     }: Props = $props();
+    let hasHiddenRunningTool = $derived(!showToolCalls && message.tools.some((tool) => tool.status === 'running'));
     let renderedContent = $derived(isStreaming ? message.content : addAssistantResourceLinks(message.content, message.tools));
 </script>
 
@@ -61,7 +62,9 @@
                     mode={isStreaming ? 'streaming' : 'static'}
                     urlTransform={normalizeAssistantUrl}
                 />
-            {:else if isStreaming}
+            {/if}
+
+            {#if isStreaming && (!message.content || hasHiddenRunningTool)}
                 <div class="text-muted-foreground flex items-center gap-2 py-1 text-sm"><Spinner /> Exie is thinking…</div>
             {/if}
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-message.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-message.svelte
@@ -19,10 +19,20 @@
         onFeedback?: (feedback: AssistantFeedback | undefined) => void;
         onRegenerate?: () => Promise<void> | void;
         onSuggestedAction?: (action: AssistantSuggestedAction) => void;
+        showToolCalls?: boolean;
         suggestionsDisabled?: boolean;
     }
 
-    let { isLast = false, isStreaming = false, message, onFeedback, onRegenerate, onSuggestedAction, suggestionsDisabled = false }: Props = $props();
+    let {
+        isLast = false,
+        isStreaming = false,
+        message,
+        onFeedback,
+        onRegenerate,
+        onSuggestedAction,
+        showToolCalls = false,
+        suggestionsDisabled = false
+    }: Props = $props();
     let renderedContent = $derived(isStreaming ? message.content : addAssistantResourceLinks(message.content, message.tools));
 </script>
 
@@ -37,9 +47,11 @@
             <Bot aria-hidden="true" class="size-4" />
         </div>
         <div class="min-w-0 flex-1">
-            {#each message.tools as tool (tool.id)}
-                <AssistantToolActivity {tool} />
-            {/each}
+            {#if showToolCalls}
+                {#each message.tools as tool (tool.id)}
+                    <AssistantToolActivity {tool} />
+                {/each}
+            {/if}
 
             {#if message.content}
                 <Response

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-message.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-message.svelte.test.ts
@@ -35,7 +35,7 @@ describe('AssistantMessage', () => {
             ]
         };
 
-        render(AssistantMessage, { props: { message } });
+        render(AssistantMessage, { props: { message, showToolCalls: true } });
 
         expect(screen.getByLabelText('Exie').textContent).toContain('Timeout expired is the best issue to investigate next.');
         expect(screen.getByText('Searched error stacks')).not.toBeNull();
@@ -44,6 +44,27 @@ describe('AssistantMessage', () => {
         const linkClasses = stackLink.className.split(/\s+/);
         expect(linkClasses).toContain('text-foreground');
         expect(linkClasses).not.toContain('text-primary');
+    });
+
+    it('shows thinking instead of tool calls by default while streaming', () => {
+        const message: AssistantChatMessage = {
+            content: '',
+            id: 'assistant-message',
+            role: 'assistant',
+            tools: [
+                {
+                    arguments: '{"sort":"-total_occurrences"}',
+                    id: 'tool-call',
+                    name: 'search_stacks',
+                    status: 'running'
+                }
+            ]
+        };
+
+        render(AssistantMessage, { props: { isStreaming: true, message } });
+
+        expect(screen.getByText('Exie is thinking…')).toBeTruthy();
+        expect(screen.queryByText('Searched error stacks')).toBeNull();
     });
 
     it('shows completed suggested actions and submits their prompts', async () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-message.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-message.svelte.test.ts
@@ -67,6 +67,28 @@ describe('AssistantMessage', () => {
         expect(screen.queryByText('Searched error stacks')).toBeNull();
     });
 
+    it('keeps showing thinking while a hidden tool runs after streamed text', () => {
+        const message: AssistantChatMessage = {
+            content: 'I will check the recent error stacks.',
+            id: 'assistant-message',
+            role: 'assistant',
+            tools: [
+                {
+                    arguments: '{"sort":"-total_occurrences"}',
+                    id: 'tool-call',
+                    name: 'search_stacks',
+                    status: 'running'
+                }
+            ]
+        };
+
+        render(AssistantMessage, { props: { isStreaming: true, message } });
+
+        expect(screen.getByText('I will check the recent error stacks.')).toBeTruthy();
+        expect(screen.getByText('Exie is thinking…')).toBeTruthy();
+        expect(screen.queryByText('Searched error stacks')).toBeNull();
+    });
+
     it('shows completed suggested actions and submits their prompts', async () => {
         const onSuggestedAction = vi.fn();
         const message: AssistantChatMessage = {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-panel.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-panel.svelte
@@ -63,6 +63,7 @@
     let errorMessage = $state<string>();
     let isStreaming = $state(false);
     let isNearBottom = $state(true);
+    let showToolCalls = $state(false);
     let showScrollToBottom = $state(false);
     let conversationElement = $state<HTMLDivElement>();
     let abortController: AbortController | undefined;
@@ -122,6 +123,11 @@
         }
 
         prompt = '';
+        if (content.toLowerCase() === '/tools') {
+            showToolCalls = !showToolCalls;
+            return;
+        }
+
         errorMessage = undefined;
         const userMessage: AssistantChatMessage = {
             content,
@@ -411,6 +417,7 @@
                                 onFeedback={(feedback) => setMessageFeedback(message.id, feedback)}
                                 onRegenerate={() => regenerateResponse(message.id)}
                                 onSuggestedAction={(action) => void handleSuggestedAction(action)}
+                                {showToolCalls}
                                 suggestionsDisabled={isStreaming}
                             />
                         {/each}
@@ -448,7 +455,7 @@
                         {/if}
                     </Alert.Root>
                 {/if}
-                <AssistantComposer bind:value={prompt} {isStreaming} onStop={stopStreaming} onSubmit={() => void submitPrompt()} />
+                <AssistantComposer bind:value={prompt} {isStreaming} onStop={stopStreaming} onSubmit={(value) => void submitPrompt(value)} {showToolCalls} />
                 <Muted class="text-center text-xs">AI can make mistakes. Check important changes.</Muted>
             </div>
         </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-panel.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/assistant/components/assistant-panel.svelte.test.ts
@@ -12,6 +12,7 @@ import AssistantPanel from './assistant-panel.svelte';
 
 describe('AssistantPanel', () => {
     beforeEach(() => {
+        HTMLElement.prototype.scrollIntoView = vi.fn();
         HTMLElement.prototype.scrollTo = vi.fn();
     });
 
@@ -153,6 +154,43 @@ describe('AssistantPanel', () => {
         };
         expect(payload.path).toBe('/next/stack/stack-b');
         expect(payload.messages.at(-1)?.suggested_action_path).toBe('/next/stack/stack-a');
+    });
+
+    it('hides tool calls by default and toggles them locally with /tools', async () => {
+        const fetchMock = vi.fn(
+            async () =>
+                new Response(
+                    `${JSON.stringify({ arguments: '{}', tool_call_id: 'tool-1', tool_name: 'search_stacks', type: 'tool_call' })}\n${JSON.stringify({ result: '{"ok":true,"data":{"items":[]}}', tool_call_id: 'tool-1', type: 'tool_result' })}\n${JSON.stringify({ text: 'No matching stacks were found.', type: 'text_delta' })}\n${JSON.stringify({ type: 'done' })}\n`
+                )
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        render(AssistantPanel, {
+            props: {
+                open: true,
+                organizationId: 'organization-1',
+                promptRequest: { id: 'request-1', prompt: 'Find matching stacks.' }
+            }
+        });
+
+        expect(await screen.findByText('No matching stacks were found.')).toBeTruthy();
+        expect(screen.queryByText('Searched error stacks')).toBeNull();
+        expect(screen.getByText(/\/ for commands/)).toBeTruthy();
+        await screen.findByRole('button', { name: 'Send message' });
+
+        const composer = screen.getByRole('textbox', { name: 'Message Exie' });
+        await fireEvent.input(composer, { target: { value: '/' } });
+        expect(screen.getByLabelText('Exie commands').textContent).toContain('/tools');
+        await fireEvent.click(screen.getByText('/tools'));
+
+        await waitFor(() => expect(screen.getByText('Searched error stacks')).toBeTruthy());
+        expect(fetchMock).toHaveBeenCalledOnce();
+
+        await fireEvent.input(composer, { target: { value: '/tools' } });
+        await fireEvent.keyDown(composer, { key: 'Enter' });
+
+        await waitFor(() => expect(screen.queryByText('Searched error stacks')).toBeNull());
+        expect(fetchMock).toHaveBeenCalledOnce();
     });
 
     it('navigates a validated setup action without submitting another prompt', async () => {


### PR DESCRIPTION
## Summary

- Show Exie's existing thinking state by default while tools are running.
- Add a `/tools` slash command to show or hide tool-call details locally.
- Keep the command UI compact and remove the persistent mode-change callout.

## Why

Tool-call cards dominated the conversation while Exie worked. The default experience is now quieter, while detailed tool activity remains available on demand.

## Verification

- `npm run validate`
- `npm run test:unit -- --run src/lib/features/assistant/components/assistant-message.svelte.test.ts src/lib/features/assistant/components/assistant-panel.svelte.test.ts src/lib/features/assistant/components/assistant-composer.svelte.test.ts src/lib/features/assistant/components/assistant-tool-activity.svelte.test.ts --maxWorkers=1 --no-file-parallelism` (4 files, 16 tests)
- Manually reviewed in the local full-page Exie chat through Aspire.

## Breaking changes

None.
