### PR TITLE
Add copy links to detail sheet flyouts

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/detail-sheet.svelte
@@ -6,8 +6,11 @@
     import { page } from '$app/state';
     import { Button } from '$comp/ui/button';
     import * as Sheet from '$comp/ui/sheet';
+    import { UseClipboard } from '$lib/hooks/use-clipboard.svelte';
+    import Copy from '@lucide/svelte/icons/copy';
     import ExternalLink from '@lucide/svelte/icons/external-link';
     import { onMount } from 'svelte';
+    import { toast } from 'svelte-sonner';
 
     import { type DetailSheetHistoryEntry, detailSheetHistoryStateKey, type DetailSheetPageState } from '../history-state';
     import { preserveDetailSheetForAssistant } from './detail-sheet-interaction';
@@ -47,6 +50,16 @@
     let pendingNavigationTimer: number | undefined;
     let selectedLinkNavigationOptions: LinkNavigationOptions | undefined;
     let wasOpen = false;
+    const clipboard = new UseClipboard();
+
+    async function copyDetailsLink(): Promise<void> {
+        await clipboard.copy(new URL(detailsHref, window.location.href).href);
+        if (clipboard.copied) {
+            toast.success(`${title} link copied`);
+        } else {
+            toast.error(`Unable to copy ${title.toLowerCase()} link`);
+        }
+    }
 
     function getCurrentUrl(): string {
         return `${page.url.pathname}${page.url.search}${page.url.hash}`;
@@ -262,6 +275,15 @@
     >
         <div class="absolute top-3 right-12 z-10 flex items-center gap-1">
             {@render actions?.()}
+            <Button
+                aria-label={`Copy ${title.toLowerCase()} link`}
+                onclick={copyDetailsLink}
+                size="icon-sm"
+                title={`Copy ${title.toLowerCase()} link`}
+                variant="ghost"
+            >
+                <Copy aria-hidden="true" />
+            </Button>
             <Button aria-label="Open details in new window" href={detailsHref} size="icon-sm" title="Open in new window" variant="ghost">
                 <ExternalLink aria-hidden="true" />
             </Button>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/detail-sheet.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/detail-sheet.svelte.test.ts
@@ -11,6 +11,9 @@ const navigation = vi.hoisted(() => ({
     replaceState: vi.fn()
 }));
 const pageState = vi.hoisted(() => ({}));
+const toast = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }));
+
+vi.mock('svelte-sonner', () => ({ toast }));
 
 function createSvelteKitHistoryState(state: App.PageState): Record<string, App.PageState> {
     return { 'sveltekit:states': state };
@@ -28,8 +31,11 @@ vi.mock('$app/state', () => ({
 }));
 
 describe('DetailSheet history', () => {
+    const writeText = vi.fn(() => Promise.resolve());
+
     beforeEach(() => {
         vi.clearAllMocks();
+        Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
         window.history.replaceState(createSvelteKitHistoryState(pageState), '', '/events?filter=open');
         navigation.goto.mockResolvedValue(undefined);
         navigation.pushState.mockImplementation((url: string | URL, state: App.PageState) =>
@@ -55,6 +61,16 @@ describe('DetailSheet history', () => {
             __exceptionlessDetailSheet: { key: 'event', value: 'abc123' }
         });
         expect(screen.getByTestId('detail-sheet-state').textContent).toBe('open:abc123');
+    });
+
+    it('copies the absolute full-page details link', async () => {
+        render(DetailSheetTestHarness);
+        await fireEvent.click(screen.getByRole('button', { name: 'Open details' }));
+
+        await fireEvent.click(screen.getByRole('button', { name: 'Copy event link' }));
+
+        expect(writeText).toHaveBeenCalledWith(new URL('/event/abc123', window.location.href).href);
+        expect(toast.success).toHaveBeenCalledWith('Event link copied');
     });
 
     it('closes details during Back navigation without traversing twice', async () => {


### PR DESCRIPTION
## Summary

- add a copy-link action to the shared event and stack detail-sheet header
- copy the absolute canonical full-page URL instead of the current flyout history URL
- show success or failure feedback after the clipboard action

## Verification

- `npm run validate`
- `npm run test:unit -- --run src/lib/features/shared/components/detail-sheet.svelte.test.ts --maxWorkers=1 --no-file-parallelism`
- localhost Playwright capture of the event flyout against the Aspire stack

## Breaking changes

None.
