### PR TITLE
Format responsive table pager

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
@@ -55,11 +55,7 @@
     }
 </script>
 
-<nav
-    bind:this={pagerElement}
-    aria-label="Table pagination"
-    class="border-border ml-auto shrink-0 max-sm:flex max-sm:w-full max-sm:justify-end max-sm:border-t"
->
+<nav bind:this={pagerElement} aria-label="Table pagination" class="border-border ml-auto shrink-0 max-sm:flex max-sm:w-full max-sm:justify-end max-sm:border-t">
     <ButtonGroup.Root aria-label="Pagination controls">
         <DataTablePageSize bind:value joined onPageSizeChange={scrollTableIntoView} {table} />
         <ButtonGroup.Text


### PR DESCRIPTION
## Summary

- applies the repository formatter to the responsive pager markup merged in #2520
- restores the frontend formatting gate without changing toolbar behavior

## Validation

- `npx prettier --check src/lib/features/shared/components/data-table/data-table-pager.svelte`
- `npm run test:unit -- src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts`

## Breaking changes

None.