### PR TITLE
Connect table toolbar controls

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-footer.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-footer.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <div
-    class={['bg-background/95 sticky top-2 z-30 flex w-full flex-wrap items-center justify-between gap-2 backdrop-blur-sm', className]}
+    class={['border-border bg-background sticky top-2 z-30 flex w-full flex-wrap items-center justify-between gap-2 border-y', className]}
     data-slot="data-table-footer"
 >
     {#if children}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
@@ -19,7 +19,7 @@ describe('DataTablePager', () => {
         scrollIntoView.mockReset();
     });
 
-    it('keeps bulk actions and pagination together in the sticky table toolbar', () => {
+    it('keeps bulk actions and pagination together in the solid sticky table toolbar', () => {
         render(DataTablePagerTestHarness, { onPageIndexChange: vi.fn(), onPageSizeChange: vi.fn() });
 
         const toolbar = document.querySelector('[data-slot="data-table-footer"]');
@@ -29,6 +29,8 @@ describe('DataTablePager', () => {
         expect(toolbar?.classList.contains('top-2')).toBe(true);
         expect(toolbar?.classList.contains('order-2')).toBe(false);
         expect(toolbar?.classList.contains('border')).toBe(false);
+        expect(toolbar?.classList.contains('border-y')).toBe(true);
+        expect(toolbar?.classList.contains('bg-background')).toBe(true);
         expect(toolbar?.classList.contains('p-2')).toBe(false);
         expect(toolbar?.contains(screen.getByRole('button', { name: 'Bulk Actions' }))).toBe(true);
         expect(toolbar?.contains(pager)).toBe(true);


### PR DESCRIPTION
## Summary
- add full-width top and bottom rules that visually connect the bulk actions and pager controls
- use a solid toolbar background while preserving the compact zero-padding layout

## Validation
- npm run validate
- npm run test:unit -- src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts

## Breaking changes
None.