### PR TITLE
Improve stack and event table workflows

### DIFF
--- a/src/Exceptionless.Core/Models/SavedViewColumnSettings.cs
+++ b/src/Exceptionless.Core/Models/SavedViewColumnSettings.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace Exceptionless.Core.Models;
 
@@ -17,6 +18,10 @@ public sealed record SavedViewColumnSettings
 
     /// <summary>Whether the column fills the table's remaining width. Null or false means use fixed-width behavior.</summary>
     public bool? AutoFill { get; set; }
+
+    /// <summary>Whether cell content wraps onto multiple lines. Null or false means keep content on one line.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Wrap { get; set; }
 
     /// <summary>Zero-based display position. Null means use the table default order.</summary>
     [Range(0, MaxPosition)]

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/event-effects-chaos.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/event-effects-chaos.e2e.ts
@@ -84,7 +84,7 @@ test('event list and detail effects stay bounded through paging and background c
         await expect(rowSelection).toBeChecked();
 
         const response = page.waitForResponse((candidate) => isEventListResponse(candidate, e2eScenario.organizationId));
-        await page.getByTitle('Return to the first page to refresh results').click();
+        await page.getByTitle('Refresh results').click();
         expect((await response).ok()).toBe(true);
         await expect(rowSelection).not.toBeChecked();
     });
