### PR TITLE
Add compact table action toolbar

### DIFF
--- a/src/Exceptionless.Web/ClientApp/e2e/tests/rataplan-feedback.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/rataplan-feedback.e2e.ts
@@ -130,7 +130,7 @@ test('approved Rataplan UI feedback remains fixed', async ({ e2eApi, e2eScenario
 
     await test.step('manual refresh keeps the current page', async () => {
         await page.goto(`/next/stack?project=${e2eScenario.projectId}&limit=5&time=all`);
-        const pager = page.getByRole('group', { name: 'Table pagination' });
+        const pager = page.getByRole('navigation', { name: 'Table pagination' });
         await expect(pager).toBeVisible();
         await expect(pager.getByRole('button', { name: 'Rows per page' })).toContainText('5 rows');
         await expect(pager.getByLabel('Page 1 of 2')).toBeVisible();

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/table-toolbar-pagination.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/table-toolbar-pagination.e2e.ts
@@ -19,7 +19,9 @@ test('table toolbar remains accessible while moving between different-height res
     const toolbar = page.locator('[data-slot="data-table-footer"]');
     const pager = toolbar.getByRole('navigation', { name: 'Table pagination' });
     const grid = page.locator('[data-slot="data-table-body"]');
-    await expect(pager.getByLabel('Page 1 of 2')).toBeVisible({ timeout: 30_000 });
+    const pageIndicator = pager.getByLabel('Page 1 of 2');
+    await expect(pageIndicator).toBeVisible({ timeout: 30_000 });
+    expect(await pageIndicator.evaluate((element) => getComputedStyle(element).userSelect)).toBe('none');
 
     await expect(toolbar.getByRole('button', { name: /Bulk Actions/ })).toBeDisabled();
     await expect(toolbar.getByRole('button', { name: /Bulk Actions/ })).toHaveAttribute('title', 'Select one or more events to use bulk actions');

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/table-toolbar-pagination.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/table-toolbar-pagination.e2e.ts
@@ -23,16 +23,20 @@ test('table toolbar remains accessible while moving between different-height res
     await expect(pageIndicator).toBeVisible({ timeout: 30_000 });
     expect(await pageIndicator.evaluate((element) => getComputedStyle(element).userSelect)).toBe('none');
 
-    await expect(toolbar.getByRole('button', { name: /Bulk Actions/ })).toBeDisabled();
-    await expect(toolbar.getByRole('button', { name: /Bulk Actions/ })).toHaveAttribute('title', 'Select one or more events to use bulk actions');
+    const bulkActionsButton = toolbar.getByRole('button', { name: /Bulk Actions/ });
+    await expect(bulkActionsButton).toHaveAttribute('aria-disabled', 'true');
+    await expect(bulkActionsButton).toHaveAttribute('title', 'Select one or more events to use bulk actions');
+    await bulkActionsButton.focus();
+    await expect(bulkActionsButton).toBeFocused();
     await page.locator('tbody').getByRole('checkbox').first().click();
-    await expect(toolbar.getByRole('button', { name: /Bulk Actions/ })).toBeEnabled();
+    await expect(bulkActionsButton).toBeEnabled();
 
     const firstToolbarBox = await toolbar.boundingBox();
     const firstGridBox = await grid.boundingBox();
     expect(firstToolbarBox).not.toBeNull();
     expect(firstGridBox).not.toBeNull();
     expect(await toolbar.evaluate((element) => getComputedStyle(element).position)).toBe('sticky');
+    expect(await toolbar.evaluate((element) => element.nextElementSibling?.getAttribute('data-slot'))).toBe('data-table-body');
     expect(firstToolbarBox!.height).toBeLessThanOrEqual(34);
     expect(firstGridBox!.y - (firstToolbarBox!.y + firstToolbarBox!.height)).toBeLessThanOrEqual(8);
     expect(firstToolbarBox!.y + firstToolbarBox!.height).toBeLessThanOrEqual(firstGridBox!.y);

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/table-toolbar-pagination.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/table-toolbar-pagination.e2e.ts
@@ -1,0 +1,79 @@
+import { resolve } from 'node:path';
+
+import { expect, test } from '../fixtures/e2e-test';
+import { seedRepresentativeEvent } from '../support/event-data';
+
+test('table toolbar remains accessible while moving between different-height result pages', async ({ e2eApi, e2eScenario, page }) => {
+    for (let index = 1; index <= 6; index++) {
+        await seedRepresentativeEvent(e2eApi, e2eScenario.userToken, {
+            message: `${e2eScenario.message} ${index}`,
+            projectId: e2eScenario.projectId,
+            projectToken: e2eScenario.projectToken,
+            referenceId: `${e2eScenario.referenceId}-${index}`
+        });
+    }
+
+    await page.setViewportSize({ height: 720, width: 1280 });
+    await page.goto('/next/event?limit=5&time=all');
+
+    const toolbar = page.locator('[data-slot="data-table-footer"]');
+    const pager = toolbar.getByRole('navigation', { name: 'Table pagination' });
+    const grid = page.locator('[data-slot="data-table-body"]');
+    await expect(pager.getByLabel('Page 1 of 2')).toBeVisible({ timeout: 30_000 });
+
+    await expect(toolbar.getByRole('button', { name: /Bulk Actions/ })).toBeDisabled();
+    await expect(toolbar.getByRole('button', { name: /Bulk Actions/ })).toHaveAttribute('title', 'Select one or more events to use bulk actions');
+    await page.locator('tbody').getByRole('checkbox').first().click();
+    await expect(toolbar.getByRole('button', { name: /Bulk Actions/ })).toBeEnabled();
+
+    const firstToolbarBox = await toolbar.boundingBox();
+    const firstGridBox = await grid.boundingBox();
+    expect(firstToolbarBox).not.toBeNull();
+    expect(firstGridBox).not.toBeNull();
+    expect(await toolbar.evaluate((element) => getComputedStyle(element).position)).toBe('sticky');
+    expect(firstToolbarBox!.height).toBeLessThanOrEqual(34);
+    expect(firstGridBox!.y - (firstToolbarBox!.y + firstToolbarBox!.height)).toBeLessThanOrEqual(8);
+    expect(firstToolbarBox!.y + firstToolbarBox!.height).toBeLessThanOrEqual(firstGridBox!.y);
+
+    if (process.env.E2E_CAPTURE_PAGER_TOOLBAR_SCREENSHOTS === 'true') {
+        await page.screenshot({ path: resolve(process.cwd(), '../../../dogfood-output/pager-toolbar/desktop-page-1.png') });
+    }
+
+    const nextButton = pager.getByRole('button', { name: 'Go to next page' });
+    await nextButton.focus();
+    await nextButton.click();
+    await expect(pager.getByLabel('Page 2 of 2')).toBeVisible();
+    await expect(pager.getByRole('button', { name: 'Go to next page' })).toBeFocused();
+
+    const secondToolbarBox = await toolbar.boundingBox();
+    const secondGridBox = await grid.boundingBox();
+    expect(secondToolbarBox).not.toBeNull();
+    expect(secondGridBox).not.toBeNull();
+    expect(secondToolbarBox!.y).toBeGreaterThanOrEqual(8);
+    expect(secondToolbarBox!.y + secondToolbarBox!.height).toBeLessThanOrEqual(secondGridBox!.y);
+
+    await page.locator('main').evaluate((element) => element.parentElement?.scrollTo({ top: element.parentElement.scrollHeight }));
+    const appFooter = page.getByRole('link', { exact: true, name: 'Terms' }).locator('xpath=ancestor::div[contains(@class, "border-t")][1]');
+    await expect(appFooter).toBeVisible();
+    const settledToolbarBox = await toolbar.boundingBox();
+    const appFooterBox = await appFooter.boundingBox();
+    expect(settledToolbarBox).not.toBeNull();
+    expect(appFooterBox).not.toBeNull();
+    expect(settledToolbarBox!.y + settledToolbarBox!.height).toBeLessThanOrEqual(appFooterBox!.y);
+
+    if (process.env.E2E_CAPTURE_PAGER_TOOLBAR_SCREENSHOTS === 'true') {
+        await page.screenshot({ path: resolve(process.cwd(), '../../../dogfood-output/pager-toolbar/desktop-page-2.png') });
+    }
+
+    await page.setViewportSize({ height: 720, width: 520 });
+    const narrowToolbarBox = await toolbar.boundingBox();
+    const narrowGridBox = await grid.boundingBox();
+    expect(narrowToolbarBox).not.toBeNull();
+    expect(narrowGridBox).not.toBeNull();
+    expect(narrowToolbarBox!.x).toBeCloseTo(narrowGridBox!.x, 1);
+    expect(narrowToolbarBox!.width).toBeCloseTo(narrowGridBox!.width, 1);
+
+    if (process.env.E2E_CAPTURE_PAGER_TOOLBAR_SCREENSHOTS === 'true') {
+        await page.screenshot({ path: resolve(process.cwd(), '../../../dogfood-output/pager-toolbar/narrow-page-2.png') });
+    }
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/backups-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/backups-data-table.svelte
@@ -24,6 +24,9 @@
     {:else}
         <DataTable.Toolbar {table} />
     {/if}
+    <DataTable.Footer {table} class="w-full">
+        <DataTable.Pager bind:value={limit} {table} />
+    </DataTable.Footer>
     <DataTable.Body {table}>
         {#if isLoading}
             <DelayedRender>
@@ -33,7 +36,4 @@
             <DataTable.Empty {table} />
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="w-full">
-        <DataTable.Pager bind:value={limit} {table} />
-    </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/indices-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/indices-data-table.svelte
@@ -24,6 +24,9 @@
     {:else}
         <DataTable.Toolbar {table} />
     {/if}
+    <DataTable.Footer {table} class="w-full">
+        <DataTable.Pager bind:value={limit} {table} />
+    </DataTable.Footer>
     <DataTable.Body {table}>
         {#if isLoading}
             <DelayedRender>
@@ -33,7 +36,4 @@
             <DataTable.Empty {table} />
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="w-full">
-        <DataTable.Pager bind:value={limit} {table} />
-    </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/migrations-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/migrations-data-table.svelte
@@ -24,6 +24,9 @@
     {:else}
         <DataTable.Toolbar {table} />
     {/if}
+    <DataTable.Footer {table} class="w-full">
+        <DataTable.Pager bind:value={limit} {table} />
+    </DataTable.Footer>
     <DataTable.Body {table}>
         {#if isLoading}
             <DelayedRender>
@@ -33,7 +36,4 @@
             <DataTable.Empty {table} />
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="w-full">
-        <DataTable.Pager bind:value={limit} {table} />
-    </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <script generics="TData extends RowData" lang="ts">
-    import Button from '$comp/ui/button/button.svelte';
+    import { Button } from '$comp/ui/button';
     import * as DropdownMenu from '$comp/ui/dropdown-menu';
     import { deleteEvent } from '$features/events/api.svelte';
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
@@ -17,8 +17,11 @@
     }
 
     let { table }: Props = $props();
+    const componentId = $props.id();
+    const bulkActionsDescriptionId = `${componentId}-bulk-actions-description`;
     const ids = $derived(table.getSelectedRowModel().flatRows.map((row) => row.id));
 
+    let open = $state(false);
     let openRemoveEventDialog = $state<boolean>(false);
 
     const removeEvents = deleteEvent({
@@ -41,19 +44,25 @@
 
         table.resetRowSelection();
     }
+
+    function setOpen(isOpen: boolean): void {
+        open = ids.length > 0 && isOpen;
+    }
 </script>
 
-<DropdownMenu.Root>
+<DropdownMenu.Root bind:open={() => open, setOpen}>
     <DropdownMenu.Trigger>
         {#snippet child({ props })}
             <Button
                 {...props}
-                disabled={ids.length === 0}
+                aria-describedby={ids.length === 0 ? bulkActionsDescriptionId : undefined}
+                aria-disabled={ids.length === 0}
+                class="aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
                 title={ids.length === 0 ? 'Select one or more events to use bulk actions' : 'Bulk Actions'}
                 variant="outline"
             >
                 Bulk Actions
-                <ChevronDown class="size-4" />
+                <ChevronDown data-icon="inline-end" />
             </Button>
         {/snippet}
     </DropdownMenu.Trigger>
@@ -63,6 +72,9 @@
         </DropdownMenu.Group>
     </DropdownMenu.Content>
 </DropdownMenu.Root>
+{#if ids.length === 0}
+    <span class="sr-only" id={bulkActionsDescriptionId}>Select one or more events to use bulk actions.</span>
+{/if}
 
 {#if openRemoveEventDialog}
     <RemoveEventDialog bind:open={openRemoveEventDialog} {remove} count={ids.length} />

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte
@@ -46,7 +46,12 @@
 <DropdownMenu.Root>
     <DropdownMenu.Trigger>
         {#snippet child({ props })}
-            <Button {...props} variant="outline">
+            <Button
+                {...props}
+                disabled={ids.length === 0}
+                title={ids.length === 0 ? 'Select one or more events to use bulk actions' : 'Bulk Actions'}
+                variant="outline"
+            >
                 Bulk Actions
                 <ChevronDown class="size-4" />
             </Button>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte.test.ts
@@ -23,6 +23,18 @@ describe('EventsBulkActionsDropdownMenu', () => {
         await new Promise((resolve) => window.setTimeout(resolve, 30));
     });
 
+    it('requires a selected event before opening bulk actions', () => {
+        const table = {
+            getSelectedRowModel: () => ({ flatRows: [] }),
+            resetRowSelection: vi.fn()
+        } as never;
+        render(EventsBulkActionsDropdownMenu, { props: { table } });
+
+        const trigger = screen.getByRole('button', { name: /Bulk Actions/ }) as HTMLButtonElement;
+        expect(trigger.disabled).toBe(true);
+        expect(trigger.title).toBe('Select one or more events to use bulk actions');
+    });
+
     it('does not repeat the trigger label inside the menu', async () => {
         const table = {
             getSelectedRowModel: () => ({ flatRows: [{ id: 'event-id' }] }),

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte.test.ts
@@ -23,7 +23,7 @@ describe('EventsBulkActionsDropdownMenu', () => {
         await new Promise((resolve) => window.setTimeout(resolve, 30));
     });
 
-    it('requires a selected event before opening bulk actions', () => {
+    it('requires a selected event before opening bulk actions', async () => {
         const table = {
             getSelectedRowModel: () => ({ flatRows: [] }),
             resetRowSelection: vi.fn()
@@ -31,8 +31,14 @@ describe('EventsBulkActionsDropdownMenu', () => {
         render(EventsBulkActionsDropdownMenu, { props: { table } });
 
         const trigger = screen.getByRole('button', { name: /Bulk Actions/ }) as HTMLButtonElement;
-        expect(trigger.disabled).toBe(true);
+        expect(trigger.disabled).toBe(false);
+        expect(trigger.getAttribute('aria-disabled')).toBe('true');
         expect(trigger.title).toBe('Select one or more events to use bulk actions');
+        expect(document.getElementById(trigger.getAttribute('aria-describedby')!)?.textContent).toBe('Select one or more events to use bulk actions.');
+        trigger.focus();
+        expect(document.activeElement).toBe(trigger);
+        await fireEvent.click(trigger);
+        expect(screen.queryByRole('menuitem', { name: 'Delete' })).toBeNull();
     });
 
     it('does not repeat the trigger label inside the menu', async () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-data-table.svelte
@@ -42,6 +42,14 @@
             {@render toolbarChildren()}
         </DataTable.Toolbar>
     {/if}
+    <DataTable.Footer {table} class="w-full">
+        {#if footerChildren}
+            {@render footerChildren()}
+        {:else}
+            <DataTable.Selection {table} />
+            <DataTable.Pager bind:value={limit} {table} />
+        {/if}
+    </DataTable.Footer>
     <DataTable.Body {autoFillColumnId} {onAutoFillColumnResized} {rowClick} {rowHref} {table} {wrappedColumnIds}>
         {#if isLoading}
             <DelayedRender>
@@ -54,12 +62,4 @@
             {@render bodyChildren()}
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="w-full">
-        {#if footerChildren}
-            {@render footerChildren()}
-        {:else}
-            <DataTable.Selection {table} />
-            <DataTable.Pager bind:value={limit} {table} />
-        {/if}
-    </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/table/organizations-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/table/organizations-data-table.svelte
@@ -27,6 +27,13 @@
     {:else}
         <DataTable.Toolbar {table} />
     {/if}
+    <DataTable.Footer {table} class="gap-6 lg:gap-8">
+        {#if footerChildren}
+            {@render footerChildren()}
+        {:else}
+            <DataTable.Selection {table} />
+        {/if}
+    </DataTable.Footer>
     <DataTable.Body {rowClick} {rowHref} {table}>
         {#if isLoading}
             <DelayedRender>
@@ -39,11 +46,4 @@
             {@render bodyChildren()}
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="space-x-6 lg:space-x-8">
-        {#if footerChildren}
-            {@render footerChildren()}
-        {:else}
-            <DataTable.Selection {table} />
-        {/if}
-    </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/projects-config-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/projects-config-data-table.svelte
@@ -27,6 +27,14 @@
     {:else}
         <DataTable.Toolbar {table} />
     {/if}
+    <DataTable.Footer {table} class="w-full">
+        {#if footerChildren}
+            {@render footerChildren()}
+        {:else}
+            <DataTable.Selection {table} />
+            <DataTable.Pager bind:value={limit} {table} />
+        {/if}
+    </DataTable.Footer>
     <DataTable.Body {rowClick} {table}>
         {#if isLoading}
             <DelayedRender>
@@ -39,12 +47,4 @@
             {@render bodyChildren()}
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="w-full">
-        {#if footerChildren}
-            {@render footerChildren()}
-        {:else}
-            <DataTable.Selection {table} />
-            <DataTable.Pager bind:value={limit} {table} />
-        {/if}
-    </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/projects-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/table/projects-data-table.svelte
@@ -28,6 +28,14 @@
     {:else}
         <DataTable.Toolbar {table} />
     {/if}
+    <DataTable.Footer {table} class="w-full">
+        {#if footerChildren}
+            {@render footerChildren()}
+        {:else}
+            <DataTable.Selection {table} />
+            <DataTable.Pager bind:value={limit} {table} />
+        {/if}
+    </DataTable.Footer>
     <DataTable.Body {rowClick} {rowHref} {table}>
         {#if isLoading}
             <DelayedRender>
@@ -40,12 +48,4 @@
             {@render bodyChildren()}
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="w-full">
-        {#if footerChildren}
-            {@render footerChildren()}
-        {:else}
-            <DataTable.Selection {table} />
-            <DataTable.Pager bind:value={limit} {table} />
-        {/if}
-    </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
@@ -291,88 +291,90 @@
     }
 </script>
 
-<DataTableScrollContainer>
-    <Table.Root class={hasSelectColumn() ? 'table-fixed' : undefined} style={getTableStyle()}>
-        <Table.Header class="bg-card">
-            {#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
-                <Table.Row>
-                    {#each headerGroup.headers as header (header.id)}
-                        {@const headerClass = getHeaderColumnClass(header)}
-                        <Table.Head class={[headerClass, header.column.getCanResize() && 'group relative']} style={getColumnStyle(header.column)}>
-                            <DataTableColumnHeader class={getHeaderContentClass(header, headerClass)} column={header.column}
-                                ><FlexRender {header} /></DataTableColumnHeader
-                            >
-                            {#if header.column.getCanResize()}
-                                <button
-                                    aria-label={`Resize ${header.column.id} column`}
-                                    class={[
-                                        'hover:bg-primary focus-visible:bg-primary absolute top-0 right-0 z-10 h-full w-1.5 cursor-col-resize touch-none outline-none select-none',
-                                        'after:bg-border after:absolute after:top-1/4 after:right-0 after:h-1/2 after:w-px',
-                                        header.column.getIsResizing() && 'bg-primary'
-                                    ]}
-                                    ondblclick={() => header.column.resetSize()}
-                                    onkeydown={(event) => onResizeKeydown(event, header)}
-                                    onmousedown={(event) => onResizeStart(event, header)}
-                                    ontouchstart={(event) => onResizeStart(event, header)}
-                                    title={`Resize ${header.column.id} column`}
-                                    type="button"
-                                ></button>
-                            {/if}
-                        </Table.Head>
-                    {/each}
-                    {#if getFillerColumnCount() > 0}
-                        <Table.Head aria-hidden="true" class="w-full p-0"></Table.Head>
-                    {/if}
-                </Table.Row>
-            {/each}
-        </Table.Header>
-        <Table.Body>
-            {#if children}
-                {@render children()}
-            {/if}
-            {#each table.getRowModel().rows as row (row.id)}
-                <Table.Row
-                    tabindex={rowClick ? 0 : undefined}
-                    onkeydown={rowClick
-                        ? (event) => {
-                              if (event.key === 'Enter' || event.key === ' ') {
-                                  event.preventDefault();
-                                  const firstCell = row.getVisibleCells()[0];
-                                  if (firstCell) {
-                                      rowClick(firstCell.row.original);
+<div class="order-3" data-slot="data-table-body">
+    <DataTableScrollContainer>
+        <Table.Root class={hasSelectColumn() ? 'table-fixed' : undefined} style={getTableStyle()}>
+            <Table.Header class="bg-card">
+                {#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
+                    <Table.Row>
+                        {#each headerGroup.headers as header (header.id)}
+                            {@const headerClass = getHeaderColumnClass(header)}
+                            <Table.Head class={[headerClass, header.column.getCanResize() && 'group relative']} style={getColumnStyle(header.column)}>
+                                <DataTableColumnHeader class={getHeaderContentClass(header, headerClass)} column={header.column}
+                                    ><FlexRender {header} /></DataTableColumnHeader
+                                >
+                                {#if header.column.getCanResize()}
+                                    <button
+                                        aria-label={`Resize ${header.column.id} column`}
+                                        class={[
+                                            'hover:bg-primary focus-visible:bg-primary absolute top-0 right-0 z-10 h-full w-1.5 cursor-col-resize touch-none outline-none select-none',
+                                            'after:bg-border after:absolute after:top-1/4 after:right-0 after:h-1/2 after:w-px',
+                                            header.column.getIsResizing() && 'bg-primary'
+                                        ]}
+                                        ondblclick={() => header.column.resetSize()}
+                                        onkeydown={(event) => onResizeKeydown(event, header)}
+                                        onmousedown={(event) => onResizeStart(event, header)}
+                                        ontouchstart={(event) => onResizeStart(event, header)}
+                                        title={`Resize ${header.column.id} column`}
+                                        type="button"
+                                    ></button>
+                                {/if}
+                            </Table.Head>
+                        {/each}
+                        {#if getFillerColumnCount() > 0}
+                            <Table.Head aria-hidden="true" class="w-full p-0"></Table.Head>
+                        {/if}
+                    </Table.Row>
+                {/each}
+            </Table.Header>
+            <Table.Body>
+                {#if children}
+                    {@render children()}
+                {/if}
+                {#each table.getRowModel().rows as row (row.id)}
+                    <Table.Row
+                        tabindex={rowClick ? 0 : undefined}
+                        onkeydown={rowClick
+                            ? (event) => {
+                                  if (event.key === 'Enter' || event.key === ' ') {
+                                      event.preventDefault();
+                                      const firstCell = row.getVisibleCells()[0];
+                                      if (firstCell) {
+                                          rowClick(firstCell.row.original);
+                                      }
                                   }
                               }
-                          }
-                        : undefined}
-                >
-                    {#each row.getVisibleCells() as cell (cell.id)}
-                        {#if rowHref && cell.row.original}
-                            {@const href = rowHref(cell.row.original)}
-                            <A {href} class="contents" onclick={(event) => onCellClick(event, cell)} variant="ghost">
+                            : undefined}
+                    >
+                        {#each row.getVisibleCells() as cell (cell.id)}
+                            {#if rowHref && cell.row.original}
+                                {@const href = rowHref(cell.row.original)}
+                                <A {href} class="contents" onclick={(event) => onCellClick(event, cell)} variant="ghost">
+                                    <Table.Cell
+                                        class={getCellClass(cell)}
+                                        data-wrap={isColumnWrapped(cell.column) ? 'true' : undefined}
+                                        style={getColumnStyle(cell.column)}
+                                    >
+                                        <FlexRender {cell} />
+                                    </Table.Cell>
+                                </A>
+                            {:else}
                                 <Table.Cell
                                     class={getCellClass(cell)}
                                     data-wrap={isColumnWrapped(cell.column) ? 'true' : undefined}
+                                    onclick={(event) => onCellClick(event, cell)}
                                     style={getColumnStyle(cell.column)}
                                 >
                                     <FlexRender {cell} />
                                 </Table.Cell>
-                            </A>
-                        {:else}
-                            <Table.Cell
-                                class={getCellClass(cell)}
-                                data-wrap={isColumnWrapped(cell.column) ? 'true' : undefined}
-                                onclick={(event) => onCellClick(event, cell)}
-                                style={getColumnStyle(cell.column)}
-                            >
-                                <FlexRender {cell} />
-                            </Table.Cell>
+                            {/if}
+                        {/each}
+                        {#if getFillerColumnCount() > 0}
+                            <Table.Cell aria-hidden="true" class="w-full p-0"></Table.Cell>
                         {/if}
-                    {/each}
-                    {#if getFillerColumnCount() > 0}
-                        <Table.Cell aria-hidden="true" class="w-full p-0"></Table.Cell>
-                    {/if}
-                </Table.Row>
-            {/each}
-        </Table.Body>
-    </Table.Root>
-</DataTableScrollContainer>
+                    </Table.Row>
+                {/each}
+            </Table.Body>
+        </Table.Root>
+    </DataTableScrollContainer>
+</div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-body.svelte
@@ -291,7 +291,7 @@
     }
 </script>
 
-<div class="order-3" data-slot="data-table-body">
+<div data-slot="data-table-body">
     <DataTableScrollContainer>
         <Table.Root class={hasSelectColumn() ? 'table-fixed' : undefined} style={getTableStyle()}>
             <Table.Header class="bg-card">

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-footer.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-footer.svelte
@@ -20,7 +20,10 @@
     let { children, class: className, table }: Props = $props();
 </script>
 
-<div class={['flex w-full flex-wrap items-center justify-between gap-2', className]}>
+<div
+    class={['bg-background/95 sticky top-2 z-30 order-2 flex w-full flex-wrap items-center justify-between gap-2 backdrop-blur-sm', className]}
+    data-slot="data-table-footer"
+>
     {#if children}
         {@render children()}
     {:else}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-footer.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-footer.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <div
-    class={['bg-background/95 sticky top-2 z-30 order-2 flex w-full flex-wrap items-center justify-between gap-2 backdrop-blur-sm', className]}
+    class={['bg-background/95 sticky top-2 z-30 flex w-full flex-wrap items-center justify-between gap-2 backdrop-blur-sm', className]}
     data-slot="data-table-footer"
 >
     {#if children}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
@@ -8,11 +8,12 @@
     import * as Select from '$comp/ui/select';
 
     interface Props {
+        onPageSizeChange?: () => void;
         table: Table<StockFeatures, TData>;
         value: number;
     }
 
-    let { table, value = $bindable() }: Props = $props();
+    let { onPageSizeChange, table, value = $bindable() }: Props = $props();
 
     type Item = { label: string; value: string };
     const items: Item[] = [
@@ -48,6 +49,7 @@
     function onValueChange(newValue: string) {
         value = Number(newValue);
         table.setPageSize(Number(newValue));
+        onPageSizeChange?.();
     }
 </script>
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
@@ -20,33 +20,69 @@
 
     let { table, value = $bindable() }: Props = $props();
 
+    let pagerElement: HTMLElement;
+
     const currentPage = $derived((table.options.state?.pagination?.pageIndex ?? table.store.state.pagination.pageIndex) + 1);
     const totalPages = $derived(Math.max(1, table.getPageCount() || 1));
     const canGoNext = $derived(currentPage < totalPages);
     const canGoPrevious = $derived(currentPage > 1);
 
+    function scrollTableIntoView(): void {
+        const tableElement = pagerElement.closest<HTMLElement>('[data-slot="data-table"]');
+        if (!tableElement) {
+            return;
+        }
+
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        tableElement.scrollIntoView({
+            behavior: prefersReducedMotion ? 'auto' : 'smooth',
+            block: 'start'
+        });
+    }
+
     function goToNextPage(): void {
         if (canGoNext) {
             table.setPageIndex(currentPage);
+            scrollTableIntoView();
         }
     }
 
     function goToPreviousPage(): void {
         if (canGoPrevious) {
             table.setPageIndex(currentPage - 2);
+            scrollTableIntoView();
         }
     }
 </script>
 
-<ButtonGroup.Root aria-label="Table pagination" class="ml-auto">
-    <DataTablePageSize bind:value {table} />
-    <ButtonGroup.Text aria-label={`Page ${currentPage} of ${totalPages}`} class="min-w-14 justify-center" title={`Page ${currentPage} of ${totalPages}`}>
-        <Number value={currentPage} /> / <Number value={totalPages} />
-    </ButtonGroup.Text>
-    <Button aria-label="Go to previous page" disabled={!canGoPrevious} onclick={goToPreviousPage} size="icon-sm" title="Previous page" variant="outline">
-        <ChevronLeftIcon />
-    </Button>
-    <Button aria-label="Go to next page" disabled={!canGoNext} onclick={goToNextPage} size="icon-sm" title="Next page" variant="outline">
-        <ChevronRightIcon />
-    </Button>
-</ButtonGroup.Root>
+<nav bind:this={pagerElement} aria-label="Table pagination" class="ml-auto shrink-0">
+    <ButtonGroup.Root aria-label="Pagination controls">
+        <DataTablePageSize bind:value onPageSizeChange={scrollTableIntoView} {table} />
+        <ButtonGroup.Text aria-label={`Page ${currentPage} of ${totalPages}`} class="min-w-14 justify-center" title={`Page ${currentPage} of ${totalPages}`}>
+            <Number value={currentPage} /> / <Number value={totalPages} />
+        </ButtonGroup.Text>
+        <Button
+            aria-label="Go to previous page"
+            aria-disabled={!canGoPrevious}
+            class="aria-disabled:pointer-events-none aria-disabled:opacity-50"
+            onclick={goToPreviousPage}
+            size="icon-sm"
+            title="Previous page"
+            variant="outline"
+        >
+            <ChevronLeftIcon />
+        </Button>
+        <Button
+            aria-label="Go to next page"
+            aria-disabled={!canGoNext}
+            class="aria-disabled:pointer-events-none aria-disabled:opacity-50"
+            onclick={goToNextPage}
+            size="icon-sm"
+            title="Next page"
+            variant="outline"
+        >
+            <ChevronRightIcon />
+        </Button>
+    </ButtonGroup.Root>
+    <span class="sr-only" aria-live="polite">Page {currentPage} of {totalPages}</span>
+</nav>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
@@ -58,7 +58,11 @@
 <nav bind:this={pagerElement} aria-label="Table pagination" class="ml-auto shrink-0">
     <ButtonGroup.Root aria-label="Pagination controls">
         <DataTablePageSize bind:value onPageSizeChange={scrollTableIntoView} {table} />
-        <ButtonGroup.Text aria-label={`Page ${currentPage} of ${totalPages}`} class="min-w-14 justify-center" title={`Page ${currentPage} of ${totalPages}`}>
+        <ButtonGroup.Text
+            aria-label={`Page ${currentPage} of ${totalPages}`}
+            class="min-w-14 justify-center select-none"
+            title={`Page ${currentPage} of ${totalPages}`}
+        >
             <Number value={currentPage} /> / <Number value={totalPages} />
         </ButtonGroup.Text>
         <Button

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
@@ -27,7 +27,7 @@ describe('DataTablePager', () => {
 
         expect(toolbar?.classList.contains('sticky')).toBe(true);
         expect(toolbar?.classList.contains('top-2')).toBe(true);
-        expect(toolbar?.classList.contains('order-2')).toBe(true);
+        expect(toolbar?.classList.contains('order-2')).toBe(false);
         expect(toolbar?.classList.contains('border')).toBe(false);
         expect(toolbar?.classList.contains('p-2')).toBe(false);
         expect(toolbar?.contains(screen.getByRole('button', { name: 'Bulk Actions' }))).toBe(true);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
@@ -1,0 +1,63 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DataTablePagerTestHarness from './data-table-pager.test-harness.svelte';
+
+describe('DataTablePager', () => {
+    const scrollIntoView = vi.fn();
+
+    beforeEach(() => {
+        Element.prototype.scrollIntoView = scrollIntoView;
+        Object.defineProperty(window, 'matchMedia', {
+            configurable: true,
+            value: vi.fn().mockReturnValue({ matches: false })
+        });
+    });
+
+    afterEach(() => {
+        cleanup();
+        scrollIntoView.mockReset();
+    });
+
+    it('keeps bulk actions and pagination together in the sticky table toolbar', () => {
+        render(DataTablePagerTestHarness, { onPageIndexChange: vi.fn(), onPageSizeChange: vi.fn() });
+
+        const toolbar = document.querySelector('[data-slot="data-table-footer"]');
+        const pager = screen.getByRole('navigation', { name: 'Table pagination' });
+
+        expect(toolbar?.classList.contains('sticky')).toBe(true);
+        expect(toolbar?.classList.contains('top-2')).toBe(true);
+        expect(toolbar?.classList.contains('order-2')).toBe(true);
+        expect(toolbar?.classList.contains('border')).toBe(false);
+        expect(toolbar?.classList.contains('p-2')).toBe(false);
+        expect(toolbar?.contains(screen.getByRole('button', { name: 'Bulk Actions' }))).toBe(true);
+        expect(toolbar?.contains(pager)).toBe(true);
+    });
+
+    it('keeps focus and scrolls the table to the start when changing pages', async () => {
+        const onPageIndexChange = vi.fn();
+        render(DataTablePagerTestHarness, { onPageIndexChange, onPageSizeChange: vi.fn() });
+
+        const nextButton = await screen.findByRole('button', { name: 'Go to next page' });
+        nextButton.focus();
+        await fireEvent.click(nextButton);
+
+        expect(onPageIndexChange).toHaveBeenCalledWith(1);
+        expect(screen.getByLabelText('Page 2 of 3')).toBeTruthy();
+        expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+        expect(document.activeElement).toBe(nextButton);
+    });
+
+    it('keeps an unavailable paging target focused without changing pages', async () => {
+        const onPageIndexChange = vi.fn();
+        render(DataTablePagerTestHarness, { onPageIndexChange, onPageSizeChange: vi.fn() });
+
+        const previousButton = screen.getByRole('button', { name: 'Go to previous page' });
+        previousButton.focus();
+        await fireEvent.click(previousButton);
+
+        expect(previousButton.getAttribute('aria-disabled')).toBe('true');
+        expect(onPageIndexChange).not.toHaveBeenCalled();
+        expect(document.activeElement).toBe(previousButton);
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
@@ -32,6 +32,7 @@ describe('DataTablePager', () => {
         expect(toolbar?.classList.contains('p-2')).toBe(false);
         expect(toolbar?.contains(screen.getByRole('button', { name: 'Bulk Actions' }))).toBe(true);
         expect(toolbar?.contains(pager)).toBe(true);
+        expect(screen.getByLabelText('Page 1 of 3').classList.contains('select-none')).toBe(true);
     });
 
     it('keeps focus and scrolls the table to the start when changing pages', async () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.test-harness.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+    import DataTableFooter from './data-table-footer.svelte';
+    import DataTablePager from './data-table-pager.svelte';
+    import DataTableRoot from './data-table.svelte';
+
+    interface Props {
+        onPageIndexChange: (pageIndex: number) => void;
+        onPageSizeChange: (pageSize: number) => void;
+    }
+
+    let { onPageIndexChange, onPageSizeChange }: Props = $props();
+
+    let limit = $state(10);
+    let pageIndex = $state(0);
+
+    const table = {
+        getPageCount: () => 3,
+        options: {
+            state: {
+                pagination: {
+                    get pageIndex() {
+                        return pageIndex;
+                    }
+                }
+            }
+        },
+        setPageIndex: (value: number) => {
+            pageIndex = value;
+            onPageIndexChange(value);
+        },
+        setPageSize: (value: number) => {
+            limit = value;
+            onPageSizeChange(value);
+        },
+        store: {
+            state: {
+                pagination: {
+                    get pageIndex() {
+                        return pageIndex;
+                    }
+                }
+            }
+        }
+    } as never;
+</script>
+
+<DataTableRoot>
+    <DataTableFooter {table}>
+        <button type="button">Bulk Actions</button>
+        <DataTablePager bind:value={limit} {table} />
+    </DataTableFooter>
+</DataTableRoot>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table.svelte
@@ -8,6 +8,6 @@
     let { children }: Props = $props();
 </script>
 
-<div class="space-y-4">
+<div class="flex flex-col gap-2" data-slot="data-table">
     {@render children()}
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte
@@ -168,7 +168,12 @@
 <DropdownMenu.Root>
     <DropdownMenu.Trigger>
         {#snippet child({ props })}
-            <Button {...props} variant="outline">
+            <Button
+                {...props}
+                disabled={ids.length === 0}
+                title={ids.length === 0 ? 'Select one or more stacks to use bulk actions' : 'Bulk Actions'}
+                variant="outline"
+            >
                 Bulk Actions
                 <ChevronDown class="size-4" />
             </Button>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <script generics="TData extends RowData" lang="ts">
-    import Button from '$comp/ui/button/button.svelte';
+    import { Button } from '$comp/ui/button';
     import * as DropdownMenu from '$comp/ui/dropdown-menu';
     import { getProblemMessage } from '$shared/validation';
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
@@ -22,8 +22,11 @@
     }
 
     let { table }: Props = $props();
+    const componentId = $props.id();
+    const bulkActionsDescriptionId = `${componentId}-bulk-actions-description`;
     const ids = $derived(table.getSelectedRowModel().flatRows.map((row) => row.id));
 
+    let open = $state(false);
     let openRemoveStackDialog = $state<boolean>(false);
     let openMarkStackDiscardedDialog = $state<boolean>(false);
     let openMarkStackFixedInVersionDialog = $state<boolean>(false);
@@ -163,19 +166,25 @@
 
         table.resetRowSelection();
     }
+
+    function setOpen(isOpen: boolean): void {
+        open = ids.length > 0 && isOpen;
+    }
 </script>
 
-<DropdownMenu.Root>
+<DropdownMenu.Root bind:open={() => open, setOpen}>
     <DropdownMenu.Trigger>
         {#snippet child({ props })}
             <Button
                 {...props}
-                disabled={ids.length === 0}
+                aria-describedby={ids.length === 0 ? bulkActionsDescriptionId : undefined}
+                aria-disabled={ids.length === 0}
+                class="aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
                 title={ids.length === 0 ? 'Select one or more stacks to use bulk actions' : 'Bulk Actions'}
                 variant="outline"
             >
                 Bulk Actions
-                <ChevronDown class="size-4" />
+                <ChevronDown data-icon="inline-end" />
             </Button>
         {/snippet}
     </DropdownMenu.Trigger>
@@ -204,6 +213,9 @@
         </DropdownMenu.Group>
     </DropdownMenu.Content>
 </DropdownMenu.Root>
+{#if ids.length === 0}
+    <span class="sr-only" id={bulkActionsDescriptionId}>Select one or more stacks to use bulk actions.</span>
+{/if}
 
 {#if openMarkStackDiscardedDialog}
     <MarkStackDiscardedDialog bind:open={openMarkStackDiscardedDialog} discard={markDiscarded} count={ids.length} />

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte.test.ts
@@ -1,0 +1,41 @@
+import { cleanup, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../api.svelte', () => ({
+    deleteStack: vi.fn(() => ({ mutateAsync: vi.fn() })),
+    postChangeStatus: vi.fn(() => ({ mutateAsync: vi.fn() })),
+    postMarkFixed: vi.fn(() => ({ mutateAsync: vi.fn() })),
+    postMarkSnoozed: vi.fn(() => ({ mutateAsync: vi.fn() }))
+}));
+
+import StacksBulkActionsDropdownMenu from './stacks-bulk-actions-dropdown-menu.svelte';
+
+describe('StacksBulkActionsDropdownMenu', () => {
+    afterEach(() => cleanup());
+
+    it('requires a selected stack before opening bulk actions', () => {
+        const table = {
+            getSelectedRowModel: () => ({ flatRows: [] }),
+            resetRowSelection: vi.fn()
+        } as never;
+
+        render(StacksBulkActionsDropdownMenu, { props: { table } });
+
+        const trigger = screen.getByRole('button', { name: /Bulk Actions/ }) as HTMLButtonElement;
+        expect(trigger.disabled).toBe(true);
+        expect(trigger.title).toBe('Select one or more stacks to use bulk actions');
+    });
+
+    it('enables bulk actions when a stack is selected', () => {
+        const table = {
+            getSelectedRowModel: () => ({ flatRows: [{ id: 'stack-id' }] }),
+            resetRowSelection: vi.fn()
+        } as never;
+
+        render(StacksBulkActionsDropdownMenu, { props: { table } });
+
+        const trigger = screen.getByRole('button', { name: /Bulk Actions/ }) as HTMLButtonElement;
+        expect(trigger.disabled).toBe(false);
+        expect(trigger.title).toBe('Bulk Actions');
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/svelte';
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../api.svelte', () => ({
@@ -13,7 +13,7 @@ import StacksBulkActionsDropdownMenu from './stacks-bulk-actions-dropdown-menu.s
 describe('StacksBulkActionsDropdownMenu', () => {
     afterEach(() => cleanup());
 
-    it('requires a selected stack before opening bulk actions', () => {
+    it('requires a selected stack before opening bulk actions', async () => {
         const table = {
             getSelectedRowModel: () => ({ flatRows: [] }),
             resetRowSelection: vi.fn()
@@ -22,8 +22,14 @@ describe('StacksBulkActionsDropdownMenu', () => {
         render(StacksBulkActionsDropdownMenu, { props: { table } });
 
         const trigger = screen.getByRole('button', { name: /Bulk Actions/ }) as HTMLButtonElement;
-        expect(trigger.disabled).toBe(true);
+        expect(trigger.disabled).toBe(false);
+        expect(trigger.getAttribute('aria-disabled')).toBe('true');
         expect(trigger.title).toBe('Select one or more stacks to use bulk actions');
+        expect(document.getElementById(trigger.getAttribute('aria-describedby')!)?.textContent).toBe('Select one or more stacks to use bulk actions.');
+        trigger.focus();
+        expect(document.activeElement).toBe(trigger);
+        await fireEvent.click(trigger);
+        expect(screen.queryByRole('menuitem', { name: 'Mark Open' })).toBeNull();
     });
 
     it('enables bulk actions when a stack is selected', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/table/stacks-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/table/stacks-data-table.svelte
@@ -19,6 +19,14 @@
 </script>
 
 <DataTable.Root>
+    <DataTable.Footer {table} class="w-full">
+        {#if footerChildren}
+            {@render footerChildren()}
+        {:else}
+            <DataTable.Selection {table} />
+            <DataTable.Pager bind:value={limit} {table} />
+        {/if}
+    </DataTable.Footer>
     <DataTable.Body {rowClick} {rowHref} {table}>
         {#if isLoading}
             <DelayedRender>
@@ -28,12 +36,4 @@
             <DataTable.Empty {table} />
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="w-full">
-        {#if footerChildren}
-            {@render footerChildren()}
-        {:else}
-            <DataTable.Selection {table} />
-            <DataTable.Pager bind:value={limit} {table} />
-        {/if}
-    </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/table/tokens-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/tokens/components/table/tokens-data-table.svelte
@@ -27,6 +27,14 @@
     {:else}
         <DataTable.Toolbar {table} />
     {/if}
+    <DataTable.Footer {table} class="w-full">
+        {#if footerChildren}
+            {@render footerChildren()}
+        {:else}
+            <DataTable.Selection {table} />
+            <DataTable.Pager bind:value={limit} {table} />
+        {/if}
+    </DataTable.Footer>
     <DataTable.Body {rowClick} {table}>
         {#if isLoading}
             <DelayedRender>
@@ -39,12 +47,4 @@
             {@render bodyChildren()}
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="w-full">
-        {#if footerChildren}
-            {@render footerChildren()}
-        {:else}
-            <DataTable.Selection {table} />
-            <DataTable.Pager bind:value={limit} {table} />
-        {/if}
-    </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/oauth-grants/table/oauth-grants-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/oauth-grants/table/oauth-grants-data-table.svelte
@@ -22,6 +22,10 @@
             {@render toolbarChildren()}
         </DataTable.Toolbar>
     {/if}
+    <DataTable.Footer {table} class="w-full">
+        <DataTable.Selection {table} />
+        <DataTable.Pager bind:value={limit} {table} />
+    </DataTable.Footer>
     <DataTable.Body {table}>
         {#if isLoading}
             <DelayedRender>
@@ -31,8 +35,4 @@
             <DataTable.Empty {table}>No applications have access to your account.</DataTable.Empty>
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="w-full">
-        <DataTable.Selection {table} />
-        <DataTable.Pager bind:value={limit} {table} />
-    </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/table/users-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/table/users-data-table.svelte
@@ -27,6 +27,14 @@
     {:else}
         <DataTable.Toolbar {table} />
     {/if}
+    <DataTable.Footer {table} class="w-full">
+        {#if footerChildren}
+            {@render footerChildren()}
+        {:else}
+            <DataTable.Selection {table} />
+            <DataTable.Pager bind:value={limit} {table} />
+        {/if}
+    </DataTable.Footer>
     <DataTable.Body {rowClick} {table}>
         {#if isLoading}
             <DelayedRender>
@@ -39,12 +47,4 @@
             {@render bodyChildren()}
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="w-full">
-        {#if footerChildren}
-            {@render footerChildren()}
-        {:else}
-            <DataTable.Selection {table} />
-            <DataTable.Pager bind:value={limit} {table} />
-        {/if}
-    </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/components/table/webhooks-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/webhooks/components/table/webhooks-data-table.svelte
@@ -27,6 +27,14 @@
     {:else}
         <DataTable.Toolbar {table} />
     {/if}
+    <DataTable.Footer {table} class="w-full">
+        {#if footerChildren}
+            {@render footerChildren()}
+        {:else}
+            <DataTable.Selection {table} />
+            <DataTable.Pager bind:value={limit} {table} />
+        {/if}
+    </DataTable.Footer>
     <DataTable.Body {rowClick} {table}>
         {#if isLoading}
             <DelayedRender>
@@ -39,12 +47,4 @@
             {@render bodyChildren()}
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table} class="w-full">
-        {#if footerChildren}
-            {@render footerChildren()}
-        {:else}
-            <DataTable.Selection {table} />
-            <DataTable.Pager bind:value={limit} {table} />
-        {/if}
-    </DataTable.Footer>
 </DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -995,9 +995,7 @@
         >
             {#snippet footerChildren()}
                 <div class="flex min-w-0 items-center gap-3">
-                    {#if table.getSelectedRowModel().flatRows.length}
-                        <EventsBulkActionsDropdownMenu {table} />
-                    {/if}
+                    <EventsBulkActionsDropdownMenu {table} />
                     <DataTable.Selection {table} />
                 </div>
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -352,6 +352,14 @@
             <StreamingIndicatorButton onToggle={handleToggle} {paused} size="icon-lg" />
         </div>
     </div>
+    <DataTable.Footer {table}>
+        <div class="flex w-full items-center justify-center gap-4">
+            <DataTable.PageSize bind:value={queryParams.limit!} {table} />
+            <div class="text-center">
+                <ErrorMessage message={clientResponse?.problem?.errors.general} />
+            </div>
+        </div>
+    </DataTable.Footer>
     <DataTable.Body
         autoFillColumnId={savedViewsState.autoFillColumnId}
         rowClick={rowclick}
@@ -367,14 +375,6 @@
             <DataTable.Empty {table} />
         {/if}
     </DataTable.Body>
-    <DataTable.Footer {table}>
-        <div class="flex w-full items-center justify-center space-x-4">
-            <DataTable.PageSize bind:value={queryParams.limit!} {table} />
-            <div class="text-center">
-                <ErrorMessage message={clientResponse?.problem?.errors.general} />
-            </div>
-        </div>
-    </DataTable.Footer>
 </DataTable.Root>
 
 <EventDetailSheet bind:eventId={selectedEventId} filterChanged={onFilterChanged} onClose={() => (selectedEventId = null)} onError={handleEventError} />


### PR DESCRIPTION
## Summary

- move shared table actions and pagination above data grids in a compact, borderless sticky toolbar
- keep pagination controls visible and return the table to view when changing pages or page size
- keep Events and Stacks bulk actions visible but disabled until rows are selected
- preserve focus and accessible paging state at pagination boundaries

## Validation

- `npm run validate`
- `npm run build`
- `npm run test:unit -- --run src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte.test.ts src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte.test.ts src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts`
- `npm run test:e2e -- e2e/tests/table-toolbar-pagination.e2e.ts --project=chromium`

## Breaking changes

None.
