### PR TITLE
Prevent dashboard chart flicker during refresh

### DIFF
--- a/src/Exceptionless.Web/ClientApp/e2e/tests/chart-refresh.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/chart-refresh.e2e.ts
@@ -1,0 +1,86 @@
+import type { Page, Route } from '@playwright/test';
+
+import { expect, test } from '../fixtures/e2e-test';
+
+test('dashboard charts stay mounted while list data refreshes', async ({ e2eApi, page }) => {
+    const userToken = await e2eApi.login();
+    const organizations = await e2eApi.getOrganizations(userToken);
+    const organizationId = organizations[0]?.id;
+    expect(organizationId).toBeTruthy();
+
+    await page.addInitScript(
+        ({ organizationId, token }) => {
+            window.localStorage.setItem('satellizer_token', token);
+            window.localStorage.setItem('organization', JSON.stringify(organizationId));
+        },
+        { organizationId, token: userToken }
+    );
+
+    await verifyChartRefresh(page, '/next/stack', (route) => isOrganizationEventListRequest(route, organizationId!, 'stack_frequent'));
+    await verifyChartRefresh(page, '/next/event', (route) => isOrganizationEventListRequest(route, organizationId!, 'summary'));
+    await verifyChartRefresh(page, '/next/sessions', (route) => {
+        return new URL(route.request().url()).pathname === `/api/v2/organizations/${organizationId}/events/sessions`;
+    });
+});
+
+function isOrganizationEventListRequest(route: Route, organizationId: string, mode: string): boolean {
+    const url = new URL(route.request().url());
+    return url.pathname === `/api/v2/organizations/${organizationId}/events` && url.searchParams.get('mode') === mode;
+}
+
+async function verifyChartRefresh(page: Page, path: string, matchesRefreshRequest: (route: Route) => boolean): Promise<void> {
+    await page.goto(path);
+    const chart = page.locator('[data-slot="chart"]').first();
+    await expect(chart).toBeVisible();
+
+    const chartElement = await chart.elementHandle();
+    expect(chartElement).not.toBeNull();
+
+    let releaseRefresh: () => void = () => {};
+    const refreshReleased = new Promise<void>((resolve) => {
+        releaseRefresh = resolve;
+    });
+    let markRefreshIntercepted: () => void = () => {};
+    const refreshIntercepted = new Promise<void>((resolve) => {
+        markRefreshIntercepted = resolve;
+    });
+    let markRefreshFinished: () => void = () => {};
+    const refreshFinished = new Promise<void>((resolve) => {
+        markRefreshFinished = resolve;
+    });
+    let refreshWasIntercepted = false;
+
+    const holdRefresh = async (route: Route) => {
+        if (!matchesRefreshRequest(route)) {
+            await route.fallback();
+            return;
+        }
+
+        refreshWasIntercepted = true;
+        markRefreshIntercepted();
+        try {
+            await refreshReleased;
+            await route.continue();
+        } finally {
+            markRefreshFinished();
+        }
+    };
+
+    await page.route('**/api/v2/organizations/**', holdRefresh);
+    try {
+        await page.getByTitle('Refresh results').click();
+        await refreshIntercepted;
+        await expect(page.getByTitle('Refresh results').locator('svg')).toHaveClass(/animate-spin/);
+        expect(await chartElement!.evaluate((element) => element.isConnected)).toBe(true);
+        await expect(chart).toBeVisible();
+    } finally {
+        releaseRefresh();
+        if (refreshWasIntercepted) {
+            await refreshFinished;
+        }
+        await page.unroute('**/api/v2/organizations/**', holdRefresh);
+    }
+
+    await expect(page.getByTitle('Refresh results').locator('svg')).not.toHaveClass(/animate-spin/);
+    expect(await chartElement!.evaluate((element) => element.isConnected)).toBe(true);
+}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
@@ -377,7 +377,7 @@
             totalUsers={stats.totalUsers}
         />
 
-        <SessionsDashboardChart data={chartData} isLoading={clientStatus.isLoading || statsQuery.isLoading} {onRangeSelect} />
+        <SessionsDashboardChart data={chartData} isLoading={statsQuery.isLoading && !statsQuery.isSuccess} {onRangeSelect} />
 
         <EventsDataTable bind:limit={queryParams.limit!} isLoading={clientStatus.isLoading} rowClick={rowclick} {rowHref} {table}>
             {#snippet footerChildren()}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -884,7 +884,7 @@
         {#if showChart}
             <EventsDashboardChart
                 data={chartData()}
-                isLoading={isSavedViewRoutePending || eventsQuery.isFetching || chartDataQuery.isLoading}
+                isLoading={isSavedViewRoutePending || (chartDataQuery.isLoading && !chartDataQuery.isSuccess)}
                 {onRangeSelect}
             />
         {/if}


### PR DESCRIPTION
## Summary

- keep the Stacks chart mounted while its table query refreshes
- keep the Sessions chart independent from unrelated fetch-client loading activity
- add Playwright coverage proving the Stacks, Events, and Sessions charts retain the same DOM node throughout a held refresh

## Behavior

Charts continue showing their existing data during background refreshes and update in place when new data arrives. Initial loads still show the chart skeleton. No API contracts or persisted data are changed.

## Verification

- `npm run validate`
- `E2E_URL=https://localhost:36173 npx playwright test e2e/tests/chart-refresh.e2e.ts --project=chromium --workers=1`
- local `/next/` and `/api/v2/about` smoke checks returned HTTP 200

## Breaking changes

None.