@@ -263,7 +263,7 @@ async function clickAndWaitForPage(
     await page.getByRole('button', { name: buttonName }).click();
     await expect(
         page
-            .getByText(new RegExp(`^Page ${expectedPage} of`))
+            .getByLabel(new RegExp(`^Page ${expectedPage} of`))
             .filter({ visible: true })
             .first()
     ).toBeVisible();

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/rataplan-feedback.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/rataplan-feedback.e2e.ts
@@ -1,0 +1,292 @@
+import { createReferenceId, expect, test } from '../fixtures/e2e-test';
+import { seedRepresentativeEvent } from '../support/event-data';
+import { ExceptionlessE2EJourney } from '../support/exceptionless-journey';
+import { createRepresentativeEvent } from '../support/synthetic-event';
+
+test('approved Rataplan UI feedback remains fixed', async ({ e2eApi, e2eScenario, page }) => {
+    const journey = ExceptionlessE2EJourney.fromScenario(page, e2eApi, e2eScenario);
+    await journey.submitRepresentativeEvent();
+
+    const firstEventId = journey.eventId!;
+    const wrappedTagValues = ['Authentication', 'Background', 'Critical', 'Customer', 'Production', 'Server', 'TeamOne', 'Version2', 'Web'];
+    const secondEvent = await seedRepresentativeEvent(e2eApi, e2eScenario.userToken, {
+        message: journey.message,
+        projectId: e2eScenario.projectId,
+        projectToken: e2eScenario.projectToken,
+        referenceId: createReferenceId(journey.run, '-second')
+    });
+    expect(secondEvent.stack_id).toBe(journey.stackId);
+
+    for (let index = 0; index < 5; index++) {
+        const referenceId = createReferenceId(journey.run, `-stack-${index}`);
+        const event = createRepresentativeEvent({
+            appUrl: e2eApi.environment.appUrl,
+            message: `${journey.message} stack ${index}`,
+            referenceId,
+            runId: e2eApi.environment.runId
+        });
+        if (index === 0) {
+            event.tags = wrappedTagValues;
+        }
+
+        const data = event.data as Record<string, unknown>;
+        const simpleError = data['@simple_error'] as Record<string, unknown>;
+        await e2eApi.submitEvent(e2eScenario.projectId, e2eScenario.projectToken, {
+            ...event,
+            data: {
+                ...data,
+                '@simple_error': {
+                    ...simpleError,
+                    type: `PlaywrightRataplanException${index}`
+                }
+            }
+        });
+        await e2eApi.pollForEventByReference(e2eScenario.userToken, e2eScenario.projectId, referenceId);
+    }
+
+    await test.step('event details use the page scroll and preserve the selected tab when the event changes', async () => {
+        await page.goto(`/next/stack/${journey.stackId}/event/${firstEventId}`);
+        const overviewTab = page.getByRole('tab', { name: 'Overview' });
+        await expect(overviewTab).toHaveAttribute('aria-selected', 'true');
+
+        const stackTrace = page.getByRole('heading', { name: 'Stack Trace' }).locator('xpath=../following-sibling::div[1]');
+        await expect(stackTrace).toBeVisible();
+        await expect.poll(() => stackTrace.evaluate((element) => element.scrollHeight === element.clientHeight)).toBe(true);
+
+        await page.getByRole('tab', { name: 'Exception' }).click();
+        await expect(page.getByRole('tab', { name: 'Exception' })).toHaveAttribute('aria-selected', 'true');
+
+        const newerEventButton = page.getByRole('button', { name: 'Newer event' });
+        const olderEventButton = page.getByRole('button', { name: 'Older event' });
+        if (await newerEventButton.isEnabled()) {
+            await newerEventButton.click();
+        } else {
+            await olderEventButton.click();
+        }
+
+        await expect(page).not.toHaveURL(new RegExp(`/event/${firstEventId}(?:[?#]|$)`));
+        await expect(page.getByRole('tab', { name: 'Exception' })).toHaveAttribute('aria-selected', 'true');
+    });
+
+    await test.step('command palette overflow is discoverable and shortcut chips have stronger emphasis', async () => {
+        await page.keyboard.press('/');
+        const commandList = page.locator('[data-slot="command-list"]');
+        await expect(commandList).toBeVisible();
+
+        const commandListState = await commandList.evaluate((element) => ({
+            hasHiddenScrollbarClass: element.classList.contains('no-scrollbar'),
+            hasOverflow: element.scrollHeight > element.clientHeight,
+            overflowY: getComputedStyle(element).overflowY,
+            scrollbarWidth: getComputedStyle(element).scrollbarWidth
+        }));
+        expect(commandListState).toEqual({
+            hasHiddenScrollbarClass: false,
+            hasOverflow: true,
+            overflowY: 'auto',
+            scrollbarWidth: 'thin'
+        });
+
+        const shortcut = commandList.locator('[data-slot="command-shortcut"]').first();
+        await expect(shortcut).toBeVisible();
+        const shortcutStyle = await shortcut.evaluate((element) => {
+            const style = getComputedStyle(element);
+            return {
+                borderTopWidth: style.borderTopWidth,
+                boxShadow: style.boxShadow,
+                fontWeight: style.fontWeight
+            };
+        });
+        expect(Number(shortcutStyle.fontWeight)).toBeGreaterThanOrEqual(600);
+        expect(Number.parseFloat(shortcutStyle.borderTopWidth)).toBeGreaterThan(0);
+        expect(shortcutStyle.boxShadow).not.toBe('none');
+
+        await commandList.hover();
+        await commandList.evaluate((element) => (element.scrollTop = 40));
+        await page.screenshot({ path: 'dogfood-output/rataplan-command-palette.png' });
+        await page.keyboard.press('Escape');
+    });
+
+    await test.step('manual refresh keeps the current page', async () => {
+        await page.goto(`/next/stack?project=${e2eScenario.projectId}&limit=5&time=all`);
+        const pager = page.getByRole('group', { name: 'Table pagination' });
+        await expect(pager).toBeVisible();
+        await expect(pager.getByRole('button', { name: 'Rows per page' })).toContainText('5 rows');
+        await expect(pager.getByLabel('Page 1 of 2')).toBeVisible();
+        await expect
+            .poll(async () => {
+                const pagerBounds = await pager.boundingBox();
+                const footerBounds = await pager.locator('xpath=..').boundingBox();
+                return pagerBounds && footerBounds ? footerBounds.x + footerBounds.width - (pagerBounds.x + pagerBounds.width) : Number.POSITIVE_INFINITY;
+            })
+            .toBeLessThanOrEqual(1);
+
+        const nextPageResponse = page.waitForResponse((response) => {
+            const url = new URL(response.url());
+            return url.pathname.includes('/api/v2/organizations/') && url.pathname.endsWith('/events') && url.searchParams.get('page') === '2';
+        });
+        await page.getByRole('button', { name: 'Go to next page' }).click();
+        expect((await nextPageResponse).ok()).toBe(true);
+        await expect(page).toHaveURL(/[?&]page=2(?:&|$)/);
+        await expect(pager.getByLabel('Page 2 of 2')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Go to previous page' })).toBeEnabled();
+        await expect(page.getByRole('button', { name: 'Go to next page' })).toBeDisabled();
+
+        const refreshResponse = page.waitForResponse((response) => {
+            const url = new URL(response.url());
+            return url.pathname.includes('/api/v2/organizations/') && url.pathname.endsWith('/events') && url.searchParams.get('page') === '2';
+        });
+        await page.getByTitle('Refresh results').click();
+        expect((await refreshResponse).ok()).toBe(true);
+        await expect(page).toHaveURL(/[?&]page=2(?:&|$)/);
+        await page.screenshot({ path: 'dogfood-output/rataplan-compact-pager.png' });
+    });
+
+    await test.step('row selection clears when navigating between stack views', async () => {
+        await page.goto(`/next/stack/all?project=${e2eScenario.projectId}&time=all`);
+        const selectedRow = page.getByRole('row').filter({ hasText: journey.message }).first();
+        await expect(selectedRow).toBeVisible({ timeout: 30_000 });
+        await selectedRow.getByRole('checkbox', { name: 'Select row' }).click();
+        await expect(page.getByText('1 selected', { exact: true })).toBeVisible();
+
+        await page.getByRole('link', { exact: true, name: 'Most Frequent Errors' }).filter({ visible: true }).first().click();
+        await expect(page).toHaveURL(/\/next\/stack\/most-frequent-errors/);
+        await expect(page.getByText(journey.message).filter({ visible: true }).first()).toBeVisible({ timeout: 30_000 });
+        await expect(page.getByText('1 selected', { exact: true })).toHaveCount(0);
+    });
+
+    await test.step('the fixed-version field has space before the dialog footer', async () => {
+        await page.goto(`/next/stack?filter=project:${e2eScenario.projectId}&time=all`);
+        await page.getByRole('checkbox', { name: 'Select row' }).first().click();
+        const bulkActionsButton = page.getByRole('button', { name: 'Bulk Actions' });
+        const selectionCount = page.getByText('1 selected', { exact: true });
+        await expect(selectionCount).toBeVisible();
+        await expect
+            .poll(async () => {
+                const buttonBounds = await bulkActionsButton.boundingBox();
+                const countBounds = await selectionCount.boundingBox();
+                return buttonBounds && countBounds ? countBounds.x - (buttonBounds.x + buttonBounds.width) : Number.POSITIVE_INFINITY;
+            })
+            .toBeLessThanOrEqual(16);
+        await bulkActionsButton.click();
+        await expect(page.locator('[data-slot="dropdown-menu-group-heading"]', { hasText: 'Bulk Actions' })).toHaveCount(0);
+        await page.getByRole('menuitem', { name: 'Mark Fixed' }).click();
+
+        const versionField = page.getByRole('textbox', { name: 'Version' }).locator('xpath=..');
+        await expect(versionField).toBeVisible();
+        await expect.poll(() => versionField.evaluate((element) => Number.parseFloat(getComputedStyle(element).paddingBottom))).toBe(16);
+        await page.screenshot({ path: 'dogfood-output/rataplan-fixed-version-dialog.png' });
+        await page.getByRole('button', { name: 'Cancel' }).click();
+    });
+
+    await test.step('message is available as a wrappable event column', async () => {
+        await page.goto(`/next/stream?project=${e2eScenario.projectId}&time=all`);
+        await expect(page.getByText(journey.message).filter({ visible: true }).first()).toBeVisible({ timeout: 30_000 });
+
+        await page.getByTitle('Manage View Settings').click();
+        await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
+        await page.getByRole('button', { name: 'Add Message column' }).click();
+        await expect(page.getByRole('checkbox', { name: 'Message wrap text' })).toBeVisible();
+        await page.getByRole('button', { name: 'Close' }).click();
+    });
+
+    await test.step('renaming a project refreshes cached stack summaries', async () => {
+        const stackUrl = `/next/stack?filter=project:${e2eScenario.projectId}&time=all`;
+        await page.goto(stackUrl);
+        await expect(page.getByText(journey.message).filter({ visible: true }).first()).toBeVisible({ timeout: 30_000 });
+
+        await page.getByTitle('Manage View Settings').click();
+        await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
+
+        const summaryWrapCheckbox = page.getByRole('checkbox', { name: 'Summary wrap text' });
+        await expect(summaryWrapCheckbox).not.toBeChecked();
+        await summaryWrapCheckbox.click();
+        await expect(summaryWrapCheckbox).toBeChecked();
+        await expect(page.getByRole('checkbox', { name: 'Status wrap text' })).toHaveCount(0);
+
+        await page.getByRole('button', { name: 'Add Tags column' }).click();
+        const tagsWrapCheckbox = page.getByRole('checkbox', { name: 'Tags wrap text' });
+        await expect(tagsWrapCheckbox).toBeVisible();
+        await tagsWrapCheckbox.click();
+        await expect(tagsWrapCheckbox).toBeChecked();
+        await expect(page.getByRole('checkbox', { name: /wrap text$/ })).toHaveCount(2);
+
+        const removeColumnButton = page.getByRole('button', { name: /^Remove .+ column$/ }).first();
+        await expect(removeColumnButton).toBeVisible();
+        await expect
+            .poll(async () => {
+                const buttonBounds = await removeColumnButton.boundingBox();
+                const rowBounds = await removeColumnButton.locator('xpath=..').boundingBox();
+                if (!buttonBounds || !rowBounds) {
+                    return Number.POSITIVE_INFINITY;
+                }
+
+                const buttonCenter = buttonBounds.y + buttonBounds.height / 2;
+                const rowCenter = rowBounds.y + rowBounds.height / 2;
+                return Math.abs(buttonCenter - rowCenter);
+            })
+            .toBeLessThanOrEqual(1);
+        await page.screenshot({ path: 'dogfood-output/rataplan-column-remove-alignment.png' });
+
+        await page.getByRole('button', { name: 'Add Project column' }).click();
+        await page.getByRole('button', { name: 'Close' }).click();
+
+        const tagsResizeHandle = page.getByRole('button', { name: 'Resize tags column' });
+        for (let index = 0; index < 12; index++) {
+            await tagsResizeHandle.press('ArrowRight');
+        }
+
+        const wrappedSummaryCell = page.locator('td[data-wrap="true"]').filter({ hasText: journey.message }).first();
+        await expect(wrappedSummaryCell).toBeVisible();
+        const wrappedSummaryStyle = await wrappedSummaryCell.evaluate((cell) => {
+            const summary = cell.querySelector('.line-clamp-2');
+            return {
+                lineClamp: summary ? getComputedStyle(summary).webkitLineClamp : undefined,
+                whiteSpace: getComputedStyle(cell).whiteSpace
+            };
+        });
+        expect(wrappedSummaryStyle).toEqual({ lineClamp: 'none', whiteSpace: 'normal' });
+
+        const taggedRow = page
+            .getByRole('row')
+            .filter({ hasText: `${journey.message} stack 0` })
+            .first();
+        const wrappedTags = taggedRow.getByLabel(`Tags: ${wrappedTagValues.join(', ')}`);
+        await expect(wrappedTags).toBeVisible();
+        const tagsCell = wrappedTags.locator('xpath=ancestor::td[1]');
+        await expect
+            .poll(async () => {
+                const listBounds = await wrappedTags.boundingBox();
+                const cellBounds = await tagsCell.boundingBox();
+                return listBounds && cellBounds ? listBounds.width / cellBounds.width : 0;
+            })
+            .toBeGreaterThan(0.9);
+        for (const tag of wrappedTagValues.slice(0, 6)) {
+            await expect(wrappedTags.getByRole('button', { exact: true, name: tag })).toBeVisible();
+        }
+        await expect(wrappedTags.getByText('+3', { exact: true })).toBeVisible();
+        await expect(wrappedTags.getByRole('button', { exact: true, name: wrappedTagValues[6] })).toHaveCount(0);
+        await page.screenshot({ path: 'dogfood-output/rataplan-wrapped-tags.png' });
+
+        await expect(page.getByRole('cell', { name: journey.projectName }).first()).toBeVisible();
+
+        await page.goto(`/next/project/${e2eScenario.projectId}/manage`);
+        const renamedProject = `${journey.projectName} Renamed`;
+        const updateResponse = page.waitForResponse(
+            (response) => response.url().includes(`/api/v2/projects/${e2eScenario.projectId}`) && response.request().method() === 'PATCH'
+        );
+        await page.getByLabel('Project name').fill(renamedProject);
+        expect((await updateResponse).ok()).toBe(true);
+
+        const refreshedStacks = page.waitForResponse((response) => {
+            const url = new URL(response.url());
+            return (
+                url.pathname.includes('/api/v2/organizations/') &&
+                url.pathname.endsWith('/events') &&
+                url.searchParams.get('mode')?.startsWith('stack') === true
+            );
+        });
+        await page.goto(stackUrl);
+        expect((await refreshedStacks).ok()).toBe(true);
+        await expect(page.getByRole('cell', { name: renamedProject }).first()).toBeVisible();
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/rataplan-feedback.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/rataplan-feedback.e2e.ts
@@ -17,6 +17,14 @@ test('approved Rataplan UI feedback remains fixed', async ({ e2eApi, e2eScenario
     });
     expect(secondEvent.stack_id).toBe(journey.stackId);
 
+    await page.route(`**/api/v2/events/${secondEvent.id}*`, async (route) => {
+        const response = await route.fetch();
+        const event = (await response.json()) as { data?: Record<string, unknown> };
+        const data = { ...event.data };
+        delete data['@request'];
+        await route.fulfill({ json: { ...event, data }, response });
+    });
+
     for (let index = 0; index < 5; index++) {
         const referenceId = createReferenceId(journey.run, `-stack-${index}`);
         const event = createRepresentativeEvent({
@@ -66,6 +74,20 @@ test('approved Rataplan UI feedback remains fixed', async ({ e2eApi, e2eScenario
 
         await expect(page).not.toHaveURL(new RegExp(`/event/${firstEventId}(?:[?#]|$)`));
         await expect(page.getByRole('tab', { name: 'Exception' })).toHaveAttribute('aria-selected', 'true');
+
+        await page.goto(`/next/stack/${journey.stackId}/event/${firstEventId}`);
+        await page.getByRole('tab', { name: 'Request' }).click();
+        await expect(page.getByRole('tab', { name: 'Request' })).toHaveAttribute('aria-selected', 'true');
+
+        if (await newerEventButton.isEnabled()) {
+            await newerEventButton.click();
+        } else {
+            await olderEventButton.click();
+        }
+
+        await expect(page).toHaveURL(new RegExp(`/event/${secondEvent.id}(?:[?#]|$)`));
+        await expect(page.getByRole('tab', { name: 'Request' })).toBeHidden();
+        await expect(overviewTab).toHaveAttribute('aria-selected', 'true');
     });
 
     await test.step('command palette overflow is discoverable and shortcut chips have stronger emphasis', async () => {

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/stack-effects-chaos.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/stack-effects-chaos.e2e.ts
@@ -122,7 +122,7 @@ test('stack effects stay bounded through background, paging, and navigation chao
         await expect(rowSelection).toBeChecked();
 
         const response = page.waitForResponse((candidate) => isStackListResponse(candidate, e2eScenario.organizationId));
-        await page.getByTitle('Return to the first page to refresh results').click();
+        await page.getByTitle('Refresh results').click();
         expect((await response).ok()).toBe(true);
         await expect(rowSelection).not.toBeChecked();
     });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/backups-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/backups-data-table.svelte
@@ -33,11 +33,7 @@
             <DataTable.Empty {table} />
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="space-x-6 lg:space-x-8">
-        <DataTable.PageSize bind:value={limit} {table} />
-        <div class="flex items-center space-x-6 lg:space-x-8">
-            <DataTable.PageCount {table} />
-            <DataTable.Pagination {table} />
-        </div>
+    <DataTable.Footer {table} class="w-full">
+        <DataTable.Pager bind:value={limit} {table} />
     </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/indices-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/indices-data-table.svelte
@@ -33,11 +33,7 @@
             <DataTable.Empty {table} />
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="space-x-6 lg:space-x-8">
-        <DataTable.PageSize bind:value={limit} {table} />
-        <div class="flex items-center space-x-6 lg:space-x-8">
-            <DataTable.PageCount {table} />
-            <DataTable.Pagination {table} />
-        </div>
+    <DataTable.Footer {table} class="w-full">
+        <DataTable.Pager bind:value={limit} {table} />
     </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/migrations-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/migrations-data-table.svelte
@@ -33,11 +33,7 @@
             <DataTable.Empty {table} />
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="space-x-6 lg:space-x-8">
-        <DataTable.PageSize bind:value={limit} {table} />
-        <div class="flex items-center space-x-6 lg:space-x-8">
-            <DataTable.PageCount {table} />
-            <DataTable.Pagination {table} />
-        </div>
+    <DataTable.Footer {table} class="w-full">
+        <DataTable.Pager bind:value={limit} {table} />
     </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview-tab-state.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview-tab-state.ts
@@ -1,0 +1,3 @@
+export function shouldResetActiveEventTab(eventLoaded: boolean, projectPending: boolean, tabs: readonly string[], activeTab: string): boolean {
+    return eventLoaded && !projectPending && !tabs.includes(activeTab);
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
@@ -30,6 +30,7 @@
     import type { PersistentEvent } from '../models/index';
 
     import { getSessionId } from '../utils';
+    import { shouldResetActiveEventTab } from './events-overview-tab-state';
     import Environment from './views/environment.svelte';
     import Error from './views/error.svelte';
     import ExtendedData from './views/extended-data.svelte';
@@ -163,7 +164,7 @@
     let showJsonDialog = $state(false);
 
     $effect(() => {
-        if (event && !tabs.includes(activeTab)) {
+        if (shouldResetActiveEventTab(!!event, projectQuery.isPending, tabs, activeTab)) {
             activeTab = 'Overview';
         }
     });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
@@ -162,6 +162,12 @@
     let notifiedEventId = $state('');
     let showJsonDialog = $state(false);
 
+    $effect(() => {
+        if (event && !tabs.includes(activeTab)) {
+            activeTab = 'Overview';
+        }
+    });
+
     function isPromotedTab(tab: TabType): boolean {
         return !!projectQuery.data?.promoted_tabs?.includes(tab);
     }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte
@@ -390,7 +390,7 @@
     </Table.Root>
 
     {#if event}
-        <Tabs.Root class="mt-4 mb-4" value={activeTab}>
+        <Tabs.Root class="mt-4 mb-4" bind:value={activeTab}>
             <div class="relative">
                 {#if canScrollTabsLeft}
                     <Button

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-overview.svelte.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldResetActiveEventTab } from './events-overview-tab-state';
+
+describe('event overview tab state', () => {
+    it('waits for project metadata before deciding whether a promoted tab is unavailable', () => {
+        const activeTab = 'Customer Context';
+
+        expect(shouldResetActiveEventTab(true, true, ['Overview', 'Exception'], activeTab)).toBe(false);
+        expect(shouldResetActiveEventTab(true, false, ['Overview', 'Exception', activeTab], activeTab)).toBe(false);
+        expect(shouldResetActiveEventTab(true, false, ['Overview', 'Exception'], activeTab)).toBe(true);
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/event-tags-summary-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/event-tags-summary-cell.svelte
@@ -9,4 +9,10 @@
     let { onTagClick, tags }: Props = $props();
 </script>
 
-<TagList class="max-w-48 flex-nowrap" maxVisible={2} {onTagClick} {tags} />
+<TagList
+    class="max-w-48 flex-nowrap group-data-[wrap=true]/wrapped:w-full group-data-[wrap=true]/wrapped:max-w-none group-data-[wrap=true]/wrapped:flex-wrap"
+    maxVisible={2}
+    wrappedMaxVisible={6}
+    {onTagClick}
+    {tags}
+/>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/event-tags-summary-cell.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/event-tags-summary-cell.svelte.test.ts
@@ -4,13 +4,16 @@ import { describe, expect, it } from 'vitest';
 import EventTagsSummaryCell from './event-tags-summary-cell.svelte';
 
 describe('EventTagsSummaryCell', () => {
-    it('shows two tags and summarizes the remaining tags', () => {
+    it('keeps compact mode to two tags and reveals more when wrapping', () => {
         render(EventTagsSummaryCell, { tags: ['api', 'production', 'critical', 'customer'] });
 
         expect(screen.getByText('api')).toBeTruthy();
         expect(screen.getByText('production')).toBeTruthy();
-        expect(screen.getByText('+2')).toBeTruthy();
-        expect(screen.queryByText('critical')).toBeNull();
+        expect(screen.getByText('+2').closest<HTMLElement>('[data-slot="tooltip-trigger"]')?.classList).toContain('group-data-[wrap=true]/wrapped:hidden');
+
+        const thirdTagTrigger = screen.getByText('critical').closest<HTMLElement>('[data-slot="tooltip-trigger"]');
+        expect(thirdTagTrigger?.classList).toContain('hidden');
+        expect(thirdTagTrigger?.classList).toContain('group-data-[wrap=true]/wrapped:inline-flex');
         expect(screen.getByLabelText('Tags: api, production, critical, customer').getAttribute('title')).toBeNull();
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte
@@ -54,7 +54,6 @@
     </DropdownMenu.Trigger>
     <DropdownMenu.Content>
         <DropdownMenu.Group>
-            <DropdownMenu.GroupHeading>Bulk Actions</DropdownMenu.GroupHeading>
             <DropdownMenu.Item onclick={() => (openRemoveEventDialog = true)} class="text-destructive" title="Delete event">Delete</DropdownMenu.Item>
         </DropdownMenu.Group>
     </DropdownMenu.Content>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte.test.ts
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mutateAsync = vi.hoisted(() => vi.fn());
 const deleteEvent = vi.hoisted(() => vi.fn(() => ({ mutateAsync })));
@@ -15,6 +15,25 @@ describe('EventsBulkActionsDropdownMenu', () => {
         mutateAsync.mockResolvedValue(undefined);
         deleteEvent.mockClear();
         toast.success.mockClear();
+    });
+
+    afterEach(async () => {
+        cleanup();
+        // Bits UI defers body-scroll restoration by 24 ms after an overlay unmounts.
+        await new Promise((resolve) => window.setTimeout(resolve, 30));
+    });
+
+    it('does not repeat the trigger label inside the menu', async () => {
+        const table = {
+            getSelectedRowModel: () => ({ flatRows: [{ id: 'event-id' }] }),
+            resetRowSelection: vi.fn()
+        } as never;
+        render(EventsBulkActionsDropdownMenu, { props: { table } });
+
+        await fireEvent.click(screen.getByRole('button', { name: /Bulk Actions/ }));
+
+        expect(document.querySelector('[data-slot="dropdown-menu-group-heading"]')).toBeNull();
+        expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeTruthy();
     });
 
     it('deletes the selected events and clears the selection', async () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-data-table.svelte
@@ -18,6 +18,7 @@
         rowHref?: (row: EventSummaryModel<SummaryTemplateKeys>) => string;
         table: Table<StockFeatures, EventSummaryModel<SummaryTemplateKeys>>;
         toolbarChildren?: Snippet;
+        wrappedColumnIds?: readonly string[];
     }
 
     let {
@@ -30,7 +31,8 @@
         rowClick,
         rowHref,
         table,
-        toolbarChildren
+        toolbarChildren,
+        wrappedColumnIds = []
     }: Props = $props();
 </script>
 
@@ -40,7 +42,7 @@
             {@render toolbarChildren()}
         </DataTable.Toolbar>
     {/if}
-    <DataTable.Body {autoFillColumnId} {onAutoFillColumnResized} {rowClick} {rowHref} {table}>
+    <DataTable.Body {autoFillColumnId} {onAutoFillColumnResized} {rowClick} {rowHref} {table} {wrappedColumnIds}>
         {#if isLoading}
             <DelayedRender>
                 <DataTable.Loading {table} />
@@ -56,20 +58,8 @@
         {#if footerChildren}
             {@render footerChildren()}
         {:else}
-            <div class="grid w-full grid-cols-1 items-center gap-2 sm:grid-cols-3">
-                <div class="flex min-w-0 items-center gap-2">
-                    <DataTable.Selection {table} />
-                </div>
-
-                <div class="flex min-w-0 items-center justify-center">
-                    <DataTable.PageCount {table} />
-                </div>
-
-                <div class="flex min-w-0 items-center justify-end gap-4">
-                    <DataTable.PageSize bind:value={limit} {table} />
-                    <DataTable.Pagination {table} />
-                </div>
-            </div>
+            <DataTable.Selection {table} />
+            <DataTable.Pager bind:value={limit} {table} />
         {/if}
     </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/options.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/options.svelte.test.ts
@@ -1,3 +1,4 @@
+import { supportsColumnWrapping } from '$features/shared/components/data-table/column-meta';
 import { describe, expect, it } from 'vitest';
 
 import type { EventSummaryModel, StackSummaryModel, SummaryTemplateKeys } from '../summary';
@@ -22,7 +23,9 @@ describe('event table columns', () => {
         const summary = columns.find((column) => column.id === 'summary');
 
         expect(summary).toMatchObject({ enableResizing: true, maxSize: 1200, minSize: 240, size: 480 });
+        expect(supportsColumnWrapping(summary?.meta)).toBe(true);
         expect(project).toMatchObject({ maxSize: 800, minSize: 160, size: 240 });
+        expect(supportsColumnWrapping(project?.meta)).toBe(false);
         expect(select?.enableResizing).toBe(false);
     });
 
@@ -34,5 +37,19 @@ describe('event table columns', () => {
         expect(columnIds).toContain('tags');
         expect(defaultStackColumnVisibility.project).toBe(false);
         expect(defaultStackColumnVisibility.tags).toBe(false);
+    });
+
+    it('allows wrapping only for summary, tags, and message event columns', () => {
+        const columns = getColumns<EventSummaryModel<SummaryTemplateKeys>>();
+        const wrappableColumnIds = columns.filter((column) => supportsColumnWrapping(column.meta)).map((column) => column.id);
+
+        expect(wrappableColumnIds).toEqual(['summary', 'tags', 'message']);
+    });
+
+    it('allows wrapping only for summary and tags stack columns', () => {
+        const columns = getColumns<StackSummaryModel<SummaryTemplateKeys>>('stack_frequent');
+        const wrappableColumnIds = columns.filter((column) => supportsColumnWrapping(column.meta)).map((column) => column.id);
+
+        expect(wrappableColumnIds).toEqual(['summary', 'tags']);
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/options.svelte.ts
@@ -85,7 +85,8 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
             id: 'summary',
             maxSize: 1200,
             meta: {
-                class: 'w-full'
+                class: 'w-full',
+                enableWrapping: true
             },
             minSize: 240,
             size: 480
@@ -149,7 +150,8 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
                 id: 'tags',
                 maxSize: 800,
                 meta: {
-                    class: 'w-52 min-w-52 max-w-52'
+                    class: 'w-52 min-w-52 max-w-52',
+                    enableWrapping: true
                 },
                 minSize: 120,
                 size: 208
@@ -162,7 +164,8 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
                 id: 'message',
                 maxSize: 800,
                 meta: {
-                    class: 'w-full'
+                    class: 'w-full',
+                    enableWrapping: true
                 },
                 minSize: 160,
                 size: 320
@@ -259,7 +262,8 @@ export function getColumns<TSummaryModel extends SummaryModel<SummaryTemplateKey
                 id: 'tags',
                 maxSize: 800,
                 meta: {
-                    class: 'w-52 min-w-52 max-w-52'
+                    class: 'w-52 min-w-52 max-w-52',
+                    enableWrapping: true
                 },
                 minSize: 120,
                 size: 208

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/overview.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/overview.svelte
@@ -241,7 +241,7 @@
             <CopyToClipboardButton size="icon-sm" title="Copy Stack Trace to Clipboard" value={stackTrace} variant="outline"></CopyToClipboardButton>
         </div>
     </div>
-    <div class="mt-2 max-h-75 grow overflow-auto text-xs">
+    <div class="mt-2 grow text-xs">
         {#if event.data?.['@error']}
             <StackTrace error={event.data['@error']} />
         {:else if event.data?.['@simple_error']}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/api.svelte.ts
@@ -3,7 +3,9 @@ import type { StringValueFromBody, WorkInProgressResult } from '$features/shared
 import type { WebSocketMessageValue } from '$features/websockets/models';
 
 import { accessToken } from '$features/auth/index.svelte';
+import { queryKeys as eventQueryKeys } from '$features/events/api.svelte';
 import { fetchApiJson } from '$features/shared/api/api.svelte';
+import { queryKeys as stackQueryKeys } from '$features/stacks/api.svelte';
 import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, QueryClient, useQueryClient } from '@tanstack/svelte-query';
 
@@ -30,6 +32,19 @@ export async function invalidateProjectQueries(queryClient: QueryClient, message
             queryKey: queryKeys.projects()
         });
     }
+
+    await invalidateProjectSummaryQueries(queryClient);
+}
+
+export async function invalidateProjectSummaryQueries(queryClient: QueryClient): Promise<void> {
+    await Promise.all([
+        queryClient.invalidateQueries({
+            queryKey: eventQueryKeys.type
+        }),
+        queryClient.invalidateQueries({
+            queryKey: stackQueryKeys.type
+        })
+    ]);
 }
 
 // TODO: Do we need to scope these all by organization?
@@ -717,8 +732,17 @@ export function updateProject(request: UpdateProjectRequest) {
                 queryKey: queryKeys.id(request.route.id)
             });
         },
-        onSuccess: (project: ViewProject) => {
+        onSuccess: async (project: ViewProject) => {
             queryClient.setQueryData(queryKeys.id(request.route.id), project);
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.organization(project.organization_id)
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.projects()
+                }),
+                invalidateProjectSummaryQueries(queryClient)
+            ]);
         }
     }));
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/api.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/api.test.ts
@@ -1,0 +1,31 @@
+import { queryKeys as eventQueryKeys } from '$features/events/api.svelte';
+import { queryKeys as stackQueryKeys } from '$features/stacks/api.svelte';
+import { ChangeType } from '$features/websockets/models';
+import { QueryClient } from '@tanstack/svelte-query';
+import { describe, expect, it, vi } from 'vitest';
+
+import { invalidateProjectQueries, queryKeys } from './api.svelte';
+
+describe('invalidateProjectQueries', () => {
+    it('invalidates project caches and summaries that embed the project name', async () => {
+        // Arrange
+        const queryClient = new QueryClient();
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries').mockImplementation(async () => {});
+
+        // Act
+        await invalidateProjectQueries(queryClient, {
+            change_type: ChangeType.Saved,
+            data: {},
+            id: 'project-id',
+            organization_id: 'organization-id',
+            type: 'Project'
+        });
+
+        // Assert
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.id('project-id') });
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.organization('organization-id') });
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.projects() });
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: eventQueryKeys.type });
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: stackQueryKeys.type });
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/projects-config-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/projects-config-data-table.svelte
@@ -39,16 +39,12 @@
             {@render bodyChildren()}
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="space-x-6 lg:space-x-8">
+    <DataTable.Footer {table} class="w-full">
         {#if footerChildren}
             {@render footerChildren()}
         {:else}
             <DataTable.Selection {table} />
-            <DataTable.PageSize bind:value={limit} {table}></DataTable.PageSize>
-            <div class="flex items-center space-x-6 lg:space-x-8">
-                <DataTable.PageCount {table} />
-                <DataTable.Pagination {table} />
-            </div>
+            <DataTable.Pager bind:value={limit} {table} />
         {/if}
     </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/projects-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/projects-data-table.svelte
@@ -40,16 +40,12 @@
             {@render bodyChildren()}
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="space-x-6 lg:space-x-8">
+    <DataTable.Footer {table} class="w-full">
         {#if footerChildren}
             {@render footerChildren()}
         {:else}
             <DataTable.Selection {table} />
-            <DataTable.PageSize bind:value={limit} {table}></DataTable.PageSize>
-            <div class="flex items-center space-x-6 lg:space-x-8">
-                <DataTable.PageCount {table} />
-                <DataTable.Pagination {table} />
-            </div>
+            <DataTable.Pager bind:value={limit} {table} />
         {/if}
     </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
@@ -9,8 +9,10 @@ import {
     getSavedColumnOrder,
     getSavedColumnSizing,
     getSavedColumnVisibility,
+    getSavedWrappedColumnIds,
     savedViewColumnOrderEqual,
-    savedViewColumnSizingEqual
+    savedViewColumnSizingEqual,
+    savedViewColumnWrappingEqual
 } from './column-settings';
 
 describe('saved view column settings', () => {
@@ -20,12 +22,14 @@ describe('saved view column settings', () => {
             ['select', 'project', 'summary'],
             { project: true, summary: true },
             { project: 360 },
-            'summary'
+            'summary',
+            undefined,
+            ['summary']
         );
 
         expect(result).toEqual({
             project: { position: 0, visible: true, width: 360 },
-            summary: { auto_fill: true, position: 1, visible: true }
+            summary: { auto_fill: true, position: 1, visible: true, wrap: true }
         });
     });
 
@@ -58,11 +62,11 @@ describe('saved view column settings', () => {
         expect(getSavedAutoFillColumnSelection(legacyFixedDefault, 'summary')).toBeNull();
     });
 
-    it('reads order, visibility, and width from structured columns', () => {
+    it('reads order, visibility, width, and wrapping from structured columns', () => {
         const view = {
             columns: {
                 project: { position: 0, visible: true, width: 360 },
-                summary: { auto_fill: true, position: 1, visible: false }
+                summary: { auto_fill: true, position: 1, visible: false, wrap: true }
             }
         } as Pick<SavedView, 'columns'>;
 
@@ -70,6 +74,7 @@ describe('saved view column settings', () => {
         expect(getSavedColumnVisibility(view)).toEqual({ project: true, summary: false });
         expect(getSavedColumnSizing(view)).toEqual({ project: 360 });
         expect(getSavedAutoFillColumnId(view)).toBe('summary');
+        expect(getSavedWrappedColumnIds(view)).toEqual(['summary']);
     });
 
     it('detects changed and reset column widths', () => {
@@ -105,5 +110,30 @@ describe('saved view column settings', () => {
         } as Pick<SavedView, 'columns'>;
 
         expect(savedViewColumnOrderEqual(['select', 'date', 'project'], view)).toBe(true);
+    });
+
+    it('treats missing wrap settings as the legacy single-line behavior', () => {
+        const view = {
+            columns: {
+                project: { visible: true },
+                summary: { visible: true }
+            }
+        } as Pick<SavedView, 'columns'>;
+
+        expect(getSavedWrappedColumnIds(view)).toEqual([]);
+        expect(savedViewColumnWrappingEqual([], view)).toBe(true);
+        expect(savedViewColumnWrappingEqual(['summary'], view)).toBe(false);
+    });
+
+    it('compares wrapped columns without depending on their order', () => {
+        const view = {
+            columns: {
+                project: { wrap: true },
+                summary: { wrap: true }
+            }
+        } as Pick<SavedView, 'columns'>;
+
+        expect(savedViewColumnWrappingEqual(['summary', 'project'], view)).toBe(true);
+        expect(savedViewColumnWrappingEqual(['summary'], view)).toBe(false);
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
@@ -3,6 +3,7 @@ import type { ColumnOrderState, ColumnSizingState, ColumnVisibilityState } from 
 import type { SavedView, SavedViewColumnSettings } from './models';
 
 export type AutoFillColumnSelection = null | string;
+export type WrappedColumnIds = string[];
 
 type SavedColumnState = Pick<SavedView, 'columns'>;
 
@@ -12,7 +13,8 @@ export function buildColumnSettings(
     columnVisibility: ColumnVisibilityState,
     columnSizing: ColumnSizingState,
     autoFillColumnId?: AutoFillColumnSelection,
-    defaultAutoFillColumnId?: string
+    defaultAutoFillColumnId?: string,
+    wrappedColumnIds: readonly string[] = []
 ): Record<string, SavedViewColumnSettings> {
     const availableColumnIds = columnIds.filter((columnId) => columnId !== 'select');
     const availableColumnIdSet = new Set(availableColumnIds);
@@ -31,6 +33,7 @@ export function buildColumnSettings(
                 visible: columnVisibility[columnId] ?? true,
                 ...(columnId === autoFillColumnId && columnVisibility[columnId] !== false && columnSizing[columnId] === undefined ? { auto_fill: true } : {}),
                 ...(columnId === explicitNoneMarkerColumnId ? { auto_fill: false } : {}),
+                ...(wrappedColumnIds.includes(columnId) ? { wrap: true } : {}),
                 ...(columnSizing[columnId] !== undefined ? { width: Math.round(columnSizing[columnId]) } : {})
             }
         ])
@@ -85,6 +88,12 @@ export function getSavedColumnVisibility(view: SavedColumnState | undefined): Co
     );
 }
 
+export function getSavedWrappedColumnIds(view: SavedColumnState | undefined): WrappedColumnIds {
+    return Object.entries(view?.columns ?? {})
+        .filter(([, settings]) => settings.wrap === true)
+        .map(([columnId]) => columnId);
+}
+
 export function savedViewColumnOrderEqual(current: ColumnOrderState | undefined, view: SavedColumnState): boolean {
     const savedOrder = getSavedColumnOrder(view);
     const savedColumnIds = new Set(savedOrder);
@@ -99,4 +108,11 @@ export function savedViewColumnSizingEqual(current: ColumnSizingState | undefine
     const savedEntries = Object.entries(saved);
 
     return currentEntries.length === savedEntries.length && currentEntries.every(([columnId, width]) => saved[columnId] === Math.round(width));
+}
+
+export function savedViewColumnWrappingEqual(current: readonly string[] | undefined, view: SavedColumnState): boolean {
+    const saved = getSavedWrappedColumnIds(view);
+    const currentIds = [...new Set(current ?? [])];
+
+    return currentIds.length === saved.length && currentIds.every((columnId) => saved.includes(columnId));
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/column-management-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/column-management-dialog.svelte
@@ -9,11 +9,13 @@
 
     import { Badge } from '$comp/ui/badge';
     import { Button } from '$comp/ui/button';
+    import { Checkbox } from '$comp/ui/checkbox';
     import * as Dialog from '$comp/ui/dialog';
     import * as InputGroup from '$comp/ui/input-group';
     import { Label } from '$comp/ui/label';
     import * as RadioGroup from '$comp/ui/radio-group';
     import { Separator } from '$comp/ui/separator';
+    import { supportsColumnWrapping } from '$features/shared/components/data-table/column-meta';
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
     import ChevronUp from '@lucide/svelte/icons/chevron-up';
     import GripVertical from '@lucide/svelte/icons/grip-vertical';
@@ -22,17 +24,19 @@
     import Search from '@lucide/svelte/icons/search';
     import X from '@lucide/svelte/icons/x';
 
-    import type { AutoFillColumnSelection } from '../column-settings';
+    import type { AutoFillColumnSelection, WrappedColumnIds } from '../column-settings';
 
     interface Props {
         autoFillColumnId: AutoFillColumnSelection;
         defaultAutoFillColumnId?: string;
         open: boolean;
         setAutoFillColumnId: (columnId: AutoFillColumnSelection) => void;
+        setWrappedColumnIds: (columnIds: WrappedColumnIds) => void;
         table: Table<StockFeatures, TData>;
+        wrappedColumnIds: WrappedColumnIds;
     }
 
-    let { autoFillColumnId, defaultAutoFillColumnId, open = $bindable(), setAutoFillColumnId, table }: Props = $props();
+    let { autoFillColumnId, defaultAutoFillColumnId, open = $bindable(), setAutoFillColumnId, setWrappedColumnIds, table, wrappedColumnIds }: Props = $props();
 
     let draggedColumnId = $state<null | string>(null);
     let search = $state('');
@@ -91,6 +95,17 @@
         return column.getCanHide() && visibleColumns.length > 1;
     }
 
+    function setColumnWrapped(columnId: string, wrapped: boolean): void {
+        if (wrapped) {
+            if (!wrappedColumnIds.includes(columnId)) {
+                setWrappedColumnIds([...wrappedColumnIds, columnId]);
+            }
+            return;
+        }
+
+        setWrappedColumnIds(wrappedColumnIds.filter((id) => id !== columnId));
+    }
+
     function moveColumnUp(columnId: string): void {
         const columnIds = visibleColumns.map((c) => c.id);
         const index = columnIds.indexOf(columnId);
@@ -131,6 +146,7 @@
         } else {
             setAutoFillColumnId(null);
         }
+        setWrappedColumnIds([]);
         search = '';
     }
 
@@ -177,7 +193,7 @@
     >
         <Dialog.Header class="border-b px-6 py-5 pr-14">
             <Dialog.Title>Column Picker</Dialog.Title>
-            <Dialog.Description>Select, reorder, and choose which column fills the available table width.</Dialog.Description>
+            <Dialog.Description>Select, reorder, wrap text, and choose which column fills the available table width.</Dialog.Description>
         </Dialog.Header>
 
         <div class="grid min-h-0 gap-0 lg:grid-cols-[minmax(0,1fr)_5rem_minmax(0,1fr)]">
@@ -244,7 +260,7 @@
                             <h3 id="selected-columns-heading" class="text-sm font-semibold">Selected Columns</h3>
                             <Badge variant="secondary">{visibleColumns.length}</Badge>
                         </div>
-                        <p class="text-muted-foreground text-sm">Drag to reorder, or mark one column to auto fill the available width.</p>
+                        <p class="text-muted-foreground text-sm">Drag to reorder, wrap text, or mark one column to auto fill the available width.</p>
                     </div>
                 </div>
 
@@ -278,7 +294,7 @@
                                 <Button
                                     variant="ghost"
                                     size="icon-sm"
-                                    class="hover:bg-muted/70 my-1 ml-1 shrink-0"
+                                    class="hover:bg-muted/70 ml-1 shrink-0 self-center"
                                     disabled={!canRemoveColumn(column)}
                                     onclick={() => removeColumn(column)}
                                     aria-label={`Remove ${getColumnLabel(column)} column`}
@@ -286,6 +302,22 @@
                                     <X class="shrink-0" aria-hidden="true" />
                                 </Button>
                                 <span class="min-w-0 flex-1 self-center truncate px-2 text-left font-medium">{getColumnLabel(column)}</span>
+                                {#if supportsColumnWrapping(column.columnDef.meta)}
+                                    <Label
+                                        class="hover:bg-muted/70 flex w-16 shrink-0 cursor-pointer items-center justify-center gap-2 rounded-md text-xs font-normal"
+                                        for={`wrap-column-${column.id}`}
+                                    >
+                                        <Checkbox
+                                            aria-label={`${getColumnLabel(column)} wrap text`}
+                                            checked={wrappedColumnIds.includes(column.id)}
+                                            id={`wrap-column-${column.id}`}
+                                            onCheckedChange={(checked) => setColumnWrapped(column.id, checked)}
+                                        />
+                                        Wrap
+                                    </Label>
+                                {:else}
+                                    <span class="w-16 shrink-0" aria-hidden="true"></span>
+                                {/if}
                                 <Label
                                     class="hover:bg-muted/70 mr-1 flex shrink-0 cursor-pointer items-center gap-2 rounded-md px-2 text-xs font-normal"
                                     for={`auto-fill-column-${column.id}`}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
@@ -14,6 +14,7 @@
     import { toFilter } from '$features/events/components/filters/helpers.svelte';
     import { serializeFilters } from '$features/events/components/filters/helpers.svelte';
     import { organization } from '$features/organizations/context.svelte';
+    import { supportsColumnWrapping } from '$features/shared/components/data-table/column-meta';
     import Columns3 from '@lucide/svelte/icons/columns-3';
     import Pencil from '@lucide/svelte/icons/pencil';
     import Plus from '@lucide/svelte/icons/plus';
@@ -24,7 +25,7 @@
     import { tick } from 'svelte';
     import { toast } from 'svelte-sonner';
 
-    import type { AutoFillColumnSelection } from '../column-settings';
+    import type { AutoFillColumnSelection, WrappedColumnIds } from '../column-settings';
     import type { NewSavedView, SavedView, UpdateSavedView } from '../models';
 
     import { deleteSavedView, markSavedViewDeleted, patchSavedView, postSavedView, restoreDeletedSavedView } from '../api.svelte';
@@ -60,12 +61,14 @@
         setAutoFillColumnId: (columnId: AutoFillColumnSelection) => void;
         setShowChart?: (show: boolean) => void;
         setShowStats?: (show: boolean) => void;
+        setWrappedColumnIds: (columnIds: WrappedColumnIds) => void;
         showChart?: boolean;
         showStats?: boolean;
         sort?: string;
         table: Table<StockFeatures, TData>;
         time?: string;
         view: string;
+        wrappedColumnIds: WrappedColumnIds;
     }
 
     let {
@@ -84,12 +87,14 @@
         setAutoFillColumnId,
         setShowChart,
         setShowStats,
+        setWrappedColumnIds,
         showChart = true,
         showStats = true,
         sort,
         table,
         time,
-        view
+        view,
+        wrappedColumnIds
     }: Props = $props();
 
     let isSaveDialogOpen = $state(false);
@@ -164,13 +169,15 @@
     }
 
     function getSavedColumnSettings() {
+        const supportedWrappedColumnIds = wrappedColumnIds.filter((columnId) => supportsColumnWrapping(table.getColumn(columnId)?.columnDef.meta));
         return buildColumnSettings(
             table.getAllLeafColumns().map((column) => column.id),
             columnOrder ?? [],
             columnVisibility ?? {},
             columnSizing ?? {},
             autoFillColumnId,
-            defaultAutoFillColumnId
+            defaultAutoFillColumnId,
+            supportedWrappedColumnIds
         );
     }
 
@@ -401,5 +408,13 @@
 {/if}
 
 {#if isColumnDialogOpen}
-    <ColumnManagementDialog bind:open={isColumnDialogOpen} {autoFillColumnId} {defaultAutoFillColumnId} {setAutoFillColumnId} {table} />
+    <ColumnManagementDialog
+        bind:open={isColumnDialogOpen}
+        {autoFillColumnId}
+        {defaultAutoFillColumnId}
+        {setAutoFillColumnId}
+        {setWrappedColumnIds}
+        {table}
+        {wrappedColumnIds}
+    />
 {/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -5,7 +5,7 @@ import { goto } from '$app/navigation';
 import { buildFilterCacheKey, deserializeFilters, serializeFilters } from '$features/events/components/filters/helpers.svelte';
 import { organization } from '$features/organizations/context.svelte';
 
-import type { AutoFillColumnSelection } from './column-settings';
+import type { AutoFillColumnSelection, WrappedColumnIds } from './column-settings';
 import type { SavedView } from './models';
 
 import { getSavedViewsByViewQuery } from './api.svelte';
@@ -14,8 +14,10 @@ import {
     getSavedColumnOrder,
     getSavedColumnSizing,
     getSavedColumnVisibility,
+    getSavedWrappedColumnIds,
     savedViewColumnOrderEqual,
-    savedViewColumnSizingEqual
+    savedViewColumnSizingEqual,
+    savedViewColumnWrappingEqual
 } from './column-settings';
 import { savedViewHref, savedViewResolvedSlug } from './slugs';
 
@@ -67,6 +69,8 @@ export interface UseSavedViewsReturn {
     isModified: boolean;
     savedViews: SavedView[];
     setAutoFillColumnId: (columnId: AutoFillColumnSelection) => void;
+    setWrappedColumnIds: (columnIds: WrappedColumnIds) => void;
+    wrappedColumnIds: WrappedColumnIds;
 }
 
 export function clearSavedViewQueryParams(queryParams: SavedViewQueryParams): void {
@@ -173,6 +177,7 @@ export function supportsTimeQueryParam(queryParams: SavedViewQueryParams): query
 export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsReturn {
     const isEnabled = $derived(!!organization.current);
     let autoFillColumnId = $state<AutoFillColumnSelection>(options.defaultAutoFillColumnId ?? null);
+    let wrappedColumnIds = $state<WrappedColumnIds>([]);
 
     // Some routes, such as stream, do not declare every saved-view query parameter.
     const supportsSort = supportsSortQueryParam(options.queryParams);
@@ -217,6 +222,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
         options.setColumnSizing?.(getSavedColumnSizing(view));
         autoFillColumnId = getSavedAutoFillColumnSelection(view, options.defaultAutoFillColumnId);
+        wrappedColumnIds = getSavedWrappedColumnIds(view);
     }
 
     function applyDisplayState(view: Pick<SavedView, 'show_chart' | 'show_stats'> | undefined): void {
@@ -325,6 +331,10 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return true;
         }
 
+        if (!savedViewColumnWrappingEqual(wrappedColumnIds, view)) {
+            return true;
+        }
+
         if (options.getShowStats && options.getShowStats() !== (view.show_stats ?? true)) {
             return true;
         }
@@ -417,6 +427,12 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         },
         setAutoFillColumnId(columnId: AutoFillColumnSelection) {
             autoFillColumnId = columnId;
+        },
+        setWrappedColumnIds(columnIds: WrappedColumnIds) {
+            wrappedColumnIds = columnIds.filter((columnId, index) => columnIds.indexOf(columnId) === index);
+        },
+        get wrappedColumnIds() {
+            return wrappedColumnIds;
         }
     };
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/column-meta.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/column-meta.ts
@@ -1,0 +1,12 @@
+export interface DataTableColumnMeta {
+    class?: string;
+    enableWrapping?: boolean;
+}
+
+export function getDataTableColumnMeta(meta: unknown): DataTableColumnMeta {
+    return (meta ?? {}) as DataTableColumnMeta;
+}
+
+export function supportsColumnWrapping(meta: unknown): boolean {
+    return getDataTableColumnMeta(meta).enableWrapping === true;
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
@@ -9,6 +9,7 @@
     import * as Table from '$comp/ui/table';
     import { type Cell, FlexRender, type Header, type RowData, type StockFeatures, type Table as SvelteTable } from '@tanstack/svelte-table';
 
+    import { getDataTableColumnMeta, supportsColumnWrapping } from './column-meta';
     import DataTableColumnHeader from './data-table-column-header.svelte';
 
     interface Props {
@@ -18,9 +19,10 @@
         rowClick?: (row: TData, event?: MouseEvent) => void;
         rowHref?: (row: TData) => string;
         table: SvelteTable<StockFeatures, TData>;
+        wrappedColumnIds?: readonly string[];
     }
 
-    let { autoFillColumnId, children, onAutoFillColumnResized, rowClick, rowHref, table }: Props = $props();
+    let { autoFillColumnId, children, onAutoFillColumnResized, rowClick, rowHref, table, wrappedColumnIds = [] }: Props = $props();
 
     const selectColumnClass = 'w-8 min-w-8 max-w-8';
     const selectColumnWidth = 32;
@@ -54,10 +56,17 @@
 
         const isOnlyDataColumn = getVisibleDataColumnCount() === 1;
         const metaClass = isOnlyDataColumn ? removeWidthClasses(getMetaClass(cell.column.columnDef.meta)) : getMetaClass(cell.column.columnDef.meta);
+        const contentClass = isColumnWrapped(cell.column)
+            ? 'group/wrapped whitespace-normal break-words [&_.line-clamp-1]:line-clamp-none [&_.line-clamp-2]:line-clamp-none'
+            : 'truncate';
         const classes = rowClick
-            ? ['cursor-pointer', 'truncate', !isOnlyDataColumn && 'max-w-sm', metaClass]
-            : ['truncate', !isOnlyDataColumn && 'max-w-sm', metaClass];
+            ? ['cursor-pointer', contentClass, !isOnlyDataColumn && 'max-w-sm', metaClass]
+            : [contentClass, !isOnlyDataColumn && 'max-w-sm', metaClass];
         return classes.filter(Boolean).join(' ');
+    }
+
+    function isColumnWrapped(column: Cell<StockFeatures, TData, unknown>['column']): boolean {
+        return supportsColumnWrapping(column.columnDef.meta) && wrappedColumnIds.includes(column.id);
     }
 
     function getHeaderContentClass(header: Header<StockFeatures, TData, unknown>, headerClass: string): string {
@@ -81,7 +90,7 @@
     }
 
     function getMetaClass(meta: unknown): string {
-        return (meta as { class?: string })?.class ?? '';
+        return getDataTableColumnMeta(meta).class ?? '';
     }
 
     function getFlexibleDataColumnId(): string | undefined {
@@ -327,12 +336,21 @@
                         {#if rowHref && cell.row.original}
                             {@const href = rowHref(cell.row.original)}
                             <A {href} class="contents" onclick={(event) => onCellClick(event, cell)} variant="ghost">
-                                <Table.Cell class={getCellClass(cell)} style={getColumnStyle(cell.column)}>
+                                <Table.Cell
+                                    class={getCellClass(cell)}
+                                    data-wrap={isColumnWrapped(cell.column) ? 'true' : undefined}
+                                    style={getColumnStyle(cell.column)}
+                                >
                                     <FlexRender {cell} />
                                 </Table.Cell>
                             </A>
                         {:else}
-                            <Table.Cell class={getCellClass(cell)} onclick={(event) => onCellClick(event, cell)} style={getColumnStyle(cell.column)}>
+                            <Table.Cell
+                                class={getCellClass(cell)}
+                                data-wrap={isColumnWrapped(cell.column) ? 'true' : undefined}
+                                onclick={(event) => onCellClick(event, cell)}
+                                style={getColumnStyle(cell.column)}
+                            >
                                 <FlexRender {cell} />
                             </Table.Cell>
                         {/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
@@ -72,6 +72,21 @@ describe('DataTableBody', () => {
         expect(dateHeader.style.cssText).toBe('width: 150px; min-width: 150px; max-width: 150px;');
     });
 
+    it('wraps only columns that opt in', () => {
+        render(DataTableBodyTestHarness, { kind: 'event', onRowClick: vi.fn(), wrappedColumnIds: ['summary', 'date'] });
+
+        const summaryCell = screen.getByText('Unexpected end of Stream, the content may have already been read by another component.').closest('td');
+        const dateCell = screen.getByText('event-id').closest('td');
+
+        expect(summaryCell?.getAttribute('data-wrap')).toBe('true');
+        expect(summaryCell?.classList.contains('whitespace-normal')).toBe(true);
+        expect(summaryCell?.classList.contains('break-words')).toBe(true);
+        expect(summaryCell?.classList.contains('truncate')).toBe(false);
+        expect(summaryCell?.className).toContain('[&_.line-clamp-2]:line-clamp-none');
+        expect(dateCell?.hasAttribute('data-wrap')).toBe(false);
+        expect(dateCell?.classList.contains('truncate')).toBe(true);
+    });
+
     it('reports when the selected auto-fill column is resized', async () => {
         const onAutoFillColumnResized = vi.fn();
         render(DataTableBodyTestHarness, {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
@@ -19,6 +19,7 @@
         onAutoFillColumnResized?: (columnId: string) => void;
         onRowClick: (row: TestSummary) => void;
         sizedFullWidthSummary?: boolean;
+        wrappedColumnIds?: readonly string[];
     }
 
     let {
@@ -28,7 +29,8 @@
         kind,
         onAutoFillColumnResized,
         onRowClick,
-        sizedFullWidthSummary = false
+        sizedFullWidthSummary = false,
+        wrappedColumnIds = []
     }: Props = $props();
 
     const summaryData = {
@@ -100,7 +102,8 @@
                     meta: {
                         get class() {
                             return fullWidthSummary ? 'w-full' : 'w-60 min-w-60 max-w-60';
-                        }
+                        },
+                        enableWrapping: true
                     },
                     minSize: 120,
                     size: 160
@@ -128,6 +131,7 @@
     {autoFillColumnId}
     {onAutoFillColumnResized}
     rowClick={onRowClick}
+    {wrappedColumnIds}
     rowHref={(row: SummaryModel<SummaryTemplateKeys>) => (kind === 'event' ? buildEventDetailsHref(row.id) : buildStackDetailsHref(row.id))}
     {table}
 />

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
@@ -51,16 +51,15 @@
     }
 </script>
 
-<div class="flex min-w-0 items-center gap-2">
-    <p class="hidden truncate text-sm font-medium sm:inline">Rows per page</p>
-    <Select.Root type="single" {items} value={valueString} {onValueChange}>
-        <Select.Trigger class="h-8 w-[70px] min-w-[46px]">
-            {selected.label}
-        </Select.Trigger>
-        <Select.Content>
+<Select.Root type="single" {items} value={valueString} {onValueChange}>
+    <Select.Trigger aria-label="Rows per page" class="min-w-18" size="sm" title="Rows per page">
+        {selected.label} rows
+    </Select.Trigger>
+    <Select.Content>
+        <Select.Group>
             {#each items as item (item.value)}
-                <Select.Item value={item.value}>{item.label}</Select.Item>
+                <Select.Item value={item.value}>{item.label} rows</Select.Item>
             {/each}
-        </Select.Content>
-    </Select.Root>
-</div>
+        </Select.Group>
+    </Select.Content>
+</Select.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
@@ -1,0 +1,52 @@
+<script module lang="ts">
+    type TData = RowData;
+</script>
+
+<script generics="TData extends RowData" lang="ts">
+    import type { RowData, StockFeatures, Table } from '@tanstack/svelte-table';
+
+    import Number from '$comp/formatters/number.svelte';
+    import { Button } from '$comp/ui/button';
+    import * as ButtonGroup from '$comp/ui/button-group';
+    import ChevronLeftIcon from '@lucide/svelte/icons/chevron-left';
+    import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
+
+    import DataTablePageSize from './data-table-page-size.svelte';
+
+    interface Props {
+        table: Table<StockFeatures, TData>;
+        value: number;
+    }
+
+    let { table, value = $bindable() }: Props = $props();
+
+    const currentPage = $derived((table.options.state?.pagination?.pageIndex ?? table.store.state.pagination.pageIndex) + 1);
+    const totalPages = $derived(Math.max(1, table.getPageCount() || 1));
+    const canGoNext = $derived(currentPage < totalPages);
+    const canGoPrevious = $derived(currentPage > 1);
+
+    function goToNextPage(): void {
+        if (canGoNext) {
+            table.setPageIndex(currentPage);
+        }
+    }
+
+    function goToPreviousPage(): void {
+        if (canGoPrevious) {
+            table.setPageIndex(currentPage - 2);
+        }
+    }
+</script>
+
+<ButtonGroup.Root aria-label="Table pagination" class="ml-auto">
+    <DataTablePageSize bind:value {table} />
+    <ButtonGroup.Text aria-label={`Page ${currentPage} of ${totalPages}`} class="min-w-14 justify-center" title={`Page ${currentPage} of ${totalPages}`}>
+        <Number value={currentPage} /> / <Number value={totalPages} />
+    </ButtonGroup.Text>
+    <Button aria-label="Go to previous page" disabled={!canGoPrevious} onclick={goToPreviousPage} size="icon-sm" title="Previous page" variant="outline">
+        <ChevronLeftIcon />
+    </Button>
+    <Button aria-label="Go to next page" disabled={!canGoNext} onclick={goToNextPage} size="icon-sm" title="Next page" variant="outline">
+        <ChevronRightIcon />
+    </Button>
+</ButtonGroup.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/index.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/index.ts
@@ -4,6 +4,7 @@ import Footer from './data-table-footer.svelte';
 import Loading from './data-table-loading.svelte';
 import PageCount from './data-table-page-count.svelte';
 import PageSize from './data-table-page-size.svelte';
+import Pager from './data-table-pager.svelte';
 import Pagination from './data-table-pagination.svelte';
 import Refresh from './data-table-refresh.svelte';
 import Selection from './data-table-selection.svelte';
@@ -18,6 +19,7 @@ export {
     Footer as DataTableFooter,
     Loading as DataTableLoading,
     PageCount as DataTablePageCount,
+    Pager as DataTablePager,
     PageSize as DataTablePageSize,
     Pagination as DataTablePagination,
     Refresh as DataTableRefresh,
@@ -27,6 +29,7 @@ export {
     Footer,
     Loading,
     PageCount,
+    Pager,
     PageSize,
     Pagination,
     Refresh,

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte
@@ -11,12 +11,16 @@
         maxVisible?: number;
         onTagClick?: (tag: string) => Promise<void> | void;
         tags?: null | string[];
+        wrappedMaxVisible?: number;
     }
 
-    let { class: className, maxVisible = Number.POSITIVE_INFINITY, onTagClick, tags }: Props = $props();
+    let { class: className, maxVisible = Number.POSITIVE_INFINITY, onTagClick, tags, wrappedMaxVisible }: Props = $props();
 
-    const visibleTags = $derived(tags?.slice(0, maxVisible) ?? []);
+    const effectiveWrappedMaxVisible = $derived(Math.max(maxVisible, wrappedMaxVisible ?? maxVisible));
+    const hasWrappedLimit = $derived(effectiveWrappedMaxVisible > maxVisible);
+    const visibleTags = $derived(tags?.slice(0, effectiveWrappedMaxVisible) ?? []);
     const hiddenTags = $derived(tags?.slice(maxVisible) ?? []);
+    const wrappedHiddenTags = $derived(tags?.slice(effectiveWrappedMaxVisible) ?? []);
     const tagList = $derived(tags?.join(', ') ?? '');
     const truncatedTags = new SvelteSet<string>();
 
@@ -74,10 +78,17 @@
         variant="outline"
         class={[
             'border-border bg-muted text-muted-foreground group-hover/button:bg-accent group-hover/button:text-accent-foreground dark:border-muted-foreground/50 rounded-md text-xs',
-            showFullValue ? 'h-auto max-w-full py-0.5 whitespace-normal' : 'max-w-28'
+            showFullValue
+                ? 'h-auto max-w-full py-0.5 whitespace-normal'
+                : 'max-w-28 group-data-[wrap=true]/wrapped:h-auto group-data-[wrap=true]/wrapped:max-w-full group-data-[wrap=true]/wrapped:py-0.5'
         ]}
     >
-        <span class={showFullValue ? 'max-w-full break-all whitespace-normal' : 'min-w-0 truncate'} use:observeTruncation={tag}>
+        <span
+            class={showFullValue
+                ? 'max-w-full break-all whitespace-normal'
+                : 'min-w-0 truncate group-data-[wrap=true]/wrapped:overflow-visible group-data-[wrap=true]/wrapped:break-all group-data-[wrap=true]/wrapped:text-clip group-data-[wrap=true]/wrapped:whitespace-normal'}
+            use:observeTruncation={tag}
+        >
             {tag}
         </span>
     </Badge>
@@ -95,7 +106,7 @@
     </span>
 {/snippet}
 
-{#snippet tag(tag: string)}
+{#snippet tag(tag: string, visibilityClass?: string)}
     {#if onTagClick}
         <Tooltip.Root suppressWhenOverlayOpen>
             <Tooltip.Trigger>
@@ -105,7 +116,7 @@
                         type="button"
                         size="sm"
                         variant="ghost"
-                        class="h-auto cursor-pointer p-0"
+                        class={['h-auto cursor-pointer p-0', visibilityClass]}
                         onclick={(event) => handleTagClick(event, tag)}
                     >
                         {@render tagBadge(tag)}
@@ -127,7 +138,7 @@
         <Tooltip.Root disabled={!truncatedTags.has(tag)} suppressWhenOverlayOpen>
             <Tooltip.Trigger>
                 {#snippet child({ props })}
-                    <span {...props} class="inline-flex min-w-0">
+                    <span {...props} class={['inline-flex min-w-0', visibilityClass]}>
                         {@render tagBadge(tag)}
                     </span>
                 {/snippet}
@@ -154,40 +165,47 @@
     {/if}
 {/snippet}
 
+{#snippet overflow(hiddenValues: string[], visibilityClass?: string)}
+    <Tooltip.Root suppressWhenOverlayOpen>
+        <Tooltip.Trigger>
+            {#snippet child({ props })}
+                <Badge
+                    {...props}
+                    variant="outline"
+                    class={['border-border bg-muted text-muted-foreground dark:border-muted-foreground/50 cursor-default rounded-md text-xs', visibilityClass]}
+                >
+                    +{hiddenValues.length}
+                </Badge>
+            {/snippet}
+        </Tooltip.Trigger>
+        <Tooltip.Content
+            arrowClasses="hidden"
+            class="border-border bg-popover text-popover-foreground max-w-[calc(100vw-2rem)] flex-col items-start gap-2 border px-3 py-2 shadow-md sm:max-w-sm"
+            sideOffset={4}
+        >
+            <div class="flex flex-wrap gap-1">
+                {#each hiddenValues as value (value)}
+                    {@render overflowTag(value)}
+                {/each}
+            </div>
+            {#if onTagClick}
+                {@render tagActionHint()}
+            {/if}
+        </Tooltip.Content>
+    </Tooltip.Root>
+{/snippet}
+
 <Tooltip.Provider>
     {#if visibleTags.length > 0}
         <div class={['flex flex-wrap items-center gap-1', className]} aria-label={`Tags: ${tagList}`}>
-            {#each visibleTags as value (value)}
-                {@render tag(value)}
+            {#each visibleTags as value, index (value)}
+                {@render tag(value, hasWrappedLimit && index >= maxVisible ? 'hidden group-data-[wrap=true]/wrapped:inline-flex' : undefined)}
             {/each}
             {#if hiddenTags.length > 0}
-                <Tooltip.Root suppressWhenOverlayOpen>
-                    <Tooltip.Trigger>
-                        {#snippet child({ props })}
-                            <Badge
-                                {...props}
-                                variant="outline"
-                                class="border-border bg-muted text-muted-foreground dark:border-muted-foreground/50 cursor-default rounded-md text-xs"
-                            >
-                                +{hiddenTags.length}
-                            </Badge>
-                        {/snippet}
-                    </Tooltip.Trigger>
-                    <Tooltip.Content
-                        arrowClasses="hidden"
-                        class="border-border bg-popover text-popover-foreground max-w-[calc(100vw-2rem)] flex-col items-start gap-2 border px-3 py-2 shadow-md sm:max-w-sm"
-                        sideOffset={4}
-                    >
-                        <div class="flex flex-wrap gap-1">
-                            {#each hiddenTags as value (value)}
-                                {@render overflowTag(value)}
-                            {/each}
-                        </div>
-                        {#if onTagClick}
-                            {@render tagActionHint()}
-                        {/if}
-                    </Tooltip.Content>
-                </Tooltip.Root>
+                {@render overflow(hiddenTags, hasWrappedLimit ? 'group-data-[wrap=true]/wrapped:hidden' : undefined)}
+            {/if}
+            {#if hasWrappedLimit && wrappedHiddenTags.length > 0}
+                {@render overflow(wrappedHiddenTags, 'hidden group-data-[wrap=true]/wrapped:inline-flex')}
             {/if}
         </div>
     {:else}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/tag-list.svelte.test.ts
@@ -68,6 +68,27 @@ describe('TagList', () => {
         }
     });
 
+    it('shows more tags before overflow when the surrounding column wraps', () => {
+        const { container } = render(TagList, {
+            maxVisible: 2,
+            tags: ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight'],
+            wrappedMaxVisible: 6
+        });
+
+        const thirdTagTrigger = screen.getByText('three').closest<HTMLElement>('[data-slot="tooltip-trigger"]');
+        expect(thirdTagTrigger?.classList).toContain('hidden');
+        expect(thirdTagTrigger?.classList).toContain('group-data-[wrap=true]/wrapped:inline-flex');
+        expect(screen.queryByText('seven')).toBeNull();
+
+        const compactOverflow = screen.getByText('+6').closest<HTMLElement>('[data-slot="tooltip-trigger"]');
+        expect(compactOverflow?.classList).toContain('group-data-[wrap=true]/wrapped:hidden');
+
+        const wrappedOverflow = screen.getByText('+2').closest<HTMLElement>('[data-slot="tooltip-trigger"]');
+        expect(wrappedOverflow?.classList).toContain('hidden');
+        expect(wrappedOverflow?.classList).toContain('group-data-[wrap=true]/wrapped:inline-flex');
+        expect(container.querySelectorAll('[data-slot="badge"]')).toHaveLength(6);
+    });
+
     it('shows full hidden tags and preserves filter actions in the overflow tooltip', async () => {
         const hiddenTag = 'customer-facing-api-that-is-unusually-long';
         const onTagClick = vi.fn();

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/command/command-list.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/command/command-list.svelte
@@ -9,9 +9,13 @@
 	}: CommandPrimitive.ListProps = $props();
 </script>
 
+<!-- CUSTOM: KEEP COMMAND PALETTE OVERFLOW VISUALLY DISCOVERABLE WITH A THIN SCROLLBAR. -->
 <CommandPrimitive.List
 	bind:ref
 	data-slot="command-list"
-	class={cn("no-scrollbar max-h-72 scroll-py-1 outline-none overflow-x-hidden overflow-y-auto", className)}
+	class={cn(
+		"max-h-72 scroll-py-1 overflow-x-hidden overflow-y-auto outline-none [scrollbar-color:var(--muted-foreground)_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-muted-foreground/50 [&::-webkit-scrollbar-track]:bg-transparent",
+		className
+	)}
 	{...restProps}
 />

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/command/command-shortcut.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/command/command-shortcut.svelte
@@ -15,7 +15,7 @@
 	bind:this={ref}
 	data-slot="command-shortcut"
 	class={cn(
-		"border-border bg-muted text-muted-foreground group-data-selected/command-item:bg-background group-data-selected/command-item:text-foreground ml-auto h-5 w-fit min-w-5 gap-1 rounded-sm border px-1 font-sans text-xs font-medium [&_svg:not([class*='size-'])]:size-3 pointer-events-none inline-flex items-center justify-center select-none",
+		"border-border bg-muted text-foreground shadow-xs group-data-selected/command-item:bg-background group-data-selected/command-item:text-foreground ml-auto h-5 w-fit min-w-5 gap-1 rounded-sm border px-1 font-sans text-xs font-semibold [&_svg:not([class*='size-'])]:size-3 pointer-events-none inline-flex items-center justify-center select-none",
 		className
 	)}
 	{...restProps}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/kbd/kbd.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/kbd/kbd.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="kbd"
 	class={cn(
-		"bg-muted text-muted-foreground in-data-[slot=tooltip-content]:bg-background/20 in-data-[slot=tooltip-content]:text-background dark:in-data-[slot=tooltip-content]:bg-background/10 h-5 w-fit min-w-5 gap-1 rounded-sm px-1 font-sans text-xs font-medium [&_svg:not([class*='size-'])]:size-3 pointer-events-none inline-flex items-center justify-center select-none",
+		"border-border bg-muted text-foreground shadow-xs in-data-[slot=tooltip-content]:border-background/20 in-data-[slot=tooltip-content]:bg-background/20 in-data-[slot=tooltip-content]:text-background dark:in-data-[slot=tooltip-content]:bg-background/10 h-5 w-fit min-w-5 gap-1 rounded-sm border px-1 font-sans text-xs font-semibold [&_svg:not([class*='size-'])]:size-3 pointer-events-none inline-flex items-center justify-center select-none",
 		className
 	)}
 	{...restProps}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/keyboard-shortcuts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/keyboard-shortcuts.test.ts
@@ -16,8 +16,8 @@ describe('formatKeyboardShortcutForPlatform', () => {
     });
 
     it('should format single key shortcuts', () => {
-        expect(formatKeyboardShortcutForPlatform(appKeyboardShortcuts.switchOrganization.keys, false)).toBe('O');
-        expect(formatKeyboardShortcutForPlatform(appKeyboardShortcuts.userMenu.keys, false)).toBe('U');
+        expect(formatKeyboardShortcutForPlatform(appKeyboardShortcuts.switchOrganization.keys, false)).toBe('o');
+        expect(formatKeyboardShortcutForPlatform(appKeyboardShortcuts.userMenu.keys, false)).toBe('u');
         expect(formatKeyboardShortcutForPlatform(appKeyboardShortcuts.keyboardShortcuts.keys, false)).toBe('?');
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/keyboard-shortcuts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/keyboard-shortcuts.ts
@@ -8,12 +8,12 @@ export type KeyboardShortcut = {
 export type ShortcutKey = 'Alt' | 'Mod' | 'Shift' | string;
 
 export const appKeyboardShortcuts = {
-    allEvents: { key: 'e', keys: ['E'] },
+    allEvents: { key: 'e', keys: ['e'] },
     commandPalette: { key: '/', keys: ['/'] },
     keyboardShortcuts: { key: '?', keys: ['?'] },
-    stacks: { key: 'i', keys: ['I'] },
-    switchOrganization: { key: 'o', keys: ['O'] },
-    userMenu: { key: 'u', keys: ['U'] }
+    stacks: { key: 'i', keys: ['i'] },
+    switchOrganization: { key: 'o', keys: ['o'] },
+    userMenu: { key: 'u', keys: ['u'] }
 } as const satisfies Record<string, KeyboardShortcut>;
 
 export function formatKeyboardShortcut(keys: readonly ShortcutKey[]): string {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/mark-stack-fixed-in-version-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/dialogs/mark-stack-fixed-in-version-dialog.svelte
@@ -122,7 +122,7 @@
 
             <form.Field name="version">
                 {#snippet children(field)}
-                    <Field.Field data-invalid={field.state.meta.errors.length > 0 ? true : undefined}>
+                    <Field.Field class="pb-4" data-invalid={field.state.meta.errors.length > 0 ? true : undefined}>
                         <Field.Label for={field.name}>Version</Field.Label>
                         <Input
                             id={field.name}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte
@@ -176,8 +176,6 @@
     </DropdownMenu.Trigger>
     <DropdownMenu.Content>
         <DropdownMenu.Group>
-            <DropdownMenu.GroupHeading>Bulk Actions</DropdownMenu.GroupHeading>
-            <DropdownMenu.Separator />
             <DropdownMenu.Item title="Mark stacks as open" onclick={() => markOpen()}>Mark Open</DropdownMenu.Item>
             <DropdownMenu.Item title="Mark stacks as fixed" onclick={() => (openMarkStackFixedInVersionDialog = true)}>Mark Fixed</DropdownMenu.Item>
             <DropdownMenu.Sub>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/table/stacks-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/table/stacks-data-table.svelte
@@ -32,20 +32,8 @@
         {#if footerChildren}
             {@render footerChildren()}
         {:else}
-            <div class="grid w-full grid-cols-1 items-center gap-2 sm:grid-cols-3">
-                <div class="flex min-w-0 items-center gap-2">
-                    <DataTable.Selection {table} />
-                </div>
-
-                <div class="flex min-w-0 items-center justify-center">
-                    <DataTable.PageCount {table} />
-                </div>
-
-                <div class="flex min-w-0 items-center justify-end gap-4">
-                    <DataTable.PageSize bind:value={limit} {table} />
-                    <DataTable.Pagination {table} />
-                </div>
-            </div>
+            <DataTable.Selection {table} />
+            <DataTable.Pager bind:value={limit} {table} />
         {/if}
     </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/table/tokens-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/table/tokens-data-table.svelte
@@ -39,16 +39,12 @@
             {@render bodyChildren()}
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="space-x-6 lg:space-x-8">
+    <DataTable.Footer {table} class="w-full">
         {#if footerChildren}
             {@render footerChildren()}
         {:else}
             <DataTable.Selection {table} />
-            <DataTable.PageSize bind:value={limit} {table}></DataTable.PageSize>
-            <div class="flex items-center space-x-6 lg:space-x-8">
-                <DataTable.PageCount {table} />
-                <DataTable.Pagination {table} />
-            </div>
+            <DataTable.Pager bind:value={limit} {table} />
         {/if}
     </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/oauth-grants/table/oauth-grants-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/oauth-grants/table/oauth-grants-data-table.svelte
@@ -31,12 +31,8 @@
             <DataTable.Empty {table}>No applications have access to your account.</DataTable.Empty>
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="space-x-6 lg:space-x-8">
+    <DataTable.Footer {table} class="w-full">
         <DataTable.Selection {table} />
-        <DataTable.PageSize bind:value={limit} {table}></DataTable.PageSize>
-        <div class="flex items-center space-x-6 lg:space-x-8">
-            <DataTable.PageCount {table} />
-            <DataTable.Pagination {table} />
-        </div>
+        <DataTable.Pager bind:value={limit} {table} />
     </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/table/users-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/table/users-data-table.svelte
@@ -39,16 +39,12 @@
             {@render bodyChildren()}
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="space-x-6 lg:space-x-8">
+    <DataTable.Footer {table} class="w-full">
         {#if footerChildren}
             {@render footerChildren()}
         {:else}
             <DataTable.Selection {table} />
-            <DataTable.PageSize bind:value={limit} {table}></DataTable.PageSize>
-            <div class="flex items-center space-x-6 lg:space-x-8">
-                <DataTable.PageCount {table} />
-                <DataTable.Pagination {table} />
-            </div>
+            <DataTable.Pager bind:value={limit} {table} />
         {/if}
     </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/components/table/webhooks-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/components/table/webhooks-data-table.svelte
@@ -39,16 +39,12 @@
             {@render bodyChildren()}
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="space-x-6 lg:space-x-8">
+    <DataTable.Footer {table} class="w-full">
         {#if footerChildren}
             {@render footerChildren()}
         {:else}
             <DataTable.Selection {table} />
-            <DataTable.PageSize bind:value={limit} {table}></DataTable.PageSize>
-            <div class="flex items-center space-x-6 lg:space-x-8">
-                <DataTable.PageCount {table} />
-                <DataTable.Pagination {table} />
-            </div>
+            <DataTable.Pager bind:value={limit} {table} />
         {/if}
     </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
@@ -398,6 +398,8 @@ export interface SavedViewColumnSettings {
   visible?: null | boolean;
   /** Whether the column fills the table's remaining width. Null or false means use fixed-width behavior. */
   auto_fill?: null | boolean;
+  /** Whether cell content wraps onto multiple lines. Null or false means keep content on one line. */
+  wrap?: null | boolean;
   /**
    * Zero-based display position. Null means use the table default order.
    * @format int32

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
@@ -518,6 +518,7 @@ export type ResetPasswordModelFormData = Infer<typeof ResetPasswordModelSchema>;
 export const SavedViewColumnSettingsSchema = object({
   visible: boolean().nullable().optional(),
   auto_fill: boolean().nullable().optional(),
+  wrap: boolean().nullable().optional(),
   position: int32()
     .min(0, "Position must be at least 0")
     .max(49, "Position must be at most 49")

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -720,6 +720,7 @@
     }
 
     async function handleRefresh() {
+        table.resetRowSelection();
         await eventsQuery.refetch();
     }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -714,22 +714,12 @@
         })
     );
 
-    const canRefresh = $derived(!table.getIsSomeRowsSelected() && !table.getIsAllRowsSelected() && table.store.state.pagination.pageIndex === 0);
-
     function reset() {
         table.resetRowSelection();
         table.setPageIndex(0);
     }
 
     async function handleRefresh() {
-        const isFirstPage = table.store.state.pagination.pageIndex === 0;
-        if (!canRefresh) {
-            reset();
-            if (!isFirstPage) {
-                return;
-            }
-        }
-
         await eventsQuery.refetch();
     }
 
@@ -957,6 +947,7 @@
                     onResetToSaved={handleResetToSaved}
                     savedViews={savedViewsState.savedViews}
                     setAutoFillColumnId={savedViewsState.setAutoFillColumnId}
+                    setWrappedColumnIds={savedViewsState.setWrappedColumnIds}
                     {showChart}
                     {showStats}
                     setShowChart={(v) => (showChart = v)}
@@ -965,14 +956,10 @@
                     {table}
                     time={getQueryTime() ?? undefined}
                     view={VIEW}
+                    wrappedColumnIds={savedViewsState.wrappedColumnIds}
                 />
             {/if}
-            <RefreshButton
-                onRefresh={handleRefresh}
-                isRefreshing={eventsQuery.isFetching}
-                size="icon-lg"
-                title={canRefresh ? 'Refresh results' : 'Return to the first page to refresh results'}
-            />
+            <RefreshButton onRefresh={handleRefresh} isRefreshing={eventsQuery.isFetching} size="icon-lg" title="Refresh results" />
         </div>
     </div>
 
@@ -1003,20 +990,17 @@
             {rowClick}
             {rowHref}
             {table}
+            wrappedColumnIds={savedViewsState.wrappedColumnIds}
         >
             {#snippet footerChildren()}
-                <div class="h-9 min-w-35">
+                <div class="flex min-w-0 items-center gap-3">
                     {#if table.getSelectedRowModel().flatRows.length}
                         <EventsBulkActionsDropdownMenu {table} />
                     {/if}
+                    <DataTable.Selection {table} />
                 </div>
 
-                <DataTable.Selection {table} />
-                <DataTable.PageSize bind:value={eventsQueryParameters.limit!} {table}></DataTable.PageSize>
-                <div class="flex items-center space-x-6 lg:space-x-8">
-                    <DataTable.PageCount {table} />
-                    <DataTable.Pagination {table} />
-                </div>
+                <DataTable.Pager bind:value={eventsQueryParameters.limit!} {table} />
             {/snippet}
         </EventsDataTable>
     </div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
@@ -238,18 +238,12 @@
 
     const table = createTable(getTableOptions(stacksQueryParameters, stacksQuery, handleTagClick));
 
-    const canRefresh = $derived(!table.getIsSomeRowsSelected() && !table.getIsAllRowsSelected() && table.store.state.pagination.pageIndex === 0);
-
     function reset() {
         table.resetRowSelection();
         table.setPageIndex(0);
     }
 
     async function handleRefresh() {
-        if (!canRefresh) {
-            reset();
-        }
-
         await stacksQuery.refetch();
     }
 
@@ -279,28 +273,19 @@
             </FacetedFilter.Root>
         </div>
         <div class="ml-auto flex shrink-0 items-start gap-2">
-            <RefreshButton
-                onRefresh={handleRefresh}
-                isRefreshing={stacksQuery.isLoading}
-                size="icon-lg"
-                title={canRefresh ? 'Refresh results' : 'Return to the first page to refresh results'}
-            />
+            <RefreshButton onRefresh={handleRefresh} isRefreshing={stacksQuery.isFetching} size="icon-lg" title="Refresh results" />
             <DataTableViewOptions size="icon-lg" {table} />
         </div>
     </div>
 
     <StacksDataTable bind:limit={queryParams.limit!} isLoading={stacksQuery.isLoading} {rowClick} {rowHref} {table}>
         {#snippet footerChildren()}
-            <div class="h-9 min-w-35">
+            <div class="flex min-w-0 items-center gap-3">
                 <TableStacksBulkActionsDropdownMenu {table} />
+                <DataTable.Selection {table} />
             </div>
 
-            <DataTable.Selection {table} />
-            <DataTable.PageSize bind:value={queryParams.limit!} {table}></DataTable.PageSize>
-            <div class="flex items-center space-x-6 lg:space-x-8">
-                <DataTable.PageCount {table} />
-                <DataTable.Pagination {table} />
-            </div>
+            <DataTable.Pager bind:value={queryParams.limit!} {table} />
         {/snippet}
     </StacksDataTable>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
@@ -244,6 +244,7 @@
     }
 
     async function handleRefresh() {
+        table.resetRowSelection();
         await stacksQuery.refetch();
     }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
@@ -210,6 +210,7 @@
     }
 
     async function handleRefresh() {
+        table.resetRowSelection();
         await loadData();
     }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
@@ -204,18 +204,12 @@
         })
     );
 
-    const canRefresh = $derived(!table.getIsSomeRowsSelected() && !table.getIsAllRowsSelected() && table.store.state.pagination.pageIndex === 0);
-
     function reset() {
         table.resetRowSelection();
         table.setPageIndex(0);
     }
 
     async function handleRefresh() {
-        if (!canRefresh) {
-            reset();
-        }
-
         await loadData();
     }
 
@@ -368,12 +362,7 @@
                 <Switch id="view-active" bind:checked={viewActive} disabled={!hasPremiumFeatures} />
                 <Label for="view-active" class="text-sm">View Active</Label>
             </div>
-            <RefreshButton
-                onRefresh={handleRefresh}
-                isRefreshing={clientStatus.isLoading}
-                size="icon-lg"
-                title={canRefresh ? 'Refresh results' : 'Return to the first page to refresh results'}
-            />
+            <RefreshButton onRefresh={handleRefresh} isRefreshing={clientStatus.isLoading} size="icon-lg" title="Refresh results" />
             <DataTableViewOptions size="icon-lg" {table} />
         </div>
     </div>
@@ -392,11 +381,7 @@
         <EventsDataTable bind:limit={queryParams.limit!} isLoading={clientStatus.isLoading} rowClick={rowclick} {rowHref} {table}>
             {#snippet footerChildren()}
                 <DataTable.Selection {table} />
-                <DataTable.PageSize bind:value={queryParams.limit!} {table}></DataTable.PageSize>
-                <div class="flex items-center space-x-6 lg:space-x-8">
-                    <DataTable.PageCount {table} />
-                    <DataTable.Pagination {table} />
-                </div>
+                <DataTable.Pager bind:value={queryParams.limit!} {table} />
             {/snippet}
         </EventsDataTable>
     </div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -407,6 +407,10 @@
         [() => page.url.pathname, () => getListFilterQueryParams(queryParams), () => savedViewsState.activeSavedView],
         ([pathname, currentQueryParams, activeSavedView], [previousPathname, , previousSavedView]) => {
             const savedViewChanged = pathname !== previousPathname || activeSavedView?.id !== previousSavedView?.id;
+            if (savedViewChanged) {
+                table.resetRowSelection();
+            }
+
             if (isInternalFilterUpdate && !savedViewChanged) {
                 isInternalFilterUpdate = false;
                 return;
@@ -686,22 +690,12 @@
         })
     );
 
-    const canRefresh = $derived(!table.getIsSomeRowsSelected() && !table.getIsAllRowsSelected() && table.store.state.pagination.pageIndex === 0);
-
     function reset() {
         table.resetRowSelection();
         table.setPageIndex(0);
     }
 
     async function handleRefresh() {
-        const isFirstPage = table.store.state.pagination.pageIndex === 0;
-        if (!canRefresh) {
-            reset();
-            if (!isFirstPage) {
-                return;
-            }
-        }
-
         await eventsQuery.refetch();
     }
 
@@ -860,6 +854,7 @@
                     onResetToSaved={handleResetToSaved}
                     savedViews={savedViewsState.savedViews}
                     setAutoFillColumnId={savedViewsState.setAutoFillColumnId}
+                    setWrappedColumnIds={savedViewsState.setWrappedColumnIds}
                     {showChart}
                     {showStats}
                     setShowChart={(v) => (showChart = v)}
@@ -867,14 +862,10 @@
                     {table}
                     time={getQueryTime() ?? undefined}
                     view={VIEW}
+                    wrappedColumnIds={savedViewsState.wrappedColumnIds}
                 />
             {/if}
-            <RefreshButton
-                onRefresh={handleRefresh}
-                isRefreshing={eventsQuery.isFetching}
-                size="icon-lg"
-                title={canRefresh ? 'Refresh results' : 'Return to the first page to refresh results'}
-            />
+            <RefreshButton onRefresh={handleRefresh} isRefreshing={eventsQuery.isFetching} size="icon-lg" title="Refresh results" />
         </div>
     </div>
 
@@ -905,18 +896,15 @@
             {rowClick}
             {rowHref}
             {table}
+            wrappedColumnIds={savedViewsState.wrappedColumnIds}
         >
             {#snippet footerChildren()}
-                <div class="h-9 min-w-35">
+                <div class="flex min-w-0 items-center gap-3">
                     <TableStacksBulkActionsDropdownMenu {table} />
+                    <DataTable.Selection {table} />
                 </div>
 
-                <DataTable.Selection {table} />
-                <DataTable.PageSize bind:value={eventsQueryParameters.limit!} {table}></DataTable.PageSize>
-                <div class="flex items-center space-x-6 lg:space-x-8">
-                    <DataTable.PageCount {table} />
-                    <DataTable.Pagination {table} />
-                </div>
+                <DataTable.Pager bind:value={eventsQueryParameters.limit!} {table} />
             {/snippet}
         </EventsDataTable>
     </div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -696,6 +696,7 @@
     }
 
     async function handleRefresh() {
+        table.resetRowSelection();
         await eventsQuery.refetch();
     }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -343,14 +343,22 @@
                     onResetToSaved={savedViewsState.handleResetToSaved}
                     savedViews={savedViewsState.savedViews}
                     setAutoFillColumnId={savedViewsState.setAutoFillColumnId}
+                    setWrappedColumnIds={savedViewsState.setWrappedColumnIds}
                     {table}
                     view={VIEW}
+                    wrappedColumnIds={savedViewsState.wrappedColumnIds}
                 />
             {/if}
             <StreamingIndicatorButton onToggle={handleToggle} {paused} size="icon-lg" />
         </div>
     </div>
-    <DataTable.Body autoFillColumnId={savedViewsState.autoFillColumnId} rowClick={rowclick} {rowHref} {table}>
+    <DataTable.Body
+        autoFillColumnId={savedViewsState.autoFillColumnId}
+        rowClick={rowclick}
+        {rowHref}
+        {table}
+        wrappedColumnIds={savedViewsState.wrappedColumnIds}
+    >
         {#if clientStatus.isLoading}
             <DelayedRender>
                 <DataTable.Loading {table} />

--- a/tests/Exceptionless.Tests/Api/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Api/Data/openapi.json
@@ -12767,6 +12767,13 @@
             ],
             "description": "Whether the column fills the table\u0027s remaining width. Null or false means use fixed-width behavior."
           },
+          "wrap": {
+            "type": [
+              "null",
+              "boolean"
+            ],
+            "description": "Whether cell content wraps onto multiple lines. Null or false means keep content on one line."
+          },
           "position": {
             "maximum": 49,
             "minimum": 0,

--- a/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
@@ -408,7 +408,7 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         // Arrange
         var columnSettings = new Dictionary<string, SavedViewColumnSettings>
         {
-            ["summary"] = new() { AutoFill = true, Position = 0, Visible = true },
+            ["summary"] = new() { AutoFill = true, Position = 0, Visible = true, Wrap = true },
             ["project"] = new() { Position = 1, Visible = true, Width = 240 }
         };
 
@@ -433,6 +433,7 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         Assert.True(result.Columns?["project"].Visible);
         Assert.Equal(1, result.Columns?["project"].Position);
         Assert.True(result.Columns?["summary"].AutoFill);
+        Assert.True(result.Columns?["summary"].Wrap);
 
         var savedView = await _savedViewRepository.GetByIdAsync(result.Id);
         Assert.NotNull(savedView);
@@ -440,6 +441,7 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         Assert.True(savedView.Columns?["project"].Visible);
         Assert.Equal(1, savedView.Columns?["project"].Position);
         Assert.True(savedView.Columns?["summary"].AutoFill);
+        Assert.True(savedView.Columns?["summary"].Wrap);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Api/OpenApiSnapshotTests.cs
+++ b/tests/Exceptionless.Tests/Api/OpenApiSnapshotTests.cs
@@ -104,6 +104,7 @@ public sealed class OpenApiSnapshotTests : IClassFixture<AppWebHostFactory>
 
         var savedViewColumnProperties = savedViewColumnSettings.GetProperty("properties");
         Assert.Equal("boolean", savedViewColumnProperties.GetProperty("auto_fill").GetProperty("type")[1].GetString());
+        Assert.Equal("boolean", savedViewColumnProperties.GetProperty("wrap").GetProperty("type")[1].GetString());
         var position = savedViewColumnProperties.GetProperty("position");
         Assert.Equal(0, position.GetProperty("minimum").GetInt32());
         Assert.Equal(SavedViewColumnSettings.MaxPosition, position.GetProperty("maximum").GetInt32());

--- a/tests/Exceptionless.Tests/Mapping/SavedViewMapperTests.cs
+++ b/tests/Exceptionless.Tests/Mapping/SavedViewMapperTests.cs
@@ -29,7 +29,7 @@ public sealed class SavedViewMapperTests
             FilterDefinitions = "[{\"type\":\"status\",\"values\":[\"open\",\"regressed\"]}]",
             Columns = new Dictionary<string, SavedViewColumnSettings>
             {
-                ["summary"] = new() { AutoFill = true, Position = 0, Visible = true },
+                ["summary"] = new() { AutoFill = true, Position = 0, Visible = true, Wrap = true },
                 ["status"] = new() { Position = 1, Visible = true, Width = 180 },
                 ["users"] = new() { Position = 2, Visible = false }
             }
@@ -52,6 +52,7 @@ public sealed class SavedViewMapperTests
         Assert.Equal(1, result.Columns["status"].Position);
         Assert.Equal(180, result.Columns["status"].Width);
         Assert.True(result.Columns["summary"].AutoFill);
+        Assert.True(result.Columns["summary"].Wrap);
     }
 
     [Fact]
@@ -113,7 +114,7 @@ public sealed class SavedViewMapperTests
             FilterDefinitions = "[{\"type\":\"status\",\"values\":[\"open\"]}]",
             Columns = new Dictionary<string, SavedViewColumnSettings>
             {
-                ["summary"] = new() { AutoFill = true, Position = 0, Visible = true },
+                ["summary"] = new() { AutoFill = true, Position = 0, Visible = true, Wrap = true },
                 ["status"] = new() { Position = 1, Visible = true, Width = 180 }
             },
             Name = "My View",
@@ -141,6 +142,7 @@ public sealed class SavedViewMapperTests
         Assert.Equal(1, result.Columns["status"].Position);
         Assert.Equal(180, result.Columns["status"].Width);
         Assert.True(result.Columns["summary"].AutoFill);
+        Assert.True(result.Columns["summary"].Wrap);
         Assert.Equal("My View", result.Name);
         Assert.Equal("[now-30d TO now]", result.Time);
         Assert.Equal("-last", result.Sort);

--- a/tests/Exceptionless.Tests/Seed/PredefinedSavedViewContentHasherTests.cs
+++ b/tests/Exceptionless.Tests/Seed/PredefinedSavedViewContentHasherTests.cs
@@ -112,4 +112,34 @@ public sealed class PredefinedSavedViewContentHasherTests
         // Assert
         Assert.Equal(originalHash, reorderedHash);
     }
+
+    [Fact]
+    public void GetContentHash_ColumnWrapSettingDiffers_ReturnsDifferentHash()
+    {
+        // Arrange
+        var singleLine = new SavedView
+        {
+            Name = "Errors",
+            Slug = "errors",
+            ViewType = "stacks",
+            Columns = new Dictionary<string, SavedViewColumnSettings>
+            {
+                ["summary"] = new() { Position = 0, Visible = true }
+            }
+        };
+        var wrapped = singleLine with
+        {
+            Columns = new Dictionary<string, SavedViewColumnSettings>
+            {
+                ["summary"] = new() { Position = 0, Visible = true, Wrap = true }
+            }
+        };
+
+        // Act
+        string singleLineHash = PredefinedSavedViewContentHasher.GetContentHash(singleLine);
+        string wrappedHash = PredefinedSavedViewContentHasher.GetContentHash(wrapped);
+
+        // Assert
+        Assert.NotEqual(singleLineHash, wrappedHash);
+    }
 }

--- a/tests/Exceptionless.Tests/Serializer/Models/SavedViewSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/SavedViewSerializerTests.cs
@@ -29,7 +29,7 @@ public class SavedViewSerializerTests : TestWithServices
             FilterDefinitions = """[{"field":"status","operator":"in","values":["open","regressed"]}]""",
             Columns = new Dictionary<string, SavedViewColumnSettings>
             {
-                ["title"] = new() { AutoFill = true, Position = 0, Visible = true },
+                ["title"] = new() { AutoFill = true, Position = 0, Visible = true, Wrap = true },
                 ["date"] = new() { Position = 1, Visible = true },
                 ["status"] = new() { Position = 2, Visible = false, Width = 180 }
             },
@@ -62,6 +62,10 @@ public class SavedViewSerializerTests : TestWithServices
         Assert.True(result.Columns["title"].Visible);
         Assert.False(result.Columns["status"].Visible);
         Assert.True(result.Columns["title"].AutoFill);
+        Assert.True(result.Columns["title"].Wrap);
+        Assert.Null(result.Columns["date"].Wrap);
+        Assert.Contains("\"wrap\":true", json);
+        Assert.DoesNotContain("\"wrap\":null", json);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- add saved-view column wrapping controls for Summary, Message, and Tags, including wider wrapped tag usage and overflow behavior
- preserve event-tab context, clear stale row selections between stack views, refresh renamed projects, and keep manual refreshes on the current page
- refine the event overview, command palette, bulk-action menus, fixed-version dialog spacing, and selected-count placement
- replace separated paging controls with a compact, right-aligned pager shared across paginated tables

## API and persisted behavior

- saved-view column settings now persist an optional wrapped state
- existing saved views without the new setting continue to use single-line columns

## Validation

- `npm run validate`
- `npm run test:unit` (74 files, 620 tests)
- saved-view backend tests (137 passed)
- OpenAPI snapshot tests (4 passed)
- Rataplan Chromium E2E scenario (1 passed)
- `npm run build`

## Breaking changes

None.
