### PR TITLE
Improve responsive list layouts

### DIFF
--- a/src/Exceptionless.Web/ClientApp/e2e/tests/rataplan-feedback.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/rataplan-feedback.e2e.ts
@@ -179,7 +179,7 @@ test('approved Rataplan UI feedback remains fixed', async ({ e2eApi, e2eScenario
     await test.step('the fixed-version field has space before the dialog footer', async () => {
         await page.goto(`/next/stack?filter=project:${e2eScenario.projectId}&time=all`);
         await page.getByRole('checkbox', { name: 'Select row' }).first().click();
-        const bulkActionsButton = page.getByRole('button', { name: 'Bulk Actions' });
+        const bulkActionsButton = page.getByRole('button', { name: 'Actions' });
         const selectionCount = page.getByText('1 selected', { exact: true });
         await expect(selectionCount).toBeVisible();
         await expect
@@ -190,7 +190,7 @@ test('approved Rataplan UI feedback remains fixed', async ({ e2eApi, e2eScenario
             })
             .toBeLessThanOrEqual(16);
         await bulkActionsButton.click();
-        await expect(page.locator('[data-slot="dropdown-menu-group-heading"]', { hasText: 'Bulk Actions' })).toHaveCount(0);
+        await expect(page.locator('[data-slot="dropdown-menu-group-heading"]', { hasText: 'Actions' })).toHaveCount(0);
         await page.getByRole('menuitem', { name: 'Mark Fixed' }).click();
 
         const versionField = page.getByRole('textbox', { name: 'Version' }).locator('xpath=..');

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/table-toolbar-pagination.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/table-toolbar-pagination.e2e.ts
@@ -23,7 +23,7 @@ test('table toolbar remains accessible while moving between different-height res
     await expect(pageIndicator).toBeVisible({ timeout: 30_000 });
     expect(await pageIndicator.evaluate((element) => getComputedStyle(element).userSelect)).toBe('none');
 
-    const bulkActionsButton = toolbar.getByRole('button', { name: /Bulk Actions/ });
+    const bulkActionsButton = toolbar.getByRole('button', { name: 'Actions' });
     await expect(bulkActionsButton).toHaveAttribute('aria-disabled', 'true');
     await expect(bulkActionsButton).toHaveAttribute('title', 'Select one or more events to use bulk actions');
     await bulkActionsButton.focus();

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte
@@ -58,10 +58,10 @@
                 aria-describedby={ids.length === 0 ? bulkActionsDescriptionId : undefined}
                 aria-disabled={ids.length === 0}
                 class="rounded-l-lg rounded-r-none border-0 border-r aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
-                title={ids.length === 0 ? 'Select one or more events to use bulk actions' : 'Bulk Actions'}
+                title={ids.length === 0 ? 'Select one or more events to use bulk actions' : 'Actions'}
                 variant="outline"
             >
-                Bulk Actions
+                Actions
                 <ChevronDown data-icon="inline-end" />
             </Button>
         {/snippet}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte.test.ts
@@ -30,7 +30,7 @@ describe('EventsBulkActionsDropdownMenu', () => {
         } as never;
         render(EventsBulkActionsDropdownMenu, { props: { table } });
 
-        const trigger = screen.getByRole('button', { name: /Bulk Actions/ }) as HTMLButtonElement;
+        const trigger = screen.getByRole('button', { name: 'Actions' }) as HTMLButtonElement;
         expect(trigger.disabled).toBe(false);
         expect(trigger.getAttribute('aria-disabled')).toBe('true');
         expect(trigger.title).toBe('Select one or more events to use bulk actions');
@@ -48,7 +48,7 @@ describe('EventsBulkActionsDropdownMenu', () => {
         } as never;
         render(EventsBulkActionsDropdownMenu, { props: { table } });
 
-        await fireEvent.click(screen.getByRole('button', { name: /Bulk Actions/ }));
+        await fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
 
         expect(document.querySelector('[data-slot="dropdown-menu-group-heading"]')).toBeNull();
         expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeTruthy();
@@ -64,7 +64,7 @@ describe('EventsBulkActionsDropdownMenu', () => {
         render(EventsBulkActionsDropdownMenu, { props: { table } });
 
         // Act
-        await fireEvent.click(screen.getByRole('button', { name: /Bulk Actions/ }));
+        await fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
         await fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
         await fireEvent.click(screen.getByRole('button', { name: 'Delete Event' }));
 
@@ -83,7 +83,7 @@ describe('EventsBulkActionsDropdownMenu', () => {
         render(EventsBulkActionsDropdownMenu, { props: { table } });
 
         // Act
-        await fireEvent.click(screen.getByRole('button', { name: /Bulk Actions/ }));
+        await fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
         await fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
         await fireEvent.click(screen.getByRole('button', { name: 'Delete 2 Events' }));
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/project-log-level.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/project-log-level.svelte
@@ -8,14 +8,16 @@
     import { deleteProjectConfig, getProjectConfig, postProjectConfig } from '$features/projects/api.svelte';
     import { Button } from '$features/shared/components/ui/button';
     import ChevronDown from '@lucide/svelte/icons/chevron-down';
+    import ListFilter from '@lucide/svelte/icons/list-filter';
     import { toast } from 'svelte-sonner';
 
     interface Props {
+        iconOnly?: boolean;
         projectId: string;
         source: string;
     }
 
-    let { projectId, source }: Props = $props();
+    let { iconOnly = false, projectId, source }: Props = $props();
     const projectConfigQuery = getProjectConfig({
         route: {
             get id() {
@@ -60,6 +62,9 @@
     const level = $derived(getLogLevel(configSettings[`@@log:${source ?? ''}`]));
     const defaultLevel = $derived(getDefaultLogLevel(configSettings, source ?? ''));
     const defaultLevelDisplayName = $derived(getLogLevelDisplayName(defaultLevel));
+    const triggerLabel = $derived(
+        level ? `Log Level: ${getLogLevelDisplayName(level)}` : defaultLevel ? `Log Level: ${defaultLevelDisplayName} (Default)` : 'Select a Default Log Level'
+    );
 
     function getDefaultLogLevel(configSettings: Record<string, string>, source: string): LogLevel | null {
         const sourcePrefix = '@@log:';
@@ -134,15 +139,19 @@
     <DropdownMenu.Root>
         <DropdownMenu.Trigger>
             {#snippet child({ props })}
-                <Button {...props} variant="outline">
-                    {#if level}
-                        Log Level: {getLogLevelDisplayName(level)}
-                    {:else if defaultLevel}
-                        Log Level: {defaultLevelDisplayName} (Default)
+                <Button
+                    {...props}
+                    aria-label={iconOnly ? triggerLabel : undefined}
+                    size={iconOnly ? 'icon' : 'default'}
+                    title={iconOnly ? triggerLabel : undefined}
+                    variant="outline"
+                >
+                    {#if iconOnly}
+                        <ListFilter aria-hidden="true" />
                     {:else}
-                        Select a Default Log Level
+                        {triggerLabel}
+                        <ChevronDown data-icon="inline-end" />
                     {/if}
-                    <ChevronDown class="size-4" />
                 </Button>
             {/snippet}
         </DropdownMenu.Trigger>
@@ -171,5 +180,5 @@
         </DropdownMenu.Content>
     </DropdownMenu.Root>
 {:else}
-    <Skeleton class="h-9 w-33.75" />
+    <Skeleton class={[iconOnly ? 'size-8' : 'h-9 w-33.75']} />
 {/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/project-log-level.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/projects/components/project-log-level.svelte.test.ts
@@ -1,0 +1,32 @@
+import { cleanup, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$features/projects/api.svelte', () => ({
+    deleteProjectConfig: vi.fn(() => ({ isPending: false, mutateAsync: vi.fn() })),
+    getProjectConfig: vi.fn(() => ({ data: { settings: {} }, isSuccess: true })),
+    postProjectConfig: vi.fn(() => ({ isPending: false, mutateAsync: vi.fn() }))
+}));
+
+import ProjectLogLevel from './project-log-level.svelte';
+
+describe('ProjectLogLevel', () => {
+    afterEach(() => cleanup());
+
+    it('renders an icon-only trigger when requested', () => {
+        render(ProjectLogLevel, { iconOnly: true, projectId: 'project-id', source: 'source' });
+
+        const trigger = screen.getByRole('button', { name: 'Select a Default Log Level' });
+        expect(trigger.classList.contains('size-8')).toBe(true);
+        expect(trigger.title).toBe('Select a Default Log Level');
+        expect(trigger.textContent?.trim()).toBe('');
+        expect(trigger.querySelector('svg')).toBeTruthy();
+    });
+
+    it('keeps the descriptive trigger for project settings', () => {
+        render(ProjectLogLevel, { projectId: 'project-id', source: '*' });
+
+        const trigger = screen.getByRole('button', { name: 'Select a Default Log Level' });
+        expect(trigger.classList.contains('size-8')).toBe(false);
+        expect(trigger.textContent).toContain('Select a Default Log Level');
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-footer.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-footer.svelte
@@ -23,7 +23,7 @@
 <div
     aria-label="Table controls"
     class={[
-        'border-border bg-background/95 sticky top-2 z-30 flex w-full flex-wrap items-center justify-between gap-0 rounded-lg border backdrop-blur-sm sm:flex-nowrap',
+        'border-border bg-background/95 sticky top-2 z-30 flex w-full flex-wrap items-center justify-between gap-0 rounded-lg border backdrop-blur-sm',
         className
     ]}
     data-slot="data-table-footer"

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
@@ -62,7 +62,7 @@
         size={joined ? 'default' : 'sm'}
         title="Rows per page"
     >
-        {selected.label}<span class="hidden sm:inline"> rows</span>
+        {selected.label} <span class="hidden sm:inline">rows</span>
     </Select.Trigger>
     <Select.Content>
         <Select.Group>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
@@ -58,11 +58,11 @@
 <Select.Root type="single" {items} value={valueString} {onValueChange}>
     <Select.Trigger
         aria-label="Rows per page"
-        class={cn('min-w-18', joined && 'rounded-none border-y-0')}
+        class={cn('min-w-14 sm:min-w-18', joined && 'rounded-none border-y-0')}
         size={joined ? 'default' : 'sm'}
         title="Rows per page"
     >
-        {selected.label} rows
+        {selected.label}<span class="hidden sm:inline"> rows</span>
     </Select.Trigger>
     <Select.Content>
         <Select.Group>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
@@ -55,7 +55,7 @@
     }
 </script>
 
-<nav bind:this={pagerElement} aria-label="Table pagination" class="border-border ml-auto shrink-0 max-sm:flex max-sm:w-full max-sm:justify-end max-sm:border-t">
+<nav bind:this={pagerElement} aria-label="Table pagination" class="ml-auto shrink-0">
     <ButtonGroup.Root aria-label="Pagination controls">
         <DataTablePageSize bind:value joined onPageSizeChange={scrollTableIntoView} {table} />
         <ButtonGroup.Text

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
@@ -46,6 +46,7 @@ describe('DataTablePager', () => {
         expect(pageSize.getAttribute('data-size')).toBe('default');
         expect(pageSize.classList.contains('min-w-14')).toBe(true);
         expect(pageSize.classList.contains('sm:min-w-18')).toBe(true);
+        expect(pageSize.textContent).toContain('10 rows');
         expect(pageSize.classList.contains('rounded-none')).toBe(true);
         expect(pageSize.classList.contains('border-y-0')).toBe(true);
         const rowsLabel = Array.from(pageSize.querySelectorAll('span')).find((element) => element.textContent?.trim() === 'rows');

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
@@ -35,17 +35,22 @@ describe('DataTablePager', () => {
         expect(toolbar?.classList.contains('rounded-lg')).toBe(true);
         expect(toolbar?.classList.contains('gap-0')).toBe(true);
         expect(toolbar?.classList.contains('flex-wrap')).toBe(true);
-        expect(toolbar?.classList.contains('sm:flex-nowrap')).toBe(true);
+        expect(toolbar?.classList.contains('sm:flex-nowrap')).toBe(false);
         expect(toolbar?.classList.contains('p-2')).toBe(false);
-        expect(toolbar?.contains(screen.getByRole('button', { name: 'Bulk Actions' }))).toBe(true);
+        expect(toolbar?.contains(screen.getByRole('button', { name: 'Actions' }))).toBe(true);
         expect(toolbar?.contains(pager)).toBe(true);
-        expect(pager.classList.contains('max-sm:w-full')).toBe(true);
-        expect(pager.classList.contains('max-sm:border-t')).toBe(true);
+        expect(pager.classList.contains('max-sm:w-full')).toBe(false);
+        expect(pager.classList.contains('max-sm:border-t')).toBe(false);
 
         const pageSize = screen.getByLabelText('Rows per page');
         expect(pageSize.getAttribute('data-size')).toBe('default');
+        expect(pageSize.classList.contains('min-w-14')).toBe(true);
+        expect(pageSize.classList.contains('sm:min-w-18')).toBe(true);
         expect(pageSize.classList.contains('rounded-none')).toBe(true);
         expect(pageSize.classList.contains('border-y-0')).toBe(true);
+        const rowsLabel = Array.from(pageSize.querySelectorAll('span')).find((element) => element.textContent?.trim() === 'rows');
+        expect(rowsLabel?.classList.contains('hidden')).toBe(true);
+        expect(rowsLabel?.classList.contains('sm:inline')).toBe(true);
         const pageLabel = screen.getByLabelText('Page 1 of 3');
         expect(pageLabel.classList.contains('select-none')).toBe(true);
         expect(pageLabel.classList.contains('rounded-none')).toBe(true);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.test-harness.svelte
@@ -46,7 +46,7 @@
 
 <DataTableRoot>
     <DataTableFooter {table}>
-        <button type="button">Bulk Actions</button>
+        <button type="button">Actions</button>
         <DataTablePager bind:value={limit} {table} />
     </DataTableFooter>
 </DataTableRoot>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/detail-sheet.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/detail-sheet.svelte
@@ -266,7 +266,7 @@
 
 <Sheet.Root onOpenChange={handleOpenChange} {open}>
     <Sheet.Content
-        class="bg-background top-15.25! bottom-0! z-40 h-auto! w-full scrollbar-gutter-stable gap-0 overflow-y-auto rounded-l-lg border-l text-base shadow-2xl duration-150 ease-out will-change-transform sm:max-w-full! md:w-5/6!"
+        class="bg-background top-15.25! bottom-0! z-40 h-auto! w-[calc(100%-1rem)]! scrollbar-gutter-stable gap-0 overflow-y-auto rounded-l-lg border-l text-base shadow-2xl duration-150 ease-out will-change-transform sm:max-w-full! md:w-5/6!"
         onInteractOutside={preserveDetailSheetForAssistant}
         overlayProps={{
             class: 'top-15.25! z-40 bg-black/5 dark:bg-black/40 supports-backdrop-filter:backdrop-blur-[0.5px]'

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/detail-sheet.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/detail-sheet.svelte.test.ts
@@ -61,6 +61,7 @@ describe('DetailSheet history', () => {
             __exceptionlessDetailSheet: { key: 'event', value: 'abc123' }
         });
         expect(screen.getByTestId('detail-sheet-state').textContent).toBe('open:abc123');
+        expect(document.querySelector('[data-slot="sheet-content"]')?.classList.contains('w-[calc(100%-1rem)]!')).toBe(true);
     });
 
     it('copies the absolute full-page details link', async () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-card.svelte
@@ -314,13 +314,17 @@
                     {#if projectQuery.isSuccess || stack.project_id}
                         <Table.Row class="group">
                             {#if projectQuery.isSuccess}
-                                <Table.Head class="w-40 font-semibold whitespace-nowrap">Project</Table.Head>
+                                <Table.Head class="w-20 max-w-20 min-w-20 font-semibold whitespace-normal sm:w-40 sm:max-w-40 sm:min-w-40 sm:whitespace-nowrap"
+                                    >Project</Table.Head
+                                >
                                 <Table.Cell class="w-4 pr-0">
                                     <EventsFacetedFilter.ProjectTrigger changed={filterChanged} value={[projectQuery.data.id!]} />
                                 </Table.Cell>
                                 <Table.Cell>{projectQuery.data.name}</Table.Cell>
                             {:else}
-                                <Table.Head class="w-40 font-semibold whitespace-nowrap"><Skeleton class="h-6 w-full rounded-full" /></Table.Head>
+                                <Table.Head class="w-20 max-w-20 min-w-20 font-semibold whitespace-normal sm:w-40 sm:max-w-40 sm:min-w-40 sm:whitespace-nowrap"
+                                    ><Skeleton class="h-6 w-full rounded-full" /></Table.Head
+                                >
                                 <Table.Cell class="w-4 pr-0"></Table.Cell>
                                 <Table.Cell class="flex items-center"><Skeleton class="h-6 w-full rounded-full" /></Table.Cell>
                             {/if}
@@ -328,7 +332,9 @@
                     {/if}
                     {#if stack.tags && stack.tags.length > 0}
                         <Table.Row class="group">
-                            <Table.Head class="w-36 font-semibold whitespace-nowrap">Tags</Table.Head>
+                            <Table.Head class="w-20 max-w-20 min-w-20 font-semibold whitespace-normal sm:w-36 sm:max-w-36 sm:min-w-36 sm:whitespace-nowrap"
+                                >Tags</Table.Head
+                            >
                             <Table.Cell class="w-4 pr-0"></Table.Cell>
                             <Table.Cell class="flex flex-wrap items-center justify-start gap-2 overflow-auto">
                                 <TagList onTagClick={(tag) => filterChanged(new EventsFacetedFilter.TagFilter([tag]))} tags={stack.tags} />
@@ -337,7 +343,9 @@
                     {/if}
                     {#if (stack.status === 'fixed' || stack.status === 'regressed') && stack.date_fixed}
                         <Table.Row>
-                            <Table.Head class="w-36 font-semibold whitespace-nowrap">Fixed</Table.Head>
+                            <Table.Head class="w-20 max-w-20 min-w-20 font-semibold whitespace-normal sm:w-36 sm:max-w-36 sm:min-w-36 sm:whitespace-nowrap"
+                                >Fixed</Table.Head
+                            >
                             <Table.Cell class="w-4 pr-0"></Table.Cell>
                             <Table.Cell>
                                 {stack.fixed_in_version && `In ${stack.fixed_in_version} on `}
@@ -347,7 +355,9 @@
                     {/if}
                     {#if stack.status === 'snoozed' && stack.snooze_until_utc}
                         <Table.Row>
-                            <Table.Head class="w-36 font-semibold whitespace-nowrap">Snoozed Until</Table.Head>
+                            <Table.Head class="w-20 max-w-20 min-w-20 font-semibold whitespace-normal sm:w-36 sm:max-w-36 sm:min-w-36 sm:whitespace-nowrap"
+                                >Snoozed Until</Table.Head
+                            >
                             <Table.Cell class="w-4 pr-0"></Table.Cell>
                             <Table.Cell><DateTime value={stack.snooze_until_utc} /></Table.Cell>
                         </Table.Row>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-log-level.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-log-level.svelte
@@ -13,5 +13,5 @@
 </script>
 
 {#if stack.type === 'log' && source}
-    <ProjectLogLevel projectId={stack.project_id} {source} />
+    <ProjectLogLevel iconOnly projectId={stack.project_id} {source} />
 {/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-references.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-references.svelte
@@ -38,7 +38,9 @@
 
 {#if stack.references?.length > 0}
     <Table.Row>
-        <Table.Head class="w-36 pt-2 align-top font-semibold whitespace-nowrap">Reference</Table.Head>
+        <Table.Head class="w-20 max-w-20 min-w-20 pt-2 align-top font-semibold whitespace-normal sm:w-36 sm:max-w-36 sm:min-w-36 sm:whitespace-nowrap"
+            >Reference</Table.Head
+        >
         <Table.Cell class="w-4 pr-0"></Table.Cell>
         <Table.Cell>
             <ul class="space-y-1.5">

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte
@@ -180,10 +180,10 @@
                 aria-describedby={ids.length === 0 ? bulkActionsDescriptionId : undefined}
                 aria-disabled={ids.length === 0}
                 class="rounded-l-lg rounded-r-none border-0 border-r aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
-                title={ids.length === 0 ? 'Select one or more stacks to use bulk actions' : 'Bulk Actions'}
+                title={ids.length === 0 ? 'Select one or more stacks to use bulk actions' : 'Actions'}
                 variant="outline"
             >
-                Bulk Actions
+                Actions
                 <ChevronDown data-icon="inline-end" />
             </Button>
         {/snippet}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte.test.ts
@@ -21,7 +21,7 @@ describe('StacksBulkActionsDropdownMenu', () => {
 
         render(StacksBulkActionsDropdownMenu, { props: { table } });
 
-        const trigger = screen.getByRole('button', { name: /Bulk Actions/ }) as HTMLButtonElement;
+        const trigger = screen.getByRole('button', { name: 'Actions' }) as HTMLButtonElement;
         expect(trigger.disabled).toBe(false);
         expect(trigger.getAttribute('aria-disabled')).toBe('true');
         expect(trigger.title).toBe('Select one or more stacks to use bulk actions');
@@ -40,8 +40,8 @@ describe('StacksBulkActionsDropdownMenu', () => {
 
         render(StacksBulkActionsDropdownMenu, { props: { table } });
 
-        const trigger = screen.getByRole('button', { name: /Bulk Actions/ }) as HTMLButtonElement;
+        const trigger = screen.getByRole('button', { name: 'Actions' }) as HTMLButtonElement;
         expect(trigger.disabled).toBe(false);
-        expect(trigger.title).toBe('Bulk Actions');
+        expect(trigger.title).toBe('Actions');
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -927,7 +927,7 @@
 <div class="flex flex-col">
     <div class="mb-4 flex flex-wrap items-start gap-2">
         <H3 class="my-0 shrink-0">{pageTitle}</H3>
-        <div class="flex min-w-0 flex-1 flex-wrap items-start gap-2">
+        <div class="order-3 flex w-full flex-wrap items-start gap-1.5 md:order-none md:w-auto md:min-w-0 md:flex-1">
             <FacetedFilter.Root changed={onFilterChanged} {filters} remove={onFilterRemoved}>
                 <OrganizationDefaultsFacetedFilterBuilder />
             </FacetedFilter.Root>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
@@ -268,7 +268,7 @@
 <div class="flex flex-col">
     <div class="mb-4 flex flex-wrap items-start gap-2">
         <Muted class="w-full shrink-0">Manage project stacks, including restoring ignored or discarded stacks</Muted>
-        <div class="flex min-w-0 flex-1 flex-wrap items-start gap-2">
+        <div class="order-3 flex w-full flex-wrap items-start gap-1.5 md:order-none md:w-auto md:min-w-0 md:flex-1">
             <FacetedFilter.Root changed={onFilterChanged} {filters} remove={onFilterRemoved}>
                 <StackFacetedFilterBuilder includeProject={false} />
             </FacetedFilter.Root>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
@@ -353,7 +353,7 @@
 <div class="flex flex-col">
     <div class="mb-4 flex flex-wrap items-start gap-2">
         <H3 class="my-0 shrink-0">Sessions</H3>
-        <div class="flex min-w-0 flex-1 flex-wrap items-start gap-2">
+        <div class="order-3 flex w-full flex-wrap items-start gap-1.5 md:order-none md:w-auto md:min-w-0 md:flex-1">
             <FacetedFilter.Root changed={onFilterChanged} {filters} remove={onFilterRemoved}>
                 <OrganizationDefaultsFacetedFilterBuilder />
             </FacetedFilter.Root>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -834,7 +834,7 @@
 <div class="flex flex-col">
     <div class="mb-4 flex flex-wrap items-start gap-2">
         <H3 class="my-0 shrink-0">{pageTitle}</H3>
-        <div class="flex min-w-0 flex-1 flex-wrap items-start gap-2">
+        <div class="order-3 flex w-full flex-wrap items-start gap-1.5 md:order-none md:w-auto md:min-w-0 md:flex-1">
             <FacetedFilter.Root changed={onFilterChanged} {filters} remove={onFilterRemoved}>
                 <OrganizationDefaultsFacetedFilterBuilder />
             </FacetedFilter.Root>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stream/+page.svelte
@@ -322,7 +322,7 @@
 <DataTable.Root>
     <div class="mb-4 flex flex-wrap items-start gap-2">
         <H3 class="my-0 shrink-0">{pageTitle}</H3>
-        <div class="flex min-w-0 flex-1 flex-wrap items-start gap-2">
+        <div class="order-3 flex w-full flex-wrap items-start gap-1.5 md:order-none md:w-auto md:min-w-0 md:flex-1">
             <FacetedFilter.Root changed={onFilterChanged} {filters} remove={onFilterRemoved}>
                 <OrganizationDefaultsFacetedFilterBuilder />
             </FacetedFilter.Root>


### PR DESCRIPTION
## Summary

- keep table actions and pagination compact on narrow screens
- let filter controls use a full row below page headings and actions when space is constrained
- expand narrow detail sheets and tighten stack metadata labels
- show the stack log-level control as an accessible icon-only action

## Verification

- npm run validate
- npm run test:unit -- --run src/lib/features/events/components/table/events-bulk-actions-dropdown-menu.svelte.test.ts src/lib/features/stacks/components/stacks-bulk-actions-dropdown-menu.svelte.test.ts src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts src/lib/features/shared/components/detail-sheet.svelte.test.ts src/lib/features/projects/components/project-log-level.svelte.test.ts (25 tests)

## Breaking changes

None.