### PR TITLE
Join table controls in a full-width toolbar

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte
@@ -57,7 +57,7 @@
                 {...props}
                 aria-describedby={ids.length === 0 ? bulkActionsDescriptionId : undefined}
                 aria-disabled={ids.length === 0}
-                class="aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+                class="rounded-l-lg rounded-r-none border-0 border-r aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
                 title={ids.length === 0 ? 'Select one or more events to use bulk actions' : 'Bulk Actions'}
                 variant="outline"
             >

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-footer.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-footer.svelte
@@ -21,8 +21,13 @@
 </script>
 
 <div
-    class={['border-border bg-background sticky top-2 z-30 flex w-full flex-wrap items-center justify-between gap-2 border-y', className]}
+    aria-label="Table controls"
+    class={[
+        'border-border bg-background/95 sticky top-2 z-30 flex w-full flex-nowrap items-center justify-between gap-0 rounded-lg border backdrop-blur-sm',
+        className
+    ]}
     data-slot="data-table-footer"
+    role="toolbar"
 >
     {#if children}
         {@render children()}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-footer.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-footer.svelte
@@ -23,7 +23,7 @@
 <div
     aria-label="Table controls"
     class={[
-        'border-border bg-background/95 sticky top-2 z-30 flex w-full flex-nowrap items-center justify-between gap-0 rounded-lg border backdrop-blur-sm',
+        'border-border bg-background/95 sticky top-2 z-30 flex w-full flex-wrap items-center justify-between gap-0 rounded-lg border backdrop-blur-sm sm:flex-nowrap',
         className
     ]}
     data-slot="data-table-footer"

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
@@ -6,14 +6,16 @@
     import type { RowData, StockFeatures, Table } from '@tanstack/svelte-table';
 
     import * as Select from '$comp/ui/select';
+    import { cn } from '$lib/utils';
 
     interface Props {
+        joined?: boolean;
         onPageSizeChange?: () => void;
         table: Table<StockFeatures, TData>;
         value: number;
     }
 
-    let { onPageSizeChange, table, value = $bindable() }: Props = $props();
+    let { joined = false, onPageSizeChange, table, value = $bindable() }: Props = $props();
 
     type Item = { label: string; value: string };
     const items: Item[] = [
@@ -54,7 +56,12 @@
 </script>
 
 <Select.Root type="single" {items} value={valueString} {onValueChange}>
-    <Select.Trigger aria-label="Rows per page" class="min-w-18 rounded-none border-y-0" title="Rows per page">
+    <Select.Trigger
+        aria-label="Rows per page"
+        class={cn('min-w-18', joined && 'rounded-none border-y-0')}
+        size={joined ? 'default' : 'sm'}
+        title="Rows per page"
+    >
         {selected.label} rows
     </Select.Trigger>
     <Select.Content>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
@@ -54,7 +54,7 @@
 </script>
 
 <Select.Root type="single" {items} value={valueString} {onValueChange}>
-    <Select.Trigger aria-label="Rows per page" class="min-w-18" size="sm" title="Rows per page">
+    <Select.Trigger aria-label="Rows per page" class="min-w-18 rounded-none border-y-0" title="Rows per page">
         {selected.label} rows
     </Select.Trigger>
     <Select.Content>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
@@ -60,7 +60,7 @@
         <DataTablePageSize bind:value onPageSizeChange={scrollTableIntoView} {table} />
         <ButtonGroup.Text
             aria-label={`Page ${currentPage} of ${totalPages}`}
-            class="min-w-14 justify-center select-none"
+            class="min-w-14 justify-center rounded-none border-y-0 select-none"
             title={`Page ${currentPage} of ${totalPages}`}
         >
             <Number value={currentPage} /> / <Number value={totalPages} />
@@ -68,9 +68,9 @@
         <Button
             aria-label="Go to previous page"
             aria-disabled={!canGoPrevious}
-            class="aria-disabled:pointer-events-none aria-disabled:opacity-50"
+            class="rounded-none border-y-0 aria-disabled:pointer-events-none aria-disabled:opacity-50"
             onclick={goToPreviousPage}
-            size="icon-sm"
+            size="icon"
             title="Previous page"
             variant="outline"
         >
@@ -79,9 +79,9 @@
         <Button
             aria-label="Go to next page"
             aria-disabled={!canGoNext}
-            class="aria-disabled:pointer-events-none aria-disabled:opacity-50"
+            class="rounded-l-none! rounded-r-lg! border-y-0 border-r-0 aria-disabled:pointer-events-none aria-disabled:opacity-50"
             onclick={goToNextPage}
-            size="icon-sm"
+            size="icon"
             title="Next page"
             variant="outline"
         >

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
@@ -55,9 +55,13 @@
     }
 </script>
 
-<nav bind:this={pagerElement} aria-label="Table pagination" class="ml-auto shrink-0">
+<nav
+    bind:this={pagerElement}
+    aria-label="Table pagination"
+    class="border-border ml-auto shrink-0 max-sm:flex max-sm:w-full max-sm:justify-end max-sm:border-t"
+>
     <ButtonGroup.Root aria-label="Pagination controls">
-        <DataTablePageSize bind:value onPageSizeChange={scrollTableIntoView} {table} />
+        <DataTablePageSize bind:value joined onPageSizeChange={scrollTableIntoView} {table} />
         <ButtonGroup.Text
             aria-label={`Page ${currentPage} of ${totalPages}`}
             class="min-w-14 justify-center rounded-none border-y-0 select-none"

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
@@ -19,22 +19,32 @@ describe('DataTablePager', () => {
         scrollIntoView.mockReset();
     });
 
-    it('keeps bulk actions and pagination together in the solid sticky table toolbar', () => {
+    it('joins bulk actions and pagination in one full-width sticky toolbar', () => {
         render(DataTablePagerTestHarness, { onPageIndexChange: vi.fn(), onPageSizeChange: vi.fn() });
 
         const toolbar = document.querySelector('[data-slot="data-table-footer"]');
         const pager = screen.getByRole('navigation', { name: 'Table pagination' });
 
+        expect(screen.getByRole('toolbar', { name: 'Table controls' })).toBe(toolbar);
         expect(toolbar?.classList.contains('sticky')).toBe(true);
         expect(toolbar?.classList.contains('top-2')).toBe(true);
         expect(toolbar?.classList.contains('order-2')).toBe(false);
-        expect(toolbar?.classList.contains('border')).toBe(false);
-        expect(toolbar?.classList.contains('border-y')).toBe(true);
-        expect(toolbar?.classList.contains('bg-background')).toBe(true);
+        expect(toolbar?.classList.contains('border')).toBe(true);
+        expect(toolbar?.classList.contains('border-y')).toBe(false);
+        expect(toolbar?.classList.contains('rounded-lg')).toBe(true);
+        expect(toolbar?.classList.contains('gap-0')).toBe(true);
         expect(toolbar?.classList.contains('p-2')).toBe(false);
         expect(toolbar?.contains(screen.getByRole('button', { name: 'Bulk Actions' }))).toBe(true);
         expect(toolbar?.contains(pager)).toBe(true);
-        expect(screen.getByLabelText('Page 1 of 3').classList.contains('select-none')).toBe(true);
+
+        const pageLabel = screen.getByLabelText('Page 1 of 3');
+        expect(pageLabel.classList.contains('select-none')).toBe(true);
+        expect(pageLabel.classList.contains('rounded-none')).toBe(true);
+        expect(pageLabel.classList.contains('border-y-0')).toBe(true);
+        const nextButton = screen.getByRole('button', { name: 'Go to next page' });
+        expect(nextButton.classList.contains('rounded-r-lg!')).toBe(true);
+        expect(nextButton.classList.contains('rounded-l-none!')).toBe(true);
+        expect(nextButton.classList.contains('border-r-0')).toBe(true);
     });
 
     it('keeps focus and scrolls the table to the start when changing pages', async () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import DataTablePageSize from './data-table-page-size.svelte';
 import DataTablePagerTestHarness from './data-table-pager.test-harness.svelte';
 
 describe('DataTablePager', () => {
@@ -33,10 +34,18 @@ describe('DataTablePager', () => {
         expect(toolbar?.classList.contains('border-y')).toBe(false);
         expect(toolbar?.classList.contains('rounded-lg')).toBe(true);
         expect(toolbar?.classList.contains('gap-0')).toBe(true);
+        expect(toolbar?.classList.contains('flex-wrap')).toBe(true);
+        expect(toolbar?.classList.contains('sm:flex-nowrap')).toBe(true);
         expect(toolbar?.classList.contains('p-2')).toBe(false);
         expect(toolbar?.contains(screen.getByRole('button', { name: 'Bulk Actions' }))).toBe(true);
         expect(toolbar?.contains(pager)).toBe(true);
+        expect(pager.classList.contains('max-sm:w-full')).toBe(true);
+        expect(pager.classList.contains('max-sm:border-t')).toBe(true);
 
+        const pageSize = screen.getByLabelText('Rows per page');
+        expect(pageSize.getAttribute('data-size')).toBe('default');
+        expect(pageSize.classList.contains('rounded-none')).toBe(true);
+        expect(pageSize.classList.contains('border-y-0')).toBe(true);
         const pageLabel = screen.getByLabelText('Page 1 of 3');
         expect(pageLabel.classList.contains('select-none')).toBe(true);
         expect(pageLabel.classList.contains('rounded-none')).toBe(true);
@@ -45,6 +54,16 @@ describe('DataTablePager', () => {
         expect(nextButton.classList.contains('rounded-r-lg!')).toBe(true);
         expect(nextButton.classList.contains('rounded-l-none!')).toBe(true);
         expect(nextButton.classList.contains('border-r-0')).toBe(true);
+    });
+
+    it('keeps a standalone page-size selector fully bordered', () => {
+        const table = { setPageSize: vi.fn() } as never;
+        render(DataTablePageSize, { table, value: 10 });
+
+        const pageSize = screen.getByLabelText('Rows per page');
+        expect(pageSize.getAttribute('data-size')).toBe('sm');
+        expect(pageSize.classList.contains('rounded-none')).toBe(false);
+        expect(pageSize.classList.contains('border-y-0')).toBe(false);
     });
 
     it('keeps focus and scrolls the table to the start when changing pages', async () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte
@@ -179,7 +179,7 @@
                 {...props}
                 aria-describedby={ids.length === 0 ? bulkActionsDescriptionId : undefined}
                 aria-disabled={ids.length === 0}
-                class="aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+                class="rounded-l-lg rounded-r-none border-0 border-r aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
                 title={ids.length === 0 ? 'Select one or more stacks to use bulk actions' : 'Bulk Actions'}
                 variant="outline"
             >


### PR DESCRIPTION
## Summary

- joins bulk actions and pagination in one full-width table toolbar
- preserves the existing control styling while using shared outer edges and separators
- keeps the Events and Stacks bulk-action controls integrated with the pager

## Validation

- `npm run validate`
- `npm run test:unit -- src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts`

## Breaking changes

None.