### PR TITLE
Fix Exie ingress request timeout

### DIFF
--- a/k8s/ex-dev-values.yaml
+++ b/k8s/ex-dev-values.yaml
@@ -30,3 +30,4 @@ ingress:
   clusterIssuer: cert-manager-webhook-dnsimple-production
   albName: public-alb
   albNamespace: kube-system
+  appRequestTimeout: 3m

--- a/k8s/ex-prod-values.yaml
+++ b/k8s/ex-prod-values.yaml
@@ -46,3 +46,4 @@ ingress:
   clusterIssuer: cert-manager-webhook-dnsimple-production
   albName: public-alb
   albNamespace: kube-system
+  appRequestTimeout: 3m

--- a/k8s/exceptionless/templates/app.yaml
+++ b/k8s/exceptionless/templates/app.yaml
@@ -167,9 +167,9 @@ spec:
         - port: 80
           protocol: HTTP
       timeouts:
-        # Exie streams multiple provider and tool rounds over one response. Disable the
-        # strict route deadline while the gateway's idle timeout still protects dead streams.
-        requestTimeout: 0s
+        # Exie allows up to two minutes for provider and tool rounds. Use an explicit
+        # bounded timeout with enough headroom for the response to finish cleanly.
+        requestTimeout: {{ .Values.ingress.appRequestTimeout }}
 
 ---
 apiVersion: networking.k8s.io/v1

--- a/k8s/exceptionless/values.yaml
+++ b/k8s/exceptionless/values.yaml
@@ -27,6 +27,7 @@ ingress:
   clusterIssuer: cert-manager-webhook-dnsimple-production
   albName: public-alb
   albNamespace: kube-system
+  appRequestTimeout: 0s
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Summary

- make the Application Gateway app request timeout configurable through Helm values
- set the development and production request timeout to three minutes
- preserve the existing zero-second default for other chart consumers

## Why

Exie streams can span multiple provider and tool rounds. Although Application Gateway accepted `requestTimeout: 0s`, affected browser requests were reset around the default 60-second boundary with `ERR_HTTP2_PROTOCOL_ERROR`. An explicit bounded timeout provides headroom beyond Exie's two-minute turn limit.

## Validation

- `helm lint k8s/exceptionless`
- `helm lint k8s/exceptionless -f k8s/ex-dev-values.yaml`
- `helm lint k8s/exceptionless -f k8s/ex-prod-values.yaml`
- rendered timeout: default `0s`, development `3m`, production `3m`
- live development A/B test: `10s` timed out at 10.008s and 10.007s; `3m` allowed the same endpoint to complete after 79.599s without an HTTP/2 reset

## Breaking changes

None.