### PR TITLE
Improve fixed-width table overflow

### DIFF
--- a/src/Exceptionless.Web/ClientApp/e2e/tests/selection-column-width.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/selection-column-width.e2e.ts
@@ -84,4 +84,29 @@ test('row selection column stays fixed at desktop and narrow widths', async ({ e
     const expectedTableWidth = explicitlySizedSelectionBox!.width + columnWidthsBeforeResize.reduce((total, width) => total + width + 16, 0);
     expect(explicitlySizedTableBox!.width).toBeCloseTo(expectedTableWidth, 1);
     expect(explicitlySizedSelectionBox!.width).toBeCloseTo(32, 1);
+
+    const border = table.locator('xpath=ancestor::div[contains(@class, "rounded-md") and contains(@class, "border")][1]');
+    const fixedHeaderWidths = await table
+        .locator('thead th:not([aria-hidden="true"])')
+        .evaluateAll((headers) => headers.map((header) => header.getBoundingClientRect().width));
+    const horizontalScrollbar = border.getByRole('scrollbar', { name: 'Horizontal table scroll' });
+
+    await page.setViewportSize({ height: 900, width: 2000 });
+    await expect.poll(async () => (await border.boundingBox())!.width).toBeGreaterThan(expectedTableWidth + 300);
+    expect(Math.abs((await table.boundingBox())!.width - (await border.boundingBox())!.width)).toBeLessThanOrEqual(2);
+    expect((await table.locator('thead th[aria-hidden="true"]').boundingBox())!.width).toBeGreaterThan(300);
+    expect(
+        await table.locator('thead th:not([aria-hidden="true"])').evaluateAll((headers) => headers.map((header) => header.getBoundingClientRect().width))
+    ).toEqual(fixedHeaderWidths);
+    await expect(horizontalScrollbar).toBeHidden();
+
+    await page.setViewportSize({ height: 900, width: 520 });
+    await expect(horizontalScrollbar).toBeVisible();
+    expect((await table.boundingBox())!.width).toBeCloseTo(expectedTableWidth, 1);
+    await expect(border.locator('[data-scroll-edge="right"]')).toBeVisible();
+
+    await horizontalScrollbar.press('End');
+    await expect.poll(async () => Number(await horizontalScrollbar.getAttribute('aria-valuenow'))).toBeGreaterThan(0);
+    await expect(border.locator('[data-scroll-edge="left"]')).toBeVisible();
+    await expect(border.locator('[data-scroll-edge="right"]')).toHaveCount(0);
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
@@ -11,6 +11,7 @@
 
     import { getDataTableColumnMeta, supportsColumnWrapping } from './column-meta';
     import DataTableColumnHeader from './data-table-column-header.svelte';
+    import { setDataTableLayoutContext } from './data-table-layout-context.svelte';
     import DataTableScrollContainer from './data-table-scroll-container.svelte';
 
     interface Props {
@@ -27,6 +28,14 @@
 
     const selectColumnClass = 'w-8 min-w-8 max-w-8';
     const selectColumnWidth = 32;
+
+    setDataTableLayoutContext({
+        getFillerColumnCount
+    });
+
+    function getFillerColumnCount(): number {
+        return hasSelectColumn() && !getFlexibleDataColumnId() ? 1 : 0;
+    }
 
     function getHeaderColumnClass(header: Header<StockFeatures, TData, unknown>) {
         if (header.column.id === 'select') {
@@ -311,7 +320,7 @@
                             {/if}
                         </Table.Head>
                     {/each}
-                    {#if hasSelectColumn() && !getFlexibleDataColumnId()}
+                    {#if getFillerColumnCount() > 0}
                         <Table.Head aria-hidden="true" class="w-full p-0"></Table.Head>
                     {/if}
                 </Table.Row>
@@ -359,7 +368,7 @@
                             </Table.Cell>
                         {/if}
                     {/each}
-                    {#if hasSelectColumn() && !getFlexibleDataColumnId()}
+                    {#if getFillerColumnCount() > 0}
                         <Table.Cell aria-hidden="true" class="w-full p-0"></Table.Cell>
                     {/if}
                 </Table.Row>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
@@ -11,6 +11,7 @@
 
     import { getDataTableColumnMeta, supportsColumnWrapping } from './column-meta';
     import DataTableColumnHeader from './data-table-column-header.svelte';
+    import DataTableScrollContainer from './data-table-scroll-container.svelte';
 
     interface Props {
         autoFillColumnId?: null | string;
@@ -127,7 +128,7 @@
         }
 
         const minimumWidth = selectColumnWidth + getVisibleDataColumns().reduce((total, column) => total + column.getSize(), 0);
-        return getFlexibleDataColumnId() ? `min-width: ${minimumWidth}px;` : `width: ${minimumWidth}px; min-width: ${minimumWidth}px;`;
+        return getFlexibleDataColumnId() ? `min-width: ${minimumWidth}px;` : `width: 100%; min-width: ${minimumWidth}px;`;
     }
 
     function hasSelectColumn(): boolean {
@@ -281,7 +282,7 @@
     }
 </script>
 
-<div class="rounded-md border">
+<DataTableScrollContainer>
     <Table.Root class={hasSelectColumn() ? 'table-fixed' : undefined} style={getTableStyle()}>
         <Table.Header class="bg-card">
             {#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
@@ -310,6 +311,9 @@
                             {/if}
                         </Table.Head>
                     {/each}
+                    {#if hasSelectColumn() && !getFlexibleDataColumnId()}
+                        <Table.Head aria-hidden="true" class="w-full p-0"></Table.Head>
+                    {/if}
                 </Table.Row>
             {/each}
         </Table.Header>
@@ -355,8 +359,11 @@
                             </Table.Cell>
                         {/if}
                     {/each}
+                    {#if hasSelectColumn() && !getFlexibleDataColumnId()}
+                        <Table.Cell aria-hidden="true" class="w-full p-0"></Table.Cell>
+                    {/if}
                 </Table.Row>
             {/each}
         </Table.Body>
     </Table.Root>
-</div>
+</DataTableScrollContainer>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
@@ -31,6 +31,22 @@ describe('DataTableBody', () => {
         expect(table.querySelector('tbody tr')?.lastElementChild?.getAttribute('aria-hidden')).toBe('true');
     });
 
+    it('spans empty state rows across the fixed-width filler column', () => {
+        render(DataTableBodyTestHarness, { allColumnsSized: true, empty: true, kind: 'event', onRowClick: vi.fn() });
+
+        const emptyCell = screen.getByText('No data was found with the current filter.').closest('td');
+
+        expect(emptyCell?.colSpan).toBe(4);
+    });
+
+    it('does not add a filler column to flexible empty state rows', () => {
+        render(DataTableBodyTestHarness, { empty: true, fullWidthSummary: true, kind: 'event', onRowClick: vi.fn() });
+
+        const emptyCell = screen.getByText('No data was found with the current filter.').closest('td');
+
+        expect(emptyCell?.colSpan).toBe(3);
+    });
+
     it('uses the full-width data column as the flexible column', () => {
         render(DataTableBodyTestHarness, { fullWidthSummary: true, kind: 'event', onRowClick: vi.fn() });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { describe, expect, it, vi } from 'vitest';
 
 import DataTableBodyTestHarness from './data-table-body.test-harness.svelte';
@@ -23,9 +24,11 @@ describe('DataTableBody', () => {
         const summaryHeader = screen.getByRole('columnheader', { name: 'Summary' });
         const dateHeader = screen.getByRole('columnheader', { name: 'Date' });
 
-        expect(table.style.cssText).toBe('width: 302px; min-width: 302px;');
+        expect(table.style.cssText).toBe('width: 100%; min-width: 302px;');
         expect(summaryHeader.style.cssText).toBe('width: 140px; min-width: 140px; max-width: 140px;');
         expect(dateHeader.style.cssText).toBe('width: 130px; min-width: 130px; max-width: 130px;');
+        expect(table.querySelector('thead tr')?.lastElementChild?.getAttribute('aria-hidden')).toBe('true');
+        expect(table.querySelector('tbody tr')?.lastElementChild?.getAttribute('aria-hidden')).toBe('true');
     });
 
     it('uses the full-width data column as the flexible column', () => {
@@ -55,7 +58,7 @@ describe('DataTableBody', () => {
         const summaryHeader = screen.getByRole('columnheader', { name: 'Summary' });
         const dateHeader = screen.getByRole('columnheader', { name: 'Date' });
 
-        expect(table.style.cssText).toBe('width: 362px; min-width: 362px;');
+        expect(table.style.cssText).toBe('width: 100%; min-width: 362px;');
         expect(summaryHeader.style.cssText).toBe('width: 180px; min-width: 180px; max-width: 180px;');
         expect(dateHeader.style.cssText).toBe('width: 150px; min-width: 150px; max-width: 150px;');
     });
@@ -67,7 +70,7 @@ describe('DataTableBody', () => {
         const summaryHeader = screen.getByRole('columnheader', { name: 'Summary' });
         const dateHeader = screen.getByRole('columnheader', { name: 'Date' });
 
-        expect(table.style.cssText).toBe('width: 342px; min-width: 342px;');
+        expect(table.style.cssText).toBe('width: 100%; min-width: 342px;');
         expect(summaryHeader.style.cssText).toBe('width: 160px; min-width: 160px; max-width: 160px;');
         expect(dateHeader.style.cssText).toBe('width: 150px; min-width: 150px; max-width: 150px;');
     });
@@ -140,6 +143,38 @@ describe('DataTableBody', () => {
         expect(summaryHeader.style.cssText).toBe('width: 316px; min-width: 316px; max-width: 316px;');
 
         await fireEvent.mouseUp(document, { clientX: 116 });
+    });
+
+    it('keeps horizontal scrolling available while the table is in view', async () => {
+        const { container } = render(DataTableBodyTestHarness, { allColumnsSized: true, kind: 'event', onRowClick: vi.fn() });
+        const tableScrollContainer = container.querySelector<HTMLDivElement>('[data-slot="table-container"]');
+        expect(tableScrollContainer).not.toBeNull();
+
+        Object.defineProperties(tableScrollContainer, {
+            clientWidth: { configurable: true, value: 300 },
+            scrollLeft: { configurable: true, value: 0, writable: true },
+            scrollWidth: { configurable: true, value: 600 }
+        });
+        await fireEvent(window, new Event('resize'));
+        await tick();
+
+        const floatingScrollbar = screen.getByRole('scrollbar', { name: 'Horizontal table scroll' });
+        expect(floatingScrollbar.classList).not.toContain('hidden');
+        expect(floatingScrollbar.firstElementChild?.getAttribute('style')).toBe('width: 600px;');
+
+        floatingScrollbar.scrollLeft = 120;
+        await fireEvent.scroll(floatingScrollbar);
+        expect(tableScrollContainer?.scrollLeft).toBe(120);
+
+        if (tableScrollContainer) {
+            tableScrollContainer.scrollLeft = 48;
+            await fireEvent.scroll(tableScrollContainer);
+        }
+        expect(floatingScrollbar.scrollLeft).toBe(48);
+
+        await fireEvent.keyDown(floatingScrollbar, { key: 'End' });
+        expect(tableScrollContainer?.scrollLeft).toBe(300);
+        expect(floatingScrollbar.getAttribute('aria-valuenow')).toBe('300');
     });
 
     it('lets a resized header shrink below its metadata width', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.test-harness.svelte
@@ -8,12 +8,14 @@
     import { type ColumnSizingState, createTable, renderComponent } from '@tanstack/svelte-table';
 
     import DataTableBody from './data-table-body.svelte';
+    import DataTableEmpty from './data-table-empty.svelte';
 
     type TestSummary = EventSummaryModel<'event-error-summary'> | StackSummaryModel<'stack-error-summary'>;
 
     interface Props {
         allColumnsSized?: boolean;
         autoFillColumnId?: null | string;
+        empty?: boolean;
         fullWidthSummary?: boolean;
         kind: 'event' | 'stack';
         onAutoFillColumnResized?: (columnId: string) => void;
@@ -25,6 +27,7 @@
     let {
         allColumnsSized = false,
         autoFillColumnId,
+        empty = false,
         fullWidthSummary = false,
         kind,
         onAutoFillColumnResized,
@@ -120,7 +123,7 @@
             enableColumnResizing: true,
             paginationStrategy: 'memory',
             get queryData() {
-                return [summary];
+                return empty ? [] : [summary];
             },
             queryParameters
         })
@@ -134,4 +137,8 @@
     {wrappedColumnIds}
     rowHref={(row: SummaryModel<SummaryTemplateKeys>) => (kind === 'event' ? buildEventDetailsHref(row.id) : buildStackDetailsHref(row.id))}
     {table}
-/>
+>
+    {#if empty}
+        <DataTableEmpty {table} />
+    {/if}
+</DataTableBody>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-empty.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-empty.svelte
@@ -8,16 +8,21 @@
     import * as Table from '$comp/ui/table';
     import { type RowData, type StockFeatures, type Table as SvelteTable } from '@tanstack/svelte-table';
 
+    import { getDataTableLayoutContext } from './data-table-layout-context.svelte';
+
     interface Props {
         children?: Snippet;
         table: SvelteTable<StockFeatures, TData>;
     }
 
     let { children, table }: Props = $props();
+
+    const dataTableLayout = getDataTableLayoutContext();
+    const columnCount = $derived(table.getVisibleLeafColumns().length + (dataTableLayout?.getFillerColumnCount() ?? 0));
 </script>
 
 <Table.Row class="hidden text-center only:table-row">
-    <Table.Cell colspan={table.getVisibleLeafColumns().length}>
+    <Table.Cell colspan={columnCount}>
         {#if children}
             {@render children()}
         {:else}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-layout-context.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-layout-context.svelte.ts
@@ -1,0 +1,15 @@
+import { getContext, setContext } from 'svelte';
+
+interface DataTableLayoutContext {
+    getFillerColumnCount: () => number;
+}
+
+const dataTableLayoutContextKey = Symbol('data-table-layout');
+
+export function getDataTableLayoutContext(): DataTableLayoutContext | undefined {
+    return getContext<DataTableLayoutContext | undefined>(dataTableLayoutContextKey);
+}
+
+export function setDataTableLayoutContext(context: DataTableLayoutContext): void {
+    setContext(dataTableLayoutContextKey, context);
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-refresh.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-refresh.svelte
@@ -9,6 +9,8 @@
     import * as Table from '$comp/ui/table';
     import { type RowData, type StockFeatures, type Table as SvelteTable } from '@tanstack/svelte-table';
 
+    import { getDataTableLayoutContext } from './data-table-layout-context.svelte';
+
     interface Props {
         children?: Snippet;
         refresh: () => Promise<void>;
@@ -16,10 +18,13 @@
     }
 
     let { children, refresh, table }: Props = $props();
+
+    const dataTableLayout = getDataTableLayoutContext();
+    const columnCount = $derived(table.getVisibleLeafColumns().length + (dataTableLayout?.getFillerColumnCount() ?? 0));
 </script>
 
 <Table.Row class="text-center">
-    <Table.Cell colspan={table.getVisibleLeafColumns().length}>
+    <Table.Cell colspan={columnCount}>
         {#if children}
             {@render children()}
         {:else}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-scroll-container.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-scroll-container.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+    import { onMount, type Snippet } from 'svelte';
+
+    interface Props {
+        children: Snippet;
+    }
+
+    let { children }: Props = $props();
+
+    let canScrollLeft = $state(false);
+    let canScrollRight = $state(false);
+    const componentId = $props.id();
+    let floatingScrollbarElement = $state<HTMLDivElement | null>(null);
+    let hasHorizontalOverflow = $state(false);
+    let horizontalScrollMaximum = $state(0);
+    let horizontalScrollPosition = $state(0);
+    let horizontalScrollWidth = $state(0);
+    const tableScrollContainerId = `data-table-scroll-container-${componentId}`;
+    let wrapperElement = $state<HTMLDivElement | null>(null);
+    let tableScrollContainer: HTMLDivElement | null = null;
+
+    function updateHorizontalOverflow(): void {
+        if (!tableScrollContainer) {
+            return;
+        }
+
+        horizontalScrollWidth = tableScrollContainer.scrollWidth;
+        hasHorizontalOverflow = horizontalScrollWidth > tableScrollContainer.clientWidth + 1;
+
+        const maximumScrollLeft = horizontalScrollWidth - tableScrollContainer.clientWidth;
+        horizontalScrollMaximum = Math.max(0, maximumScrollLeft);
+        horizontalScrollPosition = tableScrollContainer.scrollLeft;
+        canScrollLeft = hasHorizontalOverflow && tableScrollContainer.scrollLeft > 1;
+        canScrollRight = hasHorizontalOverflow && tableScrollContainer.scrollLeft < maximumScrollLeft - 1;
+
+        if (floatingScrollbarElement && floatingScrollbarElement.scrollLeft !== tableScrollContainer.scrollLeft) {
+            floatingScrollbarElement.scrollLeft = tableScrollContainer.scrollLeft;
+        }
+    }
+
+    function onFloatingScrollbarScroll(): void {
+        if (!floatingScrollbarElement || !tableScrollContainer) {
+            return;
+        }
+
+        tableScrollContainer.scrollLeft = floatingScrollbarElement.scrollLeft;
+        updateHorizontalOverflow();
+    }
+
+    function onFloatingScrollbarKeydown(event: KeyboardEvent): void {
+        if (!floatingScrollbarElement || !tableScrollContainer) {
+            return;
+        }
+
+        let nextPosition: number;
+        switch (event.key) {
+            case 'ArrowLeft':
+                nextPosition = floatingScrollbarElement.scrollLeft - 40;
+                break;
+            case 'ArrowRight':
+                nextPosition = floatingScrollbarElement.scrollLeft + 40;
+                break;
+            case 'End':
+                nextPosition = horizontalScrollMaximum;
+                break;
+            case 'Home':
+                nextPosition = 0;
+                break;
+            case 'PageDown':
+                nextPosition = floatingScrollbarElement.scrollLeft + tableScrollContainer.clientWidth * 0.8;
+                break;
+            case 'PageUp':
+                nextPosition = floatingScrollbarElement.scrollLeft - tableScrollContainer.clientWidth * 0.8;
+                break;
+            default:
+                return;
+        }
+
+        event.preventDefault();
+        floatingScrollbarElement.scrollLeft = Math.min(horizontalScrollMaximum, Math.max(0, nextPosition));
+        onFloatingScrollbarScroll();
+    }
+
+    onMount(() => {
+        tableScrollContainer = wrapperElement?.querySelector<HTMLDivElement>(':scope > [data-slot="table-container"]') ?? null;
+        const tableElement = tableScrollContainer?.querySelector<HTMLTableElement>('[data-slot="table"]') ?? null;
+        if (!tableScrollContainer || !tableElement) {
+            return;
+        }
+
+        tableScrollContainer.id = tableScrollContainerId;
+        updateHorizontalOverflow();
+        tableScrollContainer.addEventListener('scroll', updateHorizontalOverflow, {
+            passive: true
+        });
+        window.addEventListener('resize', updateHorizontalOverflow);
+
+        const resizeObserver = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(updateHorizontalOverflow);
+        resizeObserver?.observe(tableScrollContainer);
+        resizeObserver?.observe(tableElement);
+
+        return () => {
+            resizeObserver?.disconnect();
+            tableScrollContainer?.removeEventListener('scroll', updateHorizontalOverflow);
+            window.removeEventListener('resize', updateHorizontalOverflow);
+            tableScrollContainer = null;
+        };
+    });
+</script>
+
+<div bind:this={wrapperElement} class="data-table-scroll-container relative rounded-md border">
+    {@render children()}
+    {#if canScrollLeft}
+        <div
+            aria-hidden="true"
+            class="from-background/80 pointer-events-none absolute top-0 bottom-4 left-0 z-10 w-8 bg-linear-to-r to-transparent"
+            data-scroll-edge="left"
+        ></div>
+    {/if}
+    {#if canScrollRight}
+        <div
+            aria-hidden="true"
+            class="to-background/80 pointer-events-none absolute top-0 right-0 bottom-4 z-10 w-8 bg-linear-to-r from-transparent"
+            data-scroll-edge="right"
+        ></div>
+    {/if}
+    <div
+        aria-hidden={!hasHorizontalOverflow}
+        aria-label="Horizontal table scroll"
+        aria-controls={tableScrollContainerId}
+        aria-orientation="horizontal"
+        aria-valuemax={horizontalScrollMaximum}
+        aria-valuemin={0}
+        aria-valuenow={horizontalScrollPosition}
+        bind:this={floatingScrollbarElement}
+        class={[
+            'bg-background/95 sticky bottom-0 z-20 h-4 w-full overflow-x-auto overflow-y-hidden border-t backdrop-blur',
+            !hasHorizontalOverflow && 'hidden'
+        ]}
+        onkeydown={onFloatingScrollbarKeydown}
+        onscroll={onFloatingScrollbarScroll}
+        role="scrollbar"
+        tabindex={hasHorizontalOverflow ? 0 : -1}
+    >
+        <div class="h-px" style:width={`${horizontalScrollWidth}px`}></div>
+    </div>
+</div>
+
+<style>
+    .data-table-scroll-container :global([data-slot='table-container']) {
+        scrollbar-width: none;
+    }
+
+    .data-table-scroll-container :global([data-slot='table-container']::-webkit-scrollbar) {
+        display: none;
+    }
+</style>


### PR DESCRIPTION
## Summary

- preserve saved fixed column widths while completing the table grid across wider containers
- add synchronized edge fades and a sticky horizontal scrollbar when fixed columns overflow
- support pointer, touch, and keyboard scrolling with accessible scrollbar state
- extend unit and browser coverage for wide and narrow layouts

## Verification

- `npm run validate`
- `npm run test:unit -- --run src/lib/features/shared/components/data-table/data-table-body.svelte.test.ts`
- `E2E_URL=https://localhost:45823 npx playwright test e2e/tests/selection-column-width.e2e.ts --project=chromium`
- `npm run build`

## Breaking changes

None.
