### PR TITLE
Persist unsaved saved view changes locally

### DIFF
--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -249,6 +249,25 @@ test('switching saved views preserves each view temporary filter overrides acros
     ).toBeVisible();
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
     await expectColumnBefore(page, 'User', 'Summary');
+
+    await page.goto(`/next/event/${firstViewSlug}?time=15m`);
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 15 minutes/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await secondViewLink.click();
+    await expect(page.getByRole('heading', { name: secondViewName })).toBeVisible();
+    await firstViewLink.click();
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 90 days/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await expect(page).toHaveURL(/[?&]status=regressed(?:&|$)/);
+
     await openViewMenu(page);
     await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
     await expect(summaryWrap).toBeChecked();
@@ -329,6 +348,130 @@ test('switching saved views preserves each view temporary filter overrides acros
     await expect(page.getByLabel('Unsaved view changes')).toHaveCount(0);
     await expectColumnBefore(page, 'Summary', 'User');
     expect(failedApiRequests).toEqual([]);
+});
+
+test('stream waits for a browser-local saved view draft before loading events', async ({ e2eApi, e2eScenario, page, request }) => {
+    const failedApiRequests = captureFailedApiRequests(page);
+    const suffix = e2eScenario.run.slice(-28);
+    const viewName = `E2E Stream View ${suffix}`;
+    const authorizationHeaders = { Authorization: `Bearer ${e2eScenario.userToken}` };
+    const filterDefinitions = JSON.stringify([
+        { type: 'project', value: [] },
+        { type: 'status', value: ['open', 'regressed'] }
+    ]);
+
+    const savedViewResponse = await request.post(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views`, {
+        data: {
+            filter: '(status:open OR status:regressed)',
+            filter_definitions: filterDefinitions,
+            name: viewName,
+            organization_id: e2eScenario.organizationId,
+            view_type: 'stream'
+        },
+        headers: authorizationHeaders
+    });
+    expect(savedViewResponse.status()).toBe(201);
+    const savedView = (await savedViewResponse.json()) as { id: string };
+    const currentUser = await e2eApi.getCurrentUser(e2eScenario.userToken);
+    expect(currentUser).toBeDefined();
+
+    const savedViewsPath = `/api/v2/organizations/${e2eScenario.organizationId}/saved-views/stream`;
+    await expect
+        .poll(
+            async () => {
+                const response = await request.get(savedViewsPath, { headers: authorizationHeaders });
+                return response.ok() && ((await response.json()) as { id: string }[]).some((view) => view.id === savedView.id);
+            },
+            { timeout: 30_000 }
+        )
+        .toBe(true);
+
+    await page.addInitScript(
+        ({ draft, key }) => {
+            window.localStorage.setItem(key, JSON.stringify(draft));
+        },
+        {
+            draft: {
+                filterChanges: {
+                    removedKeys: [],
+                    upsertDefinitions: JSON.stringify([{ type: 'project', value: [e2eScenario.projectId] }])
+                },
+                version: 1
+            },
+            key: `exceptionless:saved-view-draft:v1:${currentUser!.id}:${e2eScenario.organizationId}:${savedView.id}`
+        }
+    );
+
+    const streamRequestFilters: string[] = [];
+    page.on('request', (request) => {
+        const url = new URL(request.url());
+        if (url.pathname === `/api/v2/organizations/${e2eScenario.organizationId}/events`) {
+            streamRequestFilters.push(url.searchParams.get('filter') ?? '');
+        }
+    });
+
+    await page.goto(`/next/stream?saved=${savedView.id}`);
+    await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await expect.poll(() => streamRequestFilters.length).toBeGreaterThan(0);
+    expect(streamRequestFilters.every((filter) => filter.includes(e2eScenario.projectId))).toBe(true);
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+    expect(failedApiRequests).toEqual([]);
+});
+
+test('saved view loads server state when the current-user lookup fails', async ({ e2eScenario, page, request }) => {
+    const suffix = e2eScenario.run.slice(-28);
+    const viewName = `E2E User Failure ${suffix}`;
+    const viewSlug = savedViewSlug(viewName);
+    const authorizationHeaders = { Authorization: `Bearer ${e2eScenario.userToken}` };
+    const filterDefinitions = JSON.stringify([
+        { term: 'date', type: 'date', value: '[now-15m TO now]' },
+        { type: 'project', value: [] },
+        { type: 'status', value: ['open', 'regressed'] }
+    ]);
+
+    const savedViewResponse = await request.post(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views`, {
+        data: {
+            filter: '(status:open OR status:regressed)',
+            filter_definitions: filterDefinitions,
+            name: viewName,
+            organization_id: e2eScenario.organizationId,
+            slug: viewSlug,
+            time: '[now-15m TO now]',
+            view_type: 'events'
+        },
+        headers: authorizationHeaders
+    });
+    expect(savedViewResponse.status()).toBe(201);
+
+    const savedViewsPath = `/api/v2/organizations/${e2eScenario.organizationId}/saved-views/events`;
+    await expect
+        .poll(
+            async () => {
+                const response = await request.get(savedViewsPath, { headers: authorizationHeaders });
+                return response.ok() && ((await response.json()) as { name: string }[]).some((view) => view.name === viewName);
+            },
+            { timeout: 30_000 }
+        )
+        .toBe(true);
+
+    await page.route('**/api/v2/users/me', async (route) => {
+        await route.fulfill({
+            body: JSON.stringify({ detail: 'Simulated current-user failure', status: 500, title: 'Internal Server Error' }),
+            contentType: 'application/problem+json',
+            status: 500
+        });
+    });
+    const eventRequests: string[] = [];
+    page.on('request', (request) => {
+        const url = new URL(request.url());
+        if (url.pathname === `/api/v2/organizations/${e2eScenario.organizationId}/events`) {
+            eventRequests.push(request.url());
+        }
+    });
+
+    await page.goto(`/next/event/${viewSlug}`);
+    await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await expect.poll(() => eventRequests.length, { timeout: 30_000 }).toBeGreaterThan(0);
 });
 
 function captureFailedApiRequests(page: Page): { error: null | string; method: string; url: string }[] {

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -384,6 +384,20 @@ test('switching saved views preserves each view temporary filter overrides acros
     await expect(summaryWrap).toBeChecked();
     await columnDialog.getByRole('button', { name: 'Done' }).click();
 
+    await navigateClientSide(page, '/next/stack');
+    await expect(page).toHaveURL(/\/next\/stack(?:[?#]|$)/);
+    await navigateClientSide(page, `/next/event/${firstViewSlug}`);
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 90 days/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await page.goBack();
+    await expect(page).toHaveURL(/\/next\/stack(?:[?#]|$)/);
+    await navigateClientSide(page, `/next/event/${firstViewSlug}`);
+    await expect(page.getByRole('heading', { name: firstViewName })).toBeVisible();
+
     await openViewMenu(page);
     await page.getByRole('menuitem', { name: 'Reset to Saved' }).click();
     await expect(page).not.toHaveURL(/[?&]time=90d(?:&|$)/);

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -509,14 +509,22 @@ test('save completion does not overwrite a newly active saved view', async ({ e2
     await page.getByRole('link', { exact: true, name: secondViewName }).first().click();
     await expect(page.getByRole('heading', { name: secondViewName })).toBeVisible();
     await expect.poll(() => secondViewRequestTimes.some((time) => time.includes('now-1d'))).toBe(true);
+    await page.getByRole('button', { name: /^Date/ }).filter({ visible: true }).first().click();
+    await page.getByRole('button', { name: 'Last 7 days' }).click();
     const saveCompleted = page.waitForResponse(
         (response) => response.request().method() === 'PATCH' && new URL(response.url()).pathname === `/api/v2/saved-views/${firstView.id}`
     );
     releaseSave();
     await saveCompleted;
-    await page.getByRole('button', { name: /^Date/ }).filter({ visible: true }).first().click();
-    await page.getByRole('button', { name: 'Last 7 days' }).click();
     await expect.poll(() => secondViewRequestTimes.some((time) => time.includes('now-7d'))).toBe(true);
+    await page.reload();
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 7 days/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
 });
 
 test('stream switches to a browser-local saved view draft without mixing in-flight results', async ({ e2eApi, e2eScenario, page, request }) => {

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -532,6 +532,8 @@ test('stream switches to a browser-local saved view draft without mixing in-flig
     const suffix = e2eScenario.run.slice(-28);
     const viewName = `E2E Stream View ${suffix}`;
     const authorizationHeaders = { Authorization: `Bearer ${e2eScenario.userToken}` };
+    const draftExpression = `error.type:Local${suffix}`;
+    const remoteExpression = `error.type:Remote${suffix}`;
     const filterDefinitions = JSON.stringify([
         { type: 'project', value: [] },
         { type: 'status', value: ['open', 'regressed'] }
@@ -570,9 +572,10 @@ test('stream switches to a browser-local saved view draft without mixing in-flig
         {
             draft: {
                 filterChanges: {
+                    duplicateKeys: ['keyword'],
                     removedKeys: [],
                     sourceDefinitions: filterDefinitions,
-                    upsertDefinitions: JSON.stringify([{ type: 'project', value: [e2eScenario.projectId] }])
+                    upsertDefinitions: JSON.stringify([{ type: 'keyword', value: draftExpression }])
                 },
                 version: 1
             },
@@ -591,7 +594,7 @@ test('stream switches to a browser-local saved view draft without mixing in-flig
     await page.route(`**/api/v2/organizations/${e2eScenario.organizationId}/events*`, async (route) => {
         const filter = new URL(route.request().url()).searchParams.get('filter') ?? '';
         streamRequestFilters.push(filter);
-        if (filter.includes(e2eScenario.projectId)) {
+        if (filter.includes(draftExpression)) {
             await route.fulfill({ body: '[]', contentType: 'application/json', status: 200 });
             return;
         }
@@ -624,18 +627,26 @@ test('stream switches to a browser-local saved view draft without mixing in-flig
     await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
     await expect(getVisibleText(page, sourceMessage)).toBeHidden();
     await page.getByRole('button', { name: 'Resume streaming updates' }).click();
-    await expect.poll(() => streamRequestFilters.some((filter) => filter.includes(e2eScenario.projectId))).toBe(true);
+    await expect.poll(() => streamRequestFilters.some((filter) => filter.includes(draftExpression))).toBe(true);
     await expect(getVisibleText(page, sourceMessage)).toBeHidden();
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+    await expect
+        .poll(() =>
+            page.evaluate(() => {
+                const state = window.history.state as { 'sveltekit:states'?: { __exceptionlessSavedViewDraftFilter?: unknown } };
+                return state['sveltekit:states']?.__exceptionlessSavedViewDraftFilter;
+            })
+        )
+        .toEqual({ filter: new URL(page.url()).searchParams.get('filter'), viewId: savedView.id });
 
-    const restoredUrl = page.url();
     const updatedFilterDefinitions = JSON.stringify([
+        { type: 'keyword', value: remoteExpression },
         { type: 'project', value: [] },
         { type: 'status', value: ['fixed'] }
     ]);
     const serverUpdateResponse = await request.patch(`/api/v2/saved-views/${savedView.id}`, {
         data: {
-            filter: 'status:fixed',
+            filter: `status:fixed AND ${remoteExpression}`,
             filter_definitions: updatedFilterDefinitions
         },
         headers: authorizationHeaders
@@ -653,15 +664,32 @@ test('stream switches to a browser-local saved view draft without mixing in-flig
         .toBe(updatedFilterDefinitions);
 
     streamRequestFilters.length = 0;
-    await page.goto(restoredUrl);
+    await page.reload();
+    await expect
+        .poll(() =>
+            page.evaluate(() => {
+                const state = window.history.state as { 'sveltekit:states'?: { __exceptionlessSavedViewDraftFilter?: unknown } };
+                return state['sveltekit:states']?.__exceptionlessSavedViewDraftFilter;
+            })
+        )
+        .toEqual({ filter: new URL(page.url()).searchParams.get('filter'), viewId: savedView.id });
     await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
-    await expect.poll(() => streamRequestFilters.some((filter) => filter.includes(e2eScenario.projectId))).toBe(true);
-    const restoredFilter = streamRequestFilters.findLast((filter) => filter.includes(e2eScenario.projectId))!;
-    expect(restoredFilter.split(e2eScenario.projectId)).toHaveLength(2);
+    await expect.poll(() => streamRequestFilters.join('\n')).toContain(remoteExpression);
+    const restoredFilter = streamRequestFilters.findLast((filter) => filter.includes(draftExpression) && filter.includes(remoteExpression))!;
+    expect(restoredFilter.split(draftExpression)).toHaveLength(2);
     expect(restoredFilter).toContain('fixed');
+    expect(restoredFilter).toContain(remoteExpression);
     expect(restoredFilter).not.toContain('open');
     expect(restoredFilter).not.toContain('regressed');
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+
+    streamRequestFilters.length = 0;
+    await page.goto(`/next/stream?saved=${savedView.id}&filter=${encodeURIComponent(draftExpression)}`);
+    await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await expect.poll(() => streamRequestFilters.some((filter) => filter.includes(draftExpression))).toBe(true);
+    const explicitFilter = streamRequestFilters.findLast((filter) => filter.includes(draftExpression))!;
+    expect(explicitFilter).toContain('fixed');
+    expect(explicitFilter).not.toContain(remoteExpression);
     expect(failedApiRequests).toEqual([]);
 });
 

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -692,6 +692,13 @@ test('stream switches to a browser-local saved view draft without mixing in-flig
     const explicitFilter = streamRequestFilters.findLast((filter) => filter.includes(draftExpression))!;
     expect(explicitFilter).not.toContain('fixed');
     expect(explicitFilter).not.toContain(remoteExpression);
+
+    streamRequestFilters.length = 0;
+    await page.goto(`/next/stream?saved=${savedView.id}&filter=`);
+    await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Status Fixed' })).toHaveCount(0);
+    await expect.poll(() => streamRequestFilters.at(-1)).toBe('');
     expect(failedApiRequests).toEqual([]);
 });
 

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -202,6 +202,14 @@ test('switching saved views preserves each view temporary filter overrides acros
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
     await expectColumnBefore(page, 'Summary', 'User');
 
+    const coldLoadEventTimes: string[] = [];
+    const captureColdLoadEventTime = (request: Request) => {
+        const url = new URL(request.url());
+        if (url.pathname === `/api/v2/organizations/${e2eScenario.organizationId}/events`) {
+            coldLoadEventTimes.push(url.searchParams.get('time') ?? '');
+        }
+    };
+    page.on('request', captureColdLoadEventTime);
     await page.goto(`/next/event/${firstViewSlug}?project=${e2eScenario.projectId}&sort=type&status=open`);
     await expect(page.getByRole('heading', { name: firstViewName })).toBeVisible();
     await expect(page).toHaveURL(new RegExp(`[?&]project=${escapeRegExp(e2eScenario.projectId)}(?:&|$)`));
@@ -212,6 +220,9 @@ test('switching saved views preserves each view temporary filter overrides acros
             .filter({ visible: true })
             .first()
     ).toBeVisible();
+    await expect.poll(() => coldLoadEventTimes.length).toBeGreaterThan(0);
+    page.off('request', captureColdLoadEventTime);
+    expect(coldLoadEventTimes.every((time) => time.includes('now-90d'))).toBe(true);
     await page.reload();
     await expect(
         page

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -468,10 +468,13 @@ test('stream switches to a browser-local saved view draft without mixing in-flig
 
     await page.goto('/next/stream');
     await expect.poll(() => sourceRequestStarted).toBe(true);
+    await page.getByRole('button', { name: 'Pause streaming updates' }).click();
     await navigateClientSide(page, `/next/stream?saved=${savedView.id}`);
     releaseSourceRequest();
     await expect.poll(() => sourceRequestCompleted).toBe(true);
     await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await expect(getVisibleText(page, sourceMessage)).toBeHidden();
+    await page.getByRole('button', { name: 'Resume streaming updates' }).click();
     await expect.poll(() => streamRequestFilters.some((filter) => filter.includes(e2eScenario.projectId))).toBe(true);
     await expect(getVisibleText(page, sourceMessage)).toBeHidden();
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -97,18 +97,69 @@ test('events saved view can be saved, renamed, loaded, and deleted', async ({ e2
     expect(failedApiRequests).toEqual([]);
 });
 
-test('switching saved views preserves each view temporary filter overrides across page reloads', async ({ e2eApi, e2eScenario, page }) => {
+test('switching saved views preserves each view temporary filter overrides across page reloads', async ({ e2eScenario, page, request }) => {
     const failedApiRequests = captureFailedApiRequests(page);
-    const journey = ExceptionlessE2EJourney.fromScenario(page, e2eApi, e2eScenario);
-    const suffix = journey.run.slice(-28);
+    const suffix = e2eScenario.run.slice(-28);
     const firstViewName = `E2E First View ${suffix}`;
     const secondViewName = `E2E Second View ${suffix}`;
     const firstViewSlug = savedViewSlug(firstViewName);
     const secondViewSlug = savedViewSlug(secondViewName);
+    const savedViewsPath = `/api/v2/organizations/${e2eScenario.organizationId}/saved-views/events`;
+    const authorizationHeaders = { Authorization: `Bearer ${e2eScenario.userToken}` };
+    const filterDefinitions = (time: string) =>
+        JSON.stringify([
+            { term: 'date', type: 'date', value: `[now-${time} TO now]` },
+            { type: 'project', value: [] },
+            { type: 'status', value: ['open', 'regressed'] }
+        ]);
 
-    await journey.submitRepresentativeEvent();
-    await saveView(page, firstViewName, journey.referenceId, '15m');
-    await saveView(page, secondViewName, journey.referenceId, '1d');
+    const firstSavedViewResponse = await request.post(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views`, {
+        data: {
+            filter: '(status:open OR status:regressed)',
+            filter_definitions: filterDefinitions('15m'),
+            name: firstViewName,
+            organization_id: e2eScenario.organizationId,
+            show_chart: true,
+            show_stats: true,
+            slug: firstViewSlug,
+            time: '[now-15m TO now]',
+            view_type: 'events'
+        },
+        headers: authorizationHeaders
+    });
+    expect(firstSavedViewResponse.status()).toBe(201);
+    const firstSavedView = (await firstSavedViewResponse.json()) as { id: string };
+
+    const secondSavedViewResponse = await request.post(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views`, {
+        data: {
+            filter: '(status:open OR status:regressed)',
+            filter_definitions: filterDefinitions('1d'),
+            name: secondViewName,
+            organization_id: e2eScenario.organizationId,
+            show_chart: true,
+            show_stats: true,
+            slug: secondViewSlug,
+            time: '[now-1d TO now]',
+            view_type: 'events'
+        },
+        headers: authorizationHeaders
+    });
+    expect(secondSavedViewResponse.status()).toBe(201);
+
+    await expect
+        .poll(
+            async () => {
+                const response = await request.get(savedViewsPath, { headers: authorizationHeaders });
+                if (!response.ok()) {
+                    return false;
+                }
+
+                const viewNames = ((await response.json()) as { name: string }[]).map((view) => view.name);
+                return viewNames.includes(firstViewName) && viewNames.includes(secondViewName);
+            },
+            { timeout: 30_000 }
+        )
+        .toBe(true);
 
     await page.goto(`/next/event/${firstViewSlug}`);
     const dateFilter = page.getByRole('button', { name: /^Date/ }).filter({ visible: true }).first();
@@ -157,6 +208,16 @@ test('switching saved views preserves each view temporary filter overrides acros
     await expect(summaryWrap).toBeChecked();
     await columnDialog.getByRole('button', { name: 'Done' }).click();
 
+    const refreshedSavedViews = page.waitForResponse(
+        (response) => response.request().method() === 'GET' && new URL(response.url()).pathname === savedViewsPath && response.ok()
+    );
+    const serverUpdateResponse = await request.patch(`/api/v2/saved-views/${firstSavedView.id}`, {
+        data: { show_chart: false },
+        headers: authorizationHeaders
+    });
+    expect(serverUpdateResponse.status()).toBe(200);
+    await refreshedSavedViews;
+
     await secondViewLink.click();
     await expect(page).toHaveURL(new RegExp(`/next/event/${escapeRegExp(secondViewSlug)}(?:[?#]|$)`));
     await expect(page.getByRole('heading', { name: secondViewName })).toBeVisible();
@@ -193,6 +254,7 @@ test('switching saved views preserves each view temporary filter overrides acros
     ).toBeVisible();
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
     await openViewMenu(page);
+    await expect(page.getByRole('menuitemcheckbox', { name: 'Chart' })).not.toBeChecked();
     await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
     await expect(summaryWrap).toBeChecked();
     await columnDialog.getByRole('button', { name: 'Done' }).click();
@@ -251,15 +313,4 @@ function savedViewSlug(value: string): string {
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/^-+|-+$/g, '')
         .replace(/-+/g, '-');
-}
-
-async function saveView(page: Page, viewName: string, referenceId: string, time: string): Promise<void> {
-    await page.goto(`/next/event?reference=${encodeURIComponent(referenceId)}&time=${time}`);
-    await openViewMenu(page);
-    await page.getByRole('menuitem', { name: 'Save As...' }).click();
-    const dialog = page.getByRole('dialog', { name: 'Save View' });
-    await dialog.getByLabel('Name', { exact: true }).fill(viewName);
-    await dialog.getByRole('button', { name: 'Save' }).click();
-    await expect(dialog).toBeHidden({ timeout: 30_000 });
-    await expect(page.getByRole('heading', { name: viewName })).toBeVisible({ timeout: 30_000 });
 }

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -531,6 +531,14 @@ test('stream switches to a browser-local saved view draft without mixing in-flig
     await expect.poll(() => streamRequestFilters.some((filter) => filter.includes(e2eScenario.projectId))).toBe(true);
     await expect(getVisibleText(page, sourceMessage)).toBeHidden();
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+
+    streamRequestFilters.length = 0;
+    await page.reload();
+    await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await expect.poll(() => streamRequestFilters.some((filter) => filter.includes(e2eScenario.projectId))).toBe(true);
+    const restoredFilter = streamRequestFilters.findLast((filter) => filter.includes(e2eScenario.projectId))!;
+    expect(restoredFilter.split(e2eScenario.projectId)).toHaveLength(2);
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
     expect(failedApiRequests).toEqual([]);
 });
 

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -4,7 +4,7 @@ import { expect, test } from '../fixtures/e2e-test';
 import { ExceptionlessE2EJourney } from '../support/exceptionless-journey';
 import { getVisibleText } from '../support/page-helpers';
 
-test('events saved view can be saved, renamed, loaded, and deleted', async ({ e2eApi, e2eScenario, page }) => {
+test('events saved view can be saved, renamed, loaded, and deleted', async ({ e2eApi, e2eScenario, page, request }) => {
     const failedApiRequests = captureFailedApiRequests(page);
     const journey = ExceptionlessE2EJourney.fromScenario(page, e2eApi, e2eScenario);
     const suffix = journey.run.slice(-36);
@@ -70,6 +70,15 @@ test('events saved view can be saved, renamed, loaded, and deleted', async ({ e2
         await page.getByRole('menuitem', { exact: true, name: 'Save' }).click();
         await expect(page.getByText(`View "${renamedViewName}" saved.`)).toBeVisible();
         await expect(page.getByLabel('Unsaved view changes')).toHaveCount(0);
+        await expect
+            .poll(async () => {
+                const response = await request.get(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views/events`, {
+                    headers: { Authorization: `Bearer ${e2eScenario.userToken}` }
+                });
+                const view = ((await response.json()) as { slug: string; time?: string }[]).find((candidate) => candidate.slug === viewSlug);
+                return view?.time;
+            })
+            .toContain('now-1d');
 
         await page.goto(`/next/event/${viewSlug}`);
         await expect(
@@ -597,9 +606,12 @@ test('reset clears a browser-local draft after delayed current-user identity res
     await page.goto(`/next/event/${viewSlug}?time=1d`);
     await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
     await openViewMenu(page);
-    await page.getByRole('menuitem', { name: 'Reset to Saved' }).click();
-    await expect(page).not.toHaveURL(/[?&]time=/);
+    const resetMenuItem = page.getByRole('menuitem', { name: 'Reset to Saved' });
+    await expect(resetMenuItem).toBeDisabled();
     releaseCurrentUser();
+    await expect(resetMenuItem).toBeEnabled();
+    await resetMenuItem.click();
+    await expect(page).not.toHaveURL(/[?&]time=/);
 
     await expect(
         page
@@ -610,7 +622,7 @@ test('reset clears a browser-local draft after delayed current-user identity res
     await expect(page.getByLabel('Unsaved view changes')).toHaveCount(0);
 });
 
-test('saved view loads server state and queues draft clears when the current-user lookup fails', async ({ e2eApi, e2eScenario, page, request }) => {
+test('saved view loads server state and protects drafts when the current-user lookup fails', async ({ e2eApi, e2eScenario, page, request }) => {
     const suffix = e2eScenario.run.slice(-28);
     const viewName = `E2E User Failure ${suffix}`;
     const viewSlug = savedViewSlug(viewName);
@@ -638,7 +650,6 @@ test('saved view loads server state and queues draft clears when the current-use
     const currentUser = await e2eApi.getCurrentUser(e2eScenario.userToken);
     expect(currentUser).toBeDefined();
     const draftKey = `exceptionless:saved-view-draft:v1:${currentUser!.id}:${e2eScenario.organizationId}:${savedView.id}`;
-    const clearKey = `exceptionless:saved-view-draft-clear:v1:${e2eScenario.organizationId}:${savedView.id}`;
     await page.addInitScript(({ draft, key }) => window.localStorage.setItem(key, JSON.stringify(draft)), {
         draft: {
             filterChanges: {
@@ -682,21 +693,20 @@ test('saved view loads server state and queues draft clears when the current-use
     await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
     await expect.poll(() => eventRequests.length, { timeout: 30_000 }).toBeGreaterThan(0);
     await openViewMenu(page);
-    await page.getByRole('menuitem', { name: 'Reset to Saved' }).click();
+    await expect(page.getByRole('menuitem', { exact: true, name: 'Save' })).toBeDisabled();
+    await expect(page.getByRole('menuitem', { name: 'Reset to Saved' })).toBeDisabled();
 
     await page.unroute('**/api/v2/users/me');
-    await page.reload();
+    await page.goto(`/next/event/${viewSlug}`);
     await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
     await expect(
         page
-            .getByRole('button', { name: /Date\s+Last 15 minutes/ })
+            .getByRole('button', { name: /Date\s+Last 90 days/ })
             .filter({ visible: true })
             .first()
     ).toBeVisible();
-    await expect(page.getByLabel('Unsaved view changes')).toHaveCount(0);
-    expect(
-        await page.evaluate(({ clearKey, draftKey }) => [window.localStorage.getItem(draftKey), window.localStorage.getItem(clearKey)], { clearKey, draftKey })
-    ).toEqual([null, null]);
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+    expect(await page.evaluate((key) => window.localStorage.getItem(key), draftKey)).not.toBeNull();
 });
 
 function captureFailedApiRequests(page: Page): { error: null | string; method: string; url: string }[] {

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -51,6 +51,36 @@ test('events saved view can be saved, renamed, loaded, and deleted', async ({ e2
         await expect(getVisibleText(page, journey.message)).toBeVisible();
     });
 
+    await test.step('updating a URL override clears the hidden browser-local draft', async () => {
+        await page.goto(`/next/event/${viewSlug}?time=90d`);
+        const dateFilter = page.getByRole('button', { name: /^Date/ }).filter({ visible: true }).first();
+        await dateFilter.click();
+        await page.getByRole('button', { name: 'Last 30 days' }).click();
+        await expect(page).toHaveURL(/[?&]time=30d(?:&|$)/);
+        await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+
+        await page.goto(`/next/event/${viewSlug}?time=1d`);
+        await expect(
+            page
+                .getByRole('button', { name: /Date\s+Last 24 hours/ })
+                .filter({ visible: true })
+                .first()
+        ).toBeVisible();
+        await openViewMenu(page);
+        await page.getByRole('menuitem', { exact: true, name: 'Save' }).click();
+        await expect(page.getByText(`View "${renamedViewName}" saved.`)).toBeVisible();
+        await expect(page.getByLabel('Unsaved view changes')).toHaveCount(0);
+
+        await page.goto(`/next/event/${viewSlug}`);
+        await expect(
+            page
+                .getByRole('button', { name: /Date\s+Last 24 hours/ })
+                .filter({ visible: true })
+                .first()
+        ).toBeVisible();
+        await expect(page.getByLabel('Unsaved view changes')).toHaveCount(0);
+    });
+
     await test.step('persist removal of a saved filter through reload', async () => {
         const referenceFilter = page
             .getByRole('button', { name: new RegExp(`^Reference\\s+${escapeRegExp(journey.referenceId)}`) })

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -476,6 +476,7 @@ test('stream switches to a browser-local saved view draft without mixing in-flig
             draft: {
                 filterChanges: {
                     removedKeys: [],
+                    sourceDefinitions: filterDefinitions,
                     upsertDefinitions: JSON.stringify([{ type: 'project', value: [e2eScenario.projectId] }])
                 },
                 version: 1
@@ -532,12 +533,39 @@ test('stream switches to a browser-local saved view draft without mixing in-flig
     await expect(getVisibleText(page, sourceMessage)).toBeHidden();
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
 
+    const restoredUrl = page.url();
+    const updatedFilterDefinitions = JSON.stringify([
+        { type: 'project', value: [] },
+        { type: 'status', value: ['fixed'] }
+    ]);
+    const serverUpdateResponse = await request.patch(`/api/v2/saved-views/${savedView.id}`, {
+        data: {
+            filter: 'status:fixed',
+            filter_definitions: updatedFilterDefinitions
+        },
+        headers: authorizationHeaders
+    });
+    expect(serverUpdateResponse.status()).toBe(200);
+    await expect
+        .poll(
+            async () => {
+                const response = await request.get(savedViewsPath, { headers: authorizationHeaders });
+                const views = response.ok() ? ((await response.json()) as { filter_definitions: string; id: string }[]) : [];
+                return views.find((view) => view.id === savedView.id)?.filter_definitions;
+            },
+            { timeout: 30_000 }
+        )
+        .toBe(updatedFilterDefinitions);
+
     streamRequestFilters.length = 0;
-    await page.reload();
+    await page.goto(restoredUrl);
     await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
     await expect.poll(() => streamRequestFilters.some((filter) => filter.includes(e2eScenario.projectId))).toBe(true);
     const restoredFilter = streamRequestFilters.findLast((filter) => filter.includes(e2eScenario.projectId))!;
     expect(restoredFilter.split(e2eScenario.projectId)).toHaveLength(2);
+    expect(restoredFilter).toContain('fixed');
+    expect(restoredFilter).not.toContain('open');
+    expect(restoredFilter).not.toContain('regressed');
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
     expect(failedApiRequests).toEqual([]);
 });

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -350,7 +350,7 @@ test('switching saved views preserves each view temporary filter overrides acros
     expect(failedApiRequests).toEqual([]);
 });
 
-test('stream waits for a browser-local saved view draft before loading events', async ({ e2eApi, e2eScenario, page, request }) => {
+test('stream switches to a browser-local saved view draft without mixing in-flight results', async ({ e2eApi, e2eScenario, page, request }) => {
     const failedApiRequests = captureFailedApiRequests(page);
     const suffix = e2eScenario.run.slice(-28);
     const viewName = `E2E Stream View ${suffix}`;
@@ -402,20 +402,72 @@ test('stream waits for a browser-local saved view draft before loading events', 
         }
     );
 
+    const sourceMessage = `Source stream result ${suffix}`;
+    let releaseSourceRequest!: () => void;
+    const sourceRequestRelease = new Promise<void>((resolve) => {
+        releaseSourceRequest = resolve;
+    });
+    let sourceRequestCompleted = false;
+    let sourceRequestStarted = false;
     const streamRequestFilters: string[] = [];
+    await page.route(`**/api/v2/organizations/${e2eScenario.organizationId}/events*`, async (route) => {
+        const filter = new URL(route.request().url()).searchParams.get('filter') ?? '';
+        streamRequestFilters.push(filter);
+        if (filter.includes(e2eScenario.projectId)) {
+            await route.fulfill({ body: '[]', contentType: 'application/json', status: 200 });
+            return;
+        }
+
+        sourceRequestStarted = true;
+        await sourceRequestRelease;
+        await route.fulfill({
+            body: JSON.stringify([
+                {
+                    data: { Message: sourceMessage },
+                    date: new Date().toISOString(),
+                    id: '000000000000000000000001',
+                    project_id: e2eScenario.projectId,
+                    tags: [],
+                    template_key: 'event-simple-summary'
+                }
+            ]),
+            contentType: 'application/json',
+            status: 200
+        });
+        sourceRequestCompleted = true;
+    });
+
+    await page.goto('/next/stream');
+    await expect.poll(() => sourceRequestStarted).toBe(true);
+    await navigateClientSide(page, `/next/stream?saved=${savedView.id}`);
+    releaseSourceRequest();
+    await expect.poll(() => sourceRequestCompleted).toBe(true);
+    await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await expect.poll(() => streamRequestFilters.some((filter) => filter.includes(e2eScenario.projectId))).toBe(true);
+    await expect(getVisibleText(page, sourceMessage)).toBeHidden();
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+    expect(failedApiRequests).toEqual([]);
+});
+
+test('stream loads default results when its saved-view lookup fails', async ({ e2eScenario, page }) => {
+    await page.route(`**/api/v2/organizations/${e2eScenario.organizationId}/saved-views/stream*`, async (route) => {
+        await route.fulfill({
+            body: JSON.stringify({ detail: 'Simulated saved-view failure', status: 500, title: 'Internal Server Error' }),
+            contentType: 'application/problem+json',
+            status: 500
+        });
+    });
+    const eventRequests: string[] = [];
     page.on('request', (request) => {
         const url = new URL(request.url());
         if (url.pathname === `/api/v2/organizations/${e2eScenario.organizationId}/events`) {
-            streamRequestFilters.push(url.searchParams.get('filter') ?? '');
+            eventRequests.push(request.url());
         }
     });
 
-    await page.goto(`/next/stream?saved=${savedView.id}`);
-    await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
-    await expect.poll(() => streamRequestFilters.length).toBeGreaterThan(0);
-    expect(streamRequestFilters.every((filter) => filter.includes(e2eScenario.projectId))).toBe(true);
-    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
-    expect(failedApiRequests).toEqual([]);
+    await page.goto('/next/stream?saved=unavailable-view');
+    await expect(page.getByRole('heading', { name: 'Event Stream' })).toBeVisible();
+    await expect.poll(() => eventRequests.length, { timeout: 30_000 }).toBeGreaterThan(0);
 });
 
 test('saved view loads server state when the current-user lookup fails', async ({ e2eScenario, page, request }) => {

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -115,6 +115,10 @@ test('switching saved views preserves each view temporary filter overrides acros
 
     const firstSavedViewResponse = await request.post(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views`, {
         data: {
+            columns: {
+                date: { position: 1, visible: true },
+                summary: { position: 0, visible: true }
+            },
             filter: '(status:open OR status:regressed)',
             filter_definitions: filterDefinitions('15m'),
             name: firstViewName,
@@ -173,7 +177,11 @@ test('switching saved views preserves each view temporary filter overrides acros
     const summaryWrap = columnDialog.getByRole('checkbox', { name: 'Summary wrap text' });
     await expect(summaryWrap).not.toBeChecked();
     await summaryWrap.click();
+    const moveUserUp = columnDialog.getByRole('button', { name: 'Move User up' });
+    await moveUserUp.click();
+    await moveUserUp.click();
     await columnDialog.getByRole('button', { name: 'Done' }).click();
+    await expectColumnBefore(page, 'User', 'Summary');
 
     const firstViewLink = page.getByRole('link', { exact: true, name: firstViewName }).first();
     const secondViewLink = page.getByRole('link', { exact: true, name: secondViewName }).first();
@@ -192,6 +200,7 @@ test('switching saved views preserves each view temporary filter overrides acros
     await page.getByRole('button', { name: 'Last 90 days' }).click();
     await expect(page).toHaveURL(/[?&]time=90d(?:&|$)/);
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+    await expectColumnBefore(page, 'Summary', 'User');
 
     await firstViewLink.click();
     await expect(page).toHaveURL(new RegExp(`/next/event/${escapeRegExp(firstViewSlug)}(?:[?#]|$)`));
@@ -203,6 +212,7 @@ test('switching saved views preserves each view temporary filter overrides acros
             .first()
     ).toBeVisible();
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+    await expectColumnBefore(page, 'User', 'Summary');
     await openViewMenu(page);
     await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
     await expect(summaryWrap).toBeChecked();
@@ -253,6 +263,7 @@ test('switching saved views preserves each view temporary filter overrides acros
             .first()
     ).toBeVisible();
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+    await expectColumnBefore(page, 'User', 'Summary');
     await openViewMenu(page);
     await expect(page.getByRole('menuitemcheckbox', { name: 'Chart' })).not.toBeChecked();
     await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
@@ -280,6 +291,7 @@ test('switching saved views preserves each view temporary filter overrides acros
             .first()
     ).toBeVisible();
     await expect(page.getByLabel('Unsaved view changes')).toHaveCount(0);
+    await expectColumnBefore(page, 'Summary', 'User');
     expect(failedApiRequests).toEqual([]);
 });
 
@@ -300,6 +312,17 @@ function captureFailedApiRequests(page: Page): { error: null | string; method: s
 
 function escapeRegExp(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function expectColumnBefore(page: Page, firstColumn: string, secondColumn: string): Promise<void> {
+    await expect
+        .poll(async () => {
+            const headings = await page.getByRole('columnheader').allTextContents();
+            const firstIndex = headings.findIndex((heading) => heading.trim().startsWith(firstColumn));
+            const secondIndex = headings.findIndex((heading) => heading.trim().startsWith(secondColumn));
+            return firstIndex >= 0 && secondIndex >= 0 && firstIndex < secondIndex;
+        })
+        .toBe(true);
 }
 
 async function openViewMenu(page: Page): Promise<void> {

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -202,6 +202,25 @@ test('switching saved views preserves each view temporary filter overrides acros
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
     await expectColumnBefore(page, 'Summary', 'User');
 
+    await page.goto(`/next/event/${firstViewSlug}?project=${e2eScenario.projectId}`);
+    await expect(page.getByRole('heading', { name: firstViewName })).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`[?&]project=${escapeRegExp(e2eScenario.projectId)}(?:&|$)`));
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 90 days/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await page.reload();
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 90 days/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await secondViewLink.click();
+    await expect(page.getByRole('heading', { name: secondViewName })).toBeVisible();
+
     await firstViewLink.click();
     await expect(page).toHaveURL(new RegExp(`/next/event/${escapeRegExp(firstViewSlug)}(?:[?#]|$)`));
     await expect(page.getByRole('heading', { name: firstViewName })).toBeVisible();

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -610,7 +610,7 @@ test('reset clears a browser-local draft after delayed current-user identity res
     await expect(page.getByLabel('Unsaved view changes')).toHaveCount(0);
 });
 
-test('saved view loads server state when the current-user lookup fails', async ({ e2eScenario, page, request }) => {
+test('saved view loads server state and queues draft clears when the current-user lookup fails', async ({ e2eApi, e2eScenario, page, request }) => {
     const suffix = e2eScenario.run.slice(-28);
     const viewName = `E2E User Failure ${suffix}`;
     const viewSlug = savedViewSlug(viewName);
@@ -634,6 +634,23 @@ test('saved view loads server state when the current-user lookup fails', async (
         headers: authorizationHeaders
     });
     expect(savedViewResponse.status()).toBe(201);
+    const savedView = (await savedViewResponse.json()) as { id: string };
+    const currentUser = await e2eApi.getCurrentUser(e2eScenario.userToken);
+    expect(currentUser).toBeDefined();
+    const draftKey = `exceptionless:saved-view-draft:v1:${currentUser!.id}:${e2eScenario.organizationId}:${savedView.id}`;
+    const clearKey = `exceptionless:saved-view-draft-clear:v1:${e2eScenario.organizationId}:${savedView.id}`;
+    await page.addInitScript(({ draft, key }) => window.localStorage.setItem(key, JSON.stringify(draft)), {
+        draft: {
+            filterChanges: {
+                baselineDefinitions: '[{"term":"date","type":"date","value":"[now-15m TO now]"}]',
+                removedDefinitions: '[{"term":"date","type":"date","value":"[now-15m TO now]"}]',
+                removedKeys: [],
+                upsertDefinitions: '[{"term":"date","type":"date","value":"[now-90d TO now]"}]'
+            },
+            version: 1
+        },
+        key: draftKey
+    });
 
     const savedViewsPath = `/api/v2/organizations/${e2eScenario.organizationId}/saved-views/events`;
     await expect
@@ -661,9 +678,25 @@ test('saved view loads server state when the current-user lookup fails', async (
         }
     });
 
-    await page.goto(`/next/event/${viewSlug}`);
+    await page.goto(`/next/event/${viewSlug}?time=1d`);
     await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
     await expect.poll(() => eventRequests.length, { timeout: 30_000 }).toBeGreaterThan(0);
+    await openViewMenu(page);
+    await page.getByRole('menuitem', { name: 'Reset to Saved' }).click();
+
+    await page.unroute('**/api/v2/users/me');
+    await page.reload();
+    await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 15 minutes/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await expect(page.getByLabel('Unsaved view changes')).toHaveCount(0);
+    expect(
+        await page.evaluate(({ clearKey, draftKey }) => [window.localStorage.getItem(draftKey), window.localStorage.getItem(clearKey)], { clearKey, draftKey })
+    ).toEqual([null, null]);
 });
 
 function captureFailedApiRequests(page: Page): { error: null | string; method: string; url: string }[] {

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -686,9 +686,11 @@ test('stream switches to a browser-local saved view draft without mixing in-flig
     streamRequestFilters.length = 0;
     await page.goto(`/next/stream?saved=${savedView.id}&filter=${encodeURIComponent(draftExpression)}`);
     await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Status Fixed' })).toHaveCount(0);
     await expect.poll(() => streamRequestFilters.some((filter) => filter.includes(draftExpression))).toBe(true);
     const explicitFilter = streamRequestFilters.findLast((filter) => filter.includes(draftExpression))!;
-    expect(explicitFilter).toContain('fixed');
+    expect(explicitFilter).not.toContain('fixed');
     expect(explicitFilter).not.toContain(remoteExpression);
     expect(failedApiRequests).toEqual([]);
 });

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -266,7 +266,7 @@ test('switching saved views preserves each view temporary filter overrides acros
 
     await firstViewLink.click();
     await expect(page).toHaveURL(new RegExp(`/next/event/${escapeRegExp(firstViewSlug)}(?:[?#]|$)`));
-    await expect(page).toHaveURL(/[?&]status=regressed(?:&|$)/);
+    await expect(page).not.toHaveURL(/[?&]status=/);
     await expect(page).not.toHaveURL(/[?&]project=/);
     await expect(page).not.toHaveURL(/[?&]sort=/);
     await expect(page.getByRole('heading', { name: firstViewName })).toBeVisible();
@@ -295,7 +295,7 @@ test('switching saved views preserves each view temporary filter overrides acros
             .filter({ visible: true })
             .first()
     ).toBeVisible();
-    await expect(page).toHaveURL(/[?&]status=regressed(?:&|$)/);
+    await expect(page).not.toHaveURL(/[?&]status=/);
 
     await openViewMenu(page);
     await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -202,9 +202,10 @@ test('switching saved views preserves each view temporary filter overrides acros
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
     await expectColumnBefore(page, 'Summary', 'User');
 
-    await page.goto(`/next/event/${firstViewSlug}?project=${e2eScenario.projectId}`);
+    await page.goto(`/next/event/${firstViewSlug}?project=${e2eScenario.projectId}&sort=type&status=open`);
     await expect(page.getByRole('heading', { name: firstViewName })).toBeVisible();
     await expect(page).toHaveURL(new RegExp(`[?&]project=${escapeRegExp(e2eScenario.projectId)}(?:&|$)`));
+    await expect(page).toHaveURL(/[?&]sort=type(?:&|$)/);
     await expect(
         page
             .getByRole('button', { name: /Date\s+Last 90 days/ })
@@ -218,11 +219,16 @@ test('switching saved views preserves each view temporary filter overrides acros
             .filter({ visible: true })
             .first()
     ).toBeVisible();
+    await navigateClientSide(page, `/next/event/${firstViewSlug}?project=${e2eScenario.projectId}&sort=type&status=regressed&time=90d`);
+    await expect(page).toHaveURL(/[?&]status=regressed(?:&|$)/);
     await secondViewLink.click();
     await expect(page.getByRole('heading', { name: secondViewName })).toBeVisible();
 
     await firstViewLink.click();
     await expect(page).toHaveURL(new RegExp(`/next/event/${escapeRegExp(firstViewSlug)}(?:[?#]|$)`));
+    await expect(page).toHaveURL(/[?&]status=regressed(?:&|$)/);
+    await expect(page).not.toHaveURL(/[?&]project=/);
+    await expect(page).not.toHaveURL(/[?&]sort=/);
     await expect(page.getByRole('heading', { name: firstViewName })).toBeVisible();
     await expect(
         page
@@ -342,6 +348,15 @@ async function expectColumnBefore(page: Page, firstColumn: string, secondColumn:
             return firstIndex >= 0 && secondIndex >= 0 && firstIndex < secondIndex;
         })
         .toBe(true);
+}
+
+async function navigateClientSide(page: Page, href: string): Promise<void> {
+    await page.evaluate((target) => {
+        const link = document.createElement('a');
+        link.href = target;
+        document.body.append(link);
+        link.click();
+    }, href);
 }
 
 async function openViewMenu(page: Page): Promise<void> {

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -622,6 +622,63 @@ test('reset clears a browser-local draft after delayed current-user identity res
     await expect(page.getByLabel('Unsaved view changes')).toHaveCount(0);
 });
 
+test('filter edits made before current-user identity resolves become browser-local drafts', async ({ e2eApi, e2eScenario, page, request }) => {
+    const suffix = e2eScenario.run.slice(-28);
+    const viewName = `E2E Delayed Edit ${suffix}`;
+    const viewSlug = savedViewSlug(viewName);
+    const authorizationHeaders = { Authorization: `Bearer ${e2eScenario.userToken}` };
+    const savedViewResponse = await request.post(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views`, {
+        data: {
+            filter: '(status:open OR status:regressed)',
+            filter_definitions: JSON.stringify([
+                { term: 'date', type: 'date', value: '[now-15m TO now]' },
+                { type: 'project', value: [] },
+                { type: 'status', value: ['open', 'regressed'] }
+            ]),
+            name: viewName,
+            organization_id: e2eScenario.organizationId,
+            slug: viewSlug,
+            time: '[now-15m TO now]',
+            view_type: 'events'
+        },
+        headers: authorizationHeaders
+    });
+    expect(savedViewResponse.status()).toBe(201);
+    const savedView = (await savedViewResponse.json()) as { id: string };
+    const currentUser = await e2eApi.getCurrentUser(e2eScenario.userToken);
+    expect(currentUser).toBeDefined();
+    const draftKey = `exceptionless:saved-view-draft:v1:${currentUser!.id}:${e2eScenario.organizationId}:${savedView.id}`;
+
+    let releaseCurrentUser!: () => void;
+    const currentUserRelease = new Promise<void>((resolve) => {
+        releaseCurrentUser = resolve;
+    });
+    await page.route('**/api/v2/users/me', async (route) => {
+        await currentUserRelease;
+        await route.continue();
+    });
+
+    await page.goto(`/next/event/${viewSlug}`);
+    await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await page.getByRole('button', { name: /^Date/ }).filter({ visible: true }).first().click();
+    await page.getByRole('button', { name: 'Last 90 days' }).click();
+    await expect(page).toHaveURL(/[?&]time=90d(?:&|$)/);
+
+    releaseCurrentUser();
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+    await expect.poll(() => page.evaluate((key) => window.localStorage.getItem(key), draftKey)).not.toBeNull();
+
+    await page.goto(`/next/event/${viewSlug}`);
+    await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 90 days/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+});
+
 test('saved view loads server state and protects drafts when the current-user lookup fails', async ({ e2eApi, e2eScenario, page, request }) => {
     const suffix = e2eScenario.run.slice(-28);
     const viewName = `E2E User Failure ${suffix}`;

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -532,6 +532,70 @@ test('stream loads default results when its saved-view lookup fails', async ({ e
     await expect.poll(() => eventRequests.length, { timeout: 30_000 }).toBeGreaterThan(0);
 });
 
+test('reset clears a browser-local draft after delayed current-user identity resolves', async ({ e2eApi, e2eScenario, page, request }) => {
+    const suffix = e2eScenario.run.slice(-28);
+    const viewName = `E2E Delayed Reset ${suffix}`;
+    const viewSlug = savedViewSlug(viewName);
+    const authorizationHeaders = { Authorization: `Bearer ${e2eScenario.userToken}` };
+    const savedViewResponse = await request.post(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views`, {
+        data: {
+            filter: '(status:open OR status:regressed)',
+            filter_definitions: JSON.stringify([
+                { term: 'date', type: 'date', value: '[now-15m TO now]' },
+                { type: 'project', value: [] },
+                { type: 'status', value: ['open', 'regressed'] }
+            ]),
+            name: viewName,
+            organization_id: e2eScenario.organizationId,
+            slug: viewSlug,
+            time: '[now-15m TO now]',
+            view_type: 'events'
+        },
+        headers: authorizationHeaders
+    });
+    expect(savedViewResponse.status()).toBe(201);
+    const savedView = (await savedViewResponse.json()) as { id: string };
+    const currentUser = await e2eApi.getCurrentUser(e2eScenario.userToken);
+    expect(currentUser).toBeDefined();
+
+    await page.addInitScript(({ draft, key }) => window.localStorage.setItem(key, JSON.stringify(draft)), {
+        draft: {
+            filterChanges: {
+                baselineDefinitions: '[{"term":"date","type":"date","value":"[now-15m TO now]"}]',
+                removedDefinitions: '[{"term":"date","type":"date","value":"[now-15m TO now]"}]',
+                removedKeys: [],
+                upsertDefinitions: '[{"term":"date","type":"date","value":"[now-90d TO now]"}]'
+            },
+            version: 1
+        },
+        key: `exceptionless:saved-view-draft:v1:${currentUser!.id}:${e2eScenario.organizationId}:${savedView.id}`
+    });
+
+    let releaseCurrentUser!: () => void;
+    const currentUserRelease = new Promise<void>((resolve) => {
+        releaseCurrentUser = resolve;
+    });
+    await page.route('**/api/v2/users/me', async (route) => {
+        await currentUserRelease;
+        await route.continue();
+    });
+
+    await page.goto(`/next/event/${viewSlug}?time=1d`);
+    await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await openViewMenu(page);
+    await page.getByRole('menuitem', { name: 'Reset to Saved' }).click();
+    await expect(page).not.toHaveURL(/[?&]time=/);
+    releaseCurrentUser();
+
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 15 minutes/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await expect(page.getByLabel('Unsaved view changes')).toHaveCount(0);
+});
+
 test('saved view loads server state when the current-user lookup fails', async ({ e2eScenario, page, request }) => {
     const suffix = e2eScenario.run.slice(-28);
     const viewName = `E2E User Failure ${suffix}`;

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -432,6 +432,93 @@ test('switching saved views preserves each view temporary filter overrides acros
     expect(failedApiRequests).toEqual([]);
 });
 
+test('save completion does not overwrite a newly active saved view', async ({ e2eScenario, page, request }) => {
+    const suffix = e2eScenario.run.slice(-28);
+    const firstViewName = `E2E Save Race A ${suffix}`;
+    const secondViewName = `E2E Save Race B ${suffix}`;
+    const firstViewSlug = savedViewSlug(firstViewName);
+    const secondViewSlug = savedViewSlug(secondViewName);
+    const authorizationHeaders = { Authorization: `Bearer ${e2eScenario.userToken}` };
+    const createView = (name: string, slug: string, time: string) =>
+        request.post(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views`, {
+            data: {
+                filter: '(status:open OR status:regressed)',
+                filter_definitions: JSON.stringify([
+                    { term: 'date', type: 'date', value: `[now-${time} TO now]` },
+                    { type: 'project', value: [] },
+                    { type: 'status', value: ['open', 'regressed'] }
+                ]),
+                name,
+                organization_id: e2eScenario.organizationId,
+                slug,
+                time: `[now-${time} TO now]`,
+                view_type: 'events'
+            },
+            headers: authorizationHeaders
+        });
+
+    const firstViewResponse = await createView(firstViewName, firstViewSlug, '15m');
+    expect(firstViewResponse.status()).toBe(201);
+    const firstView = (await firstViewResponse.json()) as { id: string };
+    const secondViewResponse = await createView(secondViewName, secondViewSlug, '1d');
+    expect(secondViewResponse.status()).toBe(201);
+    const savedViewsPath = `/api/v2/organizations/${e2eScenario.organizationId}/saved-views/events`;
+    await expect
+        .poll(async () => {
+            const response = await request.get(savedViewsPath, { headers: authorizationHeaders });
+            const names = response.ok() ? ((await response.json()) as { name: string }[]).map((view) => view.name) : [];
+            return names.includes(firstViewName) && names.includes(secondViewName);
+        })
+        .toBe(true);
+
+    await page.goto(`/next/event/${firstViewSlug}`);
+    await expect(page.getByRole('heading', { name: firstViewName })).toBeVisible();
+    await page.getByRole('button', { name: /^Date/ }).filter({ visible: true }).first().click();
+    await page.getByRole('button', { name: 'Last 90 days' }).click();
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+
+    let releaseSave!: () => void;
+    let markSaveStarted!: () => void;
+    const saveStarted = new Promise<void>((resolve) => {
+        markSaveStarted = resolve;
+    });
+    const saveRelease = new Promise<void>((resolve) => {
+        releaseSave = resolve;
+    });
+    await page.route(`**/api/v2/saved-views/${firstView.id}`, async (route) => {
+        if (route.request().method() !== 'PATCH') {
+            await route.continue();
+            return;
+        }
+
+        markSaveStarted();
+        await saveRelease;
+        await route.continue();
+    });
+
+    await openViewMenu(page);
+    await page.getByRole('menuitem', { exact: true, name: 'Save' }).click();
+    await saveStarted;
+    const secondViewRequestTimes: string[] = [];
+    page.on('request', (eventRequest) => {
+        const url = new URL(eventRequest.url());
+        if (url.pathname === `/api/v2/organizations/${e2eScenario.organizationId}/events`) {
+            secondViewRequestTimes.push(url.searchParams.get('time') ?? '');
+        }
+    });
+    await page.getByRole('link', { exact: true, name: secondViewName }).first().click();
+    await expect(page.getByRole('heading', { name: secondViewName })).toBeVisible();
+    await expect.poll(() => secondViewRequestTimes.some((time) => time.includes('now-1d'))).toBe(true);
+    const saveCompleted = page.waitForResponse(
+        (response) => response.request().method() === 'PATCH' && new URL(response.url()).pathname === `/api/v2/saved-views/${firstView.id}`
+    );
+    releaseSave();
+    await saveCompleted;
+    await page.getByRole('button', { name: /^Date/ }).filter({ visible: true }).first().click();
+    await page.getByRole('button', { name: 'Last 7 days' }).click();
+    await expect.poll(() => secondViewRequestTimes.some((time) => time.includes('now-7d'))).toBe(true);
+});
+
 test('stream switches to a browser-local saved view draft without mixing in-flight results', async ({ e2eApi, e2eScenario, page, request }) => {
     const failedApiRequests = captureFailedApiRequests(page);
     const suffix = e2eScenario.run.slice(-28);
@@ -684,6 +771,17 @@ test('filter edits made before current-user identity resolves become browser-loc
     const currentUser = await e2eApi.getCurrentUser(e2eScenario.userToken);
     expect(currentUser).toBeDefined();
     const draftKey = `exceptionless:saved-view-draft:v1:${currentUser!.id}:${e2eScenario.organizationId}:${savedView.id}`;
+    await page.addInitScript(
+        ({ key, marker }) => {
+            if (window.sessionStorage.getItem(marker)) {
+                return;
+            }
+
+            window.localStorage.setItem(key, JSON.stringify({ showChart: false, version: 1 }));
+            window.sessionStorage.setItem(marker, 'true');
+        },
+        { key: draftKey, marker: `${draftKey}:seeded` }
+    );
 
     let releaseCurrentUser!: () => void;
     const currentUserRelease = new Promise<void>((resolve) => {
@@ -696,6 +794,14 @@ test('filter edits made before current-user identity resolves become browser-loc
 
     await page.goto(`/next/event/${viewSlug}`);
     await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await openViewMenu(page);
+    const chartMenuItem = page.getByRole('menuitemcheckbox', { name: 'Chart' });
+    await expect(chartMenuItem).toBeChecked();
+    await chartMenuItem.click();
+    await expect(chartMenuItem).not.toBeChecked();
+    await chartMenuItem.click();
+    await expect(chartMenuItem).toBeChecked();
+    await page.keyboard.press('Escape');
     await page.getByRole('button', { name: /^Date/ }).filter({ visible: true }).first().click();
     await page.getByRole('button', { name: 'Last 90 days' }).click();
     await expect(page).toHaveURL(/[?&]time=90d(?:&|$)/);
@@ -703,9 +809,31 @@ test('filter edits made before current-user identity resolves become browser-loc
     releaseCurrentUser();
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
     await expect.poll(() => page.evaluate((key) => window.localStorage.getItem(key), draftKey)).not.toBeNull();
+    await openViewMenu(page);
+    await expect(page.getByRole('menuitemcheckbox', { name: 'Chart' })).toBeChecked();
+    await page.keyboard.press('Escape');
+    await expect
+        .poll(async () => JSON.parse((await page.evaluate((key) => window.localStorage.getItem(key), draftKey)) ?? '{}') as { showChart?: boolean })
+        .not.toHaveProperty('showChart');
+    await expect
+        .poll(async () => {
+            const draft = JSON.parse((await page.evaluate((key) => window.localStorage.getItem(key), draftKey)) ?? '{}') as {
+                filterChanges?: { upsertDefinitions?: string };
+            };
+            return draft.filterChanges?.upsertDefinitions;
+        })
+        .toContain('now-90d');
 
     await page.goto(`/next/event/${viewSlug}`);
     await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await expect
+        .poll(async () => {
+            const draft = JSON.parse((await page.evaluate((key) => window.localStorage.getItem(key), draftKey)) ?? '{}') as {
+                filterChanges?: { upsertDefinitions?: string };
+            };
+            return draft.filterChanges?.upsertDefinitions;
+        })
+        .toContain('now-90d');
     await expect(
         page
             .getByRole('button', { name: /Date\s+Last 90 days/ })

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -116,6 +116,14 @@ test('switching saved views preserves each view temporary filter overrides acros
     await page.getByRole('button', { name: 'Last 90 days' }).click();
     await expect(page).toHaveURL(/[?&]time=90d(?:&|$)/);
 
+    await openViewMenu(page);
+    await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
+    const columnDialog = page.getByRole('dialog', { name: 'Column Picker' });
+    const summaryWrap = columnDialog.getByRole('checkbox', { name: 'Summary wrap text' });
+    await expect(summaryWrap).not.toBeChecked();
+    await summaryWrap.click();
+    await columnDialog.getByRole('button', { name: 'Done' }).click();
+
     const firstViewLink = page.getByRole('link', { exact: true, name: firstViewName }).first();
     const secondViewLink = page.getByRole('link', { exact: true, name: secondViewName }).first();
 
@@ -144,6 +152,10 @@ test('switching saved views preserves each view temporary filter overrides acros
             .first()
     ).toBeVisible();
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+    await openViewMenu(page);
+    await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
+    await expect(summaryWrap).toBeChecked();
+    await columnDialog.getByRole('button', { name: 'Done' }).click();
 
     await secondViewLink.click();
     await expect(page).toHaveURL(new RegExp(`/next/event/${escapeRegExp(secondViewSlug)}(?:[?#]|$)`));
@@ -155,6 +167,10 @@ test('switching saved views preserves each view temporary filter overrides acros
             .first()
     ).toBeVisible();
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+    await openViewMenu(page);
+    await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
+    await expect(summaryWrap).not.toBeChecked();
+    await columnDialog.getByRole('button', { name: 'Done' }).click();
 
     await page.reload();
     await expect(page.getByRole('heading', { name: secondViewName })).toBeVisible();
@@ -176,6 +192,10 @@ test('switching saved views preserves each view temporary filter overrides acros
             .first()
     ).toBeVisible();
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+    await openViewMenu(page);
+    await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
+    await expect(summaryWrap).toBeChecked();
+    await columnDialog.getByRole('button', { name: 'Done' }).click();
 
     await openViewMenu(page);
     await page.getByRole('menuitem', { name: 'Reset to Saved' }).click();

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -202,6 +202,35 @@ test('switching saved views preserves each view temporary filter overrides acros
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
     await expectColumnBefore(page, 'Summary', 'User');
 
+    await firstViewLink.click();
+    await expect(page.getByRole('heading', { name: firstViewName })).toBeVisible();
+    await page.evaluate(
+        ({ firstHref, secondHref }) => {
+            const navigate = (href: string) => {
+                const link = document.createElement('a');
+                link.href = href;
+                document.body.append(link);
+                link.click();
+            };
+
+            navigate(secondHref);
+            setTimeout(() => navigate(firstHref), 0);
+        },
+        {
+            firstHref: `/next/event/${firstViewSlug}`,
+            secondHref: `/next/event/${secondViewSlug}`
+        }
+    );
+    await page.waitForTimeout(100);
+    await expect(page.getByRole('heading', { name: firstViewName })).toBeVisible();
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 90 days/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await expectColumnBefore(page, 'User', 'Summary');
+
     const coldLoadEventTimes: string[] = [];
     const captureColdLoadEventTime = (request: Request) => {
         const url = new URL(request.url());

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -97,7 +97,7 @@ test('events saved view can be saved, renamed, loaded, and deleted', async ({ e2
     expect(failedApiRequests).toEqual([]);
 });
 
-test('switching saved views discards temporary filter overrides', async ({ e2eApi, e2eScenario, page }) => {
+test('switching saved views preserves each view temporary filter overrides across page reloads', async ({ e2eApi, e2eScenario, page }) => {
     const failedApiRequests = captureFailedApiRequests(page);
     const journey = ExceptionlessE2EJourney.fromScenario(page, e2eApi, e2eScenario);
     const suffix = journey.run.slice(-28);
@@ -116,7 +116,10 @@ test('switching saved views discards temporary filter overrides', async ({ e2eAp
     await page.getByRole('button', { name: 'Last 90 days' }).click();
     await expect(page).toHaveURL(/[?&]time=90d(?:&|$)/);
 
-    await page.getByRole('link', { exact: true, name: secondViewName }).first().click();
+    const firstViewLink = page.getByRole('link', { exact: true, name: firstViewName }).first();
+    const secondViewLink = page.getByRole('link', { exact: true, name: secondViewName }).first();
+
+    await secondViewLink.click();
     await expect(page).toHaveURL(new RegExp(`/next/event/${escapeRegExp(secondViewSlug)}(?:[?#]|$)`));
     await expect(page.getByRole('heading', { name: secondViewName })).toBeVisible();
     await expect(
@@ -125,6 +128,76 @@ test('switching saved views discards temporary filter overrides', async ({ e2eAp
             .filter({ visible: true })
             .first()
     ).toBeVisible();
+
+    await dateFilter.click();
+    await page.getByRole('button', { name: 'Last 90 days' }).click();
+    await expect(page).toHaveURL(/[?&]time=90d(?:&|$)/);
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+
+    await firstViewLink.click();
+    await expect(page).toHaveURL(new RegExp(`/next/event/${escapeRegExp(firstViewSlug)}(?:[?#]|$)`));
+    await expect(page.getByRole('heading', { name: firstViewName })).toBeVisible();
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 90 days/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+
+    await secondViewLink.click();
+    await expect(page).toHaveURL(new RegExp(`/next/event/${escapeRegExp(secondViewSlug)}(?:[?#]|$)`));
+    await expect(page.getByRole('heading', { name: secondViewName })).toBeVisible();
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 90 days/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByRole('heading', { name: secondViewName })).toBeVisible();
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 90 days/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+    await firstViewLink.click();
+    await expect(page).toHaveURL(new RegExp(`/next/event/${escapeRegExp(firstViewSlug)}(?:[?#]|$)`));
+    await expect(page).toHaveURL(/[?&]time=90d(?:&|$)/);
+    await expect(page.getByRole('heading', { name: firstViewName })).toBeVisible();
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 90 days/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+
+    await openViewMenu(page);
+    await page.getByRole('menuitem', { name: 'Reset to Saved' }).click();
+    await expect(page).not.toHaveURL(/[?&]time=90d(?:&|$)/);
+    await secondViewLink.click();
+    await expect(page.getByRole('heading', { name: secondViewName })).toBeVisible();
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 90 days/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+    await firstViewLink.click();
+    await expect(page.getByRole('heading', { name: firstViewName })).toBeVisible();
+    await expect(
+        page
+            .getByRole('button', { name: /Date\s+Last 15 minutes/ })
+            .filter({ visible: true })
+            .first()
+    ).toBeVisible();
+    await expect(page.getByLabel('Unsaved view changes')).toHaveCount(0);
     expect(failedApiRequests).toEqual([]);
 });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
@@ -11,6 +11,7 @@ import {
     getSavedColumnSizing,
     getSavedColumnVisibility,
     getSavedWrappedColumnIds,
+    resolveAvailableColumnOrder,
     resolveSavedViewColumnOrder,
     savedViewColumnSizingEqual,
     savedViewColumnWrappingEqual
@@ -117,6 +118,15 @@ describe('saved view column settings', () => {
         } as Pick<SavedView, 'columns'>;
         const currentOrder = ['select', 'user', 'summary', 'date'];
         expect(columnOrdersEqual(currentOrder, resolveSavedViewColumnOrder(savedAfterReorder, currentOrder))).toBe(true);
+    });
+
+    it('drops unavailable draft columns and includes newly available columns', () => {
+        expect(resolveAvailableColumnOrder(['select', 'removed', 'summary'], ['select', 'project', 'summary', 'date'])).toEqual([
+            'select',
+            'summary',
+            'project',
+            'date'
+        ]);
     });
 
     it('treats missing wrap settings as the legacy single-line behavior', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
@@ -11,6 +11,7 @@ import {
     getSavedColumnSizing,
     getSavedColumnVisibility,
     getSavedWrappedColumnIds,
+    resolveSavedViewColumnOrder,
     savedViewColumnSizingEqual,
     savedViewColumnWrappingEqual
 } from './column-settings';
@@ -95,6 +96,27 @@ describe('saved view column settings', () => {
 
         expect(columnOrdersEqual(['project', 'summary', 'new-column'], hydratedOrder)).toBe(true);
         expect(columnOrdersEqual(['select', 'new-column', 'project', 'summary'], hydratedOrder)).toBe(false);
+    });
+
+    it('resolves saved positions against all currently available columns', () => {
+        const view = {
+            columns: {
+                date: { position: 1 },
+                summary: { position: 0 }
+            }
+        } as Pick<SavedView, 'columns'>;
+
+        expect(resolveSavedViewColumnOrder(view, ['select', 'user', 'summary', 'date'])).toEqual(['select', 'summary', 'date', 'user']);
+
+        const savedAfterReorder = {
+            columns: {
+                date: { position: 2 },
+                summary: { position: 1 },
+                user: { position: 0 }
+            }
+        } as Pick<SavedView, 'columns'>;
+        const currentOrder = ['select', 'user', 'summary', 'date'];
+        expect(columnOrdersEqual(currentOrder, resolveSavedViewColumnOrder(savedAfterReorder, currentOrder))).toBe(true);
     });
 
     it('treats missing wrap settings as the legacy single-line behavior', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
@@ -139,6 +139,15 @@ describe('saved view column settings', () => {
         expect(filterAvailableColumnIds(['removed', 'summary', 'summary'], availableColumnIds)).toEqual(['summary']);
         expect(resolveAvailableAutoFillColumnSelection('removed', availableColumnIds, 'summary')).toBe('summary');
         expect(resolveAvailableAutoFillColumnSelection('removed', availableColumnIds)).toBeNull();
+
+        const view = {
+            columns: {
+                removed: { width: 480, wrap: true },
+                summary: { width: 360, wrap: true }
+            }
+        } as Pick<SavedView, 'columns'>;
+        expect(savedViewColumnSizingEqual({ summary: 360 }, view, availableColumnIds)).toBe(true);
+        expect(savedViewColumnWrappingEqual(['summary'], view, availableColumnIds)).toBe(true);
     });
 
     it('treats missing wrap settings as the legacy single-line behavior', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
@@ -4,13 +4,13 @@ import type { SavedView } from './models';
 
 import {
     buildColumnSettings,
+    columnOrdersEqual,
     getSavedAutoFillColumnId,
     getSavedAutoFillColumnSelection,
     getSavedColumnOrder,
     getSavedColumnSizing,
     getSavedColumnVisibility,
     getSavedWrappedColumnIds,
-    savedViewColumnOrderEqual,
     savedViewColumnSizingEqual,
     savedViewColumnWrappingEqual
 } from './column-settings';
@@ -89,27 +89,11 @@ describe('saved view column settings', () => {
         expect(savedViewColumnSizingEqual({}, view)).toBe(false);
     });
 
-    it('compares only columns with explicitly saved positions', () => {
-        const view = {
-            columns: {
-                date: { visible: true },
-                project: { position: 0 },
-                summary: { position: 1 }
-            }
-        } as Pick<SavedView, 'columns'>;
+    it('compares complete resolved orders including columns added after the saved view', () => {
+        const hydratedOrder = ['select', 'project', 'summary', 'new-column'];
 
-        expect(savedViewColumnOrderEqual(['select', 'project', 'date', 'summary', 'tags'], view)).toBe(true);
-        expect(savedViewColumnOrderEqual(['select', 'summary', 'date', 'project', 'tags'], view)).toBe(false);
-    });
-
-    it('treats views without saved positions as unchanged', () => {
-        const view = {
-            columns: {
-                project: { visible: true }
-            }
-        } as Pick<SavedView, 'columns'>;
-
-        expect(savedViewColumnOrderEqual(['select', 'date', 'project'], view)).toBe(true);
+        expect(columnOrdersEqual(['project', 'summary', 'new-column'], hydratedOrder)).toBe(true);
+        expect(columnOrdersEqual(['select', 'new-column', 'project', 'summary'], hydratedOrder)).toBe(false);
     });
 
     it('treats missing wrap settings as the legacy single-line behavior', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
@@ -5,12 +5,15 @@ import type { SavedView } from './models';
 import {
     buildColumnSettings,
     columnOrdersEqual,
+    filterAvailableColumnIds,
+    filterAvailableColumnRecord,
     getSavedAutoFillColumnId,
     getSavedAutoFillColumnSelection,
     getSavedColumnOrder,
     getSavedColumnSizing,
     getSavedColumnVisibility,
     getSavedWrappedColumnIds,
+    resolveAvailableAutoFillColumnSelection,
     resolveAvailableColumnOrder,
     resolveSavedViewColumnOrder,
     savedViewColumnSizingEqual,
@@ -127,6 +130,15 @@ describe('saved view column settings', () => {
             'project',
             'date'
         ]);
+    });
+
+    it('drops unavailable IDs from restored column-scoped settings', () => {
+        const availableColumnIds = ['select', 'project', 'summary'];
+
+        expect(filterAvailableColumnRecord({ removed: 480, summary: 360 }, availableColumnIds)).toEqual({ summary: 360 });
+        expect(filterAvailableColumnIds(['removed', 'summary', 'summary'], availableColumnIds)).toEqual(['summary']);
+        expect(resolveAvailableAutoFillColumnSelection('removed', availableColumnIds, 'summary')).toBe('summary');
+        expect(resolveAvailableAutoFillColumnSelection('removed', availableColumnIds)).toBeNull();
     });
 
     it('treats missing wrap settings as the legacy single-line behavior', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.test.ts
@@ -85,6 +85,7 @@ describe('saved view column settings', () => {
         } as Pick<SavedView, 'columns'>;
 
         expect(savedViewColumnSizingEqual({ project: 360 }, view)).toBe(true);
+        expect(savedViewColumnSizingEqual({ project: 359.6 }, view)).toBe(true);
         expect(savedViewColumnSizingEqual({ project: 420 }, view)).toBe(false);
         expect(savedViewColumnSizingEqual({}, view)).toBe(false);
     });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
@@ -150,17 +150,21 @@ export function resolveSavedViewColumnOrder(view: SavedColumnState, availableOrd
     return resolveAvailableColumnOrder(getSavedColumnOrder(view), availableOrder);
 }
 
-export function savedViewColumnSizingEqual(current: ColumnSizingState | undefined, view: SavedColumnState): boolean {
-    const saved = getSavedColumnSizing(view);
-    const currentEntries = Object.entries(normalizeColumnSizing(current));
+export function savedViewColumnSizingEqual(current: ColumnSizingState | undefined, view: SavedColumnState, availableColumnIds?: readonly string[]): boolean {
+    const savedSizing = getSavedColumnSizing(view);
+    const saved = availableColumnIds ? filterAvailableColumnRecord(savedSizing, availableColumnIds) : savedSizing;
+    const normalizedCurrent = normalizeColumnSizing(current);
+    const resolvedCurrent = availableColumnIds ? filterAvailableColumnRecord(normalizedCurrent, availableColumnIds) : normalizedCurrent;
+    const currentEntries = Object.entries(resolvedCurrent);
     const savedEntries = Object.entries(saved);
 
     return currentEntries.length === savedEntries.length && currentEntries.every(([columnId, width]) => saved[columnId] === width);
 }
 
-export function savedViewColumnWrappingEqual(current: readonly string[] | undefined, view: SavedColumnState): boolean {
-    const saved = getSavedWrappedColumnIds(view);
-    const currentIds = [...new Set(current ?? [])];
+export function savedViewColumnWrappingEqual(current: readonly string[] | undefined, view: SavedColumnState, availableColumnIds?: readonly string[]): boolean {
+    const savedIds = getSavedWrappedColumnIds(view);
+    const saved = availableColumnIds ? filterAvailableColumnIds(savedIds, availableColumnIds) : savedIds;
+    const currentIds = availableColumnIds ? filterAvailableColumnIds(current ?? [], availableColumnIds) : [...new Set(current ?? [])];
 
     return currentIds.length === saved.length && currentIds.every((columnId) => saved.includes(columnId));
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
@@ -40,6 +40,13 @@ export function buildColumnSettings(
     );
 }
 
+export function columnOrdersEqual(left: ColumnOrderState | undefined, right: ColumnOrderState | undefined): boolean {
+    const normalizedLeft = (left ?? []).filter((columnId) => columnId !== 'select');
+    const normalizedRight = (right ?? []).filter((columnId) => columnId !== 'select');
+
+    return normalizedLeft.length === normalizedRight.length && normalizedLeft.every((columnId, index) => columnId === normalizedRight[index]);
+}
+
 export function getSavedAutoFillColumnId(view: SavedColumnState | undefined): string | undefined {
     return Object.entries(view?.columns ?? {}).find(([, settings]) => settings.auto_fill === true)?.[0];
 }
@@ -92,14 +99,6 @@ export function getSavedWrappedColumnIds(view: SavedColumnState | undefined): Wr
     return Object.entries(view?.columns ?? {})
         .filter(([, settings]) => settings.wrap === true)
         .map(([columnId]) => columnId);
-}
-
-export function savedViewColumnOrderEqual(current: ColumnOrderState | undefined, view: SavedColumnState): boolean {
-    const savedOrder = getSavedColumnOrder(view);
-    const savedColumnIds = new Set(savedOrder);
-    const currentSavedOrder = (current ?? []).filter((columnId) => columnId !== 'select' && savedColumnIds.has(columnId));
-
-    return currentSavedOrder.length === savedOrder.length && currentSavedOrder.every((columnId, index) => columnId === savedOrder[index]);
 }
 
 export function savedViewColumnSizingEqual(current: ColumnSizingState | undefined, view: SavedColumnState): boolean {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
@@ -109,14 +109,18 @@ export function normalizeColumnSizing(sizing: ColumnSizingState | undefined): Co
     );
 }
 
-export function resolveSavedViewColumnOrder(view: SavedColumnState, availableOrder: ColumnOrderState | undefined): ColumnOrderState {
+export function resolveAvailableColumnOrder(preferredOrder: ColumnOrderState, availableOrder: ColumnOrderState | undefined): ColumnOrderState {
     const hasSelectionColumn = availableOrder?.includes('select') ?? false;
     const availableColumnIds = [...new Set((availableOrder ?? []).filter((columnId) => columnId !== 'select'))];
     const availableColumnIdSet = new Set(availableColumnIds);
-    const savedOrder = getSavedColumnOrder(view).filter((columnId) => availableColumnIdSet.has(columnId));
-    const resolvedOrder = [...savedOrder, ...availableColumnIds.filter((columnId) => !savedOrder.includes(columnId))];
+    const resolvedPreferredOrder = preferredOrder.filter((columnId, index) => availableColumnIdSet.has(columnId) && preferredOrder.indexOf(columnId) === index);
+    const resolvedOrder = [...resolvedPreferredOrder, ...availableColumnIds.filter((columnId) => !resolvedPreferredOrder.includes(columnId))];
 
     return hasSelectionColumn ? ['select', ...resolvedOrder] : resolvedOrder;
+}
+
+export function resolveSavedViewColumnOrder(view: SavedColumnState, availableOrder: ColumnOrderState | undefined): ColumnOrderState {
+    return resolveAvailableColumnOrder(getSavedColumnOrder(view), availableOrder);
 }
 
 export function savedViewColumnSizingEqual(current: ColumnSizingState | undefined, view: SavedColumnState): boolean {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
@@ -109,6 +109,16 @@ export function normalizeColumnSizing(sizing: ColumnSizingState | undefined): Co
     );
 }
 
+export function resolveSavedViewColumnOrder(view: SavedColumnState, availableOrder: ColumnOrderState | undefined): ColumnOrderState {
+    const hasSelectionColumn = availableOrder?.includes('select') ?? false;
+    const availableColumnIds = [...new Set((availableOrder ?? []).filter((columnId) => columnId !== 'select'))];
+    const availableColumnIdSet = new Set(availableColumnIds);
+    const savedOrder = getSavedColumnOrder(view).filter((columnId) => availableColumnIdSet.has(columnId));
+    const resolvedOrder = [...savedOrder, ...availableColumnIds.filter((columnId) => !savedOrder.includes(columnId))];
+
+    return hasSelectionColumn ? ['select', ...resolvedOrder] : resolvedOrder;
+}
+
 export function savedViewColumnSizingEqual(current: ColumnSizingState | undefined, view: SavedColumnState): boolean {
     const saved = getSavedColumnSizing(view);
     const currentEntries = Object.entries(normalizeColumnSizing(current));

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
@@ -47,6 +47,16 @@ export function columnOrdersEqual(left: ColumnOrderState | undefined, right: Col
     return normalizedLeft.length === normalizedRight.length && normalizedLeft.every((columnId, index) => columnId === normalizedRight[index]);
 }
 
+export function filterAvailableColumnIds(columnIds: readonly string[], availableColumnIds: readonly string[]): string[] {
+    const availableColumnIdSet = new Set(availableColumnIds.filter((columnId) => columnId !== 'select'));
+    return [...new Set(columnIds.filter((columnId) => availableColumnIdSet.has(columnId)))];
+}
+
+export function filterAvailableColumnRecord<T>(values: Record<string, T>, availableColumnIds: readonly string[]): Record<string, T> {
+    const availableColumnIdSet = new Set(availableColumnIds.filter((columnId) => columnId !== 'select'));
+    return Object.fromEntries(Object.entries(values).filter(([columnId]) => availableColumnIdSet.has(columnId)));
+}
+
 export function getSavedAutoFillColumnId(view: SavedColumnState | undefined): string | undefined {
     return Object.entries(view?.columns ?? {}).find(([, settings]) => settings.auto_fill === true)?.[0];
 }
@@ -107,6 +117,23 @@ export function normalizeColumnSizing(sizing: ColumnSizingState | undefined): Co
             .filter(([columnId]) => columnId !== 'select')
             .map(([columnId, width]) => [columnId, Math.round(width)])
     );
+}
+
+export function resolveAvailableAutoFillColumnSelection(
+    selection: AutoFillColumnSelection,
+    availableColumnIds: readonly string[],
+    defaultAutoFillColumnId?: string
+): AutoFillColumnSelection {
+    if (selection === null) {
+        return null;
+    }
+
+    const availableColumnIdSet = new Set(availableColumnIds.filter((columnId) => columnId !== 'select'));
+    if (availableColumnIdSet.has(selection)) {
+        return selection;
+    }
+
+    return defaultAutoFillColumnId && availableColumnIdSet.has(defaultAutoFillColumnId) ? defaultAutoFillColumnId : null;
 }
 
 export function resolveAvailableColumnOrder(preferredOrder: ColumnOrderState, availableOrder: ColumnOrderState | undefined): ColumnOrderState {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/column-settings.ts
@@ -101,12 +101,20 @@ export function getSavedWrappedColumnIds(view: SavedColumnState | undefined): Wr
         .map(([columnId]) => columnId);
 }
 
+export function normalizeColumnSizing(sizing: ColumnSizingState | undefined): ColumnSizingState {
+    return Object.fromEntries(
+        Object.entries(sizing ?? {})
+            .filter(([columnId]) => columnId !== 'select')
+            .map(([columnId, width]) => [columnId, Math.round(width)])
+    );
+}
+
 export function savedViewColumnSizingEqual(current: ColumnSizingState | undefined, view: SavedColumnState): boolean {
     const saved = getSavedColumnSizing(view);
-    const currentEntries = Object.entries(current ?? {}).filter(([columnId]) => columnId !== 'select');
+    const currentEntries = Object.entries(normalizeColumnSizing(current));
     const savedEntries = Object.entries(saved);
 
-    return currentEntries.length === savedEntries.length && currentEntries.every(([columnId, width]) => saved[columnId] === Math.round(width));
+    return currentEntries.length === savedEntries.length && currentEntries.every(([columnId, width]) => saved[columnId] === width);
 }
 
 export function savedViewColumnWrappingEqual(current: readonly string[] | undefined, view: SavedColumnState): boolean {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
@@ -57,6 +57,7 @@
         onClearSavedView: () => void;
         onLoadView: (view: SavedView) => void;
         onResetToSaved: () => void;
+        onSavedViewUpdated: (view: SavedView) => void;
         savedViews: SavedView[];
         setAutoFillColumnId: (columnId: AutoFillColumnSelection) => void;
         setShowChart?: (show: boolean) => void;
@@ -83,6 +84,7 @@
         onClearSavedView,
         onLoadView,
         onResetToSaved,
+        onSavedViewUpdated,
         savedViews,
         setAutoFillColumnId,
         setShowChart,
@@ -258,7 +260,8 @@
         }
 
         try {
-            await updateMutation.mutateAsync(getUpdateBody());
+            const result = await updateMutation.mutateAsync(getUpdateBody());
+            onSavedViewUpdated(result);
             toast.success(`View "${activeView.name}" saved.`);
         } catch (error) {
             toast.error(getErrorMessage(error, 'Failed to save view. Please try again.'));

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-picker.svelte
@@ -48,6 +48,7 @@
     interface Props {
         activeSavedView?: SavedView;
         autoFillColumnId: AutoFillColumnSelection;
+        canModifySavedView?: boolean;
         columnOrder?: string[];
         columnSizing?: Record<string, number>;
         columnVisibility?: Record<string, boolean>;
@@ -75,6 +76,7 @@
     let {
         activeSavedView,
         autoFillColumnId,
+        canModifySavedView = true,
         columnOrder,
         columnSizing,
         columnVisibility,
@@ -190,6 +192,10 @@
     }
 
     function handleResetToSaved(): void {
+        if (!canModifySavedView) {
+            return;
+        }
+
         isMenuOpen = false;
         onResetToSaved();
     }
@@ -255,7 +261,7 @@
     }
 
     async function handleUpdate() {
-        if (!activeView || !organizationId) {
+        if (!activeView || !organizationId || !canModifySavedView) {
             return;
         }
 
@@ -314,7 +320,7 @@
         <DropdownMenu.Group>
             <DropdownMenu.Label>Saved View</DropdownMenu.Label>
             {#if activeView}
-                <DropdownMenu.Item disabled={saving || !isModified} onclick={handleUpdate}>
+                <DropdownMenu.Item disabled={saving || !isModified || !canModifySavedView} onclick={handleUpdate}>
                     <Save class="mr-2 size-4" aria-hidden="true" />
                     Save
                 </DropdownMenu.Item>
@@ -328,7 +334,7 @@
                     <Pencil class="mr-2 size-4" aria-hidden="true" />
                     Rename
                 </DropdownMenu.Item>
-                <DropdownMenu.Item disabled={!isModified} onclick={handleResetToSaved}>
+                <DropdownMenu.Item disabled={!isModified || !canModifySavedView} onclick={handleResetToSaved}>
                     <Undo2 class="mr-2 size-4" aria-hidden="true" />
                     Reset to Saved
                 </DropdownMenu.Item>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -114,6 +114,27 @@ describe('saved view drafts', () => {
         expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['bar', 'baz']);
     });
 
+    it('preserves a remote duplicate when a formerly unique definition was removed locally', () => {
+        const originalServerFilters = [new KeywordFilter('foo')];
+        const changes = buildFilterChanges(originalServerFilters, []);
+        const latestServerFilters = [new KeywordFilter('foo'), new KeywordFilter('remote')];
+
+        const mergedFilters = applyFilterChanges(latestServerFilters, changes);
+
+        expect(changes?.removedKeys).toEqual([]);
+        expect(changes?.removedDefinitions).toBe('[{"type":"keyword","value":"foo"}]');
+        expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['remote']);
+    });
+
+    it('continues to apply key removals from legacy browser-local drafts', () => {
+        const mergedFilters = applyFilterChanges([new StatusFilter([StackStatus.Open])], {
+            removedKeys: ['status'],
+            upsertDefinitions: '[]'
+        });
+
+        expect(mergedFilters).toEqual([]);
+    });
+
     it('preserves an intentional duplicate beyond the server baseline count', () => {
         const originalServerFilters = [new KeywordFilter('foo')];
         const locallyEditedFilters = [new KeywordFilter('foo'), new KeywordFilter('foo')];

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -9,9 +9,11 @@ import {
     applyRecordChanges,
     applyWrappedColumnChanges,
     buildFilterChanges,
+    buildFilterOverrideBaselines,
     buildRecordChanges,
     buildWrappedColumnChanges,
     clearSavedViewDraft,
+    getMatchingFilterOverrideKeys,
     getSavedViewDraft,
     mergeFilterOverrides,
     saveSavedViewDraft
@@ -107,6 +109,15 @@ describe('saved view drafts', () => {
 
         expect((mergedFilters.find((filter) => filter.key === 'project') as ProjectFilter).value).toEqual(['url-project']);
         expect((mergedFilters.find((filter) => filter.key === 'status') as StatusFilter).value).toEqual([StackStatus.Regressed]);
+    });
+
+    it('retires an initial filter override after its value changes', () => {
+        const initialFilters = [new ProjectFilter(['url-project']), new StatusFilter([StackStatus.Regressed])];
+        const baselines = buildFilterOverrideBaselines(initialFilters, ['project']);
+
+        expect(getMatchingFilterOverrideKeys(initialFilters, baselines)).toEqual(['project']);
+        expect(getMatchingFilterOverrideKeys([new ProjectFilter(['edited-project']), new StatusFilter([StackStatus.Regressed])], baselines)).toEqual([]);
+        expect(getMatchingFilterOverrideKeys([new StatusFilter([StackStatus.Regressed])], baselines)).toEqual([]);
     });
 
     it('applies per-column changes over the latest server configuration', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -307,6 +307,25 @@ describe('saved view drafts', () => {
         });
     });
 
+    it('clears a touched stored filter when it is reverted to the server value during pending hydration', () => {
+        const serverFilters = [new DateFilter('date', '[now-15m TO now]'), new StatusFilter([StackStatus.Open])];
+        const storedDraftFilters = [new DateFilter('date', '[now-90d TO now]'), new StatusFilter([StackStatus.Regressed])];
+
+        const merged = mergePendingSavedViewDraftEdits(
+            {
+                filterChanges: buildFilterChanges(serverFilters, storedDraftFilters),
+                version: 1
+            },
+            undefined,
+            { filterKeys: ['date-date'] },
+            serverFilters
+        );
+        const mergedFilters = applyFilterChanges(serverFilters, merged?.filterChanges);
+
+        expect((mergedFilters.find((filter) => filter.key === 'date-date') as DateFilter).value).toBe('[now-15m TO now]');
+        expect((mergedFilters.find((filter) => filter.key === 'status') as StatusFilter).value).toEqual([StackStatus.Regressed]);
+    });
+
     it('retires an initial filter override after its value changes', () => {
         const initialFilters = [new ProjectFilter(['url-project']), new StatusFilter([StackStatus.Regressed])];
         const baselines = buildFilterOverrideBaselines(initialFilters, ['project']);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -13,13 +13,10 @@ import {
     buildRecordChanges,
     buildWrappedColumnChanges,
     clearSavedViewDraft,
-    consumeSavedViewDraftClear,
     getMatchingFilterOverrideKeys,
     getSavedViewDraft,
-    getSavedViewDraftClearStorageKey,
     mergeFilterOverrides,
     mergePendingSavedViewDraftEdits,
-    queueSavedViewDraftClear,
     saveSavedViewDraft
 } from './saved-view-drafts';
 
@@ -81,32 +78,6 @@ describe('saved view drafts', () => {
             version: 1,
             wrappedColumnChanges: { summary: true }
         });
-    });
-
-    it('persists a queued clear until the user identity is available', () => {
-        const storage = createStorage();
-        saveSavedViewDraft(identity, { showChart: false, version: 1 }, storage);
-
-        queueSavedViewDraftClear(identity, storage);
-
-        expect(storage.getItem(getSavedViewDraftClearStorageKey(identity))).toBe(identity.userId);
-        expect(consumeSavedViewDraftClear({ ...identity, userId: 'user-2' }, storage)).toBe(false);
-        expect(getSavedViewDraft(identity, storage)).toBeDefined();
-        expect(consumeSavedViewDraftClear(identity, storage)).toBe(true);
-        expect(getSavedViewDraft(identity, storage)).toBeUndefined();
-        expect(storage.getItem(getSavedViewDraftClearStorageKey(identity))).toBeNull();
-        expect(consumeSavedViewDraftClear(identity, storage)).toBe(false);
-    });
-
-    it('keeps identity-independent Reset clears valid across reauthentication', () => {
-        const storage = createStorage();
-        saveSavedViewDraft(identity, { showChart: false, version: 1 }, storage);
-
-        queueSavedViewDraftClear({ organizationId: identity.organizationId, savedViewId: identity.savedViewId }, storage);
-
-        expect(storage.getItem(getSavedViewDraftClearStorageKey(identity))).toBe('*');
-        expect(consumeSavedViewDraftClear(identity, storage)).toBe(true);
-        expect(getSavedViewDraft(identity, storage)).toBeUndefined();
     });
 
     it('applies local filter changes over unrelated changes from the latest server view', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -1,4 +1,4 @@
-import { KeywordFilter, ProjectFilter, StatusFilter } from '$features/events/components/filters';
+import { DateFilter, KeywordFilter, ProjectFilter, StatusFilter } from '$features/events/components/filters';
 import { StackStatus } from '$features/stacks/models';
 import { describe, expect, it } from 'vitest';
 
@@ -90,6 +90,39 @@ describe('saved view drafts', () => {
 
         expect((mergedFilters.find((filter) => filter.key === 'project') as ProjectFilter).value).toEqual(['project-2']);
         expect((mergedFilters.find((filter) => filter.key === 'status') as StatusFilter).value).toEqual([StackStatus.Regressed]);
+    });
+
+    it('keeps a local singleton replacement authoritative over a concurrent server change', () => {
+        const changes = buildFilterChanges([new DateFilter('date', '[now-7d TO now]')], [new DateFilter('date', '[now-90d TO now]')]);
+
+        const mergedFilters = applyFilterChanges([new DateFilter('date', '[now-30d TO now]')], changes);
+
+        expect(changes?.duplicateKeys).toBeUndefined();
+        expect(mergedFilters).toHaveLength(1);
+        expect((mergedFilters[0] as DateFilter).value).toBe('[now-90d TO now]');
+    });
+
+    it('keeps previously persisted singleton replacement drafts authoritative', () => {
+        const mergedFilters = applyFilterChanges([new DateFilter('date', '[now-30d TO now]')], {
+            baselineDefinitions: '[{"type":"date","term":"date","value":"[now-7d TO now]"}]',
+            removedDefinitions: '[{"type":"date","term":"date","value":"[now-7d TO now]"}]',
+            removedKeys: [],
+            upsertDefinitions: '[{"type":"date","term":"date","value":"[now-90d TO now]"}]'
+        });
+
+        expect(mergedFilters).toHaveLength(1);
+        expect((mergedFilters[0] as DateFilter).value).toBe('[now-90d TO now]');
+    });
+
+    it('normalizes previously persisted singleton additions marked as duplicate keys', () => {
+        const mergedFilters = applyFilterChanges([new DateFilter('date', '[now-30d TO now]')], {
+            duplicateKeys: ['date-date'],
+            removedKeys: [],
+            upsertDefinitions: '[{"type":"date","term":"date","value":"[now-90d TO now]"}]'
+        });
+
+        expect(mergedFilters).toHaveLength(1);
+        expect((mergedFilters[0] as DateFilter).value).toBe('[now-90d TO now]');
     });
 
     it('preserves duplicate keyword filters while rebasing local changes', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -127,6 +127,29 @@ describe('saved view drafts', () => {
         expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['remote']);
     });
 
+    it('targets the original definition when a formerly unique replacement is duplicated remotely', () => {
+        const originalServerFilters = [new KeywordFilter('foo')];
+        const locallyEditedFilters = [new KeywordFilter('baz')];
+        const changes = buildFilterChanges(originalServerFilters, locallyEditedFilters);
+        const latestServerFilters = [new KeywordFilter('remote'), new KeywordFilter('foo')];
+
+        const mergedFilters = applyFilterChanges(latestServerFilters, changes);
+
+        expect(changes?.baselineDefinitions).toBe('[{"type":"keyword","value":"foo"}]');
+        expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['remote', 'baz']);
+    });
+
+    it('does not duplicate a unique replacement the server independently adopted', () => {
+        const originalServerFilters = [new KeywordFilter('foo')];
+        const locallyEditedFilters = [new KeywordFilter('baz')];
+        const changes = buildFilterChanges(originalServerFilters, locallyEditedFilters);
+        const latestServerFilters = [new KeywordFilter('baz'), new KeywordFilter('foo')];
+
+        const mergedFilters = applyFilterChanges(latestServerFilters, changes);
+
+        expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['baz']);
+    });
+
     it('continues to apply key removals from legacy browser-local drafts', () => {
         const mergedFilters = applyFilterChanges([new StatusFilter([StackStatus.Open])], {
             removedKeys: ['status'],

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -285,6 +285,28 @@ describe('saved view drafts', () => {
         });
     });
 
+    it('clears stored edits that were explicitly reverted while identity hydration was pending', () => {
+        const merged = mergePendingSavedViewDraftEdits(
+            {
+                columnVisibilityChanges: { date: false, summary: false },
+                showChart: false,
+                showStats: false,
+                version: 1
+            },
+            undefined,
+            {
+                fields: ['showChart'],
+                recordKeys: { columnVisibilityChanges: ['date'] }
+            }
+        );
+
+        expect(merged).toEqual({
+            columnVisibilityChanges: { summary: false },
+            showStats: false,
+            version: 1
+        });
+    });
+
     it('retires an initial filter override after its value changes', () => {
         const initialFilters = [new ProjectFilter(['url-project']), new StatusFilter([StackStatus.Regressed])];
         const baselines = buildFilterOverrideBaselines(initialFilters, ['project']);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -46,6 +46,7 @@ describe('saved view drafts', () => {
                 columnSizingChanges: { date: null, summary: 480 },
                 columnVisibilityChanges: { date: false },
                 filterChanges: {
+                    baselineDefinitions: '[{"type":"keyword","value":"old"}]',
                     duplicateKeys: ['keyword'],
                     removedDefinitions: '[{"type":"keyword","value":"old"}]',
                     removedKeys: ['status'],
@@ -65,6 +66,7 @@ describe('saved view drafts', () => {
             columnSizingChanges: { date: null, summary: 480 },
             columnVisibilityChanges: { date: false },
             filterChanges: {
+                baselineDefinitions: '[{"type":"keyword","value":"old"}]',
                 duplicateKeys: ['keyword'],
                 removedDefinitions: '[{"type":"keyword","value":"old"}]',
                 removedKeys: ['status'],
@@ -99,6 +101,27 @@ describe('saved view drafts', () => {
 
         expect(changes?.duplicateKeys).toEqual(['keyword']);
         expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['foo', 'remote', 'baz']);
+    });
+
+    it('does not append a duplicate upsert that the server independently adopted', () => {
+        const originalServerFilters = [new KeywordFilter('foo'), new KeywordFilter('bar')];
+        const locallyEditedFilters = [new KeywordFilter('bar'), new KeywordFilter('baz')];
+        const changes = buildFilterChanges(originalServerFilters, locallyEditedFilters);
+        const latestServerFilters = [new KeywordFilter('foo'), new KeywordFilter('bar'), new KeywordFilter('baz')];
+
+        const mergedFilters = applyFilterChanges(latestServerFilters, changes);
+
+        expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['bar', 'baz']);
+    });
+
+    it('preserves an intentional duplicate beyond the server baseline count', () => {
+        const originalServerFilters = [new KeywordFilter('foo')];
+        const locallyEditedFilters = [new KeywordFilter('foo'), new KeywordFilter('foo')];
+        const changes = buildFilterChanges(originalServerFilters, locallyEditedFilters);
+
+        const mergedFilters = applyFilterChanges(originalServerFilters, changes);
+
+        expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['foo', 'foo']);
     });
 
     it('lets explicit filter keys override a draft without dropping unrelated draft filters', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -16,6 +16,7 @@ import {
     getMatchingFilterOverrideKeys,
     getSavedViewDraft,
     mergeFilterOverrides,
+    mergePendingSavedViewDraftEdits,
     saveSavedViewDraft
 } from './saved-view-drafts';
 
@@ -174,6 +175,36 @@ describe('saved view drafts', () => {
 
         expect((mergedFilters.find((filter) => filter.key === 'project') as ProjectFilter).value).toEqual(['url-project']);
         expect((mergedFilters.find((filter) => filter.key === 'status') as StatusFilter).value).toEqual([StackStatus.Regressed]);
+    });
+
+    it('overlays pending non-URL edits without losing stored draft state', () => {
+        const merged = mergePendingSavedViewDraftEdits(
+            {
+                columnSizingChanges: { summary: 480 },
+                columnVisibilityChanges: { date: false },
+                filterChanges: { removedKeys: [], upsertDefinitions: '[{"type":"project","value":["project-1"]}]' },
+                showChart: false,
+                sort: 'count',
+                version: 1
+            },
+            {
+                columnSizingChanges: { date: 200 },
+                columnVisibilityChanges: { summary: false },
+                showChart: true,
+                showStats: false,
+                version: 1
+            }
+        );
+
+        expect(merged).toEqual({
+            columnSizingChanges: { date: 200, summary: 480 },
+            columnVisibilityChanges: { date: false, summary: false },
+            filterChanges: { removedKeys: [], upsertDefinitions: '[{"type":"project","value":["project-1"]}]' },
+            showChart: true,
+            showStats: false,
+            sort: 'count',
+            version: 1
+        });
     });
 
     it('retires an initial filter override after its value changes', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -1,4 +1,4 @@
-import { ProjectFilter, StatusFilter } from '$features/events/components/filters';
+import { KeywordFilter, ProjectFilter, StatusFilter } from '$features/events/components/filters';
 import { StackStatus } from '$features/stacks/models';
 import { describe, expect, it } from 'vitest';
 
@@ -43,6 +43,8 @@ describe('saved view drafts', () => {
                 columnSizingChanges: { date: null, summary: 480 },
                 columnVisibilityChanges: { date: false },
                 filterChanges: {
+                    duplicateKeys: ['keyword'],
+                    removedDefinitions: '[{"type":"keyword","value":"old"}]',
                     removedKeys: ['status'],
                     upsertDefinitions: '[{"type":"project","value":["project-1"]}]'
                 },
@@ -60,6 +62,8 @@ describe('saved view drafts', () => {
             columnSizingChanges: { date: null, summary: 480 },
             columnVisibilityChanges: { date: false },
             filterChanges: {
+                duplicateKeys: ['keyword'],
+                removedDefinitions: '[{"type":"keyword","value":"old"}]',
                 removedKeys: ['status'],
                 upsertDefinitions: '[{"type":"project","value":["project-1"]}]'
             },
@@ -80,6 +84,18 @@ describe('saved view drafts', () => {
 
         expect((mergedFilters.find((filter) => filter.key === 'project') as ProjectFilter).value).toEqual(['project-2']);
         expect((mergedFilters.find((filter) => filter.key === 'status') as StatusFilter).value).toEqual([StackStatus.Regressed]);
+    });
+
+    it('preserves duplicate keyword filters while rebasing local changes', () => {
+        const originalServerFilters = [new KeywordFilter('foo'), new KeywordFilter('bar')];
+        const locallyEditedFilters = [new KeywordFilter('foo'), new KeywordFilter('baz')];
+        const changes = buildFilterChanges(originalServerFilters, locallyEditedFilters);
+        const latestServerFilters = [new KeywordFilter('foo'), new KeywordFilter('bar'), new KeywordFilter('remote')];
+
+        const mergedFilters = applyFilterChanges(latestServerFilters, changes);
+
+        expect(changes?.duplicateKeys).toEqual(['keyword']);
+        expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['foo', 'remote', 'baz']);
     });
 
     it('applies per-column changes over the latest server configuration', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -291,11 +291,12 @@ describe('saved view drafts', () => {
                 columnVisibilityChanges: { date: false, summary: false },
                 showChart: false,
                 showStats: false,
+                sort: 'count',
                 version: 1
             },
             undefined,
             {
-                fields: ['showChart'],
+                fields: ['showChart', 'sort'],
                 recordKeys: { columnVisibilityChanges: ['date'] }
             }
         );

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -104,6 +104,17 @@ describe('saved view drafts', () => {
         expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['foo', 'remote', 'baz']);
     });
 
+    it('preserves duplicate-key additions from an empty server baseline', () => {
+        const locallyEditedFilters = [new KeywordFilter('foo'), new KeywordFilter('bar')];
+        const changes = buildFilterChanges([], locallyEditedFilters);
+
+        const mergedFilters = applyFilterChanges([], changes);
+
+        expect(changes?.baselineDefinitions).toBeUndefined();
+        expect(changes?.duplicateKeys).toEqual(['keyword']);
+        expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['foo', 'bar']);
+    });
+
     it('does not append a duplicate upsert that the server independently adopted', () => {
         const originalServerFilters = [new KeywordFilter('foo'), new KeywordFilter('bar')];
         const locallyEditedFilters = [new KeywordFilter('bar'), new KeywordFilter('baz')];

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -51,6 +51,7 @@ describe('saved view drafts', () => {
                     duplicateKeys: ['keyword'],
                     removedDefinitions: '[{"type":"keyword","value":"old"}]',
                     removedKeys: ['status'],
+                    sourceDefinitions: '[{"type":"status","value":["open"]}]',
                     upsertDefinitions: '[{"type":"project","value":["project-1"]}]'
                 },
                 showChart: false,
@@ -71,6 +72,7 @@ describe('saved view drafts', () => {
                 duplicateKeys: ['keyword'],
                 removedDefinitions: '[{"type":"keyword","value":"old"}]',
                 removedKeys: ['status'],
+                sourceDefinitions: '[{"type":"status","value":["open"]}]',
                 upsertDefinitions: '[{"type":"project","value":["project-1"]}]'
             },
             showChart: false,
@@ -88,6 +90,7 @@ describe('saved view drafts', () => {
 
         const mergedFilters = applyFilterChanges(latestServerFilters, changes);
 
+        expect(changes?.sourceDefinitions).toBe('[{"type":"project","value":["project-1"]},{"type":"status","value":["open"]}]');
         expect((mergedFilters.find((filter) => filter.key === 'project') as ProjectFilter).value).toEqual(['project-2']);
         expect((mergedFilters.find((filter) => filter.key === 'status') as StatusFilter).value).toEqual([StackStatus.Regressed]);
     });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -13,6 +13,7 @@ import {
     buildWrappedColumnChanges,
     clearSavedViewDraft,
     getSavedViewDraft,
+    mergeFilterOverrides,
     saveSavedViewDraft
 } from './saved-view-drafts';
 
@@ -96,6 +97,16 @@ describe('saved view drafts', () => {
 
         expect(changes?.duplicateKeys).toEqual(['keyword']);
         expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['foo', 'remote', 'baz']);
+    });
+
+    it('lets explicit filter keys override a draft without dropping unrelated draft filters', () => {
+        const draftFilters = [new ProjectFilter(['saved-project']), new StatusFilter([StackStatus.Regressed])];
+        const currentUrlFilters = [new ProjectFilter(['url-project']), new StatusFilter([StackStatus.Open])];
+
+        const mergedFilters = mergeFilterOverrides(draftFilters, currentUrlFilters, ['project']);
+
+        expect((mergedFilters.find((filter) => filter.key === 'project') as ProjectFilter).value).toEqual(['url-project']);
+        expect((mergedFilters.find((filter) => filter.key === 'status') as StatusFilter).value).toEqual([StackStatus.Regressed]);
     });
 
     it('applies per-column changes over the latest server configuration', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -13,10 +13,13 @@ import {
     buildRecordChanges,
     buildWrappedColumnChanges,
     clearSavedViewDraft,
+    consumeSavedViewDraftClear,
     getMatchingFilterOverrideKeys,
     getSavedViewDraft,
+    getSavedViewDraftClearStorageKey,
     mergeFilterOverrides,
     mergePendingSavedViewDraftEdits,
+    queueSavedViewDraftClear,
     saveSavedViewDraft
 } from './saved-view-drafts';
 
@@ -78,6 +81,21 @@ describe('saved view drafts', () => {
             version: 1,
             wrappedColumnChanges: { summary: true }
         });
+    });
+
+    it('persists a queued clear until the user identity is available', () => {
+        const storage = createStorage();
+        saveSavedViewDraft(identity, { showChart: false, version: 1 }, storage);
+
+        queueSavedViewDraftClear(identity, 'session-1', storage);
+
+        expect(storage.getItem(getSavedViewDraftClearStorageKey(identity))).toBe('session-1');
+        expect(consumeSavedViewDraftClear(identity, 'session-2', storage)).toBe(false);
+        expect(getSavedViewDraft(identity, storage)).toBeDefined();
+        expect(consumeSavedViewDraftClear(identity, 'session-1', storage)).toBe(true);
+        expect(getSavedViewDraft(identity, storage)).toBeUndefined();
+        expect(storage.getItem(getSavedViewDraftClearStorageKey(identity))).toBeNull();
+        expect(consumeSavedViewDraftClear(identity, 'session-1', storage)).toBe(false);
     });
 
     it('applies local filter changes over unrelated changes from the latest server view', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -87,15 +87,26 @@ describe('saved view drafts', () => {
         const storage = createStorage();
         saveSavedViewDraft(identity, { showChart: false, version: 1 }, storage);
 
-        queueSavedViewDraftClear(identity, 'session-1', storage);
+        queueSavedViewDraftClear(identity, storage);
 
-        expect(storage.getItem(getSavedViewDraftClearStorageKey(identity))).toBe('session-1');
-        expect(consumeSavedViewDraftClear(identity, 'session-2', storage)).toBe(false);
+        expect(storage.getItem(getSavedViewDraftClearStorageKey(identity))).toBe(identity.userId);
+        expect(consumeSavedViewDraftClear({ ...identity, userId: 'user-2' }, storage)).toBe(false);
         expect(getSavedViewDraft(identity, storage)).toBeDefined();
-        expect(consumeSavedViewDraftClear(identity, 'session-1', storage)).toBe(true);
+        expect(consumeSavedViewDraftClear(identity, storage)).toBe(true);
         expect(getSavedViewDraft(identity, storage)).toBeUndefined();
         expect(storage.getItem(getSavedViewDraftClearStorageKey(identity))).toBeNull();
-        expect(consumeSavedViewDraftClear(identity, 'session-1', storage)).toBe(false);
+        expect(consumeSavedViewDraftClear(identity, storage)).toBe(false);
+    });
+
+    it('keeps identity-independent Reset clears valid across reauthentication', () => {
+        const storage = createStorage();
+        saveSavedViewDraft(identity, { showChart: false, version: 1 }, storage);
+
+        queueSavedViewDraftClear({ organizationId: identity.organizationId, savedViewId: identity.savedViewId }, storage);
+
+        expect(storage.getItem(getSavedViewDraftClearStorageKey(identity))).toBe('*');
+        expect(consumeSavedViewDraftClear(identity, storage)).toBe(true);
+        expect(getSavedViewDraft(identity, storage)).toBeUndefined();
     });
 
     it('applies local filter changes over unrelated changes from the latest server view', () => {
@@ -131,6 +142,14 @@ describe('saved view drafts', () => {
         expect(changes?.baselineDefinitions).toBeUndefined();
         expect(changes?.duplicateKeys).toEqual(['keyword']);
         expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['foo', 'bar']);
+    });
+
+    it('preserves a concurrent same-key server addition over a single local addition from an empty baseline', () => {
+        const changes = buildFilterChanges([], [new KeywordFilter('local')]);
+        const mergedFilters = applyFilterChanges([new KeywordFilter('remote')], changes);
+
+        expect(changes?.duplicateKeys).toEqual(['keyword']);
+        expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['remote', 'local']);
     });
 
     it('does not append a duplicate upsert that the server independently adopted', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -1,0 +1,117 @@
+import { ProjectFilter, StatusFilter } from '$features/events/components/filters';
+import { StackStatus } from '$features/stacks/models';
+import { describe, expect, it } from 'vitest';
+
+import type { SavedViewDraftIdentity } from './saved-view-drafts';
+
+import {
+    applyFilterChanges,
+    applyRecordChanges,
+    applyWrappedColumnChanges,
+    buildFilterChanges,
+    buildRecordChanges,
+    buildWrappedColumnChanges,
+    clearSavedViewDraft,
+    getSavedViewDraft,
+    saveSavedViewDraft
+} from './saved-view-drafts';
+
+function createStorage() {
+    const values = new Map<string, string>();
+
+    return {
+        getItem: (key: string) => values.get(key) ?? null,
+        removeItem: (key: string) => values.delete(key),
+        setItem: (key: string, value: string) => values.set(key, value)
+    };
+}
+
+const identity: SavedViewDraftIdentity = {
+    organizationId: 'organization-1',
+    savedViewId: 'view-1',
+    userId: 'user-1'
+};
+
+describe('saved view drafts', () => {
+    it('round trips semantic view changes', () => {
+        const storage = createStorage();
+        saveSavedViewDraft(
+            identity,
+            {
+                autoFillColumnId: 'summary',
+                columnOrder: ['date', 'summary'],
+                columnSizingChanges: { date: null, summary: 480 },
+                columnVisibilityChanges: { date: false },
+                filterChanges: {
+                    removedKeys: ['status'],
+                    upsertDefinitions: '[{"type":"project","value":["project-1"]}]'
+                },
+                showChart: false,
+                sort: '-date',
+                version: 1,
+                wrappedColumnChanges: { summary: true }
+            },
+            storage
+        );
+
+        expect(getSavedViewDraft(identity, storage)).toEqual({
+            autoFillColumnId: 'summary',
+            columnOrder: ['date', 'summary'],
+            columnSizingChanges: { date: null, summary: 480 },
+            columnVisibilityChanges: { date: false },
+            filterChanges: {
+                removedKeys: ['status'],
+                upsertDefinitions: '[{"type":"project","value":["project-1"]}]'
+            },
+            showChart: false,
+            sort: '-date',
+            version: 1,
+            wrappedColumnChanges: { summary: true }
+        });
+    });
+
+    it('applies local filter changes over unrelated changes from the latest server view', () => {
+        const originalServerFilters = [new ProjectFilter(['project-1']), new StatusFilter([StackStatus.Open])];
+        const locallyEditedFilters = [new ProjectFilter(['project-2']), new StatusFilter([StackStatus.Open])];
+        const changes = buildFilterChanges(originalServerFilters, locallyEditedFilters);
+        const latestServerFilters = [new ProjectFilter(['project-1']), new StatusFilter([StackStatus.Regressed])];
+
+        const mergedFilters = applyFilterChanges(latestServerFilters, changes);
+
+        expect((mergedFilters.find((filter) => filter.key === 'project') as ProjectFilter).value).toEqual(['project-2']);
+        expect((mergedFilters.find((filter) => filter.key === 'status') as StatusFilter).value).toEqual([StackStatus.Regressed]);
+    });
+
+    it('applies per-column changes over the latest server configuration', () => {
+        const sizingChanges = buildRecordChanges({ date: 160, summary: 400 }, { summary: 480 });
+        const wrappingChanges = buildWrappedColumnChanges(['date'], ['date', 'summary']);
+
+        expect(applyRecordChanges({ date: 200, summary: 400, type: 120 }, sizingChanges)).toEqual({ summary: 480, type: 120 });
+        expect(applyWrappedColumnChanges(['date', 'type'], wrappingChanges)).toEqual(['date', 'type', 'summary']);
+    });
+
+    it('isolates drafts by user, organization, and saved view', () => {
+        const storage = createStorage();
+        saveSavedViewDraft(identity, { showChart: false, version: 1 }, storage);
+
+        expect(getSavedViewDraft({ ...identity, userId: 'user-2' }, storage)).toBeUndefined();
+        expect(getSavedViewDraft({ ...identity, organizationId: 'organization-2' }, storage)).toBeUndefined();
+        expect(getSavedViewDraft({ ...identity, savedViewId: 'view-2' }, storage)).toBeUndefined();
+    });
+
+    it('ignores malformed or unsupported drafts', () => {
+        const storage = createStorage();
+        storage.setItem('exceptionless:saved-view-draft:v1:user-1:organization-1:view-1', JSON.stringify({ showChart: 'no', version: 1 }));
+
+        expect(getSavedViewDraft(identity, storage)).toBeUndefined();
+    });
+
+    it('clears a draft after reset or save', () => {
+        const storage = createStorage();
+        saveSavedViewDraft(identity, { showStats: false, version: 1 }, storage);
+
+        clearSavedViewDraft(identity, storage);
+
+        expect(getSavedViewDraft(identity, storage)).toBeUndefined();
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -124,6 +124,27 @@ describe('saved view drafts', () => {
         expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['foo', 'foo']);
     });
 
+    it('does not repeat a duplicate removal that the server independently adopted', () => {
+        const originalServerFilters = [new KeywordFilter('foo'), new KeywordFilter('foo')];
+        const locallyEditedFilters = [new KeywordFilter('foo')];
+        const changes = buildFilterChanges(originalServerFilters, locallyEditedFilters);
+        const latestServerFilters = [new KeywordFilter('foo')];
+
+        const mergedFilters = applyFilterChanges(latestServerFilters, changes);
+
+        expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['foo']);
+    });
+
+    it('keeps a local duplicate addition when the server removes the baseline definition', () => {
+        const originalServerFilters = [new KeywordFilter('foo')];
+        const locallyEditedFilters = [new KeywordFilter('foo'), new KeywordFilter('foo')];
+        const changes = buildFilterChanges(originalServerFilters, locallyEditedFilters);
+
+        const mergedFilters = applyFilterChanges([], changes);
+
+        expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['foo']);
+    });
+
     it('lets explicit filter keys override a draft without dropping unrelated draft filters', () => {
         const draftFilters = [new ProjectFilter(['saved-project']), new StatusFilter([StackStatus.Regressed])];
         const currentUrlFilters = [new ProjectFilter(['url-project']), new StatusFilter([StackStatus.Open])];

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -47,13 +47,13 @@ export function applyFilterChanges(serverFilters: IFilter[], changes: SavedViewF
     const removedKeys = new Set(changes.removedKeys);
     const duplicateKeys = new Set(changes.duplicateKeys ?? []);
     const baselineFilters = changes.baselineDefinitions ? deserializeFilters(changes.baselineDefinitions) : [];
-    const rebasedKeys = new Set(baselineFilters.map((filter) => filter.key));
+    const rebasedKeys = new Set([...baselineFilters.map((filter) => filter.key), ...duplicateKeys]);
     const removedDefinitionCounts = buildSerializedFilterCounts(changes.removedDefinitions ? deserializeFilters(changes.removedDefinitions) : []);
     const upserts = deserializeFilters(changes.upsertDefinitions);
     const upsertsByKey = new Map(upserts.filter((filter) => !rebasedKeys.has(filter.key)).map((filter) => [filter.key, filter]));
     const rebasedUpserts = upserts.filter((filter) => rebasedKeys.has(filter.key));
     const rebasedTargetCounts =
-        changes.baselineDefinitions === undefined
+        changes.baselineDefinitions === undefined && duplicateKeys.size === 0
             ? undefined
             : buildDuplicateTargetCounts(
                   baselineFilters,

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -46,20 +46,22 @@ export function applyFilterChanges(serverFilters: IFilter[], changes: SavedViewF
 
     const removedKeys = new Set(changes.removedKeys);
     const duplicateKeys = new Set(changes.duplicateKeys ?? []);
+    const baselineFilters = changes.baselineDefinitions ? deserializeFilters(changes.baselineDefinitions) : [];
+    const rebasedKeys = new Set(baselineFilters.map((filter) => filter.key));
     const removedDefinitionCounts = buildSerializedFilterCounts(changes.removedDefinitions ? deserializeFilters(changes.removedDefinitions) : []);
     const upserts = deserializeFilters(changes.upsertDefinitions);
-    const upsertsByKey = new Map(upserts.filter((filter) => !duplicateKeys.has(filter.key)).map((filter) => [filter.key, filter]));
-    const duplicateUpserts = upserts.filter((filter) => duplicateKeys.has(filter.key));
-    const duplicateTargetCounts =
+    const upsertsByKey = new Map(upserts.filter((filter) => !rebasedKeys.has(filter.key)).map((filter) => [filter.key, filter]));
+    const rebasedUpserts = upserts.filter((filter) => rebasedKeys.has(filter.key));
+    const rebasedTargetCounts =
         changes.baselineDefinitions === undefined
             ? undefined
             : buildDuplicateTargetCounts(
-                  deserializeFilters(changes.baselineDefinitions),
+                  baselineFilters,
                   changes.removedDefinitions ? deserializeFilters(changes.removedDefinitions) : [],
-                  duplicateUpserts,
-                  serverFilters.filter((filter) => duplicateKeys.has(filter.key))
+                  rebasedUpserts,
+                  serverFilters.filter((filter) => rebasedKeys.has(filter.key))
               );
-    const retainedDuplicateCounts = new Map<string, number>();
+    const retainedRebasedCounts = new Map<string, number>();
     const result: IFilter[] = [];
 
     for (const serverFilter of serverFilters) {
@@ -68,11 +70,11 @@ export function applyFilterChanges(serverFilters: IFilter[], changes: SavedViewF
         }
 
         const serialized = serializeFilters([serverFilter]);
-        if (duplicateTargetCounts && duplicateKeys.has(serverFilter.key)) {
-            const retainedCount = retainedDuplicateCounts.get(serialized) ?? 0;
-            if (retainedCount < (duplicateTargetCounts.get(serialized) ?? 0)) {
+        if (rebasedTargetCounts && rebasedKeys.has(serverFilter.key)) {
+            const retainedCount = retainedRebasedCounts.get(serialized) ?? 0;
+            if (retainedCount < (rebasedTargetCounts.get(serialized) ?? 0)) {
                 result.push(serverFilter.clone());
-                retainedDuplicateCounts.set(serialized, retainedCount + 1);
+                retainedRebasedCounts.set(serialized, retainedCount + 1);
             }
 
             continue;
@@ -95,9 +97,8 @@ export function applyFilterChanges(serverFilters: IFilter[], changes: SavedViewF
     }
 
     result.push(...[...upsertsByKey.values()].map((filter) => filter.clone()));
-    const missingDuplicateUpserts =
-        duplicateTargetCounts === undefined ? duplicateUpserts : getMissingDuplicateUpserts(duplicateUpserts, duplicateTargetCounts, result);
-    result.push(...missingDuplicateUpserts.map((filter) => filter.clone()));
+    const missingRebasedUpserts = rebasedTargetCounts === undefined ? rebasedUpserts : getMissingDuplicateUpserts(rebasedUpserts, rebasedTargetCounts, result);
+    result.push(...missingRebasedUpserts.map((filter) => filter.clone()));
     return result;
 }
 
@@ -131,6 +132,7 @@ export function buildFilterChanges(serverFilters: IFilter[], currentFilters: IFi
     const serverByKey = groupFiltersByKey(serverFilters);
     const currentByKey = groupFiltersByKey(currentFilters);
     const duplicateKeys: string[] = [];
+    const baselineDefinitions: IFilter[] = [];
     const removedDefinitions: IFilter[] = [];
     const removedKeys: string[] = [];
     const upserts: IFilter[] = [];
@@ -142,13 +144,18 @@ export function buildFilterChanges(serverFilters: IFilter[], currentFilters: IFi
         if (server.length <= 1 && current.length <= 1) {
             if (server.length === 1 && current.length === 0) {
                 removedDefinitions.push(server[0]!);
-            } else if (current.length === 1 && (server.length === 0 || serializeFilters(server) !== serializeFilters(current))) {
+            } else if (current.length === 1 && server.length === 1 && serializeFilters(server) !== serializeFilters(current)) {
+                baselineDefinitions.push(server[0]!);
+                removedDefinitions.push(server[0]!);
+                upserts.push(current[0]!);
+            } else if (current.length === 1 && server.length === 0) {
                 upserts.push(current[0]!);
             }
             continue;
         }
 
         duplicateKeys.push(key);
+        baselineDefinitions.push(...server);
         removedDefinitions.push(...getUnmatchedFilters(server, current));
         upserts.push(...getUnmatchedFilters(current, server));
     }
@@ -158,7 +165,7 @@ export function buildFilterChanges(serverFilters: IFilter[], currentFilters: IFi
     }
 
     return {
-        ...(duplicateKeys.length > 0 ? { baselineDefinitions: serializeFilters(duplicateKeys.flatMap((key) => serverByKey.get(key) ?? [])) } : {}),
+        ...(baselineDefinitions.length > 0 ? { baselineDefinitions: serializeFilters(baselineDefinitions) } : {}),
         ...(duplicateKeys.length > 0 ? { duplicateKeys } : {}),
         ...(removedDefinitions.length > 0 ? { removedDefinitions: serializeFilters(removedDefinitions) } : {}),
         removedKeys,

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -9,6 +9,7 @@ const MULTISET_FILTER_TYPES = new Set(['keyword']);
 
 export interface PendingSavedViewDraftTouches {
     fields?: Array<'autoFillColumnId' | 'columnOrder' | 'showChart' | 'showStats'>;
+    filterKeys?: string[];
     recordKeys?: Partial<Record<'columnSizingChanges' | 'columnVisibilityChanges' | 'wrappedColumnChanges', string[]>>;
 }
 
@@ -281,7 +282,8 @@ export function mergeFilterOverrides(baseFilters: IFilter[], overrideFilters: IF
 export function mergePendingSavedViewDraftEdits(
     storedDraft: SavedViewDraft | undefined,
     pendingEdits: SavedViewDraft | undefined,
-    touches?: PendingSavedViewDraftTouches
+    touches?: PendingSavedViewDraftTouches,
+    serverFilters?: IFilter[]
 ): SavedViewDraft | undefined {
     if (!pendingEdits && !touches) {
         return storedDraft;
@@ -314,6 +316,12 @@ export function mergePendingSavedViewDraftEdits(
         touches?.recordKeys?.columnVisibilityChanges
     );
     merged.wrappedColumnChanges = mergeChanges(storedDraft?.wrappedColumnChanges, pending.wrappedColumnChanges, touches?.recordKeys?.wrappedColumnChanges);
+
+    if (serverFilters && touches?.filterKeys?.length) {
+        const storedFilters = applyFilterChanges(serverFilters, storedDraft?.filterChanges);
+        const pendingFilters = applyFilterChanges(serverFilters, pending.filterChanges);
+        merged.filterChanges = buildFilterChanges(serverFilters, mergeFilterOverrides(storedFilters, pendingFilters, touches.filterKeys));
+    }
 
     for (const key of ['autoFillColumnId', 'columnOrder', 'showChart', 'showStats'] as const) {
         if (key in pending) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -142,6 +142,10 @@ export function buildFilterChanges(serverFilters: IFilter[], currentFilters: IFi
     };
 }
 
+export function buildFilterOverrideBaselines(filters: IFilter[], overrideKeys: Iterable<string>): Record<string, string> {
+    return Object.fromEntries([...overrideKeys].map((key) => [key, serializeFilters(filters.filter((filter) => filter.key === key))]));
+}
+
 export function buildRecordChanges<T>(serverValue: Record<string, T>, currentValue: Record<string, T>): Record<string, null | T> | undefined {
     const changes: Record<string, null | T> = {};
     const keys = new Set([...Object.keys(serverValue), ...Object.keys(currentValue)]);
@@ -175,6 +179,12 @@ export function clearSavedViewDraft(identity: SavedViewDraftIdentity, storage: D
     } catch {
         // Storage can be unavailable by browser policy; the saved view still works without a local draft.
     }
+}
+
+export function getMatchingFilterOverrideKeys(filters: IFilter[], baselines: Record<string, string>): string[] {
+    return Object.entries(baselines)
+        .filter(([key, baseline]) => serializeFilters(filters.filter((filter) => filter.key === key)) === baseline)
+        .map(([key]) => key);
 }
 
 export function getSavedViewDraft(identity: SavedViewDraftIdentity, storage: DraftStorage | undefined = getLocalStorage()): SavedViewDraft | undefined {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -7,6 +7,11 @@ import type { AutoFillColumnSelection } from './column-settings';
 const STORAGE_PREFIX = 'exceptionless:saved-view-draft:v1:';
 const MULTISET_FILTER_TYPES = new Set(['keyword']);
 
+export interface PendingSavedViewDraftTouches {
+    fields?: Array<'autoFillColumnId' | 'columnOrder' | 'showChart' | 'showStats'>;
+    recordKeys?: Partial<Record<'columnSizingChanges' | 'columnVisibilityChanges' | 'wrappedColumnChanges', string[]>>;
+}
+
 export interface SavedViewDraft {
     autoFillColumnId?: AutoFillColumnSelection;
     columnOrder?: string[];
@@ -273,25 +278,48 @@ export function mergeFilterOverrides(baseFilters: IFilter[], overrideFilters: IF
     ];
 }
 
-export function mergePendingSavedViewDraftEdits(storedDraft: SavedViewDraft | undefined, pendingEdits: SavedViewDraft | undefined): SavedViewDraft | undefined {
-    if (!pendingEdits) {
+export function mergePendingSavedViewDraftEdits(
+    storedDraft: SavedViewDraft | undefined,
+    pendingEdits: SavedViewDraft | undefined,
+    touches?: PendingSavedViewDraftTouches
+): SavedViewDraft | undefined {
+    if (!pendingEdits && !touches) {
         return storedDraft;
     }
 
+    const pending = pendingEdits ?? { version: 1 };
     const merged: SavedViewDraft = {
         ...storedDraft,
         version: 1
     };
-    const mergeChanges = <T>(stored: Record<string, T> | undefined, pending: Record<string, T> | undefined): Record<string, T> | undefined =>
-        stored || pending ? { ...stored, ...pending } : undefined;
+    const mergeChanges = <T>(
+        stored: Record<string, T> | undefined,
+        current: Record<string, T> | undefined,
+        touchedKeys: string[] | undefined
+    ): Record<string, T> | undefined => {
+        const result = stored || current ? { ...stored, ...current } : undefined;
+        for (const key of touchedKeys ?? []) {
+            if (!current || !(key in current)) {
+                delete result?.[key];
+            }
+        }
 
-    merged.columnSizingChanges = mergeChanges(storedDraft?.columnSizingChanges, pendingEdits.columnSizingChanges);
-    merged.columnVisibilityChanges = mergeChanges(storedDraft?.columnVisibilityChanges, pendingEdits.columnVisibilityChanges);
-    merged.wrappedColumnChanges = mergeChanges(storedDraft?.wrappedColumnChanges, pendingEdits.wrappedColumnChanges);
+        return result && Object.keys(result).length > 0 ? result : undefined;
+    };
+
+    merged.columnSizingChanges = mergeChanges(storedDraft?.columnSizingChanges, pending.columnSizingChanges, touches?.recordKeys?.columnSizingChanges);
+    merged.columnVisibilityChanges = mergeChanges(
+        storedDraft?.columnVisibilityChanges,
+        pending.columnVisibilityChanges,
+        touches?.recordKeys?.columnVisibilityChanges
+    );
+    merged.wrappedColumnChanges = mergeChanges(storedDraft?.wrappedColumnChanges, pending.wrappedColumnChanges, touches?.recordKeys?.wrappedColumnChanges);
 
     for (const key of ['autoFillColumnId', 'columnOrder', 'showChart', 'showStats'] as const) {
-        if (key in pendingEdits) {
-            Object.assign(merged, { [key]: pendingEdits[key] });
+        if (key in pending) {
+            Object.assign(merged, { [key]: pending[key] });
+        } else if (touches?.fields?.includes(key)) {
+            delete merged[key];
         }
     }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -150,6 +150,7 @@ export function buildFilterChanges(serverFilters: IFilter[], currentFilters: IFi
                 removedDefinitions.push(server[0]!);
                 upserts.push(current[0]!);
             } else if (current.length === 1 && server.length === 0) {
+                duplicateKeys.push(key);
                 upserts.push(current[0]!);
             }
             continue;
@@ -213,13 +214,14 @@ export function clearSavedViewDraft(identity: SavedViewDraftIdentity, storage: D
     }
 }
 
-export function consumeSavedViewDraftClear(
-    identity: SavedViewDraftIdentity,
-    sessionId: string,
-    storage: DraftStorage | undefined = getLocalStorage()
-): boolean {
+export function consumeSavedViewDraftClear(identity: SavedViewDraftIdentity, storage: DraftStorage | undefined = getLocalStorage()): boolean {
     try {
-        if (storage?.getItem(getSavedViewDraftClearStorageKey(identity)) !== sessionId) {
+        if (!storage) {
+            return false;
+        }
+
+        const userId = storage.getItem(getSavedViewDraftClearStorageKey(identity));
+        if (!userId || (userId !== '*' && userId !== identity.userId)) {
             return false;
         }
 
@@ -297,12 +299,11 @@ export function mergePendingSavedViewDraftEdits(storedDraft: SavedViewDraft | un
 }
 
 export function queueSavedViewDraftClear(
-    identity: Pick<SavedViewDraftIdentity, 'organizationId' | 'savedViewId'>,
-    sessionId: string,
+    identity: Partial<Pick<SavedViewDraftIdentity, 'userId'>> & Pick<SavedViewDraftIdentity, 'organizationId' | 'savedViewId'>,
     storage: DraftStorage | undefined = getLocalStorage()
 ): void {
     try {
-        storage?.setItem(getSavedViewDraftClearStorageKey(identity), sessionId);
+        storage?.setItem(getSavedViewDraftClearStorageKey(identity), identity.userId ?? '*');
     } catch {
         // Storage can be unavailable or full; the in-memory clear still protects this session.
     }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -8,7 +8,7 @@ const STORAGE_PREFIX = 'exceptionless:saved-view-draft:v1:';
 const MULTISET_FILTER_TYPES = new Set(['keyword']);
 
 export interface PendingSavedViewDraftTouches {
-    fields?: Array<'autoFillColumnId' | 'columnOrder' | 'showChart' | 'showStats'>;
+    fields?: Array<'autoFillColumnId' | 'columnOrder' | 'showChart' | 'showStats' | 'sort'>;
     filterKeys?: string[];
     recordKeys?: Partial<Record<'columnSizingChanges' | 'columnVisibilityChanges' | 'wrappedColumnChanges', string[]>>;
 }
@@ -323,7 +323,7 @@ export function mergePendingSavedViewDraftEdits(
         merged.filterChanges = buildFilterChanges(serverFilters, mergeFilterOverrides(storedFilters, pendingFilters, touches.filterKeys));
     }
 
-    for (const key of ['autoFillColumnId', 'columnOrder', 'showChart', 'showStats'] as const) {
+    for (const key of ['autoFillColumnId', 'columnOrder', 'showChart', 'showStats', 'sort'] as const) {
         if (key in pending) {
             Object.assign(merged, { [key]: pending[key] });
         } else if (touches?.fields?.includes(key)) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -195,6 +195,18 @@ export function getSavedViewDraftStorageKey(identity: SavedViewDraftIdentity): s
     return `${STORAGE_PREFIX}${identity.userId}:${identity.organizationId}:${identity.savedViewId}`;
 }
 
+export function mergeFilterOverrides(baseFilters: IFilter[], overrideFilters: IFilter[], overrideKeys: Iterable<string>): IFilter[] {
+    const keys = new Set(overrideKeys);
+    if (keys.size === 0) {
+        return baseFilters.map((filter) => filter.clone());
+    }
+
+    return [
+        ...baseFilters.filter((filter) => !keys.has(filter.key)).map((filter) => filter.clone()),
+        ...overrideFilters.filter((filter) => keys.has(filter.key)).map((filter) => filter.clone())
+    ];
+}
+
 export function saveSavedViewDraft(identity: SavedViewDraftIdentity, draft: SavedViewDraft, storage: DraftStorage | undefined = getLocalStorage()): void {
     try {
         storage?.setItem(getSavedViewDraftStorageKey(identity), JSON.stringify(draft));

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -5,6 +5,7 @@ import { deserializeFilters, serializeFilters } from '$features/events/component
 import type { AutoFillColumnSelection } from './column-settings';
 
 const STORAGE_PREFIX = 'exceptionless:saved-view-draft:v1:';
+const CLEAR_STORAGE_PREFIX = 'exceptionless:saved-view-draft-clear:v1:';
 
 export interface SavedViewDraft {
     autoFillColumnId?: AutoFillColumnSelection;
@@ -212,6 +213,24 @@ export function clearSavedViewDraft(identity: SavedViewDraftIdentity, storage: D
     }
 }
 
+export function consumeSavedViewDraftClear(
+    identity: SavedViewDraftIdentity,
+    sessionId: string,
+    storage: DraftStorage | undefined = getLocalStorage()
+): boolean {
+    try {
+        if (storage?.getItem(getSavedViewDraftClearStorageKey(identity)) !== sessionId) {
+            return false;
+        }
+
+        storage.removeItem(getSavedViewDraftStorageKey(identity));
+        storage.removeItem(getSavedViewDraftClearStorageKey(identity));
+        return true;
+    } catch {
+        return false;
+    }
+}
+
 export function getMatchingFilterOverrideKeys(filters: IFilter[], baselines: Record<string, string>): string[] {
     return Object.entries(baselines)
         .filter(([key, baseline]) => serializeFilters(filters.filter((filter) => filter.key === key)) === baseline)
@@ -230,6 +249,10 @@ export function getSavedViewDraft(identity: SavedViewDraftIdentity, storage: Dra
     } catch {
         return undefined;
     }
+}
+
+export function getSavedViewDraftClearStorageKey(identity: Pick<SavedViewDraftIdentity, 'organizationId' | 'savedViewId'>): string {
+    return `${CLEAR_STORAGE_PREFIX}${identity.organizationId}:${identity.savedViewId}`;
 }
 
 export function getSavedViewDraftStorageKey(identity: SavedViewDraftIdentity): string {
@@ -271,6 +294,18 @@ export function mergePendingSavedViewDraftEdits(storedDraft: SavedViewDraft | un
     }
 
     return Object.entries(merged).some(([key, value]) => key !== 'version' && value !== undefined) ? merged : undefined;
+}
+
+export function queueSavedViewDraftClear(
+    identity: Pick<SavedViewDraftIdentity, 'organizationId' | 'savedViewId'>,
+    sessionId: string,
+    storage: DraftStorage | undefined = getLocalStorage()
+): void {
+    try {
+        storage?.setItem(getSavedViewDraftClearStorageKey(identity), sessionId);
+    } catch {
+        // Storage can be unavailable or full; the in-memory clear still protects this session.
+    }
 }
 
 export function saveSavedViewDraft(identity: SavedViewDraftIdentity, draft: SavedViewDraft, storage: DraftStorage | undefined = getLocalStorage()): void {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -26,6 +26,8 @@ export interface SavedViewDraftIdentity {
 }
 
 export interface SavedViewFilterChanges {
+    duplicateKeys?: string[];
+    removedDefinitions?: string;
     removedKeys: string[];
     upsertDefinitions: string;
 }
@@ -42,12 +44,27 @@ export function applyFilterChanges(serverFilters: IFilter[], changes: SavedViewF
     }
 
     const removedKeys = new Set(changes.removedKeys);
+    const duplicateKeys = new Set(changes.duplicateKeys ?? []);
+    const removedDefinitionCounts = buildSerializedFilterCounts(changes.removedDefinitions ? deserializeFilters(changes.removedDefinitions) : []);
     const upserts = deserializeFilters(changes.upsertDefinitions);
-    const upsertsByKey = new Map(upserts.map((filter) => [filter.key, filter]));
+    const upsertsByKey = new Map(upserts.filter((filter) => !duplicateKeys.has(filter.key)).map((filter) => [filter.key, filter]));
+    const duplicateUpserts = upserts.filter((filter) => duplicateKeys.has(filter.key));
     const result: IFilter[] = [];
 
     for (const serverFilter of serverFilters) {
         if (removedKeys.has(serverFilter.key)) {
+            continue;
+        }
+
+        const serialized = serializeFilters([serverFilter]);
+        const removedCount = removedDefinitionCounts.get(serialized) ?? 0;
+        if (removedCount > 0) {
+            removedDefinitionCounts.set(serialized, removedCount - 1);
+            continue;
+        }
+
+        if (duplicateKeys.has(serverFilter.key)) {
+            result.push(serverFilter.clone());
             continue;
         }
 
@@ -57,6 +74,7 @@ export function applyFilterChanges(serverFilters: IFilter[], changes: SavedViewF
     }
 
     result.push(...[...upsertsByKey.values()].map((filter) => filter.clone()));
+    result.push(...duplicateUpserts.map((filter) => filter.clone()));
     return result;
 }
 
@@ -87,16 +105,38 @@ export function applyWrappedColumnChanges(serverValue: string[], changes: Record
 }
 
 export function buildFilterChanges(serverFilters: IFilter[], currentFilters: IFilter[]): SavedViewFilterChanges | undefined {
-    const serverByKey = new Map(serverFilters.map((filter) => [filter.key, serializeFilters([filter])]));
-    const currentByKey = new Map(currentFilters.map((filter) => [filter.key, filter]));
-    const removedKeys = [...serverByKey.keys()].filter((key) => !currentByKey.has(key));
-    const upserts = [...currentByKey.values()].filter((filter) => serverByKey.get(filter.key) !== serializeFilters([filter]));
+    const serverByKey = groupFiltersByKey(serverFilters);
+    const currentByKey = groupFiltersByKey(currentFilters);
+    const duplicateKeys: string[] = [];
+    const removedDefinitions: IFilter[] = [];
+    const removedKeys: string[] = [];
+    const upserts: IFilter[] = [];
 
-    if (removedKeys.length === 0 && upserts.length === 0) {
+    for (const key of new Set([...serverByKey.keys(), ...currentByKey.keys()])) {
+        const server = serverByKey.get(key) ?? [];
+        const current = currentByKey.get(key) ?? [];
+
+        if (server.length <= 1 && current.length <= 1) {
+            if (server.length === 1 && current.length === 0) {
+                removedKeys.push(key);
+            } else if (current.length === 1 && (server.length === 0 || serializeFilters(server) !== serializeFilters(current))) {
+                upserts.push(current[0]!);
+            }
+            continue;
+        }
+
+        duplicateKeys.push(key);
+        removedDefinitions.push(...getUnmatchedFilters(server, current));
+        upserts.push(...getUnmatchedFilters(current, server));
+    }
+
+    if (removedKeys.length === 0 && removedDefinitions.length === 0 && upserts.length === 0) {
         return undefined;
     }
 
     return {
+        ...(duplicateKeys.length > 0 ? { duplicateKeys } : {}),
+        ...(removedDefinitions.length > 0 ? { removedDefinitions: serializeFilters(removedDefinitions) } : {}),
         removedKeys,
         upsertDefinitions: serializeFilters(upserts)
     };
@@ -163,12 +203,45 @@ export function saveSavedViewDraft(identity: SavedViewDraftIdentity, draft: Save
     }
 }
 
+function buildSerializedFilterCounts(filters: IFilter[]): Map<string, number> {
+    const counts = new Map<string, number>();
+    for (const filter of filters) {
+        const serialized = serializeFilters([filter]);
+        counts.set(serialized, (counts.get(serialized) ?? 0) + 1);
+    }
+
+    return counts;
+}
+
 function getLocalStorage(): DraftStorage | undefined {
     try {
         return typeof localStorage === 'undefined' ? undefined : localStorage;
     } catch {
         return undefined;
     }
+}
+
+function getUnmatchedFilters(filters: IFilter[], comparison: IFilter[]): IFilter[] {
+    const comparisonCounts = buildSerializedFilterCounts(comparison);
+    return filters.filter((filter) => {
+        const serialized = serializeFilters([filter]);
+        const remaining = comparisonCounts.get(serialized) ?? 0;
+        if (remaining === 0) {
+            return true;
+        }
+
+        comparisonCounts.set(serialized, remaining - 1);
+        return false;
+    });
+}
+
+function groupFiltersByKey(filters: IFilter[]): Map<string, IFilter[]> {
+    const result = new Map<string, IFilter[]>();
+    for (const filter of filters) {
+        result.set(filter.key, [...(result.get(filter.key) ?? []), filter]);
+    }
+
+    return result;
 }
 
 function isBooleanRecord(value: unknown): value is Record<string, boolean> {
@@ -178,6 +251,8 @@ function isBooleanRecord(value: unknown): value is Record<string, boolean> {
 function isFilterChanges(value: unknown): value is SavedViewFilterChanges {
     return (
         isRecord(value) &&
+        (value.duplicateKeys === undefined || isStringArray(value.duplicateKeys)) &&
+        (value.removedDefinitions === undefined || typeof value.removedDefinitions === 'string') &&
         Array.isArray(value.removedKeys) &&
         value.removedKeys.every((item) => typeof item === 'string') &&
         typeof value.upsertDefinitions === 'string'

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -26,6 +26,7 @@ export interface SavedViewDraftIdentity {
 }
 
 export interface SavedViewFilterChanges {
+    baselineDefinitions?: string;
     duplicateKeys?: string[];
     removedDefinitions?: string;
     removedKeys: string[];
@@ -74,7 +75,11 @@ export function applyFilterChanges(serverFilters: IFilter[], changes: SavedViewF
     }
 
     result.push(...[...upsertsByKey.values()].map((filter) => filter.clone()));
-    result.push(...duplicateUpserts.map((filter) => filter.clone()));
+    const missingDuplicateUpserts =
+        changes.baselineDefinitions === undefined
+            ? duplicateUpserts
+            : getMissingDuplicateUpserts(deserializeFilters(changes.baselineDefinitions), duplicateUpserts, result);
+    result.push(...missingDuplicateUpserts.map((filter) => filter.clone()));
     return result;
 }
 
@@ -135,6 +140,7 @@ export function buildFilterChanges(serverFilters: IFilter[], currentFilters: IFi
     }
 
     return {
+        ...(duplicateKeys.length > 0 ? { baselineDefinitions: serializeFilters(duplicateKeys.flatMap((key) => serverByKey.get(key) ?? [])) } : {}),
         ...(duplicateKeys.length > 0 ? { duplicateKeys } : {}),
         ...(removedDefinitions.length > 0 ? { removedDefinitions: serializeFilters(removedDefinitions) } : {}),
         removedKeys,
@@ -243,6 +249,29 @@ function getLocalStorage(): DraftStorage | undefined {
     }
 }
 
+function getMissingDuplicateUpserts(baselineFilters: IFilter[], upserts: IFilter[], currentFilters: IFilter[]): IFilter[] {
+    const baselineCounts = buildSerializedFilterCounts(baselineFilters);
+    const currentCounts = buildSerializedFilterCounts(currentFilters);
+    const upsertCounts = buildSerializedFilterCounts(upserts);
+    const missingCounts = new Map<string, number>();
+
+    for (const [serialized, upsertCount] of upsertCounts) {
+        const desiredCount = (baselineCounts.get(serialized) ?? 0) + upsertCount;
+        missingCounts.set(serialized, Math.max(0, desiredCount - (currentCounts.get(serialized) ?? 0)));
+    }
+
+    return upserts.filter((filter) => {
+        const serialized = serializeFilters([filter]);
+        const remaining = missingCounts.get(serialized) ?? 0;
+        if (remaining === 0) {
+            return false;
+        }
+
+        missingCounts.set(serialized, remaining - 1);
+        return true;
+    });
+}
+
 function getUnmatchedFilters(filters: IFilter[], comparison: IFilter[]): IFilter[] {
     const comparisonCounts = buildSerializedFilterCounts(comparison);
     return filters.filter((filter) => {
@@ -273,6 +302,7 @@ function isBooleanRecord(value: unknown): value is Record<string, boolean> {
 function isFilterChanges(value: unknown): value is SavedViewFilterChanges {
     return (
         isRecord(value) &&
+        (value.baselineDefinitions === undefined || typeof value.baselineDefinitions === 'string') &&
         (value.duplicateKeys === undefined || isStringArray(value.duplicateKeys)) &&
         (value.removedDefinitions === undefined || typeof value.removedDefinitions === 'string') &&
         Array.isArray(value.removedKeys) &&

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -1,0 +1,227 @@
+import type { IFilter } from '$comp/faceted-filter';
+
+import { deserializeFilters, serializeFilters } from '$features/events/components/filters/helpers.svelte';
+
+import type { AutoFillColumnSelection } from './column-settings';
+
+const STORAGE_PREFIX = 'exceptionless:saved-view-draft:v1:';
+
+export interface SavedViewDraft {
+    autoFillColumnId?: AutoFillColumnSelection;
+    columnOrder?: string[];
+    columnSizingChanges?: Record<string, null | number>;
+    columnVisibilityChanges?: Record<string, boolean | null>;
+    filterChanges?: SavedViewFilterChanges;
+    showChart?: boolean;
+    showStats?: boolean;
+    sort?: null | string;
+    version: 1;
+    wrappedColumnChanges?: Record<string, boolean>;
+}
+
+export interface SavedViewDraftIdentity {
+    organizationId: string;
+    savedViewId: string;
+    userId: string;
+}
+
+export interface SavedViewFilterChanges {
+    removedKeys: string[];
+    upsertDefinitions: string;
+}
+
+interface DraftStorage {
+    getItem(key: string): null | string;
+    removeItem(key: string): void;
+    setItem(key: string, value: string): void;
+}
+
+export function applyFilterChanges(serverFilters: IFilter[], changes: SavedViewFilterChanges | undefined): IFilter[] {
+    if (!changes) {
+        return serverFilters.map((filter) => filter.clone());
+    }
+
+    const removedKeys = new Set(changes.removedKeys);
+    const upserts = deserializeFilters(changes.upsertDefinitions);
+    const upsertsByKey = new Map(upserts.map((filter) => [filter.key, filter]));
+    const result: IFilter[] = [];
+
+    for (const serverFilter of serverFilters) {
+        if (removedKeys.has(serverFilter.key)) {
+            continue;
+        }
+
+        const upsert = upsertsByKey.get(serverFilter.key);
+        result.push((upsert ?? serverFilter).clone());
+        upsertsByKey.delete(serverFilter.key);
+    }
+
+    result.push(...[...upsertsByKey.values()].map((filter) => filter.clone()));
+    return result;
+}
+
+export function applyRecordChanges<T>(serverValue: Record<string, T>, changes: Record<string, null | T> | undefined): Record<string, T> {
+    const result = { ...serverValue };
+    for (const [key, value] of Object.entries(changes ?? {})) {
+        if (value === null) {
+            delete result[key];
+        } else {
+            result[key] = value;
+        }
+    }
+
+    return result;
+}
+
+export function applyWrappedColumnChanges(serverValue: string[], changes: Record<string, boolean> | undefined): string[] {
+    const result = new Set(serverValue);
+    for (const [columnId, isWrapped] of Object.entries(changes ?? {})) {
+        if (isWrapped) {
+            result.add(columnId);
+        } else {
+            result.delete(columnId);
+        }
+    }
+
+    return [...result];
+}
+
+export function buildFilterChanges(serverFilters: IFilter[], currentFilters: IFilter[]): SavedViewFilterChanges | undefined {
+    const serverByKey = new Map(serverFilters.map((filter) => [filter.key, serializeFilters([filter])]));
+    const currentByKey = new Map(currentFilters.map((filter) => [filter.key, filter]));
+    const removedKeys = [...serverByKey.keys()].filter((key) => !currentByKey.has(key));
+    const upserts = [...currentByKey.values()].filter((filter) => serverByKey.get(filter.key) !== serializeFilters([filter]));
+
+    if (removedKeys.length === 0 && upserts.length === 0) {
+        return undefined;
+    }
+
+    return {
+        removedKeys,
+        upsertDefinitions: serializeFilters(upserts)
+    };
+}
+
+export function buildRecordChanges<T>(serverValue: Record<string, T>, currentValue: Record<string, T>): Record<string, null | T> | undefined {
+    const changes: Record<string, null | T> = {};
+    const keys = new Set([...Object.keys(serverValue), ...Object.keys(currentValue)]);
+    for (const key of keys) {
+        if (!(key in currentValue)) {
+            changes[key] = null;
+        } else if (!(key in serverValue) || !Object.is(serverValue[key], currentValue[key])) {
+            changes[key] = currentValue[key]!;
+        }
+    }
+
+    return Object.keys(changes).length > 0 ? changes : undefined;
+}
+
+export function buildWrappedColumnChanges(serverValue: string[], currentValue: string[]): Record<string, boolean> | undefined {
+    const serverIds = new Set(serverValue);
+    const currentIds = new Set(currentValue);
+    const changes: Record<string, boolean> = {};
+    for (const columnId of new Set([...serverIds, ...currentIds])) {
+        if (serverIds.has(columnId) !== currentIds.has(columnId)) {
+            changes[columnId] = currentIds.has(columnId);
+        }
+    }
+
+    return Object.keys(changes).length > 0 ? changes : undefined;
+}
+
+export function clearSavedViewDraft(identity: SavedViewDraftIdentity, storage: DraftStorage | undefined = getLocalStorage()): void {
+    try {
+        storage?.removeItem(getSavedViewDraftStorageKey(identity));
+    } catch {
+        // Storage can be unavailable by browser policy; the saved view still works without a local draft.
+    }
+}
+
+export function getSavedViewDraft(identity: SavedViewDraftIdentity, storage: DraftStorage | undefined = getLocalStorage()): SavedViewDraft | undefined {
+    try {
+        const value = storage?.getItem(getSavedViewDraftStorageKey(identity));
+        if (!value) {
+            return undefined;
+        }
+
+        const draft: unknown = JSON.parse(value);
+        return isSavedViewDraft(draft) ? draft : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+export function getSavedViewDraftStorageKey(identity: SavedViewDraftIdentity): string {
+    return `${STORAGE_PREFIX}${identity.userId}:${identity.organizationId}:${identity.savedViewId}`;
+}
+
+export function saveSavedViewDraft(identity: SavedViewDraftIdentity, draft: SavedViewDraft, storage: DraftStorage | undefined = getLocalStorage()): void {
+    try {
+        storage?.setItem(getSavedViewDraftStorageKey(identity), JSON.stringify(draft));
+    } catch {
+        // Storage can be unavailable or full; the current in-memory edits remain usable.
+    }
+}
+
+function getLocalStorage(): DraftStorage | undefined {
+    try {
+        return typeof localStorage === 'undefined' ? undefined : localStorage;
+    } catch {
+        return undefined;
+    }
+}
+
+function isBooleanRecord(value: unknown): value is Record<string, boolean> {
+    return isRecord(value) && Object.values(value).every((item) => typeof item === 'boolean');
+}
+
+function isFilterChanges(value: unknown): value is SavedViewFilterChanges {
+    return (
+        isRecord(value) &&
+        Array.isArray(value.removedKeys) &&
+        value.removedKeys.every((item) => typeof item === 'string') &&
+        typeof value.upsertDefinitions === 'string'
+    );
+}
+
+function isNullableBooleanRecord(value: unknown): value is Record<string, boolean | null> {
+    return isRecord(value) && Object.values(value).every((item) => item === null || typeof item === 'boolean');
+}
+
+function isNullableNumberRecord(value: unknown): value is Record<string, null | number> {
+    return isRecord(value) && Object.values(value).every((item) => item === null || (typeof item === 'number' && Number.isFinite(item)));
+}
+
+function isOptionalBoolean(value: unknown): value is boolean | undefined {
+    return value === undefined || typeof value === 'boolean';
+}
+
+function isOptionalNullableString(value: unknown): value is null | string | undefined {
+    return value === undefined || value === null || typeof value === 'string';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isSavedViewDraft(value: unknown): value is SavedViewDraft {
+    if (!isRecord(value) || value.version !== 1) {
+        return false;
+    }
+
+    return (
+        isOptionalNullableString(value.sort) &&
+        isOptionalBoolean(value.showChart) &&
+        isOptionalBoolean(value.showStats) &&
+        (value.autoFillColumnId === undefined || value.autoFillColumnId === null || typeof value.autoFillColumnId === 'string') &&
+        (value.columnOrder === undefined || isStringArray(value.columnOrder)) &&
+        (value.columnSizingChanges === undefined || isNullableNumberRecord(value.columnSizingChanges)) &&
+        (value.columnVisibilityChanges === undefined || isNullableBooleanRecord(value.columnVisibilityChanges)) &&
+        (value.filterChanges === undefined || isFilterChanges(value.filterChanges)) &&
+        (value.wrappedColumnChanges === undefined || isBooleanRecord(value.wrappedColumnChanges))
+    );
+}
+
+function isStringArray(value: unknown): value is string[] {
+    return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -5,6 +5,7 @@ import { deserializeFilters, serializeFilters } from '$features/events/component
 import type { AutoFillColumnSelection } from './column-settings';
 
 const STORAGE_PREFIX = 'exceptionless:saved-view-draft:v1:';
+const MULTISET_FILTER_TYPES = new Set(['keyword']);
 
 export interface SavedViewDraft {
     autoFillColumnId?: AutoFillColumnSelection;
@@ -47,13 +48,20 @@ export function applyFilterChanges(serverFilters: IFilter[], changes: SavedViewF
     const removedKeys = new Set(changes.removedKeys);
     const duplicateKeys = new Set(changes.duplicateKeys ?? []);
     const baselineFilters = changes.baselineDefinitions ? deserializeFilters(changes.baselineDefinitions) : [];
-    const rebasedKeys = new Set([...baselineFilters.map((filter) => filter.key), ...duplicateKeys]);
-    const removedDefinitionCounts = buildSerializedFilterCounts(changes.removedDefinitions ? deserializeFilters(changes.removedDefinitions) : []);
     const upserts = deserializeFilters(changes.upsertDefinitions);
+    const multisetKeys = new Set(
+        [...baselineFilters, ...upserts, ...serverFilters].filter((filter) => supportsMultipleDefinitions(filter)).map((filter) => filter.key)
+    );
+    const rebasedKeys = new Set([
+        ...baselineFilters.filter((filter) => supportsMultipleDefinitions(filter)).map((filter) => filter.key),
+        ...[...duplicateKeys].filter((key) => multisetKeys.has(key))
+    ]);
+    const removedDefinitionCounts = buildSerializedFilterCounts(changes.removedDefinitions ? deserializeFilters(changes.removedDefinitions) : []);
     const upsertsByKey = new Map(upserts.filter((filter) => !rebasedKeys.has(filter.key)).map((filter) => [filter.key, filter]));
+    const authoritativeUpsertKeys = new Set(upsertsByKey.keys());
     const rebasedUpserts = upserts.filter((filter) => rebasedKeys.has(filter.key));
     const rebasedTargetCounts =
-        changes.baselineDefinitions === undefined && duplicateKeys.size === 0
+        rebasedKeys.size === 0
             ? undefined
             : buildDuplicateTargetCounts(
                   baselineFilters,
@@ -86,14 +94,18 @@ export function applyFilterChanges(serverFilters: IFilter[], changes: SavedViewF
             continue;
         }
 
-        if (duplicateKeys.has(serverFilter.key)) {
+        if (rebasedKeys.has(serverFilter.key)) {
             result.push(serverFilter.clone());
             continue;
         }
 
         const upsert = upsertsByKey.get(serverFilter.key);
-        result.push((upsert ?? serverFilter).clone());
-        upsertsByKey.delete(serverFilter.key);
+        if (upsert) {
+            result.push(upsert.clone());
+            upsertsByKey.delete(serverFilter.key);
+        } else if (!authoritativeUpsertKeys.has(serverFilter.key)) {
+            result.push(serverFilter.clone());
+        }
     }
 
     result.push(...[...upsertsByKey.values()].map((filter) => filter.clone()));
@@ -140,6 +152,16 @@ export function buildFilterChanges(serverFilters: IFilter[], currentFilters: IFi
     for (const key of new Set([...serverByKey.keys(), ...currentByKey.keys()])) {
         const server = serverByKey.get(key) ?? [];
         const current = currentByKey.get(key) ?? [];
+
+        if (![...server, ...current].some((filter) => supportsMultipleDefinitions(filter))) {
+            if (current.length === 0 && server.length > 0) {
+                removedKeys.push(key);
+            } else if (current.length > 0 && (server.length !== 1 || serializeFilters(server) !== serializeFilters(current))) {
+                upserts.push(current[0]!);
+            }
+
+            continue;
+        }
 
         if (server.length <= 1 && current.length <= 1) {
             if (server.length === 1 && current.length === 0) {
@@ -419,4 +441,8 @@ function isSavedViewDraft(value: unknown): value is SavedViewDraft {
 
 function isStringArray(value: unknown): value is string[] {
     return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function supportsMultipleDefinitions(filter: IFilter): boolean {
+    return MULTISET_FILTER_TYPES.has(filter.type);
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -141,7 +141,7 @@ export function buildFilterChanges(serverFilters: IFilter[], currentFilters: IFi
 
         if (server.length <= 1 && current.length <= 1) {
             if (server.length === 1 && current.length === 0) {
-                removedKeys.push(key);
+                removedDefinitions.push(server[0]!);
             } else if (current.length === 1 && (server.length === 0 || serializeFilters(server) !== serializeFilters(current))) {
                 upserts.push(current[0]!);
             }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -31,6 +31,7 @@ export interface SavedViewFilterChanges {
     duplicateKeys?: string[];
     removedDefinitions?: string;
     removedKeys: string[];
+    sourceDefinitions?: string;
     upsertDefinitions: string;
 }
 
@@ -192,6 +193,7 @@ export function buildFilterChanges(serverFilters: IFilter[], currentFilters: IFi
         ...(duplicateKeys.length > 0 ? { duplicateKeys } : {}),
         ...(removedDefinitions.length > 0 ? { removedDefinitions: serializeFilters(removedDefinitions) } : {}),
         removedKeys,
+        sourceDefinitions: serializeFilters(serverFilters),
         upsertDefinitions: serializeFilters(upserts)
     };
 }
@@ -397,6 +399,7 @@ function isFilterChanges(value: unknown): value is SavedViewFilterChanges {
         (value.removedDefinitions === undefined || typeof value.removedDefinitions === 'string') &&
         Array.isArray(value.removedKeys) &&
         value.removedKeys.every((item) => typeof item === 'string') &&
+        (value.sourceDefinitions === undefined || typeof value.sourceDefinitions === 'string') &&
         typeof value.upsertDefinitions === 'string'
     );
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -50,6 +50,16 @@ export function applyFilterChanges(serverFilters: IFilter[], changes: SavedViewF
     const upserts = deserializeFilters(changes.upsertDefinitions);
     const upsertsByKey = new Map(upserts.filter((filter) => !duplicateKeys.has(filter.key)).map((filter) => [filter.key, filter]));
     const duplicateUpserts = upserts.filter((filter) => duplicateKeys.has(filter.key));
+    const duplicateTargetCounts =
+        changes.baselineDefinitions === undefined
+            ? undefined
+            : buildDuplicateTargetCounts(
+                  deserializeFilters(changes.baselineDefinitions),
+                  changes.removedDefinitions ? deserializeFilters(changes.removedDefinitions) : [],
+                  duplicateUpserts,
+                  serverFilters.filter((filter) => duplicateKeys.has(filter.key))
+              );
+    const retainedDuplicateCounts = new Map<string, number>();
     const result: IFilter[] = [];
 
     for (const serverFilter of serverFilters) {
@@ -58,6 +68,16 @@ export function applyFilterChanges(serverFilters: IFilter[], changes: SavedViewF
         }
 
         const serialized = serializeFilters([serverFilter]);
+        if (duplicateTargetCounts && duplicateKeys.has(serverFilter.key)) {
+            const retainedCount = retainedDuplicateCounts.get(serialized) ?? 0;
+            if (retainedCount < (duplicateTargetCounts.get(serialized) ?? 0)) {
+                result.push(serverFilter.clone());
+                retainedDuplicateCounts.set(serialized, retainedCount + 1);
+            }
+
+            continue;
+        }
+
         const removedCount = removedDefinitionCounts.get(serialized) ?? 0;
         if (removedCount > 0) {
             removedDefinitionCounts.set(serialized, removedCount - 1);
@@ -76,9 +96,7 @@ export function applyFilterChanges(serverFilters: IFilter[], changes: SavedViewF
 
     result.push(...[...upsertsByKey.values()].map((filter) => filter.clone()));
     const missingDuplicateUpserts =
-        changes.baselineDefinitions === undefined
-            ? duplicateUpserts
-            : getMissingDuplicateUpserts(deserializeFilters(changes.baselineDefinitions), duplicateUpserts, result);
+        duplicateTargetCounts === undefined ? duplicateUpserts : getMissingDuplicateUpserts(duplicateUpserts, duplicateTargetCounts, result);
     result.push(...missingDuplicateUpserts.map((filter) => filter.clone()));
     return result;
 }
@@ -231,6 +249,26 @@ export function saveSavedViewDraft(identity: SavedViewDraftIdentity, draft: Save
     }
 }
 
+function buildDuplicateTargetCounts(baselineFilters: IFilter[], removals: IFilter[], upserts: IFilter[], latestFilters: IFilter[]): Map<string, number> {
+    const baselineCounts = buildSerializedFilterCounts(baselineFilters);
+    const latestCounts = buildSerializedFilterCounts(latestFilters);
+    const removalCounts = buildSerializedFilterCounts(removals);
+    const upsertCounts = buildSerializedFilterCounts(upserts);
+    const serializedDefinitions = new Set([...baselineCounts.keys(), ...latestCounts.keys(), ...removalCounts.keys(), ...upsertCounts.keys()]);
+    const targetCounts = new Map<string, number>();
+
+    for (const serialized of serializedDefinitions) {
+        const baselineCount = baselineCounts.get(serialized) ?? 0;
+        const latestCount = latestCounts.get(serialized) ?? 0;
+        const localDelta = (upsertCounts.get(serialized) ?? 0) - (removalCounts.get(serialized) ?? 0);
+        const adoptedDelta = localDelta > 0 ? Math.max(0, latestCount - baselineCount) : Math.max(0, baselineCount - latestCount);
+        const remainingDelta = Math.sign(localDelta) * Math.max(0, Math.abs(localDelta) - adoptedDelta);
+        targetCounts.set(serialized, Math.max(0, latestCount + remainingDelta));
+    }
+
+    return targetCounts;
+}
+
 function buildSerializedFilterCounts(filters: IFilter[]): Map<string, number> {
     const counts = new Map<string, number>();
     for (const filter of filters) {
@@ -249,15 +287,12 @@ function getLocalStorage(): DraftStorage | undefined {
     }
 }
 
-function getMissingDuplicateUpserts(baselineFilters: IFilter[], upserts: IFilter[], currentFilters: IFilter[]): IFilter[] {
-    const baselineCounts = buildSerializedFilterCounts(baselineFilters);
+function getMissingDuplicateUpserts(upserts: IFilter[], targetCounts: Map<string, number>, currentFilters: IFilter[]): IFilter[] {
     const currentCounts = buildSerializedFilterCounts(currentFilters);
-    const upsertCounts = buildSerializedFilterCounts(upserts);
     const missingCounts = new Map<string, number>();
 
-    for (const [serialized, upsertCount] of upsertCounts) {
-        const desiredCount = (baselineCounts.get(serialized) ?? 0) + upsertCount;
-        missingCounts.set(serialized, Math.max(0, desiredCount - (currentCounts.get(serialized) ?? 0)));
+    for (const [serialized, targetCount] of targetCounts) {
+        missingCounts.set(serialized, Math.max(0, targetCount - (currentCounts.get(serialized) ?? 0)));
     }
 
     return upserts.filter((filter) => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -241,6 +241,31 @@ export function mergeFilterOverrides(baseFilters: IFilter[], overrideFilters: IF
     ];
 }
 
+export function mergePendingSavedViewDraftEdits(storedDraft: SavedViewDraft | undefined, pendingEdits: SavedViewDraft | undefined): SavedViewDraft | undefined {
+    if (!pendingEdits) {
+        return storedDraft;
+    }
+
+    const merged: SavedViewDraft = {
+        ...storedDraft,
+        version: 1
+    };
+    const mergeChanges = <T>(stored: Record<string, T> | undefined, pending: Record<string, T> | undefined): Record<string, T> | undefined =>
+        stored || pending ? { ...stored, ...pending } : undefined;
+
+    merged.columnSizingChanges = mergeChanges(storedDraft?.columnSizingChanges, pendingEdits.columnSizingChanges);
+    merged.columnVisibilityChanges = mergeChanges(storedDraft?.columnVisibilityChanges, pendingEdits.columnVisibilityChanges);
+    merged.wrappedColumnChanges = mergeChanges(storedDraft?.wrappedColumnChanges, pendingEdits.wrappedColumnChanges);
+
+    for (const key of ['autoFillColumnId', 'columnOrder', 'showChart', 'showStats'] as const) {
+        if (key in pendingEdits) {
+            Object.assign(merged, { [key]: pendingEdits[key] });
+        }
+    }
+
+    return Object.entries(merged).some(([key, value]) => key !== 'version' && value !== undefined) ? merged : undefined;
+}
+
 export function saveSavedViewDraft(identity: SavedViewDraftIdentity, draft: SavedViewDraft, storage: DraftStorage | undefined = getLocalStorage()): void {
     try {
         storage?.setItem(getSavedViewDraftStorageKey(identity), JSON.stringify(draft));

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -5,7 +5,6 @@ import { deserializeFilters, serializeFilters } from '$features/events/component
 import type { AutoFillColumnSelection } from './column-settings';
 
 const STORAGE_PREFIX = 'exceptionless:saved-view-draft:v1:';
-const CLEAR_STORAGE_PREFIX = 'exceptionless:saved-view-draft-clear:v1:';
 
 export interface SavedViewDraft {
     autoFillColumnId?: AutoFillColumnSelection;
@@ -214,25 +213,6 @@ export function clearSavedViewDraft(identity: SavedViewDraftIdentity, storage: D
     }
 }
 
-export function consumeSavedViewDraftClear(identity: SavedViewDraftIdentity, storage: DraftStorage | undefined = getLocalStorage()): boolean {
-    try {
-        if (!storage) {
-            return false;
-        }
-
-        const userId = storage.getItem(getSavedViewDraftClearStorageKey(identity));
-        if (!userId || (userId !== '*' && userId !== identity.userId)) {
-            return false;
-        }
-
-        storage.removeItem(getSavedViewDraftStorageKey(identity));
-        storage.removeItem(getSavedViewDraftClearStorageKey(identity));
-        return true;
-    } catch {
-        return false;
-    }
-}
-
 export function getMatchingFilterOverrideKeys(filters: IFilter[], baselines: Record<string, string>): string[] {
     return Object.entries(baselines)
         .filter(([key, baseline]) => serializeFilters(filters.filter((filter) => filter.key === key)) === baseline)
@@ -251,10 +231,6 @@ export function getSavedViewDraft(identity: SavedViewDraftIdentity, storage: Dra
     } catch {
         return undefined;
     }
-}
-
-export function getSavedViewDraftClearStorageKey(identity: Pick<SavedViewDraftIdentity, 'organizationId' | 'savedViewId'>): string {
-    return `${CLEAR_STORAGE_PREFIX}${identity.organizationId}:${identity.savedViewId}`;
 }
 
 export function getSavedViewDraftStorageKey(identity: SavedViewDraftIdentity): string {
@@ -296,17 +272,6 @@ export function mergePendingSavedViewDraftEdits(storedDraft: SavedViewDraft | un
     }
 
     return Object.entries(merged).some(([key, value]) => key !== 'version' && value !== undefined) ? merged : undefined;
-}
-
-export function queueSavedViewDraftClear(
-    identity: Partial<Pick<SavedViewDraftIdentity, 'userId'>> & Pick<SavedViewDraftIdentity, 'organizationId' | 'savedViewId'>,
-    storage: DraftStorage | undefined = getLocalStorage()
-): void {
-    try {
-        storage?.setItem(getSavedViewDraftClearStorageKey(identity), identity.userId ?? '*');
-    } catch {
-        // Storage can be unavailable or full; the in-memory clear still protects this session.
-    }
 }
 
 export function saveSavedViewDraft(identity: SavedViewDraftIdentity, draft: SavedViewDraft, storage: DraftStorage | undefined = getLocalStorage()): void {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -13,7 +13,6 @@ import {
 import { organization } from '$features/organizations/context.svelte';
 import { getMeQuery } from '$features/users/api.svelte';
 import { tick, untrack } from 'svelte';
-import { SvelteSet } from 'svelte/reactivity';
 
 import type { AutoFillColumnSelection, WrappedColumnIds } from './column-settings';
 import type { SavedView } from './models';
@@ -44,12 +43,10 @@ import {
     buildRecordChanges,
     buildWrappedColumnChanges,
     clearSavedViewDraft,
-    consumeSavedViewDraftClear,
     getMatchingFilterOverrideKeys,
     getSavedViewDraft,
     mergeFilterOverrides,
     mergePendingSavedViewDraftEdits,
-    queueSavedViewDraftClear,
     type SavedViewDraft,
     type SavedViewDraftIdentity,
     saveSavedViewDraft
@@ -97,6 +94,7 @@ export interface UseSavedViewsOptions {
 export interface UseSavedViewsReturn {
     activeSavedView: SavedView | undefined;
     autoFillColumnId: AutoFillColumnSelection;
+    canModifySavedView: boolean;
     handleClearSavedView: () => void;
     handleLoadView: (view: SavedView) => void;
     handleResetToSaved: () => void;
@@ -276,6 +274,10 @@ export function isSavedViewHydrationPending(
     isUnavailable: boolean
 ): boolean {
     return !!savedViewKey && !isUnavailable && (!activeSavedViewId || activeSavedViewId !== hydratedSavedViewId);
+}
+
+export function isSavedViewUnavailable(activeSavedViewId: string | undefined, isMissing: boolean, isError: boolean): boolean {
+    return isMissing || (isError && !activeSavedViewId);
 }
 
 export function savedViewColumnsEqual(
@@ -622,7 +624,6 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     let activeFilterOverrideBaselines = $state<Record<string, string>>({});
     let activeSortOverride = $state<{ value: null | string }>();
     let appliedDraftKey = $state('');
-    const pendingDraftClearViewIds = new SvelteSet<string>();
     let pendingDraftKey = '';
     let pendingDraftGeneration = -1;
     let draftHydrationGeneration = $state(0);
@@ -780,15 +781,6 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         const draftKey = `${identity.userId}:${identity.organizationId}:${identity.savedViewId}`;
-        const wasPendingInMemory = pendingDraftClearViewIds.delete(view.id);
-        const wasPendingInStorage = consumeSavedViewDraftClear(identity);
-        if (wasPendingInMemory || wasPendingInStorage) {
-            clearSavedViewDraft(identity);
-            appliedDraftKey = draftKey;
-            hydratedSavedViewId = view.id;
-            return;
-        }
-
         if (appliedDraftKey === draftKey || (pendingDraftKey === draftKey && pendingDraftGeneration === generation)) {
             return;
         }
@@ -975,22 +967,15 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return;
         }
 
+        const identity = getDraftIdentity(view);
+        if (!identity) {
+            return;
+        }
+
         draftPersistenceGeneration++;
         hydratedSavedView = view;
         hydratedSavedViewSignature = getSavedViewStateSignature(view);
-        const identity = getDraftIdentity(view);
-        if (identity) {
-            clearSavedViewDraft(identity);
-        } else {
-            pendingDraftClearViewIds.add(view.id);
-            const organizationId = organization.current;
-            if (organizationId) {
-                queueSavedViewDraftClear({
-                    organizationId,
-                    savedViewId: view.id
-                });
-            }
-        }
+        clearSavedViewDraft(identity);
 
         if (view.filter_definitions) {
             try {
@@ -1015,20 +1000,19 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
     function handleSavedViewUpdated(view: SavedView) {
         draftPersistenceGeneration++;
-        const identity = getDraftIdentity(view);
+        const organizationId = organization.current;
+        const identity =
+            getDraftIdentity(view) ??
+            (organizationId && view.updated_by_user_id
+                ? {
+                      organizationId,
+                      savedViewId: view.id,
+                      userId: view.updated_by_user_id
+                  }
+                : undefined);
         if (identity) {
             clearSavedViewDraft(identity);
             appliedDraftKey = `${identity.userId}:${identity.organizationId}:${identity.savedViewId}`;
-        } else {
-            pendingDraftClearViewIds.add(view.id);
-            const organizationId = organization.current;
-            if (organizationId) {
-                queueSavedViewDraftClear({
-                    organizationId,
-                    savedViewId: view.id,
-                    userId: view.updated_by_user_id ?? undefined
-                });
-            }
         }
 
         activeFilterOverrideBaselines = {};
@@ -1056,6 +1040,9 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         },
         get autoFillColumnId() {
             return autoFillColumnId;
+        },
+        get canModifySavedView() {
+            return !!currentUserQuery.data?.id;
         },
         handleClearSavedView,
         handleLoadView,

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -243,8 +243,17 @@ export function hasMissingSavedView(options: {
     return !!options.savedViewKey && !options.activeSavedView && !!options.savedViews && !options.isLoading;
 }
 
-export function hasSavedViewAutoFillChange(current: AutoFillColumnSelection, view: Pick<SavedView, 'columns'>, defaultAutoFillColumnId?: string): boolean {
-    return current !== getSavedAutoFillColumnSelection(view, defaultAutoFillColumnId);
+export function hasSavedViewAutoFillChange(
+    current: AutoFillColumnSelection,
+    view: Pick<SavedView, 'columns'>,
+    defaultAutoFillColumnId?: string,
+    availableColumnIds?: readonly string[]
+): boolean {
+    const savedSelection = getSavedAutoFillColumnSelection(view, defaultAutoFillColumnId);
+    const resolvedSavedSelection = availableColumnIds
+        ? resolveAvailableAutoFillColumnSelection(savedSelection, availableColumnIds, defaultAutoFillColumnId)
+        : savedSelection;
+    return current !== resolvedSavedSelection;
 }
 
 export function hasSavedViewColumnChanges(
@@ -508,6 +517,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             version: 1
         };
         const storedDraft = preserveExplicitFilterOverrides ? getStoredDraft(view) : undefined;
+        const availableColumnIds = options.getAvailableColumnIds?.() ?? options.getColumnOrder?.() ?? [];
 
         if (options.getFilterDefinitions) {
             const serverFilters = getServerFilters(view);
@@ -521,14 +531,20 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         if (options.getColumnVisibility) {
-            const serverVisibility = {
-                ...options.defaultColumnVisibility,
-                ...getSavedColumnVisibility(view)
-            };
-            const currentVisibility = {
-                ...options.defaultColumnVisibility,
-                ...options.getColumnVisibility()
-            };
+            const serverVisibility = filterAvailableColumnRecord(
+                {
+                    ...options.defaultColumnVisibility,
+                    ...getSavedColumnVisibility(view)
+                },
+                availableColumnIds
+            );
+            const currentVisibility = filterAvailableColumnRecord(
+                {
+                    ...options.defaultColumnVisibility,
+                    ...options.getColumnVisibility()
+                },
+                availableColumnIds
+            );
             draft.columnVisibilityChanges = buildRecordChanges(serverVisibility, currentVisibility);
         }
 
@@ -537,14 +553,20 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         if (options.getColumnSizing) {
-            draft.columnSizingChanges = buildRecordChanges(getSavedColumnSizing(view), normalizeColumnSizing(options.getColumnSizing()));
+            draft.columnSizingChanges = buildRecordChanges(
+                filterAvailableColumnRecord(getSavedColumnSizing(view), availableColumnIds),
+                filterAvailableColumnRecord(normalizeColumnSizing(options.getColumnSizing()), availableColumnIds)
+            );
         }
 
-        if (hasSavedViewAutoFillChange(autoFillColumnId, view, options.defaultAutoFillColumnId)) {
+        if (hasSavedViewAutoFillChange(autoFillColumnId, view, options.defaultAutoFillColumnId, availableColumnIds)) {
             draft.autoFillColumnId = autoFillColumnId;
         }
 
-        draft.wrappedColumnChanges = buildWrappedColumnChanges(getSavedWrappedColumnIds(view), wrappedColumnIds);
+        draft.wrappedColumnChanges = buildWrappedColumnChanges(
+            filterAvailableColumnIds(getSavedWrappedColumnIds(view), availableColumnIds),
+            filterAvailableColumnIds(wrappedColumnIds, availableColumnIds)
+        );
 
         if (options.getShowStats && options.getShowStats() !== (view.show_stats ?? true)) {
             draft.showStats = options.getShowStats();
@@ -753,6 +775,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         if (!view || activeSavedView?.id !== view.id) {
             return false;
         }
+        const availableColumnIds = options.getAvailableColumnIds?.() ?? options.getColumnOrder?.() ?? [];
 
         const savedViewFilter = getComparableSavedViewFilter(view.filter, view.filter_definitions, options.defaultFilter);
         if ((options.getFilter?.() ?? options.queryParams.filter ?? null) !== savedViewFilter) {
@@ -774,7 +797,11 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
         if (
             options.getColumnVisibility &&
-            hasSavedViewColumnChanges(options.getColumnVisibility(), getSavedColumnVisibility(view), options.defaultColumnVisibility)
+            hasSavedViewColumnChanges(
+                filterAvailableColumnRecord(options.getColumnVisibility(), availableColumnIds),
+                filterAvailableColumnRecord(getSavedColumnVisibility(view), availableColumnIds),
+                filterAvailableColumnRecord(options.defaultColumnVisibility ?? {}, availableColumnIds)
+            )
         ) {
             return true;
         }
@@ -783,15 +810,15 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return true;
         }
 
-        if (options.getColumnSizing && !savedViewColumnSizingEqual(options.getColumnSizing(), view)) {
+        if (options.getColumnSizing && !savedViewColumnSizingEqual(options.getColumnSizing(), view, availableColumnIds)) {
             return true;
         }
 
-        if (hasSavedViewAutoFillChange(autoFillColumnId, view, options.defaultAutoFillColumnId)) {
+        if (hasSavedViewAutoFillChange(autoFillColumnId, view, options.defaultAutoFillColumnId, availableColumnIds)) {
             return true;
         }
 
-        if (!savedViewColumnWrappingEqual(wrappedColumnIds, view)) {
+        if (!savedViewColumnWrappingEqual(wrappedColumnIds, view, availableColumnIds)) {
             return true;
         }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -179,6 +179,21 @@ export function clearSavedViewQueryParams(queryParams: SavedViewQueryParams): vo
     }
 }
 
+export function createSavedViewDraftFilterHistoryEntry(
+    viewId: string,
+    filter: null | string,
+    isDraftGenerated: boolean
+): SavedViewDraftFilterHistoryEntry | undefined {
+    if (!isDraftGenerated || filter === null) {
+        return undefined;
+    }
+
+    return {
+        filter,
+        viewId
+    };
+}
+
 export function filterDefinitionsEqual(a: null | string | undefined, b: null | string | undefined): boolean {
     return normalizeFilterDefinitions(a) === normalizeFilterDefinitions(b);
 }
@@ -555,11 +570,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             ...getCurrentPageState()
         };
         const filter = new SvelteURL(window.location.href).searchParams.get('filter');
-        if (isDraftGenerated && filter) {
-            const entry = {
-                filter,
-                viewId
-            };
+        const entry = createSavedViewDraftFilterHistoryEntry(viewId, filter, isDraftGenerated);
+        if (entry) {
             state[savedViewDraftFilterHistoryStateKey] = entry;
             storeDraftFilterHistoryEntry(entry);
         } else {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -25,6 +25,7 @@ import {
     getSavedColumnSizing,
     getSavedColumnVisibility,
     getSavedWrappedColumnIds,
+    normalizeColumnSizing,
     savedViewColumnSizingEqual,
     savedViewColumnWrappingEqual
 } from './column-settings';
@@ -381,7 +382,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         if (options.getColumnSizing) {
-            draft.columnSizingChanges = buildRecordChanges(getSavedColumnSizing(view), options.getColumnSizing());
+            draft.columnSizingChanges = buildRecordChanges(getSavedColumnSizing(view), normalizeColumnSizing(options.getColumnSizing()));
         }
 
         if (hasSavedViewAutoFillChange(autoFillColumnId, view, options.defaultAutoFillColumnId)) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -12,7 +12,7 @@ import {
 } from '$features/events/components/filters/helpers.svelte';
 import { organization } from '$features/organizations/context.svelte';
 import { getMeQuery } from '$features/users/api.svelte';
-import { tick } from 'svelte';
+import { tick, untrack } from 'svelte';
 
 import type { AutoFillColumnSelection, WrappedColumnIds } from './column-settings';
 import type { SavedView } from './models';
@@ -129,6 +129,31 @@ export function getComparableSavedViewFilter(
 
 export function getComparableSavedViewTime(time: null | string | undefined, defaultTime: null | string | undefined): null | string {
     return time ?? defaultTime ?? null;
+}
+
+export function getSavedViewStateSignature(
+    view: Pick<SavedView, 'columns' | 'filter' | 'filter_definitions' | 'show_chart' | 'show_stats' | 'sort' | 'time'>
+): string {
+    const columns = Object.entries(view.columns ?? {})
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([columnId, settings]) => [
+            columnId,
+            settings.auto_fill ?? null,
+            settings.position ?? null,
+            settings.visible ?? null,
+            settings.width ?? null,
+            settings.wrap ?? null
+        ]);
+
+    return JSON.stringify({
+        columns,
+        filter: view.filter ?? null,
+        filterDefinitions: view.filter_definitions ?? null,
+        showChart: view.show_chart ?? true,
+        showStats: view.show_stats ?? true,
+        sort: view.sort ?? null,
+        time: view.time ?? null
+    });
 }
 
 export function hasMissingSavedViewSlug(options: {
@@ -388,6 +413,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     let lastLoadedViewId = '';
     let appliedDraftKey = $state('');
     let pendingDraftKey = '';
+    let hydratedSavedView = $state<SavedView>();
+    let hydratedSavedViewSignature = '';
     let hydratedSavedViewId = $state<string>();
     $effect(() => {
         const savedViewKey = options.slug ?? options.queryParams.saved;
@@ -405,6 +432,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
                 lastLoadedViewId = '';
                 appliedDraftKey = '';
+                hydratedSavedView = undefined;
+                hydratedSavedViewSignature = '';
             }
 
             hydratedSavedViewId = undefined;
@@ -421,13 +450,25 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return;
         }
 
-        // Already loaded this view — skip to avoid stomping user edits on background refetch
+        const viewSignature = getSavedViewStateSignature(view);
+
+        // Keep the last hydrated server content as the local-edit baseline. If a
+        // same-ID update matches the current UI, it was saved and becomes the new
+        // baseline. Otherwise leave the UI and baseline alone until navigation so
+        // remote changes cannot be persisted back as local reverse edits.
         if (view.id === lastLoadedViewId) {
+            if (viewSignature !== hydratedSavedViewSignature && untrack(() => buildSavedViewDraft(view) === undefined)) {
+                hydratedSavedView = view;
+                hydratedSavedViewSignature = viewSignature;
+            }
+
             hydratedSavedViewId = view.id;
             return;
         }
 
         lastLoadedViewId = view.id;
+        hydratedSavedView = view;
+        hydratedSavedViewSignature = viewSignature;
 
         if (view.filter_definitions) {
             try {
@@ -494,8 +535,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
     // Detect if current filters or columns differ from the active saved view
     const isModified = $derived.by(() => {
-        const view = activeSavedView;
-        if (!view) {
+        const view = hydratedSavedView;
+        if (!view || activeSavedView?.id !== view.id) {
             return false;
         }
 
@@ -552,8 +593,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     });
 
     const currentDraft = $derived.by(() => {
-        const view = activeSavedView;
-        return view ? buildSavedViewDraft(view) : undefined;
+        const view = hydratedSavedView;
+        return view && activeSavedView?.id === view.id ? buildSavedViewDraft(view) : undefined;
     });
 
     async function persistDraftAfterStateSettles(
@@ -615,6 +656,9 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         if (!view) {
             return;
         }
+
+        hydratedSavedView = view;
+        hydratedSavedViewSignature = getSavedViewStateSignature(view);
 
         if (view.filter_definitions) {
             try {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -551,7 +551,17 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         return false;
     });
 
-    async function persistDraftAfterStateSettles(viewId: string, identity: SavedViewDraftIdentity, draftKey: string): Promise<void> {
+    const currentDraft = $derived.by(() => {
+        const view = activeSavedView;
+        return view ? buildSavedViewDraft(view) : undefined;
+    });
+
+    async function persistDraftAfterStateSettles(
+        viewId: string,
+        identity: SavedViewDraftIdentity,
+        draftKey: string,
+        draft: SavedViewDraft | undefined
+    ): Promise<void> {
         await tick();
 
         const view = activeSavedView;
@@ -559,7 +569,6 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return;
         }
 
-        const draft = buildSavedViewDraft(view);
         if (draft) {
             saveSavedViewDraft(identity, draft);
         } else {
@@ -579,10 +588,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return;
         }
 
-        // Subscribe to every field that contributes to dirty state, then persist after
-        // route-level filter normalization has settled for this render cycle.
-        void isModified;
-        void persistDraftAfterStateSettles(view.id, identity, draftKey);
+        // The draft value tracks every persisted field even while isModified remains true.
+        void persistDraftAfterStateSettles(view.id, identity, draftKey, currentDraft);
     });
 
     const isMissing = $derived(

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -174,13 +174,13 @@ export function getSavedViewStateSignature(
     });
 }
 
-export function hasMissingSavedViewSlug(options: {
+export function hasMissingSavedView(options: {
     activeSavedView: SavedView | undefined;
     isLoading: boolean;
+    savedViewKey: null | string | undefined;
     savedViews: SavedView[] | undefined;
-    slug: string | undefined;
 }): boolean {
-    return !!options.slug && !options.activeSavedView && !!options.savedViews && !options.isLoading;
+    return !!options.savedViewKey && !options.activeSavedView && !!options.savedViews && !options.isLoading;
 }
 
 export function hasSavedViewAutoFillChange(current: AutoFillColumnSelection, view: Pick<SavedView, 'columns'>, defaultAutoFillColumnId?: string): boolean {
@@ -193,6 +193,15 @@ export function hasSavedViewColumnChanges(
     defaultColumnVisibility: ColumnVisibilityState = {}
 ): boolean {
     return !savedViewColumnsEqual(current, saved, defaultColumnVisibility);
+}
+
+export function isSavedViewHydrationPending(
+    savedViewKey: null | string | undefined,
+    activeSavedViewId: string | undefined,
+    hydratedSavedViewId: string | undefined,
+    isMissing: boolean
+): boolean {
+    return !!savedViewKey && !isMissing && (!activeSavedViewId || activeSavedViewId !== hydratedSavedViewId);
 }
 
 export function savedViewColumnsEqual(
@@ -436,8 +445,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         if (options.getFilterDefinitions) {
             const serverFilters = getServerFilters(view);
             let currentFilters = deserializeFilters(options.getFilterDefinitions());
-            const currentFilterChanges = buildFilterChanges(serverFilters, currentFilters);
-            if (preserveExplicitFilterOverrides && currentFilterChanges) {
+            if (preserveExplicitFilterOverrides) {
                 const storedDraftFilters = applyFilterChanges(serverFilters, storedDraft?.filterChanges);
                 currentFilters = mergeFilterOverrides(currentFilters, storedDraftFilters, getActiveFilterOverrideKeys(currentFilters));
             }
@@ -641,6 +649,10 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
         const identity = getDraftIdentity(view);
         if (!identity) {
+            if (currentUserQuery.isError) {
+                hydratedSavedViewId = view.id;
+            }
+
             return;
         }
 
@@ -774,11 +786,11 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     });
 
     const isMissing = $derived(
-        hasMissingSavedViewSlug({
+        hasMissingSavedView({
             activeSavedView,
             isLoading: savedViewsListQuery.isLoading,
-            savedViews: savedViewsListQuery.data,
-            slug: options.slug
+            savedViewKey: options.slug ?? options.queryParams.saved,
+            savedViews: savedViewsListQuery.data
         })
     );
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -13,6 +13,7 @@ import {
 import { organization } from '$features/organizations/context.svelte';
 import { getMeQuery } from '$features/users/api.svelte';
 import { tick, untrack } from 'svelte';
+import { SvelteSet, SvelteURL } from 'svelte/reactivity';
 
 import type { AutoFillColumnSelection, WrappedColumnIds } from './column-settings';
 import type { SavedView } from './models';
@@ -111,6 +112,13 @@ export interface UseSavedViewsReturn {
     wrappedColumnIds: WrappedColumnIds;
 }
 
+interface InitialQueryState {
+    filterDefinitions: string;
+    sort: null | string;
+    url: URL;
+    viewId: string;
+}
+
 const SAVED_VIEW_QUERY_PARAMETER_FILTER_KEYS: readonly string[] = [
     'boolean-bot',
     'boolean-first',
@@ -144,6 +152,14 @@ export function filterDefinitionsEqual(a: null | string | undefined, b: null | s
     return normalizeFilterDefinitions(a) === normalizeFilterDefinitions(b);
 }
 
+export function getChangedFilterKeys(initialFilters: IFilter[], currentFilters: IFilter[]): string[] {
+    const keys = new SvelteSet([...initialFilters.map((filter) => filter.key), ...currentFilters.map((filter) => filter.key)]);
+    return [...keys].filter(
+        (key) =>
+            serializeFilters(initialFilters.filter((filter) => filter.key === key)) !== serializeFilters(currentFilters.filter((filter) => filter.key === key))
+    );
+}
+
 export function getComparableSavedViewFilter(
     filter: null | string | undefined,
     filterDefinitions: null | string | undefined,
@@ -154,6 +170,14 @@ export function getComparableSavedViewFilter(
     }
 
     return filterDefinitions ? null : (defaultFilter ?? null);
+}
+
+export function getComparableSavedViewFilterDefinitions(
+    filterDefinitions: string,
+    time: null | string | undefined,
+    defaultTime: null | string | undefined
+): string {
+    return serializeFilters(getSavedViewDefinitionFilters(filterDefinitions, time, defaultTime));
 }
 
 export function getComparableSavedViewTime(time: null | string | undefined, defaultTime: null | string | undefined): null | string {
@@ -428,7 +452,12 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         return applyTimeFilter(filters, getComparableSavedViewTime(view.time, options.defaultTime));
     }
 
-    function getExplicitFilterOverrideKeys(serverFilters: IFilter[], currentFilters: IFilter[], draft: SavedViewDraft | undefined): string[] {
+    function getExplicitFilterOverrideKeys(
+        serverFilters: IFilter[],
+        currentFilters: IFilter[],
+        draft: SavedViewDraft | undefined,
+        url: URL = page.url
+    ): string[] {
         const keys: string[] = [];
         const queryParameterKeys = [
             ['bot', 'boolean-bot'],
@@ -451,13 +480,13 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         };
 
         for (const [parameter, key] of queryParameterKeys) {
-            if (page.url.searchParams.has(parameter)) {
+            if (url.searchParams.has(parameter)) {
                 addKey(key);
             }
         }
 
-        if (page.url.searchParams.has('filter')) {
-            const filter = page.url.searchParams.get('filter') ?? '';
+        if (url.searchParams.has('filter')) {
+            const filter = url.searchParams.get('filter') ?? '';
             if (filter) {
                 for (const override of getFiltersFromCache(options.filterCacheKey(filter), filter)) {
                     addKey(override.key);
@@ -469,8 +498,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             }
         }
 
-        if (page.url.searchParams.has('filters')) {
-            const definitions = page.url.searchParams.get('filters');
+        if (url.searchParams.has('filters')) {
+            const definitions = url.searchParams.get('filters');
             if (definitions) {
                 try {
                     for (const override of deserializeFilters(definitions)) {
@@ -485,7 +514,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         return keys;
     }
 
-    function applyDraftState(view: SavedView, draft: SavedViewDraft | undefined, overrideKeys: string[]): void {
+    function applyDraftState(view: SavedView, draft: SavedViewDraft | undefined, overrideKeys: string[], preservePendingSort = false): void {
         const availableColumnIds = options.getAvailableColumnIds?.() ?? options.getColumnOrder?.() ?? [];
 
         if (options.applyFilters) {
@@ -518,7 +547,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         options.setShowStats?.(draft && 'showStats' in draft ? draft.showStats! : (view.show_stats ?? true));
         options.setShowChart?.(draft && 'showChart' in draft ? draft.showChart! : (view.show_chart ?? true));
 
-        if (draft && 'sort' in draft && !page.url.searchParams.has('sort')) {
+        if (draft && 'sort' in draft && !page.url.searchParams.has('sort') && !preservePendingSort) {
             setSortQueryParam(options.queryParams, getDraftSortQueryParam(view.sort ?? null, draft.sort ?? null), 'replace');
         }
     }
@@ -622,6 +651,23 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         hydratedColumnOrder = options.getColumnOrder ? [...options.getColumnOrder()] : undefined;
     }
 
+    async function captureInitialQueryStateAfterStateSettles(viewId: string): Promise<InitialQueryState | undefined> {
+        await tick();
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        await tick();
+
+        if (activeSavedView?.id !== viewId || serverHydratedSavedViewId !== viewId) {
+            return undefined;
+        }
+
+        return {
+            filterDefinitions: options.getFilterDefinitions?.() ?? '[]',
+            sort: options.getSort?.() ?? options.queryParams.sort ?? null,
+            url: new SvelteURL(page.url),
+            viewId
+        };
+    }
+
     // Hydrate saved view state when a saved view loads. Query params remain URL overrides.
     // lastLoadedViewId prevents re-hydration on background refetches (which would stomp user edits).
     let lastLoadedViewId = '';
@@ -636,6 +682,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     let hydratedSavedView = $state<SavedView>();
     let hydratedSavedViewSignature = '';
     let hydratedSavedViewId = $state<string>();
+    let initialQueryStatePromise: Promise<InitialQueryState | undefined> = Promise.resolve(undefined);
     let serverHydratedSavedViewId = $state<string>();
     $effect(() => {
         const savedViewKey = options.slug ?? options.queryParams.saved;
@@ -661,6 +708,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
                 hydratedColumnOrder = undefined;
                 hydratedSavedView = undefined;
                 hydratedSavedViewSignature = '';
+                initialQueryStatePromise = Promise.resolve(undefined);
             }
 
             hydratedSavedViewId = undefined;
@@ -721,16 +769,12 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         applyDisplayState(view);
         hydratedSavedViewId = undefined;
         serverHydratedSavedViewId = view.id;
+        initialQueryStatePromise = captureInitialQueryStateAfterStateSettles(view.id);
         void captureHydratedColumnOrderAfterStateSettles(view.id);
     });
 
     async function applyDraftAfterViewHydrates(viewId: string, identity: SavedViewDraftIdentity, draftKey: string, generation: number): Promise<void> {
-        // A dirty source view can leave a queued query-param reset behind during
-        // client-side navigation. Let that navigation task and route hydration
-        // finish before applying the destination view's browser-local draft.
-        await tick();
-        await new Promise<void>((resolve) => setTimeout(resolve, 0));
-        await tick();
+        const initialState = await initialQueryStatePromise;
 
         const view = activeSavedView;
         const currentIdentity = view ? getDraftIdentity(view) : undefined;
@@ -747,13 +791,18 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         const draft = mergePendingSavedViewDraftEdits(getSavedViewDraft(identity), pendingEdits);
         const serverFilters = getServerFilters(view);
         const currentFilters = options.getFilterDefinitions ? deserializeFilters(options.getFilterDefinitions()) : [];
-        const overrideKeys = getExplicitFilterOverrideKeys(serverFilters, currentFilters, draft);
-        activeFilterOverrideBaselines = buildFilterOverrideBaselines(currentFilters, overrideKeys);
-        activeSortOverride = page.url.searchParams.has('sort')
+        const matchingInitialState = initialState?.viewId === view.id ? initialState : undefined;
+        const initialFilters = matchingInitialState ? deserializeFilters(matchingInitialState.filterDefinitions) : currentFilters;
+        const initialOverrideKeys = getExplicitFilterOverrideKeys(serverFilters, initialFilters, draft, matchingInitialState?.url ?? page.url);
+        const overrideKeys = [...new SvelteSet([...initialOverrideKeys, ...getChangedFilterKeys(initialFilters, currentFilters)])];
+        activeFilterOverrideBaselines = buildFilterOverrideBaselines(initialFilters, initialOverrideKeys);
+        activeSortOverride = (matchingInitialState?.url ?? page.url).searchParams.has('sort')
             ? {
-                  value: options.getSort?.() ?? options.queryParams.sort ?? null
+                  value: matchingInitialState?.sort ?? options.getSort?.() ?? options.queryParams.sort ?? null
               }
             : undefined;
+        const preservePendingSort =
+            matchingInitialState !== undefined && (options.getSort?.() ?? options.queryParams.sort ?? null) !== matchingInitialState.sort;
         hydratedColumnOrder = options.getColumnOrder ? resolveSavedViewColumnOrder(view, options.getColumnOrder()) : undefined;
         hydratedSavedView = view;
         hydratedSavedViewSignature = getSavedViewStateSignature(view);
@@ -763,7 +812,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             pendingDraftGeneration = -1;
         }
 
-        applyDraftState(view, draft, overrideKeys);
+        applyDraftState(view, draft, overrideKeys, preservePendingSort);
 
         hydratedSavedViewId = view.id;
     }
@@ -816,7 +865,14 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return true;
         }
 
-        if (options.getFilterDefinitions && view.filter_definitions && !filterDefinitionsEqual(options.getFilterDefinitions(), view.filter_definitions)) {
+        if (
+            options.getFilterDefinitions &&
+            view.filter_definitions &&
+            !filterDefinitionsEqual(
+                options.getFilterDefinitions(),
+                getComparableSavedViewFilterDefinitions(view.filter_definitions, view.time, options.defaultTime)
+            )
+        ) {
             return true;
         }
 
@@ -944,6 +1000,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return;
         }
 
+        initialQueryStatePromise = captureInitialQueryStateAfterStateSettles(view.id);
         hydratedSavedViewId = undefined;
         appliedDraftKey = '';
         pendingDraftKey = '';

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -49,6 +49,7 @@ import {
     getSavedViewDraft,
     mergeFilterOverrides,
     mergePendingSavedViewDraftEdits,
+    type PendingSavedViewDraftTouches,
     type SavedViewDraft,
     type SavedViewDraftIdentity,
     saveSavedViewDraft
@@ -117,6 +118,17 @@ interface InitialQueryState {
     filterDefinitions: string;
     sort: null | string;
     url: URL;
+    viewId: string;
+}
+
+type PendingDraftField = NonNullable<PendingSavedViewDraftTouches['fields']>[number];
+type PendingDraftRecordField = keyof NonNullable<PendingSavedViewDraftTouches['recordKeys']>;
+
+interface PendingDraftTracker {
+    columnOrderBaseline: ColumnOrderState | undefined;
+    previousDraft: SavedViewDraft | undefined;
+    touchedFields: Set<PendingDraftField>;
+    touchedRecordKeys: Record<PendingDraftRecordField, Set<string>>;
     viewId: string;
 }
 
@@ -680,6 +692,26 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         };
     }
 
+    async function initializePendingDraftTrackingAfterStateSettles(view: SavedView): Promise<void> {
+        const initialState = await initialQueryStatePromise;
+        if (!initialState || initialState.viewId !== view.id || activeSavedView?.id !== view.id || serverHydratedSavedViewId !== view.id) {
+            return;
+        }
+
+        const columnOrderBaseline = options.getColumnOrder ? resolveSavedViewColumnOrder(view, options.getColumnOrder()) : undefined;
+        pendingDraftTracker = {
+            columnOrderBaseline,
+            previousDraft: buildSavedViewDraft(view, columnOrderBaseline),
+            touchedFields: new SvelteSet(),
+            touchedRecordKeys: {
+                columnSizingChanges: new SvelteSet(),
+                columnVisibilityChanges: new SvelteSet(),
+                wrappedColumnChanges: new SvelteSet()
+            },
+            viewId: view.id
+        };
+    }
+
     // Hydrate saved view state when a saved view loads. Query params remain URL overrides.
     // lastLoadedViewId prevents re-hydration on background refetches (which would stomp user edits).
     let lastLoadedViewId = '';
@@ -688,6 +720,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     let appliedDraftKey = $state('');
     let pendingDraftKey = '';
     let pendingDraftGeneration = -1;
+    let pendingDraftTracker = $state.raw<PendingDraftTracker>();
     let draftHydrationGeneration = $state(0);
     let draftPersistenceGeneration = 0;
     let hydratedColumnOrder = $state<ColumnOrderState>();
@@ -710,6 +743,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
                     applyDisplayState(undefined);
                     pendingDraftKey = '';
                     pendingDraftGeneration = -1;
+                    pendingDraftTracker = undefined;
                     draftHydrationGeneration++;
                 }
 
@@ -763,6 +797,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         appliedDraftKey = '';
         pendingDraftKey = '';
         pendingDraftGeneration = -1;
+        pendingDraftTracker = undefined;
         draftHydrationGeneration++;
         hydratedColumnOrder = undefined;
         hydratedSavedView = view;
@@ -782,7 +817,19 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         hydratedSavedViewId = undefined;
         serverHydratedSavedViewId = view.id;
         initialQueryStatePromise = captureInitialQueryStateAfterStateSettles(view.id);
+        void initializePendingDraftTrackingAfterStateSettles(view);
         void captureHydratedColumnOrderAfterStateSettles(view.id);
+    });
+
+    $effect(() => {
+        const tracker = pendingDraftTracker;
+        const view = activeSavedView;
+        if (!tracker || !view || tracker.viewId !== view.id || hydratedSavedViewId === view.id) {
+            return;
+        }
+
+        const currentDraft = buildSavedViewDraft(view, tracker.columnOrderBaseline);
+        untrack(() => trackPendingDraftChanges(tracker, currentDraft));
     });
 
     async function applyDraftAfterViewHydrates(viewId: string, identity: SavedViewDraftIdentity, draftKey: string, generation: number): Promise<void> {
@@ -799,8 +846,9 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return;
         }
 
+        const tracker = pendingDraftTracker?.viewId === view.id ? pendingDraftTracker : undefined;
         const pendingEdits = hydratedSavedView?.id === view.id ? buildSavedViewDraft(hydratedSavedView, hydratedColumnOrder) : undefined;
-        const draft = mergePendingSavedViewDraftEdits(getSavedViewDraft(identity), pendingEdits);
+        const draft = mergePendingSavedViewDraftEdits(getSavedViewDraft(identity), pendingEdits, tracker ? getPendingDraftTouches(tracker) : undefined);
         const serverFilters = getServerFilters(view);
         const currentFilters = options.getFilterDefinitions ? deserializeFilters(options.getFilterDefinitions()) : [];
         const matchingInitialState = initialState?.viewId === view.id ? initialState : undefined;
@@ -819,6 +867,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         hydratedSavedView = view;
         hydratedSavedViewSignature = getSavedViewStateSignature(view);
         appliedDraftKey = draftKey;
+        pendingDraftTracker = undefined;
         if (pendingDraftKey === draftKey && pendingDraftGeneration === generation) {
             pendingDraftKey = '';
             pendingDraftGeneration = -1;
@@ -1085,6 +1134,13 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
                 : undefined);
         if (identity) {
             clearSavedViewDraft(identity);
+        }
+
+        if (activeSavedView?.id !== view.id) {
+            return;
+        }
+
+        if (identity) {
             appliedDraftKey = `${identity.userId}:${identity.organizationId}:${identity.savedViewId}`;
         }
 
@@ -1154,6 +1210,28 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     };
 }
 
+function getPendingDraftTouches(tracker: PendingDraftTracker): PendingSavedViewDraftTouches | undefined {
+    const recordKeys = Object.fromEntries(
+        Object.entries(tracker.touchedRecordKeys)
+            .filter(([, keys]) => keys.size > 0)
+            .map(([field, keys]) => [field, [...keys]])
+    ) as PendingSavedViewDraftTouches['recordKeys'];
+    const touches: PendingSavedViewDraftTouches = {
+        ...(tracker.touchedFields.size > 0
+            ? {
+                  fields: [...tracker.touchedFields]
+              }
+            : {}),
+        ...(Object.keys(recordKeys ?? {}).length > 0
+            ? {
+                  recordKeys
+              }
+            : {})
+    };
+
+    return touches.fields || touches.recordKeys ? touches : undefined;
+}
+
 function normalizeFilterDefinitions(value: null | string | undefined): string {
     if (!value) {
         return '[]';
@@ -1181,6 +1259,26 @@ function supportsFiltersQueryParam(queryParams: SavedViewQueryParams): queryPara
 
 function supportsSavedQueryParam(queryParams: SavedViewQueryParams): queryParams is SavedViewQueryParams & { saved: null | string | undefined } {
     return Object.prototype.hasOwnProperty.call(queryParams, 'saved');
+}
+
+function trackPendingDraftChanges(tracker: PendingDraftTracker, currentDraft: SavedViewDraft | undefined): void {
+    for (const field of ['autoFillColumnId', 'columnOrder', 'showChart', 'showStats'] as const) {
+        if (JSON.stringify(tracker.previousDraft?.[field]) !== JSON.stringify(currentDraft?.[field])) {
+            tracker.touchedFields.add(field);
+        }
+    }
+
+    for (const field of ['columnSizingChanges', 'columnVisibilityChanges', 'wrappedColumnChanges'] as const) {
+        const previous = (tracker.previousDraft?.[field] ?? {}) as Record<string, unknown>;
+        const current = (currentDraft?.[field] ?? {}) as Record<string, unknown>;
+        for (const key of new SvelteSet([...Object.keys(previous), ...Object.keys(current)])) {
+            if (!Object.is(previous[key], current[key])) {
+                tracker.touchedRecordKeys[field].add(key);
+            }
+        }
+    }
+
+    tracker.previousDraft = currentDraft;
 }
 
 function updateSavedViewFilterCache(options: UseSavedViewsOptions, view: SavedView, filters: IFilter[]): void {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -501,7 +501,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         try {
-            return JSON.parse(localStorage.getItem(`${savedViewDraftFilterStoragePrefix}${historyEntryId}`) ?? 'null') as
+            return JSON.parse(sessionStorage.getItem(`${savedViewDraftFilterStoragePrefix}${historyEntryId}`) ?? 'null') as
                 SavedViewDraftFilterHistoryEntry | undefined;
         } catch {
             return undefined;
@@ -517,9 +517,9 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         try {
             const key = `${savedViewDraftFilterStoragePrefix}${historyEntryId}`;
             if (entry) {
-                localStorage.setItem(key, JSON.stringify(entry));
+                sessionStorage.setItem(key, JSON.stringify(entry));
             } else {
-                localStorage.removeItem(key);
+                sessionStorage.removeItem(key);
             }
         } catch {
             // Storage can be unavailable by browser policy; page-state provenance still works until reload.
@@ -610,6 +610,14 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             const filter = url.searchParams.get('filter') ?? '';
             if (filter) {
                 if (!draftGeneratedFilter) {
+                    if (!supportsTime) {
+                        for (const candidate of [...serverFilters, ...applyFilterChanges(serverFilters, draft?.filterChanges)]) {
+                            if (candidate.type !== 'date') {
+                                addKey(candidate.key);
+                            }
+                        }
+                    }
+
                     for (const override of getFiltersFromCache(options.filterCacheKey(filter), filter)) {
                         addKey(override.key);
                     }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -1406,7 +1406,7 @@ function trackPendingDraftChanges(tracker: PendingDraftTracker, currentDraft: Sa
     trackChangedFilterKeys(tracker.touchedFilterKeys, tracker.previousFilterDefinitions, currentFilterDefinitions);
     tracker.previousFilterDefinitions = currentFilterDefinitions;
 
-    for (const field of ['autoFillColumnId', 'columnOrder', 'showChart', 'showStats'] as const) {
+    for (const field of ['autoFillColumnId', 'columnOrder', 'showChart', 'showStats', 'sort'] as const) {
         if (JSON.stringify(tracker.previousDraft?.[field]) !== JSON.stringify(currentDraft?.[field])) {
             tracker.touchedFields.add(field);
         }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -35,9 +35,11 @@ import {
     applyRecordChanges,
     applyWrappedColumnChanges,
     buildFilterChanges,
+    buildFilterOverrideBaselines,
     buildRecordChanges,
     buildWrappedColumnChanges,
     clearSavedViewDraft,
+    getMatchingFilterOverrideKeys,
     getSavedViewDraft,
     mergeFilterOverrides,
     type SavedViewDraft,
@@ -132,6 +134,19 @@ export function getComparableSavedViewFilter(
 
 export function getComparableSavedViewTime(time: null | string | undefined, defaultTime: null | string | undefined): null | string {
     return time ?? defaultTime ?? null;
+}
+
+export function getDraftSortValue(
+    serverSort: null | string,
+    currentSort: null | string,
+    initialOverride: undefined | { value: null | string },
+    storedDraft: SavedViewDraft | undefined
+): null | string {
+    if (currentSort === serverSort || initialOverride?.value !== currentSort) {
+        return currentSort;
+    }
+
+    return storedDraft && 'sort' in storedDraft ? (storedDraft.sort ?? null) : serverSort;
 }
 
 export function getSavedViewStateSignature(
@@ -399,6 +414,15 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
     }
 
+    function getActiveFilterOverrideKeys(currentFilters: IFilter[]): string[] {
+        return getMatchingFilterOverrideKeys(currentFilters, activeFilterOverrideBaselines);
+    }
+
+    function getStoredDraft(view: SavedView): SavedViewDraft | undefined {
+        const identity = getDraftIdentity(view);
+        return identity ? getSavedViewDraft(identity) : undefined;
+    }
+
     function buildSavedViewDraft(
         view: SavedView,
         columnOrderBaseline: ColumnOrderState | undefined = hydratedColumnOrder,
@@ -407,16 +431,15 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         const draft: SavedViewDraft = {
             version: 1
         };
+        const storedDraft = preserveExplicitFilterOverrides ? getStoredDraft(view) : undefined;
 
         if (options.getFilterDefinitions) {
             const serverFilters = getServerFilters(view);
             let currentFilters = deserializeFilters(options.getFilterDefinitions());
             const currentFilterChanges = buildFilterChanges(serverFilters, currentFilters);
             if (preserveExplicitFilterOverrides && currentFilterChanges) {
-                const identity = getDraftIdentity(view);
-                const storedDraft = identity ? getSavedViewDraft(identity) : undefined;
                 const storedDraftFilters = applyFilterChanges(serverFilters, storedDraft?.filterChanges);
-                currentFilters = mergeFilterOverrides(currentFilters, storedDraftFilters, activeFilterOverrideKeys);
+                currentFilters = mergeFilterOverrides(currentFilters, storedDraftFilters, getActiveFilterOverrideKeys(currentFilters));
             }
 
             draft.filterChanges = buildFilterChanges(serverFilters, currentFilters);
@@ -458,8 +481,10 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
         if (supportsSort) {
             const currentSort = options.getSort?.() ?? options.queryParams.sort ?? null;
-            if (currentSort !== (view.sort ?? null)) {
-                draft.sort = currentSort;
+            const serverSort = view.sort ?? null;
+            const sortForDraft = preserveExplicitFilterOverrides ? getDraftSortValue(serverSort, currentSort, activeSortOverride, storedDraft) : currentSort;
+            if (sortForDraft !== serverSort) {
+                draft.sort = sortForDraft;
             }
         }
 
@@ -479,7 +504,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     // Hydrate saved view state when a saved view loads. Query params remain URL overrides.
     // lastLoadedViewId prevents re-hydration on background refetches (which would stomp user edits).
     let lastLoadedViewId = '';
-    let activeFilterOverrideKeys = $state<string[]>([]);
+    let activeFilterOverrideBaselines = $state<Record<string, string>>({});
+    let activeSortOverride = $state<{ value: null | string }>();
     let appliedDraftKey = $state('');
     let pendingDraftKey = '';
     let hydratedColumnOrder = $state<ColumnOrderState>();
@@ -501,7 +527,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
                 }
 
                 lastLoadedViewId = '';
-                activeFilterOverrideKeys = [];
+                activeFilterOverrideBaselines = {};
+                activeSortOverride = undefined;
                 appliedDraftKey = '';
                 hydratedColumnOrder = undefined;
                 hydratedSavedView = undefined;
@@ -541,7 +568,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         lastLoadedViewId = view.id;
-        activeFilterOverrideKeys = [];
+        activeFilterOverrideBaselines = {};
+        activeSortOverride = undefined;
         hydratedColumnOrder = undefined;
         hydratedSavedView = view;
         hydratedSavedViewSignature = viewSignature;
@@ -580,14 +608,22 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         const draft = getSavedViewDraft(identity);
-        activeFilterOverrideKeys = getExplicitFilterOverrideKeys(getServerFilters(view));
+        const serverFilters = getServerFilters(view);
+        const currentFilters = options.getFilterDefinitions ? deserializeFilters(options.getFilterDefinitions()) : [];
+        const overrideKeys = getExplicitFilterOverrideKeys(serverFilters);
+        activeFilterOverrideBaselines = buildFilterOverrideBaselines(currentFilters, overrideKeys);
+        activeSortOverride = page.url.searchParams.has('sort')
+            ? {
+                  value: options.getSort?.() ?? options.queryParams.sort ?? null
+              }
+            : undefined;
         appliedDraftKey = draftKey;
         if (pendingDraftKey === draftKey) {
             pendingDraftKey = '';
         }
 
         if (draft) {
-            applyDraftState(view, draft, activeFilterOverrideKeys);
+            applyDraftState(view, draft, overrideKeys);
         }
     }
 
@@ -675,6 +711,26 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         return view && activeSavedView?.id === view.id ? buildSavedViewDraft(view, hydratedColumnOrder, true) : undefined;
     });
 
+    $effect(() => {
+        if (!appliedDraftKey) {
+            return;
+        }
+
+        if (options.getFilterDefinitions) {
+            const currentFilters = deserializeFilters(options.getFilterDefinitions());
+            const activeKeys = getActiveFilterOverrideKeys(currentFilters);
+            const remainingBaselines = Object.fromEntries(Object.entries(activeFilterOverrideBaselines).filter(([key]) => activeKeys.includes(key)));
+            if (Object.keys(remainingBaselines).length !== Object.keys(activeFilterOverrideBaselines).length) {
+                activeFilterOverrideBaselines = remainingBaselines;
+            }
+        }
+
+        const currentSort = options.getSort?.() ?? options.queryParams.sort ?? null;
+        if (activeSortOverride && currentSort !== activeSortOverride.value) {
+            activeSortOverride = undefined;
+        }
+    });
+
     async function persistDraftAfterStateSettles(
         viewId: string,
         identity: SavedViewDraftIdentity,
@@ -755,7 +811,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         options.queryParams.filters = null;
         setSortQueryParam(options.queryParams, null);
         setTimeQueryParam(options.queryParams, null);
-        activeFilterOverrideKeys = [];
+        activeFilterOverrideBaselines = {};
+        activeSortOverride = undefined;
         hydratedColumnOrder = undefined;
         applyColumnState(view);
         applyDisplayState(view);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -1,15 +1,14 @@
 import type { IFilter } from '$comp/faceted-filter';
 import type { ColumnOrderState, ColumnSizingState, ColumnVisibilityState } from '@tanstack/svelte-table';
 
-import { afterNavigate, goto } from '$app/navigation';
+import { afterNavigate, goto, replaceState } from '$app/navigation';
 import { page } from '$app/state';
 import {
     applyTimeFilter,
     buildFilterCacheKey,
     deserializeFilters,
     getFiltersFromCache,
-    serializeFilters,
-    toFilter
+    serializeFilters
 } from '$features/events/components/filters/helpers.svelte';
 import { organization } from '$features/organizations/context.svelte';
 import { getMeQuery } from '$features/users/api.svelte';
@@ -115,6 +114,7 @@ export interface UseSavedViewsReturn {
 }
 
 interface InitialQueryState {
+    draftGeneratedFilter: boolean;
     filterDefinitions: string;
     sort: null | string;
     url: URL;
@@ -122,6 +122,7 @@ interface InitialQueryState {
 }
 
 type PendingDraftField = NonNullable<PendingSavedViewDraftTouches['fields']>[number];
+
 type PendingDraftRecordField = keyof NonNullable<PendingSavedViewDraftTouches['recordKeys']>;
 
 interface PendingDraftTracker {
@@ -131,6 +132,19 @@ interface PendingDraftTracker {
     touchedRecordKeys: Record<PendingDraftRecordField, Set<string>>;
     viewId: string;
 }
+
+interface SavedViewDraftFilterHistoryEntry {
+    filter: string;
+    viewId: string;
+}
+type SavedViewDraftFilterPageState = App.PageState & {
+    [savedViewDraftFilterHistoryStateKey]?: SavedViewDraftFilterHistoryEntry;
+};
+
+type SvelteKitSavedViewDraftFilterHistoryState = {
+    'sveltekit:history'?: number;
+    'sveltekit:states'?: SavedViewDraftFilterPageState;
+};
 
 const SAVED_VIEW_QUERY_PARAMETER_FILTER_KEYS: readonly string[] = [
     'boolean-bot',
@@ -145,6 +159,8 @@ const SAVED_VIEW_QUERY_PARAMETER_FILTER_KEYS: readonly string[] = [
     'type',
     'version-version'
 ];
+const savedViewDraftFilterHistoryStateKey = '__exceptionlessSavedViewDraftFilter';
+const savedViewDraftFilterStoragePrefix = 'exceptionless:saved-view-filter-history:';
 
 export function clearSavedViewQueryParams(queryParams: SavedViewQueryParams): void {
     queryParams.filter = null;
@@ -231,6 +247,21 @@ export function getSavedViewDefinitionFilters(filterDefinitions: string, time: n
     return applyTimeFilter(deserializeFilters(filterDefinitions), getComparableSavedViewTime(time, defaultTime));
 }
 
+export function getSavedViewDraftIdentity(
+    view: Pick<SavedView, 'id' | 'organization_id'>,
+    userId: null | string | undefined
+): SavedViewDraftIdentity | undefined {
+    if (!view.organization_id || !userId) {
+        return undefined;
+    }
+
+    return {
+        organizationId: view.organization_id,
+        savedViewId: view.id,
+        userId
+    };
+}
+
 export function getSavedViewStateSignature(
     view: Pick<SavedView, 'columns' | 'filter' | 'filter_definitions' | 'show_chart' | 'show_stats' | 'sort' | 'time'>
 ): string {
@@ -254,6 +285,15 @@ export function getSavedViewStateSignature(
         sort: view.sort ?? null,
         time: view.time ?? null
     });
+}
+
+export function isSavedViewDraftFilterHistoryEntry(entry: unknown, viewId: string, filter: null | string): boolean {
+    if (!entry || typeof entry !== 'object') {
+        return false;
+    }
+
+    const candidate = entry as Partial<SavedViewDraftFilterHistoryEntry>;
+    return candidate.viewId === viewId && candidate.filter === filter;
 }
 
 const SAVED_VIEW_OVERRIDE_QUERY_PARAMETERS = [
@@ -442,17 +482,84 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     }
 
     function getDraftIdentity(view: SavedView): SavedViewDraftIdentity | undefined {
-        const organizationId = organization.current;
-        const userId = currentUserQuery.data?.id;
-        if (!organizationId || !userId) {
+        return getSavedViewDraftIdentity(view, currentUserQuery.data?.id);
+    }
+
+    function getCurrentPageState(): SavedViewDraftFilterPageState {
+        const historyState = window.history.state as null | SvelteKitSavedViewDraftFilterHistoryState;
+        return historyState?.['sveltekit:states'] ?? (page.state as SavedViewDraftFilterPageState);
+    }
+
+    function getCurrentHistoryEntryId(): number | undefined {
+        return (window.history.state as null | SvelteKitSavedViewDraftFilterHistoryState)?.['sveltekit:history'];
+    }
+
+    function getStoredDraftFilterHistoryEntry(): SavedViewDraftFilterHistoryEntry | undefined {
+        const historyEntryId = getCurrentHistoryEntryId();
+        if (historyEntryId === undefined) {
             return undefined;
         }
 
-        return {
-            organizationId,
-            savedViewId: view.id,
-            userId
+        try {
+            return JSON.parse(localStorage.getItem(`${savedViewDraftFilterStoragePrefix}${historyEntryId}`) ?? 'null') as
+                SavedViewDraftFilterHistoryEntry | undefined;
+        } catch {
+            return undefined;
+        }
+    }
+
+    function storeDraftFilterHistoryEntry(entry: SavedViewDraftFilterHistoryEntry | undefined): void {
+        const historyEntryId = getCurrentHistoryEntryId();
+        if (historyEntryId === undefined) {
+            return;
+        }
+
+        try {
+            const key = `${savedViewDraftFilterStoragePrefix}${historyEntryId}`;
+            if (entry) {
+                localStorage.setItem(key, JSON.stringify(entry));
+            } else {
+                localStorage.removeItem(key);
+            }
+        } catch {
+            // Storage can be unavailable by browser policy; page-state provenance still works until reload.
+        }
+    }
+
+    function isDraftGeneratedFilter(viewId: string, url: URL = page.url, state: App.PageState = getCurrentPageState()): boolean {
+        const entry = (state as SavedViewDraftFilterPageState)[savedViewDraftFilterHistoryStateKey];
+        const filter = url.searchParams.get('filter');
+        return (
+            isSavedViewDraftFilterHistoryEntry(entry, viewId, filter) || isSavedViewDraftFilterHistoryEntry(getStoredDraftFilterHistoryEntry(), viewId, filter)
+        );
+    }
+
+    async function updateDraftFilterHistoryState(viewId: string, isDraftGenerated: boolean, generation: number): Promise<void> {
+        await tick();
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        await tick();
+
+        if (activeSavedView?.id !== viewId || draftFilterHistoryGeneration !== generation) {
+            return;
+        }
+
+        const state = {
+            ...getCurrentPageState()
         };
+        const filter = new SvelteURL(window.location.href).searchParams.get('filter');
+        if (isDraftGenerated && filter) {
+            const entry = {
+                filter,
+                viewId
+            };
+            state[savedViewDraftFilterHistoryStateKey] = entry;
+            storeDraftFilterHistoryEntry(entry);
+        } else {
+            delete state[savedViewDraftFilterHistoryStateKey];
+            storeDraftFilterHistoryEntry(undefined);
+        }
+
+        replaceState('', state);
     }
 
     function getServerFilters(view: SavedView): IFilter[] {
@@ -469,7 +576,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         serverFilters: IFilter[],
         currentFilters: IFilter[],
         draft: SavedViewDraft | undefined,
-        url: URL = page.url
+        url: URL = page.url,
+        draftGeneratedFilter = false
     ): string[] {
         const keys: string[] = [];
         const queryParameterKeys = [
@@ -501,16 +609,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         if (url.searchParams.has('filter')) {
             const filter = url.searchParams.get('filter') ?? '';
             if (filter) {
-                const draftFilters = applyFilterChanges(serverFilters, draft?.filterChanges);
-                const draftExpressionFilters = supportsTime
-                    ? draftFilters.filter((candidate) => candidate.type !== 'date' && !SAVED_VIEW_QUERY_PARAMETER_FILTER_KEYS.includes(candidate.key))
-                    : draftFilters;
-                const sourceFilters = draft?.filterChanges?.sourceDefinitions ? deserializeFilters(draft.filterChanges.sourceDefinitions) : serverFilters;
-                const restoredDraftFilters = applyFilterChanges(sourceFilters, draft?.filterChanges);
-                const restoredDraftExpressionFilters = supportsTime
-                    ? restoredDraftFilters.filter((candidate) => candidate.type !== 'date' && !SAVED_VIEW_QUERY_PARAMETER_FILTER_KEYS.includes(candidate.key))
-                    : restoredDraftFilters;
-                if (filter !== toFilter(draftExpressionFilters) && filter !== toFilter(restoredDraftExpressionFilters)) {
+                if (!draftGeneratedFilter) {
                     for (const override of getFiltersFromCache(options.filterCacheKey(filter), filter)) {
                         addKey(override.key);
                     }
@@ -538,7 +637,13 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         return keys;
     }
 
-    function applyDraftState(view: SavedView, draft: SavedViewDraft | undefined, overrideKeys: string[], preservePendingSort = false): void {
+    function applyDraftState(
+        view: SavedView,
+        draft: SavedViewDraft | undefined,
+        overrideKeys: string[],
+        preservePendingSort = false,
+        preserveDraftFilterProvenance = false
+    ): void {
         const availableColumnIds = options.getAvailableColumnIds?.() ?? options.getColumnOrder?.() ?? [];
 
         if (options.applyFilters) {
@@ -548,6 +653,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             options.applyFilters(mergeFilterOverrides(draftFilters, currentFilters, overrideKeys), {
                 history: 'replace'
             });
+            const filterHistoryGeneration = ++draftFilterHistoryGeneration;
+            void updateDraftFilterHistoryState(view.id, preserveDraftFilterProvenance, filterHistoryGeneration);
         }
 
         if (options.setColumnVisibility) {
@@ -685,6 +792,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         return {
+            draftGeneratedFilter: isDraftGeneratedFilter(viewId),
             filterDefinitions: options.getFilterDefinitions?.() ?? '[]',
             sort: options.getSort?.() ?? options.queryParams.sort ?? null,
             url: new SvelteURL(page.url),
@@ -721,6 +829,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     let pendingDraftKey = '';
     let pendingDraftGeneration = -1;
     let pendingDraftTracker = $state.raw<PendingDraftTracker>();
+    let draftFilterHistoryGeneration = 0;
     let draftHydrationGeneration = $state(0);
     let draftPersistenceGeneration = 0;
     let hydratedColumnOrder = $state<ColumnOrderState>();
@@ -853,8 +962,11 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         const currentFilters = options.getFilterDefinitions ? deserializeFilters(options.getFilterDefinitions()) : [];
         const matchingInitialState = initialState?.viewId === view.id ? initialState : undefined;
         const initialFilters = matchingInitialState ? deserializeFilters(matchingInitialState.filterDefinitions) : currentFilters;
-        const initialOverrideKeys = getExplicitFilterOverrideKeys(serverFilters, initialFilters, draft, matchingInitialState?.url ?? page.url);
-        const overrideKeys = [...new SvelteSet([...initialOverrideKeys, ...getChangedFilterKeys(initialFilters, currentFilters)])];
+        const initialUrl = matchingInitialState?.url ?? page.url;
+        const draftGeneratedFilter = matchingInitialState?.draftGeneratedFilter ?? isDraftGeneratedFilter(view.id, initialUrl);
+        const initialOverrideKeys = getExplicitFilterOverrideKeys(serverFilters, initialFilters, draft, initialUrl, draftGeneratedFilter);
+        const pendingOverrideKeys = draftGeneratedFilter ? [] : getChangedFilterKeys(initialFilters, currentFilters);
+        const overrideKeys = [...new SvelteSet([...initialOverrideKeys, ...pendingOverrideKeys])];
         activeFilterOverrideBaselines = buildFilterOverrideBaselines(initialFilters, initialOverrideKeys);
         activeSortOverride = (matchingInitialState?.url ?? page.url).searchParams.has('sort')
             ? {
@@ -873,7 +985,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             pendingDraftGeneration = -1;
         }
 
-        applyDraftState(view, draft, overrideKeys, preservePendingSort);
+        applyDraftState(view, draft, overrideKeys, preservePendingSort, draftGeneratedFilter || !initialUrl.searchParams.has('filter'));
 
         hydratedSavedViewId = view.id;
     }
@@ -1121,12 +1233,11 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     }
 
     function handleSavedViewUpdated(view: SavedView) {
-        const organizationId = organization.current;
         const identity =
             getDraftIdentity(view) ??
-            (organizationId && view.updated_by_user_id
+            (view.organization_id && view.updated_by_user_id
                 ? {
-                      organizationId,
+                      organizationId: view.organization_id,
                       savedViewId: view.id,
                       userId: view.updated_by_user_id
                   }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -102,6 +102,20 @@ export interface UseSavedViewsReturn {
     wrappedColumnIds: WrappedColumnIds;
 }
 
+const SAVED_VIEW_QUERY_PARAMETER_FILTER_KEYS: readonly string[] = [
+    'boolean-bot',
+    'boolean-first',
+    'level',
+    'project',
+    'reference',
+    'session',
+    'string-stack',
+    'status',
+    'tag',
+    'type',
+    'version-version'
+];
+
 export function clearSavedViewQueryParams(queryParams: SavedViewQueryParams): void {
     queryParams.filter = null;
 
@@ -148,6 +162,15 @@ export function getDraftSortValue(
     }
 
     return currentSort;
+}
+
+export function getEmptyFilterOverrideKeys(serverFilters: IFilter[], currentFilters: IFilter[], draft: SavedViewDraft | undefined): string[] {
+    const draftFilters = applyFilterChanges(serverFilters, draft?.filterChanges);
+    const keys = [...serverFilters, ...currentFilters, ...draftFilters]
+        .filter((filter) => filter.type !== 'date' && !SAVED_VIEW_QUERY_PARAMETER_FILTER_KEYS.includes(filter.key))
+        .map((filter) => filter.key);
+
+    return keys.filter((key, index) => keys.indexOf(key) === index);
 }
 
 export function getSavedViewStateSignature(
@@ -354,7 +377,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         return applyTimeFilter(filters, getComparableSavedViewTime(view.time, options.defaultTime));
     }
 
-    function getExplicitFilterOverrideKeys(serverFilters: IFilter[]): string[] {
+    function getExplicitFilterOverrideKeys(serverFilters: IFilter[], currentFilters: IFilter[], draft: SavedViewDraft | undefined): string[] {
         const keys: string[] = [];
         const queryParameterKeys = [
             ['bot', 'boolean-bot'],
@@ -370,7 +393,6 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             ['type', 'type'],
             ['version', 'version-version']
         ] as const;
-        const dedicatedQueryFilterKeys: string[] = queryParameterKeys.map(([, key]) => key);
         const addKey = (key: string) => {
             if (!keys.includes(key)) {
                 keys.push(key);
@@ -390,10 +412,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
                     addKey(override.key);
                 }
             } else {
-                for (const serverFilter of serverFilters) {
-                    if (serverFilter.type !== 'date' && !dedicatedQueryFilterKeys.includes(serverFilter.key)) {
-                        addKey(serverFilter.key);
-                    }
+                for (const key of getEmptyFilterOverrideKeys(serverFilters, currentFilters, draft)) {
+                    addKey(key);
                 }
             }
         }
@@ -414,35 +434,31 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         return keys;
     }
 
-    function applyDraftState(view: SavedView, draft: SavedViewDraft, overrideKeys: string[]): void {
-        if (draft.filterChanges && options.applyFilters) {
+    function applyDraftState(view: SavedView, draft: SavedViewDraft | undefined, overrideKeys: string[]): void {
+        if (options.applyFilters) {
             const serverFilters = getServerFilters(view);
-            const draftFilters = applyFilterChanges(serverFilters, draft.filterChanges);
+            const draftFilters = applyFilterChanges(serverFilters, draft?.filterChanges);
             const currentFilters = options.getFilterDefinitions ? deserializeFilters(options.getFilterDefinitions()) : [];
             options.applyFilters(mergeFilterOverrides(draftFilters, currentFilters, overrideKeys));
         }
 
         if (options.setColumnVisibility) {
-            options.setColumnVisibility(applyRecordChanges(getSavedColumnVisibility(view), draft.columnVisibilityChanges));
+            options.setColumnVisibility(applyRecordChanges(getSavedColumnVisibility(view), draft?.columnVisibilityChanges));
         }
 
         if (options.setColumnOrder) {
-            options.setColumnOrder(draft.columnOrder ?? getSavedColumnOrder(view));
+            options.setColumnOrder(draft?.columnOrder ?? getSavedColumnOrder(view));
         }
 
-        options.setColumnSizing?.(applyRecordChanges(getSavedColumnSizing(view), draft.columnSizingChanges));
-        autoFillColumnId = 'autoFillColumnId' in draft ? draft.autoFillColumnId! : getSavedAutoFillColumnSelection(view, options.defaultAutoFillColumnId);
-        wrappedColumnIds = applyWrappedColumnChanges(getSavedWrappedColumnIds(view), draft.wrappedColumnChanges);
+        options.setColumnSizing?.(applyRecordChanges(getSavedColumnSizing(view), draft?.columnSizingChanges));
+        autoFillColumnId =
+            draft && 'autoFillColumnId' in draft ? draft.autoFillColumnId! : getSavedAutoFillColumnSelection(view, options.defaultAutoFillColumnId);
+        wrappedColumnIds = applyWrappedColumnChanges(getSavedWrappedColumnIds(view), draft?.wrappedColumnChanges);
 
-        if ('showStats' in draft) {
-            options.setShowStats?.(draft.showStats!);
-        }
+        options.setShowStats?.(draft && 'showStats' in draft ? draft.showStats! : (view.show_stats ?? true));
+        options.setShowChart?.(draft && 'showChart' in draft ? draft.showChart! : (view.show_chart ?? true));
 
-        if ('showChart' in draft) {
-            options.setShowChart?.(draft.showChart!);
-        }
-
-        if ('sort' in draft && !page.url.searchParams.has('sort')) {
+        if (draft && 'sort' in draft && !page.url.searchParams.has('sort')) {
             setSortQueryParam(options.queryParams, draft.sort === (view.sort ?? null) ? null : (draft.sort ?? null));
         }
     }
@@ -656,22 +672,23 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         const draft = getSavedViewDraft(identity);
         const serverFilters = getServerFilters(view);
         const currentFilters = options.getFilterDefinitions ? deserializeFilters(options.getFilterDefinitions()) : [];
-        const overrideKeys = getExplicitFilterOverrideKeys(serverFilters);
+        const overrideKeys = getExplicitFilterOverrideKeys(serverFilters, currentFilters, draft);
         activeFilterOverrideBaselines = buildFilterOverrideBaselines(currentFilters, overrideKeys);
         activeSortOverride = page.url.searchParams.has('sort')
             ? {
                   value: options.getSort?.() ?? options.queryParams.sort ?? null
               }
             : undefined;
+        hydratedColumnOrder = options.getColumnOrder ? resolveSavedViewColumnOrder(view, options.getColumnOrder()) : undefined;
+        hydratedSavedView = view;
+        hydratedSavedViewSignature = getSavedViewStateSignature(view);
         appliedDraftKey = draftKey;
         if (pendingDraftKey === draftKey && pendingDraftGeneration === generation) {
             pendingDraftKey = '';
             pendingDraftGeneration = -1;
         }
 
-        if (draft) {
-            applyDraftState(view, draft, overrideKeys);
-        }
+        applyDraftState(view, draft, overrideKeys);
 
         hydratedSavedViewId = view.id;
     }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -26,6 +26,7 @@ import {
     getSavedColumnVisibility,
     getSavedWrappedColumnIds,
     normalizeColumnSizing,
+    resolveAvailableColumnOrder,
     resolveSavedViewColumnOrder,
     savedViewColumnSizingEqual,
     savedViewColumnWrappingEqual
@@ -42,6 +43,7 @@ import {
     getMatchingFilterOverrideKeys,
     getSavedViewDraft,
     mergeFilterOverrides,
+    mergePendingSavedViewDraftEdits,
     type SavedViewDraft,
     type SavedViewDraftIdentity,
     saveSavedViewDraft
@@ -455,7 +457,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         if (options.setColumnOrder) {
-            options.setColumnOrder(draft?.columnOrder ?? getSavedColumnOrder(view));
+            options.setColumnOrder(draft?.columnOrder ? resolveAvailableColumnOrder(draft.columnOrder, options.getColumnOrder?.()) : getSavedColumnOrder(view));
         }
 
         options.setColumnSizing?.(applyRecordChanges(getSavedColumnSizing(view), draft?.columnSizingChanges));
@@ -677,7 +679,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return;
         }
 
-        const draft = getSavedViewDraft(identity);
+        const pendingEdits = hydratedSavedView?.id === view.id ? buildSavedViewDraft(hydratedSavedView, hydratedColumnOrder) : undefined;
+        const draft = mergePendingSavedViewDraftEdits(getSavedViewDraft(identity), pendingEdits);
         const serverFilters = getServerFilters(view);
         const currentFilters = options.getFilterDefinitions ? deserializeFilters(options.getFilterDefinitions()) : [];
         const overrideKeys = getExplicitFilterOverrideKeys(serverFilters, currentFilters, draft);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -151,6 +151,14 @@ export function getComparableSavedViewTime(time: null | string | undefined, defa
     return time ?? defaultTime ?? null;
 }
 
+export function getDraftSortQueryParam(serverSort: null | string, draftSort: null | string): null | string {
+    if (draftSort === serverSort) {
+        return null;
+    }
+
+    return draftSort ?? '';
+}
+
 export function getDraftSortValue(
     serverSort: null | string,
     currentSort: null | string,
@@ -459,7 +467,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         options.setShowChart?.(draft && 'showChart' in draft ? draft.showChart! : (view.show_chart ?? true));
 
         if (draft && 'sort' in draft && !page.url.searchParams.has('sort')) {
-            setSortQueryParam(options.queryParams, draft.sort === (view.sort ?? null) ? null : (draft.sort ?? null));
+            setSortQueryParam(options.queryParams, getDraftSortQueryParam(view.sort ?? null, draft.sort ?? null));
         }
     }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -60,10 +60,11 @@ export interface SavedViewQueryParams {
     saved?: null | string | undefined;
     sort?: null | string;
     time?: null | string;
+    update?: (values: Partial<SavedViewQueryParams>, options?: { history?: 'push' | 'replace' }) => void;
 }
 
 export interface UseSavedViewsOptions {
-    applyFilters?: (filters: IFilter[]) => void;
+    applyFilters?: (filters: IFilter[], options?: { history?: 'push' | 'replace' }) => void;
     baseHref?: string;
     defaultAutoFillColumnId?: string;
     defaultColumnVisibility?: ColumnVisibilityState;
@@ -300,9 +301,20 @@ export function savedViewColumnsEqual(
     });
 }
 
-export function setSortQueryParam(queryParams: SavedViewQueryParams, value: null | string): void {
+export function setSortQueryParam(queryParams: SavedViewQueryParams, value: null | string, history?: 'push' | 'replace'): void {
     if (supportsSortQueryParam(queryParams)) {
-        queryParams.sort = value;
+        if (queryParams.update) {
+            queryParams.update(
+                {
+                    sort: value
+                },
+                {
+                    history
+                }
+            );
+        } else {
+            queryParams.sort = value;
+        }
     }
 }
 
@@ -472,7 +484,9 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             const serverFilters = getServerFilters(view);
             const draftFilters = applyFilterChanges(serverFilters, draft?.filterChanges);
             const currentFilters = options.getFilterDefinitions ? deserializeFilters(options.getFilterDefinitions()) : [];
-            options.applyFilters(mergeFilterOverrides(draftFilters, currentFilters, overrideKeys));
+            options.applyFilters(mergeFilterOverrides(draftFilters, currentFilters, overrideKeys), {
+                history: 'replace'
+            });
         }
 
         if (options.setColumnVisibility) {
@@ -497,7 +511,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         options.setShowChart?.(draft && 'showChart' in draft ? draft.showChart! : (view.show_chart ?? true));
 
         if (draft && 'sort' in draft && !page.url.searchParams.has('sort')) {
-            setSortQueryParam(options.queryParams, getDraftSortQueryParam(view.sort ?? null, draft.sort ?? null));
+            setSortQueryParam(options.queryParams, getDraftSortQueryParam(view.sort ?? null, draft.sort ?? null), 'replace');
         }
     }
 
@@ -610,6 +624,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     let pendingDraftKey = '';
     let pendingDraftGeneration = -1;
     let draftHydrationGeneration = $state(0);
+    let draftPersistenceGeneration = 0;
     let hydratedColumnOrder = $state<ColumnOrderState>();
     let hydratedSavedView = $state<SavedView>();
     let hydratedSavedViewSignature = '';
@@ -872,12 +887,13 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         viewId: string,
         identity: SavedViewDraftIdentity,
         draftKey: string,
-        draft: SavedViewDraft | undefined
+        draft: SavedViewDraft | undefined,
+        generation: number
     ): Promise<void> {
         await tick();
 
         const view = activeSavedView;
-        if (!view || view.id !== viewId || hydratedSavedViewId !== view.id || appliedDraftKey !== draftKey) {
+        if (!view || view.id !== viewId || hydratedSavedViewId !== view.id || appliedDraftKey !== draftKey || draftPersistenceGeneration !== generation) {
             return;
         }
 
@@ -901,7 +917,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         // The draft value tracks every persisted field even while isModified remains true.
-        void persistDraftAfterStateSettles(view.id, identity, draftKey, currentDraft);
+        void persistDraftAfterStateSettles(view.id, identity, draftKey, currentDraft, draftPersistenceGeneration);
     });
 
     const isMissing = $derived(
@@ -955,6 +971,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return;
         }
 
+        draftPersistenceGeneration++;
         hydratedSavedView = view;
         hydratedSavedViewSignature = getSavedViewStateSignature(view);
         const identity = getDraftIdentity(view);
@@ -986,6 +1003,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     }
 
     function handleSavedViewUpdated(view: SavedView) {
+        draftPersistenceGeneration++;
         const identity = getDraftIdentity(view);
         if (identity) {
             clearSavedViewDraft(identity);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -20,12 +20,15 @@ import type { SavedView } from './models';
 import { getSavedViewsByViewQuery } from './api.svelte';
 import {
     columnOrdersEqual,
+    filterAvailableColumnIds,
+    filterAvailableColumnRecord,
     getSavedAutoFillColumnSelection,
     getSavedColumnOrder,
     getSavedColumnSizing,
     getSavedColumnVisibility,
     getSavedWrappedColumnIds,
     normalizeColumnSizing,
+    resolveAvailableAutoFillColumnSelection,
     resolveAvailableColumnOrder,
     resolveSavedViewColumnOrder,
     savedViewColumnSizingEqual,
@@ -66,6 +69,7 @@ export interface UseSavedViewsOptions {
     defaultFilter?: null | string;
     defaultTime?: null | string;
     filterCacheKey: (filter: null | string) => string;
+    getAvailableColumnIds?: () => string[];
     getColumnOrder?: () => ColumnOrderState;
     getColumnSizing?: () => ColumnSizingState;
     getColumnVisibility?: () => ColumnVisibilityState;
@@ -345,17 +349,23 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     });
 
     function applyColumnState(view: Pick<SavedView, 'columns'> | undefined): void {
+        const availableColumnIds = options.getAvailableColumnIds?.() ?? options.getColumnOrder?.() ?? [];
+
         if (options.setColumnVisibility) {
-            options.setColumnVisibility(getSavedColumnVisibility(view));
+            options.setColumnVisibility(filterAvailableColumnRecord(getSavedColumnVisibility(view), availableColumnIds));
         }
 
         if (options.setColumnOrder) {
-            options.setColumnOrder(getSavedColumnOrder(view));
+            options.setColumnOrder(resolveAvailableColumnOrder(getSavedColumnOrder(view), availableColumnIds));
         }
 
-        options.setColumnSizing?.(getSavedColumnSizing(view));
-        autoFillColumnId = getSavedAutoFillColumnSelection(view, options.defaultAutoFillColumnId);
-        wrappedColumnIds = getSavedWrappedColumnIds(view);
+        options.setColumnSizing?.(filterAvailableColumnRecord(getSavedColumnSizing(view), availableColumnIds));
+        autoFillColumnId = resolveAvailableAutoFillColumnSelection(
+            getSavedAutoFillColumnSelection(view, options.defaultAutoFillColumnId),
+            availableColumnIds,
+            options.defaultAutoFillColumnId
+        );
+        wrappedColumnIds = filterAvailableColumnIds(getSavedWrappedColumnIds(view), availableColumnIds);
     }
 
     function applyDisplayState(view: Pick<SavedView, 'show_chart' | 'show_stats'> | undefined): void {
@@ -445,6 +455,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     }
 
     function applyDraftState(view: SavedView, draft: SavedViewDraft | undefined, overrideKeys: string[]): void {
+        const availableColumnIds = options.getAvailableColumnIds?.() ?? options.getColumnOrder?.() ?? [];
+
         if (options.applyFilters) {
             const serverFilters = getServerFilters(view);
             const draftFilters = applyFilterChanges(serverFilters, draft?.filterChanges);
@@ -453,17 +465,22 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         if (options.setColumnVisibility) {
-            options.setColumnVisibility(applyRecordChanges(getSavedColumnVisibility(view), draft?.columnVisibilityChanges));
+            options.setColumnVisibility(
+                filterAvailableColumnRecord(applyRecordChanges(getSavedColumnVisibility(view), draft?.columnVisibilityChanges), availableColumnIds)
+            );
         }
 
         if (options.setColumnOrder) {
-            options.setColumnOrder(draft?.columnOrder ? resolveAvailableColumnOrder(draft.columnOrder, options.getColumnOrder?.()) : getSavedColumnOrder(view));
+            options.setColumnOrder(resolveAvailableColumnOrder(draft?.columnOrder ?? getSavedColumnOrder(view), availableColumnIds));
         }
 
-        options.setColumnSizing?.(applyRecordChanges(getSavedColumnSizing(view), draft?.columnSizingChanges));
-        autoFillColumnId =
-            draft && 'autoFillColumnId' in draft ? draft.autoFillColumnId! : getSavedAutoFillColumnSelection(view, options.defaultAutoFillColumnId);
-        wrappedColumnIds = applyWrappedColumnChanges(getSavedWrappedColumnIds(view), draft?.wrappedColumnChanges);
+        options.setColumnSizing?.(filterAvailableColumnRecord(applyRecordChanges(getSavedColumnSizing(view), draft?.columnSizingChanges), availableColumnIds));
+        autoFillColumnId = resolveAvailableAutoFillColumnSelection(
+            draft && 'autoFillColumnId' in draft ? draft.autoFillColumnId! : getSavedAutoFillColumnSelection(view, options.defaultAutoFillColumnId),
+            availableColumnIds,
+            options.defaultAutoFillColumnId
+        );
+        wrappedColumnIds = filterAvailableColumnIds(applyWrappedColumnChanges(getSavedWrappedColumnIds(view), draft?.wrappedColumnChanges), availableColumnIds);
 
         options.setShowStats?.(draft && 'showStats' in draft ? draft.showStats! : (view.show_stats ?? true));
         options.setShowChart?.(draft && 'showChart' in draft ? draft.showChart! : (view.show_chart ?? true));

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -96,6 +96,7 @@ export interface UseSavedViewsReturn {
     handleClearSavedView: () => void;
     handleLoadView: (view: SavedView) => void;
     handleResetToSaved: () => void;
+    handleSavedViewUpdated: (view: SavedView) => void;
     hydratedSavedViewId: string | undefined;
     isEnabled: boolean;
     isError: boolean;
@@ -973,6 +974,22 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         void captureHydratedColumnOrderAfterStateSettles(view.id);
     }
 
+    function handleSavedViewUpdated(view: SavedView) {
+        const identity = getDraftIdentity(view);
+        if (identity) {
+            clearSavedViewDraft(identity);
+            appliedDraftKey = `${identity.userId}:${identity.organizationId}:${identity.savedViewId}`;
+        }
+
+        activeFilterOverrideBaselines = {};
+        activeSortOverride = undefined;
+        hydratedColumnOrder = options.getColumnOrder ? [...options.getColumnOrder()] : undefined;
+        hydratedSavedView = view;
+        hydratedSavedViewSignature = getSavedViewStateSignature(view);
+        hydratedSavedViewId = view.id;
+        serverHydratedSavedViewId = view.id;
+    }
+
     function handleClearSavedView() {
         clearSavedViewQueryParams(options.queryParams);
         applyColumnState(undefined);
@@ -993,6 +1010,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         handleClearSavedView,
         handleLoadView,
         handleResetToSaved,
+        handleSavedViewUpdated,
         get hydratedSavedViewId() {
             return hydratedSavedViewId;
         },

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -251,7 +251,7 @@ export function getDraftSortValue(
     return currentSort;
 }
 
-export function getEmptyFilterOverrideKeys(serverFilters: IFilter[], currentFilters: IFilter[], draft: SavedViewDraft | undefined): string[] {
+export function getExpressionFilterOverrideKeys(serverFilters: IFilter[], currentFilters: IFilter[], draft: SavedViewDraft | undefined): string[] {
     const draftFilters = applyFilterChanges(serverFilters, draft?.filterChanges);
     const keys = [...serverFilters, ...currentFilters, ...draftFilters]
         .filter((filter) => filter.type !== 'date' && !SAVED_VIEW_QUERY_PARAMETER_FILTER_KEYS.includes(filter.key))
@@ -635,6 +635,10 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
                         addKey(candidate.key);
                     }
                 }
+            } else if (!draftGeneratedFilter) {
+                for (const key of getExpressionFilterOverrideKeys(serverFilters, currentFilters, draft)) {
+                    addKey(key);
+                }
             }
 
             if (filter) {
@@ -642,10 +646,6 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
                     for (const override of getFiltersFromCache(options.filterCacheKey(filter), filter)) {
                         addKey(override.key);
                     }
-                }
-            } else if (!isExplicitFullStateFilter) {
-                for (const key of getEmptyFilterOverrideKeys(serverFilters, currentFilters, draft)) {
-                    addKey(key);
                 }
             }
         }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -426,6 +426,10 @@ export function setTimeQueryParam(queryParams: SavedViewQueryParams, value: null
     }
 }
 
+export function shouldTrackPendingSavedViewDraft(trackerViewId: string, activeViewId: string | undefined, appliedDraftKey: string): boolean {
+    return trackerViewId === activeViewId && !appliedDraftKey;
+}
+
 export function supportsSortQueryParam(queryParams: SavedViewQueryParams): queryParams is SavedViewQueryParams & { sort: null | string | undefined } {
     return Object.prototype.hasOwnProperty.call(queryParams, 'sort');
 }
@@ -964,7 +968,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     $effect(() => {
         const tracker = pendingDraftTracker;
         const view = activeSavedView;
-        if (!tracker || !view || tracker.viewId !== view.id || hydratedSavedViewId === view.id) {
+        if (!tracker || !view || !shouldTrackPendingSavedViewDraft(tracker.viewId, view.id, appliedDraftKey)) {
             return;
         }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -19,12 +19,12 @@ import type { SavedView } from './models';
 
 import { getSavedViewsByViewQuery } from './api.svelte';
 import {
+    columnOrdersEqual,
     getSavedAutoFillColumnSelection,
     getSavedColumnOrder,
     getSavedColumnSizing,
     getSavedColumnVisibility,
     getSavedWrappedColumnIds,
-    savedViewColumnOrderEqual,
     savedViewColumnSizingEqual,
     savedViewColumnWrappingEqual
 } from './column-settings';
@@ -376,7 +376,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             draft.columnVisibilityChanges = buildRecordChanges(serverVisibility, currentVisibility);
         }
 
-        if (options.getColumnOrder && !savedViewColumnOrderEqual(options.getColumnOrder(), view)) {
+        if (options.getColumnOrder && hydratedColumnOrder && !columnOrdersEqual(options.getColumnOrder(), hydratedColumnOrder)) {
             draft.columnOrder = [...options.getColumnOrder()];
         }
 
@@ -408,11 +408,22 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         return Object.entries(draft).some(([key, value]) => key !== 'version' && value !== undefined) ? draft : undefined;
     }
 
+    async function captureHydratedColumnOrderAfterStateSettles(viewId: string): Promise<void> {
+        await tick();
+
+        if (activeSavedView?.id !== viewId || hydratedSavedViewId !== viewId) {
+            return;
+        }
+
+        hydratedColumnOrder = options.getColumnOrder ? [...options.getColumnOrder()] : undefined;
+    }
+
     // Hydrate saved view state when a saved view loads. Query params remain URL overrides.
     // lastLoadedViewId prevents re-hydration on background refetches (which would stomp user edits).
     let lastLoadedViewId = '';
     let appliedDraftKey = $state('');
     let pendingDraftKey = '';
+    let hydratedColumnOrder = $state<ColumnOrderState>();
     let hydratedSavedView = $state<SavedView>();
     let hydratedSavedViewSignature = '';
     let hydratedSavedViewId = $state<string>();
@@ -432,6 +443,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
                 lastLoadedViewId = '';
                 appliedDraftKey = '';
+                hydratedColumnOrder = undefined;
                 hydratedSavedView = undefined;
                 hydratedSavedViewSignature = '';
             }
@@ -458,6 +470,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         // remote changes cannot be persisted back as local reverse edits.
         if (view.id === lastLoadedViewId) {
             if (viewSignature !== hydratedSavedViewSignature && untrack(() => buildSavedViewDraft(view) === undefined)) {
+                hydratedColumnOrder = options.getColumnOrder ? [...options.getColumnOrder()] : undefined;
                 hydratedSavedView = view;
                 hydratedSavedViewSignature = viewSignature;
             }
@@ -467,6 +480,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         lastLoadedViewId = view.id;
+        hydratedColumnOrder = undefined;
         hydratedSavedView = view;
         hydratedSavedViewSignature = viewSignature;
 
@@ -482,6 +496,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         applyColumnState(view);
         applyDisplayState(view);
         hydratedSavedViewId = view.id;
+        void captureHydratedColumnOrderAfterStateSettles(view.id);
     });
 
     async function applyDraftAfterViewHydrates(viewId: string, identity: SavedViewDraftIdentity, draftKey: string): Promise<void> {
@@ -565,7 +580,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return true;
         }
 
-        if (options.getColumnOrder && !savedViewColumnOrderEqual(options.getColumnOrder(), view)) {
+        if (options.getColumnOrder && hydratedColumnOrder && !columnOrdersEqual(options.getColumnOrder(), hydratedColumnOrder)) {
             return true;
         }
 
@@ -659,6 +674,10 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
         hydratedSavedView = view;
         hydratedSavedViewSignature = getSavedViewStateSignature(view);
+        const identity = getDraftIdentity(view);
+        if (identity) {
+            clearSavedViewDraft(identity);
+        }
 
         if (view.filter_definitions) {
             try {
@@ -673,8 +692,10 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         options.queryParams.filters = null;
         setSortQueryParam(options.queryParams, null);
         setTimeQueryParam(options.queryParams, null);
+        hydratedColumnOrder = undefined;
         applyColumnState(view);
         applyDisplayState(view);
+        void captureHydratedColumnOrderAfterStateSettles(view.id);
     }
 
     function handleClearSavedView() {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -3,6 +3,7 @@ import type { ColumnOrderState, ColumnSizingState, ColumnVisibilityState } from 
 
 import { afterNavigate, goto } from '$app/navigation';
 import { page } from '$app/state';
+import { accessToken } from '$features/auth/index.svelte';
 import {
     applyTimeFilter,
     buildFilterCacheKey,
@@ -44,10 +45,12 @@ import {
     buildRecordChanges,
     buildWrappedColumnChanges,
     clearSavedViewDraft,
+    consumeSavedViewDraftClear,
     getMatchingFilterOverrideKeys,
     getSavedViewDraft,
     mergeFilterOverrides,
     mergePendingSavedViewDraftEdits,
+    queueSavedViewDraftClear,
     type SavedViewDraft,
     type SavedViewDraftIdentity,
     saveSavedViewDraft
@@ -778,7 +781,10 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         const draftKey = `${identity.userId}:${identity.organizationId}:${identity.savedViewId}`;
-        if (pendingDraftClearViewIds.delete(view.id)) {
+        const wasPendingInMemory = pendingDraftClearViewIds.delete(view.id);
+        const sessionId = accessToken.current;
+        const wasPendingInStorage = sessionId ? consumeSavedViewDraftClear(identity, sessionId) : false;
+        if (wasPendingInMemory || wasPendingInStorage) {
             clearSavedViewDraft(identity);
             appliedDraftKey = draftKey;
             hydratedSavedViewId = view.id;
@@ -979,6 +985,17 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             clearSavedViewDraft(identity);
         } else {
             pendingDraftClearViewIds.add(view.id);
+            const organizationId = organization.current;
+            const sessionId = accessToken.current;
+            if (organizationId && sessionId) {
+                queueSavedViewDraftClear(
+                    {
+                        organizationId,
+                        savedViewId: view.id
+                    },
+                    sessionId
+                );
+            }
         }
 
         if (view.filter_definitions) {
@@ -1010,6 +1027,17 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             appliedDraftKey = `${identity.userId}:${identity.organizationId}:${identity.savedViewId}`;
         } else {
             pendingDraftClearViewIds.add(view.id);
+            const organizationId = organization.current;
+            const sessionId = accessToken.current;
+            if (organizationId && sessionId) {
+                queueSavedViewDraftClear(
+                    {
+                        organizationId,
+                        savedViewId: view.id
+                    },
+                    sessionId
+                );
+            }
         }
 
         activeFilterOverrideBaselines = {};

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -1121,7 +1121,6 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     }
 
     function handleSavedViewUpdated(view: SavedView) {
-        draftPersistenceGeneration++;
         const organizationId = organization.current;
         const identity =
             getDraftIdentity(view) ??
@@ -1140,6 +1139,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return;
         }
 
+        draftPersistenceGeneration++;
         if (identity) {
             appliedDraftKey = `${identity.userId}:${identity.organizationId}:${identity.savedViewId}`;
         }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -1,7 +1,7 @@
 import type { IFilter } from '$comp/faceted-filter';
 import type { ColumnOrderState, ColumnSizingState, ColumnVisibilityState } from '@tanstack/svelte-table';
 
-import { goto } from '$app/navigation';
+import { afterNavigate, goto } from '$app/navigation';
 import { page } from '$app/state';
 import {
     applyTimeFilter,
@@ -175,6 +175,28 @@ export function getSavedViewStateSignature(
     });
 }
 
+const SAVED_VIEW_OVERRIDE_QUERY_PARAMETERS = [
+    'bot',
+    'filter',
+    'filters',
+    'first',
+    'level',
+    'project',
+    'reference',
+    'session',
+    'sort',
+    'stack',
+    'status',
+    'tag',
+    'time',
+    'type',
+    'version'
+] as const;
+
+export function getSavedViewOverrideSignature(url: URL): string {
+    return JSON.stringify(SAVED_VIEW_OVERRIDE_QUERY_PARAMETERS.map((parameter) => [parameter, url.searchParams.getAll(parameter)]));
+}
+
 export function hasMissingSavedView(options: {
     activeSavedView: SavedView | undefined;
     isLoading: boolean;
@@ -257,6 +279,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     const currentUserQuery = getMeQuery();
 
     // Some routes, such as stream, do not declare every saved-view query parameter.
+    const supportsSaved = supportsSavedQueryParam(options.queryParams);
     const supportsSort = supportsSortQueryParam(options.queryParams);
     const supportsTime = supportsTimeQueryParam(options.queryParams);
 
@@ -517,6 +540,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     let activeSortOverride = $state<{ value: null | string }>();
     let appliedDraftKey = $state('');
     let pendingDraftKey = '';
+    let pendingDraftGeneration = -1;
+    let draftHydrationGeneration = $state(0);
     let hydratedColumnOrder = $state<ColumnOrderState>();
     let hydratedSavedView = $state<SavedView>();
     let hydratedSavedViewSignature = '';
@@ -534,6 +559,9 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
                 if (lastLoadedViewId !== '') {
                     applyColumnState(undefined);
                     applyDisplayState(undefined);
+                    pendingDraftKey = '';
+                    pendingDraftGeneration = -1;
+                    draftHydrationGeneration++;
                 }
 
                 lastLoadedViewId = '';
@@ -584,6 +612,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         activeSortOverride = undefined;
         appliedDraftKey = '';
         pendingDraftKey = '';
+        pendingDraftGeneration = -1;
+        draftHydrationGeneration++;
         hydratedColumnOrder = undefined;
         hydratedSavedView = view;
         hydratedSavedViewSignature = viewSignature;
@@ -604,7 +634,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         void captureHydratedColumnOrderAfterStateSettles(view.id);
     });
 
-    async function applyDraftAfterViewHydrates(viewId: string, identity: SavedViewDraftIdentity, draftKey: string): Promise<void> {
+    async function applyDraftAfterViewHydrates(viewId: string, identity: SavedViewDraftIdentity, draftKey: string, generation: number): Promise<void> {
         // A dirty source view can leave a queued query-param reset behind during
         // client-side navigation. Let that navigation task and route hydration
         // finish before applying the destination view's browser-local draft.
@@ -615,9 +645,10 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         const view = activeSavedView;
         const currentIdentity = view ? getDraftIdentity(view) : undefined;
         const currentDraftKey = currentIdentity ? `${currentIdentity.userId}:${currentIdentity.organizationId}:${currentIdentity.savedViewId}` : undefined;
-        if (!view || view.id !== viewId || serverHydratedSavedViewId !== view.id || currentDraftKey !== draftKey) {
-            if (pendingDraftKey === draftKey) {
+        if (!view || view.id !== viewId || serverHydratedSavedViewId !== view.id || currentDraftKey !== draftKey || draftHydrationGeneration !== generation) {
+            if (pendingDraftKey === draftKey && pendingDraftGeneration === generation) {
                 pendingDraftKey = '';
+                pendingDraftGeneration = -1;
             }
             return;
         }
@@ -633,8 +664,9 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
               }
             : undefined;
         appliedDraftKey = draftKey;
-        if (pendingDraftKey === draftKey) {
+        if (pendingDraftKey === draftKey && pendingDraftGeneration === generation) {
             pendingDraftKey = '';
+            pendingDraftGeneration = -1;
         }
 
         if (draft) {
@@ -645,6 +677,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     }
 
     $effect(() => {
+        const generation = draftHydrationGeneration;
         const view = activeSavedView;
         if (!view || serverHydratedSavedViewId !== view.id) {
             return;
@@ -660,12 +693,13 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         const draftKey = `${identity.userId}:${identity.organizationId}:${identity.savedViewId}`;
-        if (appliedDraftKey === draftKey || pendingDraftKey === draftKey) {
+        if (appliedDraftKey === draftKey || (pendingDraftKey === draftKey && pendingDraftGeneration === generation)) {
             return;
         }
 
         pendingDraftKey = draftKey;
-        void applyDraftAfterViewHydrates(view.id, identity, draftKey);
+        pendingDraftGeneration = generation;
+        void applyDraftAfterViewHydrates(view.id, identity, draftKey, generation);
     });
 
     // Detect if current filters or columns differ from the active saved view
@@ -805,6 +839,33 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
         options.queryParams.saved = view.id;
     }
+
+    function rehydrateQueryOverrides() {
+        const view = activeSavedView;
+        if (!view || serverHydratedSavedViewId !== view.id) {
+            return;
+        }
+
+        hydratedSavedViewId = undefined;
+        appliedDraftKey = '';
+        pendingDraftKey = '';
+        pendingDraftGeneration = -1;
+        draftHydrationGeneration++;
+    }
+
+    afterNavigate(({ from, to }) => {
+        if (!from?.url || !to?.url || from.url.pathname !== to.url.pathname) {
+            return;
+        }
+
+        if (supportsSaved && from.url.searchParams.get('saved') !== to.url.searchParams.get('saved')) {
+            return;
+        }
+
+        if (getSavedViewOverrideSignature(from.url) !== getSavedViewOverrideSignature(to.url)) {
+            rehydrateQueryOverrides();
+        }
+    });
 
     function handleResetToSaved() {
         const view = activeSavedView;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -493,7 +493,12 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
                 const draftExpressionFilters = supportsTime
                     ? draftFilters.filter((candidate) => candidate.type !== 'date' && !SAVED_VIEW_QUERY_PARAMETER_FILTER_KEYS.includes(candidate.key))
                     : draftFilters;
-                if (filter !== toFilter(draftExpressionFilters)) {
+                const sourceFilters = draft?.filterChanges?.sourceDefinitions ? deserializeFilters(draft.filterChanges.sourceDefinitions) : serverFilters;
+                const restoredDraftFilters = applyFilterChanges(sourceFilters, draft?.filterChanges);
+                const restoredDraftExpressionFilters = supportsTime
+                    ? restoredDraftFilters.filter((candidate) => candidate.type !== 'date' && !SAVED_VIEW_QUERY_PARAMETER_FILTER_KEYS.includes(candidate.key))
+                    : restoredDraftFilters;
+                if (filter !== toFilter(draftExpressionFilters) && filter !== toFilter(restoredDraftExpressionFilters)) {
                     for (const override of getFiltersFromCache(options.filterCacheKey(filter), filter)) {
                         addKey(override.key);
                     }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -190,6 +190,10 @@ export function getEmptyFilterOverrideKeys(serverFilters: IFilter[], currentFilt
     return keys.filter((key, index) => keys.indexOf(key) === index);
 }
 
+export function getSavedViewDefinitionFilters(filterDefinitions: string, time: null | string | undefined, defaultTime: null | string | undefined): IFilter[] {
+    return applyTimeFilter(deserializeFilters(filterDefinitions), getComparableSavedViewTime(time, defaultTime));
+}
+
 export function getSavedViewStateSignature(
     view: Pick<SavedView, 'columns' | 'filter' | 'filter_definitions' | 'show_chart' | 'show_stats' | 'sort' | 'time'>
 ): string {
@@ -416,7 +420,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
     function getServerFilters(view: SavedView): IFilter[] {
         if (view.filter_definitions) {
-            return deserializeFilters(view.filter_definitions);
+            return getSavedViewDefinitionFilters(view.filter_definitions, view.time, options.defaultTime);
         }
 
         const filter = getComparableSavedViewFilter(view.filter, view.filter_definitions, options.defaultFilter);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -8,7 +8,8 @@ import {
     buildFilterCacheKey,
     deserializeFilters,
     getFiltersFromCache,
-    serializeFilters
+    serializeFilters,
+    toFilter
 } from '$features/events/components/filters/helpers.svelte';
 import { organization } from '$features/organizations/context.svelte';
 import { getMeQuery } from '$features/users/api.svelte';
@@ -488,8 +489,14 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         if (url.searchParams.has('filter')) {
             const filter = url.searchParams.get('filter') ?? '';
             if (filter) {
-                for (const override of getFiltersFromCache(options.filterCacheKey(filter), filter)) {
-                    addKey(override.key);
+                const draftFilters = applyFilterChanges(serverFilters, draft?.filterChanges);
+                const draftExpressionFilters = supportsTime
+                    ? draftFilters.filter((candidate) => candidate.type !== 'date' && !SAVED_VIEW_QUERY_PARAMETER_FILTER_KEYS.includes(candidate.key))
+                    : draftFilters;
+                if (filter !== toFilter(draftExpressionFilters)) {
+                    for (const override of getFiltersFromCache(options.filterCacheKey(filter), filter)) {
+                        addKey(override.key);
+                    }
                 }
             } else {
                 for (const key of getEmptyFilterOverrideKeys(serverFilters, currentFilters, draft)) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -13,6 +13,7 @@ import {
 import { organization } from '$features/organizations/context.svelte';
 import { getMeQuery } from '$features/users/api.svelte';
 import { tick, untrack } from 'svelte';
+import { SvelteSet } from 'svelte/reactivity';
 
 import type { AutoFillColumnSelection, WrappedColumnIds } from './column-settings';
 import type { SavedView } from './models';
@@ -605,6 +606,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     let activeFilterOverrideBaselines = $state<Record<string, string>>({});
     let activeSortOverride = $state<{ value: null | string }>();
     let appliedDraftKey = $state('');
+    const pendingDraftClearViewIds = new SvelteSet<string>();
     let pendingDraftKey = '';
     let pendingDraftGeneration = -1;
     let draftHydrationGeneration = $state(0);
@@ -761,6 +763,13 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         const draftKey = `${identity.userId}:${identity.organizationId}:${identity.savedViewId}`;
+        if (pendingDraftClearViewIds.delete(view.id)) {
+            clearSavedViewDraft(identity);
+            appliedDraftKey = draftKey;
+            hydratedSavedViewId = view.id;
+            return;
+        }
+
         if (appliedDraftKey === draftKey || (pendingDraftKey === draftKey && pendingDraftGeneration === generation)) {
             return;
         }
@@ -951,6 +960,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         const identity = getDraftIdentity(view);
         if (identity) {
             clearSavedViewDraft(identity);
+        } else {
+            pendingDraftClearViewIds.add(view.id);
         }
 
         if (view.filter_definitions) {
@@ -979,6 +990,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         if (identity) {
             clearSavedViewDraft(identity);
             appliedDraftKey = `${identity.userId}:${identity.organizationId}:${identity.savedViewId}`;
+        } else {
+            pendingDraftClearViewIds.add(view.id);
         }
 
         activeFilterOverrideBaselines = {};

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -92,6 +92,7 @@ export interface UseSavedViewsReturn {
     handleResetToSaved: () => void;
     hydratedSavedViewId: string | undefined;
     isEnabled: boolean;
+    isError: boolean;
     isLoading: boolean;
     isMissing: boolean;
     isModified: boolean;
@@ -142,11 +143,11 @@ export function getDraftSortValue(
     initialOverride: undefined | { value: null | string },
     storedDraft: SavedViewDraft | undefined
 ): null | string {
-    if (currentSort === serverSort || initialOverride?.value !== currentSort) {
-        return currentSort;
+    if (initialOverride?.value === currentSort) {
+        return storedDraft && 'sort' in storedDraft ? (storedDraft.sort ?? null) : serverSort;
     }
 
-    return storedDraft && 'sort' in storedDraft ? (storedDraft.sort ?? null) : serverSort;
+    return currentSort;
 }
 
 export function getSavedViewStateSignature(
@@ -199,9 +200,9 @@ export function isSavedViewHydrationPending(
     savedViewKey: null | string | undefined,
     activeSavedViewId: string | undefined,
     hydratedSavedViewId: string | undefined,
-    isMissing: boolean
+    isUnavailable: boolean
 ): boolean {
-    return !!savedViewKey && !isMissing && (!activeSavedViewId || activeSavedViewId !== hydratedSavedViewId);
+    return !!savedViewKey && !isUnavailable && (!activeSavedViewId || activeSavedViewId !== hydratedSavedViewId);
 }
 
 export function savedViewColumnsEqual(
@@ -862,6 +863,9 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         },
         get isEnabled() {
             return isEnabled;
+        },
+        get isError() {
+            return savedViewsListQuery.isError;
         },
         get isLoading() {
             return savedViewsListQuery.isLoading;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -128,7 +128,9 @@ type PendingDraftRecordField = keyof NonNullable<PendingSavedViewDraftTouches['r
 interface PendingDraftTracker {
     columnOrderBaseline: ColumnOrderState | undefined;
     previousDraft: SavedViewDraft | undefined;
+    previousFilterDefinitions: string;
     touchedFields: Set<PendingDraftField>;
+    touchedFilterKeys: Set<string>;
     touchedRecordKeys: Record<PendingDraftRecordField, Set<string>>;
     viewId: string;
 }
@@ -415,6 +417,12 @@ export function supportsSortQueryParam(queryParams: SavedViewQueryParams): query
 
 export function supportsTimeQueryParam(queryParams: SavedViewQueryParams): queryParams is SavedViewQueryParams & { time: null | string | undefined } {
     return Object.prototype.hasOwnProperty.call(queryParams, 'time');
+}
+
+export function trackChangedFilterKeys(touchedKeys: Set<string>, previousDefinitions: string, currentDefinitions: string): void {
+    for (const key of getChangedFilterKeys(deserializeFilters(previousDefinitions), deserializeFilters(currentDefinitions))) {
+        touchedKeys.add(key);
+    }
 }
 
 export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsReturn {
@@ -819,7 +827,9 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         pendingDraftTracker = {
             columnOrderBaseline,
             previousDraft: buildSavedViewDraft(view, columnOrderBaseline),
+            previousFilterDefinitions: initialState.filterDefinitions,
             touchedFields: new SvelteSet(),
+            touchedFilterKeys: new SvelteSet(),
             touchedRecordKeys: {
                 columnSizingChanges: new SvelteSet(),
                 columnVisibilityChanges: new SvelteSet(),
@@ -947,7 +957,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         const currentDraft = buildSavedViewDraft(view, tracker.columnOrderBaseline);
-        untrack(() => trackPendingDraftChanges(tracker, currentDraft));
+        const currentFilterDefinitions = options.getFilterDefinitions?.() ?? '[]';
+        untrack(() => trackPendingDraftChanges(tracker, currentDraft, currentFilterDefinitions));
     });
 
     async function applyDraftAfterViewHydrates(viewId: string, identity: SavedViewDraftIdentity, draftKey: string, generation: number): Promise<void> {
@@ -965,9 +976,14 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         const tracker = pendingDraftTracker?.viewId === view.id ? pendingDraftTracker : undefined;
-        const pendingEdits = hydratedSavedView?.id === view.id ? buildSavedViewDraft(hydratedSavedView, hydratedColumnOrder) : undefined;
-        const draft = mergePendingSavedViewDraftEdits(getSavedViewDraft(identity), pendingEdits, tracker ? getPendingDraftTouches(tracker) : undefined);
         const serverFilters = getServerFilters(view);
+        const pendingEdits = hydratedSavedView?.id === view.id ? buildSavedViewDraft(hydratedSavedView, hydratedColumnOrder) : undefined;
+        const draft = mergePendingSavedViewDraftEdits(
+            getSavedViewDraft(identity),
+            pendingEdits,
+            tracker ? getPendingDraftTouches(tracker) : undefined,
+            serverFilters
+        );
         const currentFilters = options.getFilterDefinitions ? deserializeFilters(options.getFilterDefinitions()) : [];
         const matchingInitialState = initialState?.viewId === view.id ? initialState : undefined;
         const initialFilters = matchingInitialState ? deserializeFilters(matchingInitialState.filterDefinitions) : currentFilters;
@@ -1342,6 +1358,11 @@ function getPendingDraftTouches(tracker: PendingDraftTracker): PendingSavedViewD
                   fields: [...tracker.touchedFields]
               }
             : {}),
+        ...(tracker.touchedFilterKeys.size > 0
+            ? {
+                  filterKeys: [...tracker.touchedFilterKeys]
+              }
+            : {}),
         ...(Object.keys(recordKeys ?? {}).length > 0
             ? {
                   recordKeys
@@ -1349,7 +1370,7 @@ function getPendingDraftTouches(tracker: PendingDraftTracker): PendingSavedViewD
             : {})
     };
 
-    return touches.fields || touches.recordKeys ? touches : undefined;
+    return touches.fields || touches.filterKeys || touches.recordKeys ? touches : undefined;
 }
 
 function normalizeFilterDefinitions(value: null | string | undefined): string {
@@ -1381,7 +1402,10 @@ function supportsSavedQueryParam(queryParams: SavedViewQueryParams): queryParams
     return Object.prototype.hasOwnProperty.call(queryParams, 'saved');
 }
 
-function trackPendingDraftChanges(tracker: PendingDraftTracker, currentDraft: SavedViewDraft | undefined): void {
+function trackPendingDraftChanges(tracker: PendingDraftTracker, currentDraft: SavedViewDraft | undefined, currentFilterDefinitions: string): void {
+    trackChangedFilterKeys(tracker.touchedFilterKeys, tracker.previousFilterDefinitions, currentFilterDefinitions);
+    tracker.previousFilterDefinitions = currentFilterDefinitions;
+
     for (const field of ['autoFillColumnId', 'columnOrder', 'showChart', 'showStats'] as const) {
         if (JSON.stringify(tracker.previousDraft?.[field]) !== JSON.stringify(currentDraft?.[field])) {
             tracker.touchedFields.add(field);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -2,8 +2,17 @@ import type { IFilter } from '$comp/faceted-filter';
 import type { ColumnOrderState, ColumnSizingState, ColumnVisibilityState } from '@tanstack/svelte-table';
 
 import { goto } from '$app/navigation';
-import { buildFilterCacheKey, deserializeFilters, serializeFilters } from '$features/events/components/filters/helpers.svelte';
+import { page } from '$app/state';
+import {
+    applyTimeFilter,
+    buildFilterCacheKey,
+    deserializeFilters,
+    getFiltersFromCache,
+    serializeFilters
+} from '$features/events/components/filters/helpers.svelte';
 import { organization } from '$features/organizations/context.svelte';
+import { getMeQuery } from '$features/users/api.svelte';
+import { tick } from 'svelte';
 
 import type { AutoFillColumnSelection, WrappedColumnIds } from './column-settings';
 import type { SavedView } from './models';
@@ -19,6 +28,19 @@ import {
     savedViewColumnSizingEqual,
     savedViewColumnWrappingEqual
 } from './column-settings';
+import {
+    applyFilterChanges,
+    applyRecordChanges,
+    applyWrappedColumnChanges,
+    buildFilterChanges,
+    buildRecordChanges,
+    buildWrappedColumnChanges,
+    clearSavedViewDraft,
+    getSavedViewDraft,
+    type SavedViewDraft,
+    type SavedViewDraftIdentity,
+    saveSavedViewDraft
+} from './saved-view-drafts';
 import { savedViewHref, savedViewResolvedSlug } from './slugs';
 
 export interface SavedViewQueryParams {
@@ -30,6 +52,7 @@ export interface SavedViewQueryParams {
 }
 
 export interface UseSavedViewsOptions {
+    applyFilters?: (filters: IFilter[]) => void;
     baseHref?: string;
     defaultAutoFillColumnId?: string;
     defaultColumnVisibility?: ColumnVisibilityState;
@@ -178,6 +201,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     const isEnabled = $derived(!!organization.current);
     let autoFillColumnId = $state<AutoFillColumnSelection>(options.defaultAutoFillColumnId ?? null);
     let wrappedColumnIds = $state<WrappedColumnIds>([]);
+    const currentUserQuery = getMeQuery();
 
     // Some routes, such as stream, do not declare every saved-view query parameter.
     const supportsSort = supportsSortQueryParam(options.queryParams);
@@ -230,9 +254,140 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         options.setShowChart?.(view?.show_chart ?? true);
     }
 
+    function getDraftIdentity(view: SavedView): SavedViewDraftIdentity | undefined {
+        const organizationId = organization.current;
+        const userId = currentUserQuery.data?.id;
+        if (!organizationId || !userId) {
+            return undefined;
+        }
+
+        return {
+            organizationId,
+            savedViewId: view.id,
+            userId
+        };
+    }
+
+    function getServerFilters(view: SavedView): IFilter[] {
+        if (view.filter_definitions) {
+            return deserializeFilters(view.filter_definitions);
+        }
+
+        const filter = getComparableSavedViewFilter(view.filter, view.filter_definitions, options.defaultFilter);
+        const filters = getFiltersFromCache(options.filterCacheKey(filter), filter);
+        return applyTimeFilter(filters, getComparableSavedViewTime(view.time, options.defaultTime));
+    }
+
+    function hasExplicitFilterOverrides(): boolean {
+        const filterParameterNames = [
+            'bot',
+            'filter',
+            'filters',
+            'first',
+            'level',
+            'project',
+            'reference',
+            'session',
+            'stack',
+            'status',
+            'tag',
+            'time',
+            'type',
+            'version'
+        ];
+
+        return filterParameterNames.some((name) => page.url.searchParams.has(name));
+    }
+
+    function applyDraftState(view: SavedView, draft: SavedViewDraft): void {
+        if (draft.filterChanges && options.applyFilters && !hasExplicitFilterOverrides()) {
+            options.applyFilters(applyFilterChanges(getServerFilters(view), draft.filterChanges));
+        }
+
+        if (options.setColumnVisibility) {
+            options.setColumnVisibility(applyRecordChanges(getSavedColumnVisibility(view), draft.columnVisibilityChanges));
+        }
+
+        if (options.setColumnOrder) {
+            options.setColumnOrder(draft.columnOrder ?? getSavedColumnOrder(view));
+        }
+
+        options.setColumnSizing?.(applyRecordChanges(getSavedColumnSizing(view), draft.columnSizingChanges));
+        autoFillColumnId = 'autoFillColumnId' in draft ? draft.autoFillColumnId! : getSavedAutoFillColumnSelection(view, options.defaultAutoFillColumnId);
+        wrappedColumnIds = applyWrappedColumnChanges(getSavedWrappedColumnIds(view), draft.wrappedColumnChanges);
+
+        if ('showStats' in draft) {
+            options.setShowStats?.(draft.showStats!);
+        }
+
+        if ('showChart' in draft) {
+            options.setShowChart?.(draft.showChart!);
+        }
+
+        if ('sort' in draft && !page.url.searchParams.has('sort')) {
+            setSortQueryParam(options.queryParams, draft.sort === (view.sort ?? null) ? null : (draft.sort ?? null));
+        }
+    }
+
+    function buildSavedViewDraft(view: SavedView): SavedViewDraft | undefined {
+        const draft: SavedViewDraft = {
+            version: 1
+        };
+
+        if (options.getFilterDefinitions) {
+            const currentFilters = deserializeFilters(options.getFilterDefinitions());
+            draft.filterChanges = buildFilterChanges(getServerFilters(view), currentFilters);
+        }
+
+        if (options.getColumnVisibility) {
+            const serverVisibility = {
+                ...options.defaultColumnVisibility,
+                ...getSavedColumnVisibility(view)
+            };
+            const currentVisibility = {
+                ...options.defaultColumnVisibility,
+                ...options.getColumnVisibility()
+            };
+            draft.columnVisibilityChanges = buildRecordChanges(serverVisibility, currentVisibility);
+        }
+
+        if (options.getColumnOrder && !savedViewColumnOrderEqual(options.getColumnOrder(), view)) {
+            draft.columnOrder = [...options.getColumnOrder()];
+        }
+
+        if (options.getColumnSizing) {
+            draft.columnSizingChanges = buildRecordChanges(getSavedColumnSizing(view), options.getColumnSizing());
+        }
+
+        if (hasSavedViewAutoFillChange(autoFillColumnId, view, options.defaultAutoFillColumnId)) {
+            draft.autoFillColumnId = autoFillColumnId;
+        }
+
+        draft.wrappedColumnChanges = buildWrappedColumnChanges(getSavedWrappedColumnIds(view), wrappedColumnIds);
+
+        if (options.getShowStats && options.getShowStats() !== (view.show_stats ?? true)) {
+            draft.showStats = options.getShowStats();
+        }
+
+        if (options.getShowChart && options.getShowChart() !== (view.show_chart ?? true)) {
+            draft.showChart = options.getShowChart();
+        }
+
+        if (supportsSort) {
+            const currentSort = options.getSort?.() ?? options.queryParams.sort ?? null;
+            if (currentSort !== (view.sort ?? null)) {
+                draft.sort = currentSort;
+            }
+        }
+
+        return Object.entries(draft).some(([key, value]) => key !== 'version' && value !== undefined) ? draft : undefined;
+    }
+
     // Hydrate saved view state when a saved view loads. Query params remain URL overrides.
     // lastLoadedViewId prevents re-hydration on background refetches (which would stomp user edits).
     let lastLoadedViewId = '';
+    let appliedDraftKey = $state('');
+    let pendingDraftKey = '';
     let hydratedSavedViewId = $state<string>();
     $effect(() => {
         const savedViewKey = options.slug ?? options.queryParams.saved;
@@ -249,6 +404,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
                 }
 
                 lastLoadedViewId = '';
+                appliedDraftKey = '';
             }
 
             hydratedSavedViewId = undefined;
@@ -285,6 +441,55 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         applyColumnState(view);
         applyDisplayState(view);
         hydratedSavedViewId = view.id;
+    });
+
+    async function applyDraftAfterViewHydrates(viewId: string, identity: SavedViewDraftIdentity, draftKey: string): Promise<void> {
+        // A dirty source view can leave a queued query-param reset behind during
+        // client-side navigation. Let that navigation task and route hydration
+        // finish before applying the destination view's browser-local draft.
+        await tick();
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        await tick();
+
+        const view = activeSavedView;
+        const currentIdentity = view ? getDraftIdentity(view) : undefined;
+        const currentDraftKey = currentIdentity ? `${currentIdentity.userId}:${currentIdentity.organizationId}:${currentIdentity.savedViewId}` : undefined;
+        if (!view || view.id !== viewId || hydratedSavedViewId !== view.id || currentDraftKey !== draftKey) {
+            if (pendingDraftKey === draftKey) {
+                pendingDraftKey = '';
+            }
+            return;
+        }
+
+        const draft = getSavedViewDraft(identity);
+        appliedDraftKey = draftKey;
+        if (pendingDraftKey === draftKey) {
+            pendingDraftKey = '';
+        }
+
+        if (draft) {
+            applyDraftState(view, draft);
+        }
+    }
+
+    $effect(() => {
+        const view = activeSavedView;
+        if (!view || hydratedSavedViewId !== view.id) {
+            return;
+        }
+
+        const identity = getDraftIdentity(view);
+        if (!identity) {
+            return;
+        }
+
+        const draftKey = `${identity.userId}:${identity.organizationId}:${identity.savedViewId}`;
+        if (appliedDraftKey === draftKey || pendingDraftKey === draftKey) {
+            return;
+        }
+
+        pendingDraftKey = draftKey;
+        void applyDraftAfterViewHydrates(view.id, identity, draftKey);
     });
 
     // Detect if current filters or columns differ from the active saved view
@@ -344,6 +549,40 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         return false;
+    });
+
+    async function persistDraftAfterStateSettles(viewId: string, identity: SavedViewDraftIdentity, draftKey: string): Promise<void> {
+        await tick();
+
+        const view = activeSavedView;
+        if (!view || view.id !== viewId || hydratedSavedViewId !== view.id || appliedDraftKey !== draftKey) {
+            return;
+        }
+
+        const draft = buildSavedViewDraft(view);
+        if (draft) {
+            saveSavedViewDraft(identity, draft);
+        } else {
+            clearSavedViewDraft(identity);
+        }
+    }
+
+    $effect(() => {
+        const view = activeSavedView;
+        if (!view || hydratedSavedViewId !== view.id) {
+            return;
+        }
+
+        const identity = getDraftIdentity(view);
+        const draftKey = identity ? `${identity.userId}:${identity.organizationId}:${identity.savedViewId}` : undefined;
+        if (!identity || !draftKey || appliedDraftKey !== draftKey) {
+            return;
+        }
+
+        // Subscribe to every field that contributes to dirty state, then persist after
+        // route-level filter normalization has settled for this render cycle.
+        void isModified;
+        void persistDraftAfterStateSettles(view.id, identity, draftKey);
     });
 
     const isMissing = $derived(

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -39,6 +39,7 @@ import {
     buildWrappedColumnChanges,
     clearSavedViewDraft,
     getSavedViewDraft,
+    mergeFilterOverrides,
     type SavedViewDraft,
     type SavedViewDraftIdentity,
     saveSavedViewDraft
@@ -305,30 +306,72 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         return applyTimeFilter(filters, getComparableSavedViewTime(view.time, options.defaultTime));
     }
 
-    function hasExplicitFilterOverrides(): boolean {
-        const filterParameterNames = [
-            'bot',
-            'filter',
-            'filters',
-            'first',
-            'level',
-            'project',
-            'reference',
-            'session',
-            'stack',
-            'status',
-            'tag',
-            'time',
-            'type',
-            'version'
-        ];
+    function getExplicitFilterOverrideKeys(serverFilters: IFilter[]): string[] {
+        const keys: string[] = [];
+        const queryParameterKeys = [
+            ['bot', 'boolean-bot'],
+            ['first', 'boolean-first'],
+            ['level', 'level'],
+            ['project', 'project'],
+            ['reference', 'reference'],
+            ['session', 'session'],
+            ['stack', 'string-stack'],
+            ['status', 'status'],
+            ['tag', 'tag'],
+            ['time', 'date-date'],
+            ['type', 'type'],
+            ['version', 'version-version']
+        ] as const;
+        const dedicatedQueryFilterKeys: string[] = queryParameterKeys.map(([, key]) => key);
+        const addKey = (key: string) => {
+            if (!keys.includes(key)) {
+                keys.push(key);
+            }
+        };
 
-        return filterParameterNames.some((name) => page.url.searchParams.has(name));
+        for (const [parameter, key] of queryParameterKeys) {
+            if (page.url.searchParams.has(parameter)) {
+                addKey(key);
+            }
+        }
+
+        if (page.url.searchParams.has('filter')) {
+            const filter = page.url.searchParams.get('filter') ?? '';
+            if (filter) {
+                for (const override of getFiltersFromCache(options.filterCacheKey(filter), filter)) {
+                    addKey(override.key);
+                }
+            } else {
+                for (const serverFilter of serverFilters) {
+                    if (serverFilter.type !== 'date' && !dedicatedQueryFilterKeys.includes(serverFilter.key)) {
+                        addKey(serverFilter.key);
+                    }
+                }
+            }
+        }
+
+        if (page.url.searchParams.has('filters')) {
+            const definitions = page.url.searchParams.get('filters');
+            if (definitions) {
+                try {
+                    for (const override of deserializeFilters(definitions)) {
+                        addKey(override.key);
+                    }
+                } catch {
+                    // Ignore malformed URL state and let the route's normal parsing handle it.
+                }
+            }
+        }
+
+        return keys;
     }
 
-    function applyDraftState(view: SavedView, draft: SavedViewDraft): void {
-        if (draft.filterChanges && options.applyFilters && !hasExplicitFilterOverrides()) {
-            options.applyFilters(applyFilterChanges(getServerFilters(view), draft.filterChanges));
+    function applyDraftState(view: SavedView, draft: SavedViewDraft, overrideKeys: string[]): void {
+        if (draft.filterChanges && options.applyFilters) {
+            const serverFilters = getServerFilters(view);
+            const draftFilters = applyFilterChanges(serverFilters, draft.filterChanges);
+            const currentFilters = options.getFilterDefinitions ? deserializeFilters(options.getFilterDefinitions()) : [];
+            options.applyFilters(mergeFilterOverrides(draftFilters, currentFilters, overrideKeys));
         }
 
         if (options.setColumnVisibility) {
@@ -356,14 +399,27 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
     }
 
-    function buildSavedViewDraft(view: SavedView, columnOrderBaseline: ColumnOrderState | undefined = hydratedColumnOrder): SavedViewDraft | undefined {
+    function buildSavedViewDraft(
+        view: SavedView,
+        columnOrderBaseline: ColumnOrderState | undefined = hydratedColumnOrder,
+        preserveExplicitFilterOverrides = false
+    ): SavedViewDraft | undefined {
         const draft: SavedViewDraft = {
             version: 1
         };
 
         if (options.getFilterDefinitions) {
-            const currentFilters = deserializeFilters(options.getFilterDefinitions());
-            draft.filterChanges = buildFilterChanges(getServerFilters(view), currentFilters);
+            const serverFilters = getServerFilters(view);
+            let currentFilters = deserializeFilters(options.getFilterDefinitions());
+            const currentFilterChanges = buildFilterChanges(serverFilters, currentFilters);
+            if (preserveExplicitFilterOverrides && currentFilterChanges) {
+                const identity = getDraftIdentity(view);
+                const storedDraft = identity ? getSavedViewDraft(identity) : undefined;
+                const storedDraftFilters = applyFilterChanges(serverFilters, storedDraft?.filterChanges);
+                currentFilters = mergeFilterOverrides(currentFilters, storedDraftFilters, activeFilterOverrideKeys);
+            }
+
+            draft.filterChanges = buildFilterChanges(serverFilters, currentFilters);
         }
 
         if (options.getColumnVisibility) {
@@ -423,6 +479,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     // Hydrate saved view state when a saved view loads. Query params remain URL overrides.
     // lastLoadedViewId prevents re-hydration on background refetches (which would stomp user edits).
     let lastLoadedViewId = '';
+    let activeFilterOverrideKeys = $state<string[]>([]);
     let appliedDraftKey = $state('');
     let pendingDraftKey = '';
     let hydratedColumnOrder = $state<ColumnOrderState>();
@@ -444,6 +501,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
                 }
 
                 lastLoadedViewId = '';
+                activeFilterOverrideKeys = [];
                 appliedDraftKey = '';
                 hydratedColumnOrder = undefined;
                 hydratedSavedView = undefined;
@@ -483,6 +541,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         lastLoadedViewId = view.id;
+        activeFilterOverrideKeys = [];
         hydratedColumnOrder = undefined;
         hydratedSavedView = view;
         hydratedSavedViewSignature = viewSignature;
@@ -521,13 +580,14 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
 
         const draft = getSavedViewDraft(identity);
+        activeFilterOverrideKeys = getExplicitFilterOverrideKeys(getServerFilters(view));
         appliedDraftKey = draftKey;
         if (pendingDraftKey === draftKey) {
             pendingDraftKey = '';
         }
 
         if (draft) {
-            applyDraftState(view, draft);
+            applyDraftState(view, draft, activeFilterOverrideKeys);
         }
     }
 
@@ -612,7 +672,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
     const currentDraft = $derived.by(() => {
         const view = hydratedSavedView;
-        return view && activeSavedView?.id === view.id ? buildSavedViewDraft(view) : undefined;
+        return view && activeSavedView?.id === view.id ? buildSavedViewDraft(view, hydratedColumnOrder, true) : undefined;
     });
 
     async function persistDraftAfterStateSettles(
@@ -695,6 +755,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         options.queryParams.filters = null;
         setSortQueryParam(options.queryParams, null);
         setTimeQueryParam(options.queryParams, null);
+        activeFilterOverrideKeys = [];
         hydratedColumnOrder = undefined;
         applyColumnState(view);
         applyDisplayState(view);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -494,7 +494,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     async function captureHydratedColumnOrderAfterStateSettles(viewId: string): Promise<void> {
         await tick();
 
-        if (activeSavedView?.id !== viewId || hydratedSavedViewId !== viewId) {
+        if (activeSavedView?.id !== viewId || serverHydratedSavedViewId !== viewId) {
             return;
         }
 
@@ -512,6 +512,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     let hydratedSavedView = $state<SavedView>();
     let hydratedSavedViewSignature = '';
     let hydratedSavedViewId = $state<string>();
+    let serverHydratedSavedViewId = $state<string>();
     $effect(() => {
         const savedViewKey = options.slug ?? options.queryParams.saved;
         const view = activeSavedView;
@@ -536,16 +537,18 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             }
 
             hydratedSavedViewId = undefined;
+            serverHydratedSavedViewId = undefined;
             return;
         }
 
         if (!view) {
-            hydratedSavedViewId = undefined;
             // Skip while refetching to avoid false-positive clears during cache invalidation
             if (isFetching) {
                 return;
             }
 
+            hydratedSavedViewId = undefined;
+            serverHydratedSavedViewId = undefined;
             return;
         }
 
@@ -563,7 +566,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
                 hydratedSavedViewSignature = viewSignature;
             }
 
-            hydratedSavedViewId = view.id;
+            serverHydratedSavedViewId = view.id;
             return;
         }
 
@@ -585,7 +588,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
         applyColumnState(view);
         applyDisplayState(view);
-        hydratedSavedViewId = view.id;
+        hydratedSavedViewId = undefined;
+        serverHydratedSavedViewId = view.id;
         void captureHydratedColumnOrderAfterStateSettles(view.id);
     });
 
@@ -600,7 +604,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         const view = activeSavedView;
         const currentIdentity = view ? getDraftIdentity(view) : undefined;
         const currentDraftKey = currentIdentity ? `${currentIdentity.userId}:${currentIdentity.organizationId}:${currentIdentity.savedViewId}` : undefined;
-        if (!view || view.id !== viewId || hydratedSavedViewId !== view.id || currentDraftKey !== draftKey) {
+        if (!view || view.id !== viewId || serverHydratedSavedViewId !== view.id || currentDraftKey !== draftKey) {
             if (pendingDraftKey === draftKey) {
                 pendingDraftKey = '';
             }
@@ -625,11 +629,13 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         if (draft) {
             applyDraftState(view, draft, overrideKeys);
         }
+
+        hydratedSavedViewId = view.id;
     }
 
     $effect(() => {
         const view = activeSavedView;
-        if (!view || hydratedSavedViewId !== view.id) {
+        if (!view || serverHydratedSavedViewId !== view.id) {
             return;
         }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -582,6 +582,8 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         lastLoadedViewId = view.id;
         activeFilterOverrideBaselines = {};
         activeSortOverride = undefined;
+        appliedDraftKey = '';
+        pendingDraftKey = '';
         hydratedColumnOrder = undefined;
         hydratedSavedView = view;
         hydratedSavedViewSignature = viewSignature;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -3,7 +3,6 @@ import type { ColumnOrderState, ColumnSizingState, ColumnVisibilityState } from 
 
 import { afterNavigate, goto } from '$app/navigation';
 import { page } from '$app/state';
-import { accessToken } from '$features/auth/index.svelte';
 import {
     applyTimeFilter,
     buildFilterCacheKey,
@@ -782,8 +781,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
         const draftKey = `${identity.userId}:${identity.organizationId}:${identity.savedViewId}`;
         const wasPendingInMemory = pendingDraftClearViewIds.delete(view.id);
-        const sessionId = accessToken.current;
-        const wasPendingInStorage = sessionId ? consumeSavedViewDraftClear(identity, sessionId) : false;
+        const wasPendingInStorage = consumeSavedViewDraftClear(identity);
         if (wasPendingInMemory || wasPendingInStorage) {
             clearSavedViewDraft(identity);
             appliedDraftKey = draftKey;
@@ -986,15 +984,11 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         } else {
             pendingDraftClearViewIds.add(view.id);
             const organizationId = organization.current;
-            const sessionId = accessToken.current;
-            if (organizationId && sessionId) {
-                queueSavedViewDraftClear(
-                    {
-                        organizationId,
-                        savedViewId: view.id
-                    },
-                    sessionId
-                );
+            if (organizationId) {
+                queueSavedViewDraftClear({
+                    organizationId,
+                    savedViewId: view.id
+                });
             }
         }
 
@@ -1028,15 +1022,12 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         } else {
             pendingDraftClearViewIds.add(view.id);
             const organizationId = organization.current;
-            const sessionId = accessToken.current;
-            if (organizationId && sessionId) {
-                queueSavedViewDraftClear(
-                    {
-                        organizationId,
-                        savedViewId: view.id
-                    },
-                    sessionId
-                );
+            if (organizationId) {
+                queueSavedViewDraftClear({
+                    organizationId,
+                    savedViewId: view.id,
+                    userId: view.updated_by_user_id ?? undefined
+                });
             }
         }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -1021,7 +1021,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
         activeFilterOverrideBaselines = {};
         activeSortOverride = undefined;
-        hydratedColumnOrder = options.getColumnOrder ? [...options.getColumnOrder()] : undefined;
+        hydratedColumnOrder = options.getColumnOrder ? resolveSavedViewColumnOrder(view, options.getColumnOrder()) : undefined;
         hydratedSavedView = view;
         hydratedSavedViewSignature = getSavedViewStateSignature(view);
         hydratedSavedViewId = view.id;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -26,6 +26,7 @@ import {
     getSavedColumnVisibility,
     getSavedWrappedColumnIds,
     normalizeColumnSizing,
+    resolveSavedViewColumnOrder,
     savedViewColumnSizingEqual,
     savedViewColumnWrappingEqual
 } from './column-settings';
@@ -355,7 +356,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
     }
 
-    function buildSavedViewDraft(view: SavedView): SavedViewDraft | undefined {
+    function buildSavedViewDraft(view: SavedView, columnOrderBaseline: ColumnOrderState | undefined = hydratedColumnOrder): SavedViewDraft | undefined {
         const draft: SavedViewDraft = {
             version: 1
         };
@@ -377,7 +378,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             draft.columnVisibilityChanges = buildRecordChanges(serverVisibility, currentVisibility);
         }
 
-        if (options.getColumnOrder && hydratedColumnOrder && !columnOrdersEqual(options.getColumnOrder(), hydratedColumnOrder)) {
+        if (options.getColumnOrder && columnOrderBaseline && !columnOrdersEqual(options.getColumnOrder(), columnOrderBaseline)) {
             draft.columnOrder = [...options.getColumnOrder()];
         }
 
@@ -470,8 +471,9 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         // baseline. Otherwise leave the UI and baseline alone until navigation so
         // remote changes cannot be persisted back as local reverse edits.
         if (view.id === lastLoadedViewId) {
-            if (viewSignature !== hydratedSavedViewSignature && untrack(() => buildSavedViewDraft(view) === undefined)) {
-                hydratedColumnOrder = options.getColumnOrder ? [...options.getColumnOrder()] : undefined;
+            const resolvedServerColumnOrder = options.getColumnOrder ? resolveSavedViewColumnOrder(view, options.getColumnOrder()) : undefined;
+            if (viewSignature !== hydratedSavedViewSignature && untrack(() => buildSavedViewDraft(view, resolvedServerColumnOrder) === undefined)) {
+                hydratedColumnOrder = resolvedServerColumnOrder;
                 hydratedSavedView = view;
                 hydratedSavedViewSignature = viewSignature;
             }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -608,21 +608,22 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
         if (url.searchParams.has('filter')) {
             const filter = url.searchParams.get('filter') ?? '';
+            const isExplicitFullStateFilter = !draftGeneratedFilter && !supportsTime;
+            if (isExplicitFullStateFilter) {
+                for (const candidate of [...serverFilters, ...applyFilterChanges(serverFilters, draft?.filterChanges)]) {
+                    if (candidate.type !== 'date') {
+                        addKey(candidate.key);
+                    }
+                }
+            }
+
             if (filter) {
                 if (!draftGeneratedFilter) {
-                    if (!supportsTime) {
-                        for (const candidate of [...serverFilters, ...applyFilterChanges(serverFilters, draft?.filterChanges)]) {
-                            if (candidate.type !== 'date') {
-                                addKey(candidate.key);
-                            }
-                        }
-                    }
-
                     for (const override of getFiltersFromCache(options.filterCacheKey(filter), filter)) {
                         addKey(override.key);
                     }
                 }
-            } else {
+            } else if (!isExplicitFullStateFilter) {
                 for (const key of getEmptyFilterOverrideKeys(serverFilters, currentFilters, draft)) {
                     addKey(key);
                 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -11,7 +11,9 @@ import { savedViewHref, savedViewResolvedSlug } from './slugs';
 import {
     clearSavedViewQueryParams,
     filterDefinitionsEqual,
+    getChangedFilterKeys,
     getComparableSavedViewFilter,
+    getComparableSavedViewFilterDefinitions,
     getComparableSavedViewTime,
     getDraftSortQueryParam,
     getDraftSortValue,
@@ -251,6 +253,19 @@ describe('useSavedViews', () => {
     });
 
     describe('filter definition comparison', () => {
+        it('finds filter keys edited while saved-view draft hydration is pending', () => {
+            const initial = [new ProjectFilter(['project-1'])];
+            const current = [new ProjectFilter(['project-2'])];
+
+            expect(getChangedFilterKeys(initial, current)).toEqual(['project']);
+            expect(
+                getChangedFilterKeys(
+                    initial,
+                    initial.map((filter) => filter.clone())
+                )
+            ).toEqual([]);
+        });
+
         it('treats omitted empty filter values as equal to hydrated empty values', () => {
             // Arrange
             const seededDefinitions = '[{"type":"date","term":"date","value":"[now-7d TO now]"},{"type":"project"}]';
@@ -317,6 +332,16 @@ describe('useSavedViews', () => {
 
             // Assert
             expect(serializeFilters(result)).toBe('[{"type":"date","term":"date","value":"[now-90d TO now]"}]');
+        });
+
+        it('normalizes the saved time for modified-state comparisons', () => {
+            const result = getComparableSavedViewFilterDefinitions(
+                '[{"type":"project","value":[]},{"type":"date","term":"date","value":"[now-7d TO now]"}]',
+                '[now-90d TO now]',
+                '[now-15m TO now]'
+            );
+
+            expect(result).toBe('[{"type":"project","value":[]},{"type":"date","term":"date","value":"[now-90d TO now]"}]');
         });
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -13,9 +13,10 @@ import {
     getComparableSavedViewTime,
     getDraftSortValue,
     getSavedViewStateSignature,
-    hasMissingSavedViewSlug,
+    hasMissingSavedView,
     hasSavedViewAutoFillChange,
     hasSavedViewColumnChanges,
+    isSavedViewHydrationPending,
     savedViewColumnsEqual,
     type SavedViewQueryParams,
     setSortQueryParam,
@@ -130,11 +131,11 @@ describe('useSavedViews', () => {
             const savedView = buildSavedView({ id: 'view-1', name: 'My Saved View' });
 
             // Act
-            const result = hasMissingSavedViewSlug({
+            const result = hasMissingSavedView({
                 activeSavedView: undefined,
                 isLoading: false,
-                savedViews: [savedView],
-                slug: 'most-frequent'
+                savedViewKey: 'most-frequent',
+                savedViews: [savedView]
             });
 
             // Assert
@@ -143,11 +144,11 @@ describe('useSavedViews', () => {
 
         it('reports a missing slug while cached saved-view data is background fetching', () => {
             // Act
-            const result = hasMissingSavedViewSlug({
+            const result = hasMissingSavedView({
                 activeSavedView: undefined,
                 isLoading: false,
-                savedViews: [],
-                slug: 'most-frequent'
+                savedViewKey: 'most-frequent',
+                savedViews: []
             });
 
             // Assert
@@ -156,11 +157,11 @@ describe('useSavedViews', () => {
 
         it('does not report a missing slug before saved views are available', () => {
             // Act
-            const result = hasMissingSavedViewSlug({
+            const result = hasMissingSavedView({
                 activeSavedView: undefined,
                 isLoading: false,
-                savedViews: undefined,
-                slug: 'most-frequent'
+                savedViewKey: 'most-frequent',
+                savedViews: undefined
             });
 
             // Assert
@@ -169,15 +170,39 @@ describe('useSavedViews', () => {
 
         it('does not report a missing slug when there is no slug route parameter', () => {
             // Act
-            const result = hasMissingSavedViewSlug({
+            const result = hasMissingSavedView({
                 activeSavedView: undefined,
                 isLoading: false,
-                savedViews: [],
-                slug: undefined
+                savedViewKey: undefined,
+                savedViews: []
             });
 
             // Assert
             expect(result).toBe(false);
+        });
+
+        it('reports a missing query-selected saved view after loading finishes', () => {
+            const result = hasMissingSavedView({
+                activeSavedView: undefined,
+                isLoading: false,
+                savedViewKey: 'view-1',
+                savedViews: []
+            });
+
+            expect(result).toBe(true);
+        });
+    });
+
+    describe('saved view hydration readiness', () => {
+        it('waits until the selected saved view draft is applied', () => {
+            expect(isSavedViewHydrationPending('view-1', undefined, undefined, false)).toBe(true);
+            expect(isSavedViewHydrationPending('view-1', 'view-1', undefined, false)).toBe(true);
+            expect(isSavedViewHydrationPending('view-1', 'view-1', 'view-1', false)).toBe(false);
+        });
+
+        it('does not wait when no view is selected or the selected view is missing', () => {
+            expect(isSavedViewHydrationPending(undefined, undefined, undefined, false)).toBe(false);
+            expect(isSavedViewHydrationPending('missing', undefined, undefined, true)).toBe(false);
         });
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -11,6 +11,7 @@ import {
     filterDefinitionsEqual,
     getComparableSavedViewFilter,
     getComparableSavedViewTime,
+    getSavedViewStateSignature,
     hasMissingSavedViewSlug,
     hasSavedViewAutoFillChange,
     hasSavedViewColumnChanges,
@@ -63,6 +64,41 @@ function buildSavedView({ id, name, ...overrides }: Partial<SavedView> & Pick<Sa
 }
 
 describe('useSavedViews', () => {
+    describe('saved view state signatures', () => {
+        it('ignores audit and naming changes outside the hydrated state baseline', () => {
+            // Arrange
+            const savedView = buildSavedView({ id: 'view-1', name: 'Original Name', show_chart: false });
+            const renamedView = {
+                ...savedView,
+                name: 'Renamed View',
+                updated_utc: new Date(Date.now() + 1000).toISOString(),
+                version: savedView.version + 1
+            };
+
+            // Act / Assert
+            expect(getSavedViewStateSignature(renamedView)).toBe(getSavedViewStateSignature(savedView));
+        });
+
+        it('detects server changes that affect saved view state', () => {
+            // Arrange
+            const savedView = buildSavedView({
+                columns: { summary: { visible: true, wrap: false } },
+                id: 'view-1',
+                name: 'My View',
+                show_chart: true
+            });
+
+            // Act / Assert
+            expect(getSavedViewStateSignature({ ...savedView, show_chart: false })).not.toBe(getSavedViewStateSignature(savedView));
+            expect(
+                getSavedViewStateSignature({
+                    ...savedView,
+                    columns: { summary: { visible: true, wrap: true } }
+                })
+            ).not.toBe(getSavedViewStateSignature(savedView));
+        });
+    });
+
     describe('saved view slugs', () => {
         it('falls back to the normalized name for views created before slugs were stored', () => {
             // Arrange

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -33,6 +33,7 @@ import {
     type SavedViewQueryParams,
     setSortQueryParam,
     setTimeQueryParam,
+    shouldTrackPendingSavedViewDraft,
     supportsSortQueryParam,
     supportsTimeQueryParam,
     trackChangedFilterKeys
@@ -286,6 +287,14 @@ describe('useSavedViews', () => {
             expect(isSavedViewUnavailable('view-1', false, true)).toBe(false);
             expect(isSavedViewUnavailable(undefined, false, true)).toBe(true);
             expect(isSavedViewUnavailable(undefined, true, false)).toBe(true);
+        });
+    });
+
+    describe('pending saved view draft tracking', () => {
+        it('continues until the draft is applied even after the route data gate is released', () => {
+            expect(shouldTrackPendingSavedViewDraft('view-1', 'view-1', '')).toBe(true);
+            expect(shouldTrackPendingSavedViewDraft('view-1', 'view-1', 'user-1:organization-1:view-1')).toBe(false);
+            expect(shouldTrackPendingSavedViewDraft('view-1', 'view-2', '')).toBe(false);
         });
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -21,6 +21,7 @@ import {
     hasSavedViewAutoFillChange,
     hasSavedViewColumnChanges,
     isSavedViewHydrationPending,
+    isSavedViewUnavailable,
     savedViewColumnsEqual,
     type SavedViewQueryParams,
     setSortQueryParam,
@@ -238,6 +239,12 @@ describe('useSavedViews', () => {
         it('does not wait when no view is selected or the selected view is missing', () => {
             expect(isSavedViewHydrationPending(undefined, undefined, undefined, false)).toBe(false);
             expect(isSavedViewHydrationPending('missing', undefined, undefined, true)).toBe(false);
+        });
+
+        it('keeps cached saved views available while a background refetch is failing', () => {
+            expect(isSavedViewUnavailable('view-1', false, true)).toBe(false);
+            expect(isSavedViewUnavailable(undefined, false, true)).toBe(true);
+            expect(isSavedViewUnavailable(undefined, true, false)).toBe(true);
         });
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -11,6 +11,7 @@ import {
     filterDefinitionsEqual,
     getComparableSavedViewFilter,
     getComparableSavedViewTime,
+    getDraftSortValue,
     getSavedViewStateSignature,
     hasMissingSavedViewSlug,
     hasSavedViewAutoFillChange,
@@ -231,6 +232,20 @@ describe('useSavedViews', () => {
 
             // Assert
             expect(result).toBe('[now-7d TO now]');
+        });
+    });
+
+    describe('sort drafts', () => {
+        it('keeps a one-off URL sort override out of a local draft', () => {
+            expect(getDraftSortValue('-date', 'type', { value: 'type' }, undefined)).toBe('-date');
+        });
+
+        it('preserves an older local sort behind a one-off URL override', () => {
+            expect(getDraftSortValue('-date', 'type', { value: 'type' }, { sort: 'count', version: 1 })).toBe('count');
+        });
+
+        it('persists a sort changed after hydration', () => {
+            expect(getDraftSortValue('-date', 'count', { value: 'type' }, undefined)).toBe('count');
         });
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -12,6 +12,7 @@ import {
     getComparableSavedViewFilter,
     getComparableSavedViewTime,
     getDraftSortValue,
+    getSavedViewOverrideSignature,
     getSavedViewStateSignature,
     hasMissingSavedView,
     hasSavedViewAutoFillChange,
@@ -98,6 +99,23 @@ describe('useSavedViews', () => {
                     columns: { summary: { visible: true, wrap: true } }
                 })
             ).not.toBe(getSavedViewStateSignature(savedView));
+        });
+    });
+
+    describe('saved view URL override signatures', () => {
+        it('ignores pagination-only query changes', () => {
+            const first = new URL('https://example.test/next/event/errors?time=90d&project=project-1&page=1&limit=10');
+            const second = new URL('https://example.test/next/event/errors?project=project-1&time=90d&page=4&limit=100');
+
+            expect(getSavedViewOverrideSignature(first)).toBe(getSavedViewOverrideSignature(second));
+        });
+
+        it('detects additions, removals, and changes to saved view overrides', () => {
+            const baseline = getSavedViewOverrideSignature(new URL('https://example.test/next/event/errors?time=90d&status=open'));
+
+            expect(getSavedViewOverrideSignature(new URL('https://example.test/next/event/errors?time=30d&status=open'))).not.toBe(baseline);
+            expect(getSavedViewOverrideSignature(new URL('https://example.test/next/event/errors?time=90d'))).not.toBe(baseline);
+            expect(getSavedViewOverrideSignature(new URL('https://example.test/next/event/errors?time=90d&status=open&sort=type'))).not.toBe(baseline);
         });
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -269,6 +269,10 @@ describe('useSavedViews', () => {
             expect(getDraftSortValue('-date', 'type', { value: 'type' }, { sort: 'count', version: 1 })).toBe('count');
         });
 
+        it('preserves an older local sort when a URL override matches the server', () => {
+            expect(getDraftSortValue('-date', '-date', { value: '-date' }, { sort: 'count', version: 1 })).toBe('count');
+        });
+
         it('persists a sort changed after hydration', () => {
             expect(getDraftSortValue('-date', 'count', { value: 'type' }, undefined)).toBe('count');
         });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -1,4 +1,4 @@
-import { DateFilter, ProjectFilter } from '$features/events/components/filters';
+import { DateFilter, ProjectFilter, StringFilter } from '$features/events/components/filters';
 import { serializeFilters } from '$features/events/components/filters/helpers.svelte';
 import { ChangeType } from '$features/websockets/models';
 import { QueryClient } from '@tanstack/svelte-query';
@@ -18,7 +18,7 @@ import {
     getComparableSavedViewTime,
     getDraftSortQueryParam,
     getDraftSortValue,
-    getEmptyFilterOverrideKeys,
+    getExpressionFilterOverrideKeys,
     getSavedViewDefinitionFilters,
     getSavedViewDraftIdentity,
     getSavedViewOverrideSignature,
@@ -161,8 +161,8 @@ describe('useSavedViews', () => {
         });
     });
 
-    describe('empty expression filter overrides', () => {
-        it('includes expression filters that exist only in the browser-local draft', () => {
+    describe('expression filter overrides', () => {
+        it('includes saved and browser-local expression filters without typed query parameter filters', () => {
             const draft = {
                 filterChanges: {
                     removedKeys: [],
@@ -171,7 +171,10 @@ describe('useSavedViews', () => {
                 version: 1 as const
             };
 
-            expect(getEmptyFilterOverrideKeys([], [new ProjectFilter(['project-1'])], draft)).toEqual(['keyword']);
+            expect(getExpressionFilterOverrideKeys([new StringFilter('error.type', 'OldException')], [new ProjectFilter(['project-1'])], draft)).toEqual([
+                'string-error.type',
+                'keyword'
+            ]);
         });
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -1,4 +1,5 @@
 import { ProjectFilter } from '$features/events/components/filters';
+import { serializeFilters } from '$features/events/components/filters/helpers.svelte';
 import { ChangeType } from '$features/websockets/models';
 import { QueryClient } from '@tanstack/svelte-query';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -15,6 +16,7 @@ import {
     getDraftSortQueryParam,
     getDraftSortValue,
     getEmptyFilterOverrideKeys,
+    getSavedViewDefinitionFilters,
     getSavedViewOverrideSignature,
     getSavedViewStateSignature,
     hasMissingSavedView,
@@ -299,6 +301,22 @@ describe('useSavedViews', () => {
 
             // Assert
             expect(result).toBe('[now-7d TO now]');
+        });
+
+        it('adds the saved time to legacy filter definitions without a date filter', () => {
+            // Act
+            const result = getSavedViewDefinitionFilters('[{"type":"project","value":["project-1"]}]', '[now-90d TO now]', '[now-7d TO now]');
+
+            // Assert
+            expect(serializeFilters(result)).toBe('[{"type":"project","value":["project-1"]},{"type":"date","term":"date","value":"[now-90d TO now]"}]');
+        });
+
+        it('replaces a stale serialized date with the saved time', () => {
+            // Act
+            const result = getSavedViewDefinitionFilters('[{"type":"date","term":"date","value":"[now-7d TO now]"}]', '[now-90d TO now]', '[now-7d TO now]');
+
+            // Assert
+            expect(serializeFilters(result)).toBe('[{"type":"date","term":"date","value":"[now-90d TO now]"}]');
         });
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -12,6 +12,7 @@ import {
     filterDefinitionsEqual,
     getComparableSavedViewFilter,
     getComparableSavedViewTime,
+    getDraftSortQueryParam,
     getDraftSortValue,
     getEmptyFilterOverrideKeys,
     getSavedViewOverrideSignature,
@@ -295,6 +296,18 @@ describe('useSavedViews', () => {
     });
 
     describe('sort drafts', () => {
+        it('uses an explicit empty override when a draft clears the server sort', () => {
+            expect(getDraftSortQueryParam('-date', null)).toBe('');
+        });
+
+        it('removes the override when the draft matches the server sort', () => {
+            expect(getDraftSortQueryParam('-date', '-date')).toBeNull();
+        });
+
+        it('restores a non-empty draft sort', () => {
+            expect(getDraftSortQueryParam('-date', 'count')).toBe('count');
+        });
+
         it('keeps a one-off URL sort override out of a local draft', () => {
             expect(getDraftSortValue('-date', 'type', { value: 'type' }, undefined)).toBe('-date');
         });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -10,6 +10,7 @@ import { invalidateSavedViewQueries, queryKeys, removeSavedViewFromCaches, SAVED
 import { savedViewHref, savedViewResolvedSlug } from './slugs';
 import {
     clearSavedViewQueryParams,
+    createSavedViewDraftFilterHistoryEntry,
     filterDefinitionsEqual,
     getChangedFilterKeys,
     getComparableSavedViewFilter,
@@ -91,6 +92,12 @@ describe('useSavedViews', () => {
     });
 
     describe('saved view draft filter history', () => {
+        it('preserves provenance for a draft-generated empty filter', () => {
+            expect(createSavedViewDraftFilterHistoryEntry('view-1', '', true)).toEqual({ filter: '', viewId: 'view-1' });
+            expect(createSavedViewDraftFilterHistoryEntry('view-1', null, true)).toBeUndefined();
+            expect(createSavedViewDraftFilterHistoryEntry('view-1', '', false)).toBeUndefined();
+        });
+
         it('requires explicit history provenance instead of inferring it from matching filter content', () => {
             expect(isSavedViewDraftFilterHistoryEntry(undefined, 'view-1', 'error.type:TimeoutException')).toBe(false);
             expect(

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -19,11 +19,13 @@ import {
     getDraftSortValue,
     getEmptyFilterOverrideKeys,
     getSavedViewDefinitionFilters,
+    getSavedViewDraftIdentity,
     getSavedViewOverrideSignature,
     getSavedViewStateSignature,
     hasMissingSavedView,
     hasSavedViewAutoFillChange,
     hasSavedViewColumnChanges,
+    isSavedViewDraftFilterHistoryEntry,
     isSavedViewHydrationPending,
     isSavedViewUnavailable,
     savedViewColumnsEqual,
@@ -75,6 +77,30 @@ function buildSavedView({ id, name, ...overrides }: Partial<SavedView> & Pick<Sa
 }
 
 describe('useSavedViews', () => {
+    describe('saved view draft identity', () => {
+        it('uses the saved view organization when the active organization changes', () => {
+            const savedView = buildSavedView({ id: 'view-1', name: 'My View', organization_id: 'original-organization' });
+
+            expect(getSavedViewDraftIdentity(savedView, TEST_USER_ID)).toEqual({
+                organizationId: 'original-organization',
+                savedViewId: 'view-1',
+                userId: TEST_USER_ID
+            });
+        });
+    });
+
+    describe('saved view draft filter history', () => {
+        it('requires explicit history provenance instead of inferring it from matching filter content', () => {
+            expect(isSavedViewDraftFilterHistoryEntry(undefined, 'view-1', 'error.type:TimeoutException')).toBe(false);
+            expect(
+                isSavedViewDraftFilterHistoryEntry({ filter: 'error.type:TimeoutException', viewId: 'view-1' }, 'view-1', 'error.type:TimeoutException')
+            ).toBe(true);
+            expect(
+                isSavedViewDraftFilterHistoryEntry({ filter: 'error.type:TimeoutException', viewId: 'view-2' }, 'view-1', 'error.type:TimeoutException')
+            ).toBe(false);
+        });
+    });
+
     describe('saved view state signatures', () => {
         it('ignores audit and naming changes outside the hydrated state baseline', () => {
             // Arrange

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -1,3 +1,4 @@
+import { ProjectFilter } from '$features/events/components/filters';
 import { ChangeType } from '$features/websockets/models';
 import { QueryClient } from '@tanstack/svelte-query';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -12,6 +13,7 @@ import {
     getComparableSavedViewFilter,
     getComparableSavedViewTime,
     getDraftSortValue,
+    getEmptyFilterOverrideKeys,
     getSavedViewOverrideSignature,
     getSavedViewStateSignature,
     hasMissingSavedView,
@@ -116,6 +118,20 @@ describe('useSavedViews', () => {
             expect(getSavedViewOverrideSignature(new URL('https://example.test/next/event/errors?time=30d&status=open'))).not.toBe(baseline);
             expect(getSavedViewOverrideSignature(new URL('https://example.test/next/event/errors?time=90d'))).not.toBe(baseline);
             expect(getSavedViewOverrideSignature(new URL('https://example.test/next/event/errors?time=90d&status=open&sort=type'))).not.toBe(baseline);
+        });
+    });
+
+    describe('empty expression filter overrides', () => {
+        it('includes expression filters that exist only in the browser-local draft', () => {
+            const draft = {
+                filterChanges: {
+                    removedKeys: [],
+                    upsertDefinitions: '[{"type":"keyword","value":"error.type:TimeoutException"}]'
+                },
+                version: 1 as const
+            };
+
+            expect(getEmptyFilterOverrideKeys([], [new ProjectFilter(['project-1'])], draft)).toEqual(['keyword']);
         });
     });
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -1,4 +1,4 @@
-import { ProjectFilter } from '$features/events/components/filters';
+import { DateFilter, ProjectFilter } from '$features/events/components/filters';
 import { serializeFilters } from '$features/events/components/filters/helpers.svelte';
 import { ChangeType } from '$features/websockets/models';
 import { QueryClient } from '@tanstack/svelte-query';
@@ -33,7 +33,8 @@ import {
     setSortQueryParam,
     setTimeQueryParam,
     supportsSortQueryParam,
-    supportsTimeQueryParam
+    supportsTimeQueryParam,
+    trackChangedFilterKeys
 } from './use-saved-views.svelte';
 
 vi.mock('$features/auth/index.svelte', () => ({
@@ -279,6 +280,17 @@ describe('useSavedViews', () => {
     });
 
     describe('filter definition comparison', () => {
+        it('retains touched filter keys after an edit is reverted', () => {
+            const touchedKeys = new Set<string>();
+            const serverDefinitions = serializeFilters([new DateFilter('date', '[now-15m TO now]')]);
+            const editedDefinitions = serializeFilters([new DateFilter('date', '[now-90d TO now]')]);
+
+            trackChangedFilterKeys(touchedKeys, serverDefinitions, editedDefinitions);
+            trackChangedFilterKeys(touchedKeys, editedDefinitions, serverDefinitions);
+
+            expect([...touchedKeys]).toEqual(['date-date']);
+        });
+
         it('finds filter keys edited while saved-view draft hydration is pending', () => {
             const initial = [new ProjectFilter(['project-1'])];
             const current = [new ProjectFilter(['project-2'])];

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/proxy.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/proxy.ts
@@ -1,7 +1,7 @@
-import type { QueryParameterInput, QueryParameters, QueryParameterSchema, QueryParameterState } from './types.js';
+import type { QueryParameterInput, QueryParameters, QueryParameterSchema, QueryParameterState, QueryParameterUpdateOptions } from './types.js';
 
 interface QueryParameterActions<T extends QueryParameterSchema> {
-    update: (values: Partial<QueryParameterInput<T>>) => void;
+    update: (values: Partial<QueryParameterInput<T>>, options?: QueryParameterUpdateOptions) => void;
 }
 
 export function createQueryParameterProxy<T extends QueryParameterSchema>(

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/query-params.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/query-params.svelte.test.ts
@@ -72,6 +72,16 @@ describe('createQueryParameters', () => {
         expect(window.location.search).toBe('?filter=second');
     });
 
+    it('allows hydration updates to replace even when user edits use push history', async () => {
+        render(QueryParametersTestHarness);
+
+        await fireEvent.click(screen.getByRole('button', { name: 'Hydrate' }));
+
+        expect(navigation.pushState).not.toHaveBeenCalled();
+        expect(navigation.replaceState).toHaveBeenCalledOnce();
+        expect(navigation.replaceState).toHaveBeenCalledWith('/?filter=hydrated', pageState);
+    });
+
     it('replaces a detail sheet entry when a filter adds push-history state', async () => {
         // Arrange
         const detailEntry = { key: 'event', value: 'abc123' };

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/query-params.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/query-params.svelte.ts
@@ -4,7 +4,7 @@ import { page } from '$app/state';
 import { onDestroy } from 'svelte';
 import { SvelteURL } from 'svelte/reactivity';
 
-import type { CreateQueryParametersOptions, QueryParameterSchema, QueryParameterState } from './types.js';
+import type { CreateQueryParametersOptions, QueryParameterSchema, QueryParameterState, QueryParameterUpdateOptions } from './types.js';
 
 import { hasDetailSheetHistoryEntry, withoutDetailSheetHistoryEntry } from '../history-state.js';
 import { createQueryParameterProxy } from './proxy.js';
@@ -120,13 +120,17 @@ export function createQueryParameters<T extends QueryParameterSchema>({
 
     const schedulePushHistoryEntryFinalization = createDebouncedFunction(finalizePushHistoryEntry, debounceMilliseconds);
 
-    const synchronizeURL = () => {
+    const synchronizeURL = (updateHistory = history) => {
         if (searchParamsEqual(searchParams, window.location.search)) {
             discardPendingReplacement();
             return;
         }
 
-        if (history === 'push' && isCoalescingPushHistoryEntry && getCurrentHistoryEntryId() !== coalescingEntryId) {
+        if (updateHistory === 'replace') {
+            schedulePushHistoryEntryFinalization.cancel();
+            discardPendingReplacement();
+            settlePushHistoryEntry();
+        } else if (isCoalescingPushHistoryEntry && getCurrentHistoryEntryId() !== coalescingEntryId) {
             // A popstate traversal may retain a pending replacement for the entry
             // we left. Editing this destination discards that Forward entry, so
             // start a fresh burst here instead of mutating the retained source.
@@ -137,7 +141,7 @@ export function createQueryParameters<T extends QueryParameterSchema>({
 
         const query = searchParams.toString();
         const url = `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`;
-        if (history === 'replace') {
+        if (updateHistory === 'replace') {
             replaceState(url, page.state);
         } else if (!isCoalescingPushHistoryEntry) {
             coalescingStartUrl = getCurrentUrl();
@@ -167,7 +171,7 @@ export function createQueryParameters<T extends QueryParameterSchema>({
             }
         }
 
-        if (history === 'push' && isCoalescingPushHistoryEntry) {
+        if (updateHistory === 'push' && isCoalescingPushHistoryEntry) {
             schedulePushHistoryEntryFinalization();
         }
     };
@@ -204,19 +208,19 @@ export function createQueryParameters<T extends QueryParameterSchema>({
 
     onDestroy(finalizePushHistoryEntry);
 
-    const commit = (result: ReturnType<typeof applyQueryParameterUpdates<T>>) => {
+    const commit = (result: ReturnType<typeof applyQueryParameterUpdates<T>>, options?: QueryParameterUpdateOptions) => {
         searchParams = result.searchParams;
         if (result.stateChanged) {
             Object.assign(current, result.state);
         }
 
         if (result.urlChanged) {
-            synchronizeURL();
+            synchronizeURL(options?.history);
         }
     };
 
-    const update = (values: Parameters<typeof applyQueryParameterUpdates<T>>[2]) => {
-        commit(applyQueryParameterUpdates(current, searchParams, values, schema));
+    const update = (values: Parameters<typeof applyQueryParameterUpdates<T>>[2], options?: QueryParameterUpdateOptions) => {
+        commit(applyQueryParameterUpdates(current, searchParams, values, schema), options);
     };
 
     const synchronizeState = (search: string) => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/query-params.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/query-params.test-harness.svelte
@@ -20,4 +20,15 @@
 <button onclick={() => (queryParameters.filter = 'a')}>Alpha</button>
 <button onclick={() => (queryParameters.filter = 'a b')}>Spaced</button>
 <button onclick={() => (queryParameters.filter = null)}>Clear</button>
+<button
+    onclick={() =>
+        queryParameters.update(
+            {
+                filter: 'hydrated'
+            },
+            {
+                history: 'replace'
+            }
+        )}>Hydrate</button
+>
 <output>{queryParameters.filter}</output>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/types.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/query-params/types.ts
@@ -10,7 +10,7 @@ export type QueryParameterInput<T extends QueryParameterSchema> = {
 };
 
 export type QueryParameters<T extends QueryParameterSchema> = QueryParameterState<T> & {
-    update: (values: Partial<QueryParameterInput<T>>) => void;
+    update: (values: Partial<QueryParameterInput<T>>, options?: QueryParameterUpdateOptions) => void;
 };
 
 export type QueryParameterSchema = Record<string, QueryParameterType>;
@@ -30,6 +30,10 @@ export type QueryParameterTypeOutput<T extends QueryParameterType> = T extends '
         : T extends 'boolean'
           ? boolean | null
           : InferEnum<T>;
+
+export interface QueryParameterUpdateOptions {
+    history?: 'push' | 'replace';
+}
 
 export type QueryParameterValue = boolean | Date | null | number | string;
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -50,7 +50,7 @@
     import { organization } from '$features/organizations/context.svelte';
     import { premiumPage } from '$features/organizations/premium-page.svelte';
     import SavedViewPicker from '$features/saved-views/components/saved-view-picker.svelte';
-    import { useSavedViews } from '$features/saved-views/use-saved-views.svelte';
+    import { isSavedViewHydrationPending, isSavedViewUnavailable, useSavedViews } from '$features/saved-views/use-saved-views.svelte';
     import * as agg from '$features/shared/api/aggregations';
     import { createPageSizePreference, getSharedTableOptions, removeTableData, removeTableSelection } from '$features/shared/table.svelte';
     import { fillDateSeries } from '$features/shared/utils/charts.js';
@@ -292,7 +292,12 @@
     // Keep queries disabled until saved-view state and its URL overrides have both settled.
     let normalizedSavedViewId = $state<string>();
     const isSavedViewRoutePending = $derived(
-        !!page.params.slug && !savedViewsState.isError && (!savedViewsState.activeSavedView || savedViewsState.activeSavedView.id !== normalizedSavedViewId)
+        isSavedViewHydrationPending(
+            page.params.slug,
+            savedViewsState.activeSavedView?.id,
+            normalizedSavedViewId,
+            isSavedViewUnavailable(savedViewsState.activeSavedView?.id, savedViewsState.isMissing, savedViewsState.isError)
+        )
     );
 
     $effect(() => {
@@ -955,6 +960,7 @@
                 <SavedViewPicker
                     activeSavedView={savedViewsState.activeSavedView}
                     autoFillColumnId={savedViewsState.autoFillColumnId}
+                    canModifySavedView={savedViewsState.canModifySavedView}
                     columnOrder={table.store.state.columnOrder}
                     columnSizing={table.store.state.columnSizing}
                     columnVisibility={table.store.state.columnVisibility}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -286,7 +286,7 @@
     // Keep queries disabled until saved-view state and its URL overrides have both settled.
     let normalizedSavedViewId = $state<string>();
     const isSavedViewRoutePending = $derived(
-        !!page.params.slug && (!savedViewsState.activeSavedView || savedViewsState.activeSavedView.id !== normalizedSavedViewId)
+        !!page.params.slug && !savedViewsState.isError && (!savedViewsState.activeSavedView || savedViewsState.activeSavedView.id !== normalizedSavedViewId)
     );
 
     $effect(() => {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -957,6 +957,7 @@
                     onLoadView={savedViewsState.handleLoadView}
                     onClearSavedView={savedViewsState.handleClearSavedView}
                     onResetToSaved={handleResetToSaved}
+                    onSavedViewUpdated={savedViewsState.handleSavedViewUpdated}
                     savedViews={savedViewsState.savedViews}
                     setAutoFillColumnId={savedViewsState.setAutoFillColumnId}
                     setWrappedColumnIds={savedViewsState.setWrappedColumnIds}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -249,9 +249,10 @@
     let showStats = $state(true);
     let showChart = $state(true);
     const savedViewsState = useSavedViews({
-        applyFilters: (draftFilters) => {
+        applyFilters: (draftFilters, options) => {
             updateFilters(draftFilters, {
-                clearPagination: false
+                clearPagination: false,
+                history: options?.history
             });
             filters = draftFilters;
         },
@@ -471,7 +472,7 @@
         filters = updatedFilters;
     }
 
-    function updateFilters(updatedFilters: FacetedFilter.IFilter[], options: { clearPagination?: boolean } = {}): void {
+    function updateFilters(updatedFilters: FacetedFilter.IFilter[], options: { clearPagination?: boolean; history?: 'push' | 'replace' } = {}): void {
         const shouldClearPagination = options.clearPagination ?? true;
         const filter = toFilter(updatedFilters.filter((f) => f.type !== 'date'));
         const expressionFilters = updatedFilters.filter((f) => f.type !== 'date' && !isQueryParamFilter(f));
@@ -512,24 +513,29 @@
             isInternalFilterUpdate = true;
         }
 
-        queryParams.update({
-            after: shouldClearPaginationForFilter ? null : queryParams.after,
-            before: shouldClearPaginationForFilter ? null : queryParams.before,
-            bot: queryFilterParams.bot,
-            filter: newFilterParam,
-            first: queryFilterParams.first,
-            level: queryFilterParams.level,
-            page: shouldClearPaginationForFilter ? null : queryParams.page,
-            project: queryFilterParams.project,
-            reference: queryFilterParams.reference,
-            session: queryFilterParams.session,
-            stack: queryFilterParams.stack,
-            status: queryFilterParams.status,
-            tag: queryFilterParams.tag,
-            time: newTimeParam,
-            type: queryFilterParams.type,
-            version: queryFilterParams.version
-        });
+        queryParams.update(
+            {
+                after: shouldClearPaginationForFilter ? null : queryParams.after,
+                before: shouldClearPaginationForFilter ? null : queryParams.before,
+                bot: queryFilterParams.bot,
+                filter: newFilterParam,
+                first: queryFilterParams.first,
+                level: queryFilterParams.level,
+                page: shouldClearPaginationForFilter ? null : queryParams.page,
+                project: queryFilterParams.project,
+                reference: queryFilterParams.reference,
+                session: queryFilterParams.session,
+                stack: queryFilterParams.stack,
+                status: queryFilterParams.status,
+                tag: queryFilterParams.tag,
+                time: newTimeParam,
+                type: queryFilterParams.type,
+                version: queryFilterParams.version
+            },
+            {
+                history: options.history
+            }
+        );
     }
 
     $effect(() => {
@@ -541,7 +547,8 @@
 
         untrack(() => {
             updateFilters(getCurrentFilters(getListFilterQueryParams(queryParams)), {
-                clearPagination: false
+                clearPagination: false,
+                history: 'replace'
             });
         });
         normalizedSavedViewId = activeSavedViewId;

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -249,6 +249,12 @@
     let showStats = $state(true);
     let showChart = $state(true);
     const savedViewsState = useSavedViews({
+        applyFilters: (draftFilters) => {
+            updateFilters(draftFilters, {
+                clearPagination: false
+            });
+            filters = draftFilters;
+        },
         baseHref: resolve('/(app)/event'),
         defaultAutoFillColumnId: 'summary',
         defaultColumnVisibility: defaultEventColumnVisibility,

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -261,6 +261,11 @@
         defaultFilter: DEFAULT_FILTER,
         defaultTime: DEFAULT_TIME_RANGE,
         filterCacheKey,
+        getAvailableColumnIds: () =>
+            table
+                .getAllFlatColumns()
+                .filter((column) => column.columns.length === 0)
+                .map((column) => column.id),
         getColumnOrder: () => table.store.state.columnOrder,
         getColumnSizing: () => table.store.state.columnSizing,
         getColumnVisibility: () => table.store.state.columnVisibility,

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -49,7 +49,7 @@
     import { organization } from '$features/organizations/context.svelte';
     import { premiumPage } from '$features/organizations/premium-page.svelte';
     import SavedViewPicker from '$features/saved-views/components/saved-view-picker.svelte';
-    import { useSavedViews } from '$features/saved-views/use-saved-views.svelte';
+    import { isSavedViewHydrationPending, isSavedViewUnavailable, useSavedViews } from '$features/saved-views/use-saved-views.svelte';
     import * as agg from '$features/shared/api/aggregations';
     import { createPageSizePreference, getSharedTableOptions, removeTableData, removeTableSelection } from '$features/shared/table.svelte';
     import { fillDateSeries } from '$features/shared/utils/charts';
@@ -284,7 +284,12 @@
     // Keep queries disabled until saved-view state and its URL overrides have both settled.
     let normalizedSavedViewId = $state<string>();
     const isSavedViewRoutePending = $derived(
-        !!page.params.slug && !savedViewsState.isError && (!savedViewsState.activeSavedView || savedViewsState.activeSavedView.id !== normalizedSavedViewId)
+        isSavedViewHydrationPending(
+            page.params.slug,
+            savedViewsState.activeSavedView?.id,
+            normalizedSavedViewId,
+            isSavedViewUnavailable(savedViewsState.activeSavedView?.id, savedViewsState.isMissing, savedViewsState.isError)
+        )
     );
 
     $effect(() => {
@@ -862,6 +867,7 @@
                 <SavedViewPicker
                     activeSavedView={savedViewsState.activeSavedView}
                     autoFillColumnId={savedViewsState.autoFillColumnId}
+                    canModifySavedView={savedViewsState.canModifySavedView}
                     columnOrder={table.store.state.columnOrder}
                     columnSizing={table.store.state.columnSizing}
                     columnVisibility={table.store.state.columnVisibility}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -242,6 +242,12 @@
     let showStats = $state(true);
     let showChart = $state(true);
     const savedViewsState = useSavedViews({
+        applyFilters: (draftFilters) => {
+            updateFilters(draftFilters, {
+                clearPagination: false
+            });
+            filters = draftFilters;
+        },
         baseHref: resolve('/(app)/stack'),
         defaultAutoFillColumnId: 'summary',
         defaultColumnVisibility: defaultStackColumnVisibility,

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -242,9 +242,10 @@
     let showStats = $state(true);
     let showChart = $state(true);
     const savedViewsState = useSavedViews({
-        applyFilters: (draftFilters) => {
+        applyFilters: (draftFilters, options) => {
             updateFilters(draftFilters, {
-                clearPagination: false
+                clearPagination: false,
+                history: options?.history
             });
             filters = draftFilters;
         },
@@ -471,7 +472,7 @@
         filters = updatedFilters;
     }
 
-    function updateFilters(updatedFilters: FacetedFilter.IFilter[], options: { clearPagination?: boolean } = {}): void {
+    function updateFilters(updatedFilters: FacetedFilter.IFilter[], options: { clearPagination?: boolean; history?: 'push' | 'replace' } = {}): void {
         const shouldClearPagination = options.clearPagination ?? true;
         const filter = toFilter(updatedFilters.filter((f) => f.type !== 'date'));
         const expressionFilters = updatedFilters.filter((f) => f.type !== 'date' && !isQueryParamFilter(f));
@@ -512,22 +513,27 @@
             isInternalFilterUpdate = true;
         }
 
-        queryParams.update({
-            bot: queryFilterParams.bot,
-            filter: newFilterParam,
-            first: queryFilterParams.first,
-            level: queryFilterParams.level,
-            page: shouldClearPaginationForFilter ? null : queryParams.page,
-            project: queryFilterParams.project,
-            reference: queryFilterParams.reference,
-            session: queryFilterParams.session,
-            stack: queryFilterParams.stack,
-            status: queryFilterParams.status,
-            tag: queryFilterParams.tag,
-            time: newTimeParam,
-            type: queryFilterParams.type,
-            version: queryFilterParams.version
-        });
+        queryParams.update(
+            {
+                bot: queryFilterParams.bot,
+                filter: newFilterParam,
+                first: queryFilterParams.first,
+                level: queryFilterParams.level,
+                page: shouldClearPaginationForFilter ? null : queryParams.page,
+                project: queryFilterParams.project,
+                reference: queryFilterParams.reference,
+                session: queryFilterParams.session,
+                stack: queryFilterParams.stack,
+                status: queryFilterParams.status,
+                tag: queryFilterParams.tag,
+                time: newTimeParam,
+                type: queryFilterParams.type,
+                version: queryFilterParams.version
+            },
+            {
+                history: options.history
+            }
+        );
     }
 
     $effect(() => {
@@ -539,7 +545,8 @@
 
         untrack(() => {
             updateFilters(getCurrentFilters(getListFilterQueryParams(queryParams)), {
-                clearPagination: false
+                clearPagination: false,
+                history: 'replace'
             });
         });
         normalizedSavedViewId = activeSavedViewId;

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -864,6 +864,7 @@
                     onLoadView={savedViewsState.handleLoadView}
                     onClearSavedView={savedViewsState.handleClearSavedView}
                     onResetToSaved={handleResetToSaved}
+                    onSavedViewUpdated={savedViewsState.handleSavedViewUpdated}
                     savedViews={savedViewsState.savedViews}
                     setAutoFillColumnId={savedViewsState.setAutoFillColumnId}
                     setWrappedColumnIds={savedViewsState.setWrappedColumnIds}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -278,7 +278,7 @@
     // Keep queries disabled until saved-view state and its URL overrides have both settled.
     let normalizedSavedViewId = $state<string>();
     const isSavedViewRoutePending = $derived(
-        !!page.params.slug && (!savedViewsState.activeSavedView || savedViewsState.activeSavedView.id !== normalizedSavedViewId)
+        !!page.params.slug && !savedViewsState.isError && (!savedViewsState.activeSavedView || savedViewsState.activeSavedView.id !== normalizedSavedViewId)
     );
 
     $effect(() => {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -254,6 +254,11 @@
         defaultFilter: DEFAULT_FILTER,
         defaultTime: DEFAULT_TIME_RANGE,
         filterCacheKey,
+        getAvailableColumnIds: () =>
+            table
+                .getAllFlatColumns()
+                .filter((column) => column.columns.length === 0)
+                .map((column) => column.id),
         getColumnOrder: () => table.store.state.columnOrder,
         getColumnSizing: () => table.store.state.columnSizing,
         getColumnVisibility: () => table.store.state.columnVisibility,

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -101,7 +101,12 @@
         view: VIEW
     });
     const isSavedViewPending = $derived(
-        isSavedViewHydrationPending(queryParams.saved, savedViewsState.activeSavedView?.id, savedViewsState.hydratedSavedViewId, savedViewsState.isMissing)
+        isSavedViewHydrationPending(
+            queryParams.saved,
+            savedViewsState.activeSavedView?.id,
+            savedViewsState.hydratedSavedViewId,
+            savedViewsState.isMissing || savedViewsState.isError
+        )
     );
     const pageTitle = $derived(savedViewsState.activeSavedView?.name ?? 'Event Stream');
 
@@ -233,6 +238,10 @@
 
     async function loadData(filterChanged: boolean = false) {
         if (isSavedViewPending) {
+            loadDataRequestId++;
+            before = undefined;
+            clientResponse = undefined;
+            queryData = [];
             return;
         }
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -28,7 +28,7 @@
     import { defaultEventColumnVisibility, getColumns } from '$features/events/components/table/options.svelte';
     import { organization } from '$features/organizations/context.svelte';
     import SavedViewPicker from '$features/saved-views/components/saved-view-picker.svelte';
-    import { isSavedViewHydrationPending, useSavedViews } from '$features/saved-views/use-saved-views.svelte';
+    import { isSavedViewHydrationPending, isSavedViewUnavailable, useSavedViews } from '$features/saved-views/use-saved-views.svelte';
     import { getSharedTableOptions, isTableEmpty, removeTableData } from '$features/shared/table.svelte';
     import { StackStatus } from '$features/stacks/models';
     import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
@@ -110,7 +110,7 @@
             queryParams.saved,
             savedViewsState.activeSavedView?.id,
             savedViewsState.hydratedSavedViewId,
-            savedViewsState.isMissing || savedViewsState.isError
+            isSavedViewUnavailable(savedViewsState.activeSavedView?.id, savedViewsState.isMissing, savedViewsState.isError)
         )
     );
     const pageTitle = $derived(savedViewsState.activeSavedView?.name ?? 'Event Stream');
@@ -375,6 +375,7 @@
                 <SavedViewPicker
                     activeSavedView={savedViewsState.activeSavedView}
                     autoFillColumnId={savedViewsState.autoFillColumnId}
+                    canModifySavedView={savedViewsState.canModifySavedView}
                     columnOrder={table.store.state.columnOrder}
                     columnSizing={table.store.state.columnSizing}
                     columnVisibility={table.store.state.columnVisibility}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -81,8 +81,8 @@
 
     const VIEW = 'stream';
     const savedViewsState = useSavedViews({
-        applyFilters: (draftFilters) => {
-            updateFilters(draftFilters);
+        applyFilters: (draftFilters, options) => {
+            updateFilters(draftFilters, options);
             filters = draftFilters;
         },
         defaultAutoFillColumnId: 'summary',
@@ -168,10 +168,17 @@
         filters = updatedFilters;
     }
 
-    function updateFilters(updatedFilters: FacetedFilter.IFilter[]): void {
+    function updateFilters(updatedFilters: FacetedFilter.IFilter[], options: { history?: 'push' | 'replace' } = {}): void {
         const filter = toFilter(updatedFilters);
         updateFilterCache(filterCacheKey(filter), updatedFilters);
-        queryParams.filter = filter;
+        queryParams.update(
+            {
+                filter
+            },
+            {
+                history: options.history
+            }
+        );
     }
 
     const eventsQueryParameters: GetEventsParams = $state({

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -81,6 +81,10 @@
 
     const VIEW = 'stream';
     const savedViewsState = useSavedViews({
+        applyFilters: (draftFilters) => {
+            updateFilters(draftFilters);
+            filters = draftFilters;
+        },
         defaultAutoFillColumnId: 'summary',
         defaultColumnVisibility: defaultEventColumnVisibility,
         defaultFilter: DEFAULT_PARAMS.filter,

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -331,6 +331,17 @@
     });
 
     $effect(() => {
+        if (!isSavedViewPending) {
+            return;
+        }
+
+        loadDataRequestId++;
+        before = undefined;
+        clientResponse = undefined;
+        queryData = [];
+    });
+
+    $effect(() => {
         if (paused) {
             return;
         }

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -28,7 +28,7 @@
     import { defaultEventColumnVisibility, getColumns } from '$features/events/components/table/options.svelte';
     import { organization } from '$features/organizations/context.svelte';
     import SavedViewPicker from '$features/saved-views/components/saved-view-picker.svelte';
-    import { useSavedViews } from '$features/saved-views/use-saved-views.svelte';
+    import { isSavedViewHydrationPending, useSavedViews } from '$features/saved-views/use-saved-views.svelte';
     import { getSharedTableOptions, isTableEmpty, removeTableData } from '$features/shared/table.svelte';
     import { StackStatus } from '$features/stacks/models';
     import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
@@ -100,6 +100,9 @@
         updateFilterCache,
         view: VIEW
     });
+    const isSavedViewPending = $derived(
+        isSavedViewHydrationPending(queryParams.saved, savedViewsState.activeSavedView?.id, savedViewsState.hydratedSavedViewId, savedViewsState.isMissing)
+    );
     const pageTitle = $derived(savedViewsState.activeSavedView?.name ?? 'Event Stream');
 
     $effect(() => {
@@ -229,6 +232,10 @@
     }
 
     async function loadData(filterChanged: boolean = false) {
+        if (isSavedViewPending) {
+            return;
+        }
+
         if (client.isLoading && filterChanged && !before) {
             return;
         }
@@ -371,7 +378,7 @@
         {table}
         wrappedColumnIds={savedViewsState.wrappedColumnIds}
     >
-        {#if clientStatus.isLoading}
+        {#if isSavedViewPending || clientStatus.isLoading}
             <DelayedRender>
                 <DataTable.Loading {table} />
             </DelayedRender>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -89,6 +89,11 @@
         defaultColumnVisibility: defaultEventColumnVisibility,
         defaultFilter: DEFAULT_PARAMS.filter,
         filterCacheKey,
+        getAvailableColumnIds: () =>
+            table
+                .getAllFlatColumns()
+                .filter((column) => column.columns.length === 0)
+                .map((column) => column.id),
         getColumnOrder: () => table.store.state.columnOrder,
         getColumnSizing: () => table.store.state.columnSizing,
         getColumnVisibility: () => table.store.state.columnVisibility,

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -377,6 +377,7 @@
                     onLoadView={savedViewsState.handleLoadView}
                     onClearSavedView={savedViewsState.handleClearSavedView}
                     onResetToSaved={savedViewsState.handleResetToSaved}
+                    onSavedViewUpdated={savedViewsState.handleSavedViewUpdated}
                     savedViews={savedViewsState.savedViews}
                     setAutoFillColumnId={savedViewsState.setAutoFillColumnId}
                     setWrappedColumnIds={savedViewsState.setWrappedColumnIds}


### PR DESCRIPTION
## Summary

- persist unsaved saved-view filters, columns, display options, and sorting in browser-local storage scoped by user, organization, and view
- reapply semantic local changes over the latest server view while keeping explicit URL overrides authoritative
- preserve independent dirty state while switching among Events, Stacks, and Stream saved views, including across browser reloads
- clear only the active view draft when the view is reset or returned to its saved state

## Validation

- `npm run validate`
- `npx vitest run src/lib/features/saved-views/saved-view-drafts.test.ts src/lib/features/saved-views/use-saved-views.test.ts src/lib/features/saved-views/column-settings.test.ts` (58 tests)
- `E2E_URL=https://localhost:34565 npm run test:e2e -- --project=chromium e2e/tests/saved-views.e2e.ts` (2 tests)

## Breaking changes

None.
