### PR TITLE
Preserve table scroll position during pagination

### DIFF
--- a/src/Exceptionless.Web/ClientApp/e2e/tests/table-toolbar-pagination.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/table-toolbar-pagination.e2e.ts
@@ -46,10 +46,13 @@ test('table toolbar remains accessible while moving between different-height res
     }
 
     const nextButton = pager.getByRole('button', { name: 'Go to next page' });
+    const scrollContainer = page.locator('main').locator('..');
+    const scrollTopBeforePaging = await scrollContainer.evaluate((element) => element.scrollTop);
     await nextButton.focus();
     await nextButton.click();
     await expect(pager.getByLabel('Page 2 of 2')).toBeVisible();
     await expect(pager.getByRole('button', { name: 'Go to next page' })).toBeFocused();
+    await expect.poll(() => scrollContainer.evaluate((element) => element.scrollTop)).toBe(scrollTopBeforePaging);
 
     const secondToolbarBox = await toolbar.boundingBox();
     const secondGridBox = await grid.boundingBox();

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
@@ -20,44 +20,27 @@
 
     let { table, value = $bindable() }: Props = $props();
 
-    let pagerElement: HTMLElement;
-
     const currentPage = $derived((table.options.state?.pagination?.pageIndex ?? table.store.state.pagination.pageIndex) + 1);
     const totalPages = $derived(Math.max(1, table.getPageCount() || 1));
     const canGoNext = $derived(currentPage < totalPages);
     const canGoPrevious = $derived(currentPage > 1);
 
-    function scrollTableIntoView(): void {
-        const tableElement = pagerElement.closest<HTMLElement>('[data-slot="data-table"]');
-        if (!tableElement) {
-            return;
-        }
-
-        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-        tableElement.scrollIntoView({
-            behavior: prefersReducedMotion ? 'auto' : 'smooth',
-            block: 'start'
-        });
-    }
-
     function goToNextPage(): void {
         if (canGoNext) {
             table.setPageIndex(currentPage);
-            scrollTableIntoView();
         }
     }
 
     function goToPreviousPage(): void {
         if (canGoPrevious) {
             table.setPageIndex(currentPage - 2);
-            scrollTableIntoView();
         }
     }
 </script>
 
-<nav bind:this={pagerElement} aria-label="Table pagination" class="ml-auto shrink-0">
+<nav aria-label="Table pagination" class="ml-auto shrink-0">
     <ButtonGroup.Root aria-label="Pagination controls">
-        <DataTablePageSize bind:value joined onPageSizeChange={scrollTableIntoView} {table} />
+        <DataTablePageSize bind:value joined {table} />
         <ButtonGroup.Text
             aria-label={`Page ${currentPage} of ${totalPages}`}
             class="min-w-14 justify-center rounded-none border-y-0 select-none"

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
@@ -9,10 +9,6 @@ describe('DataTablePager', () => {
 
     beforeEach(() => {
         Element.prototype.scrollIntoView = scrollIntoView;
-        Object.defineProperty(window, 'matchMedia', {
-            configurable: true,
-            value: vi.fn().mockReturnValue({ matches: false })
-        });
     });
 
     afterEach(() => {
@@ -72,7 +68,7 @@ describe('DataTablePager', () => {
         expect(pageSize.classList.contains('border-y-0')).toBe(false);
     });
 
-    it('keeps focus and scrolls the table to the start when changing pages', async () => {
+    it('keeps focus without scrolling the table when changing pages', async () => {
         const onPageIndexChange = vi.fn();
         render(DataTablePagerTestHarness, { onPageIndexChange, onPageSizeChange: vi.fn() });
 
@@ -82,7 +78,7 @@ describe('DataTablePager', () => {
 
         expect(onPageIndexChange).toHaveBeenCalledWith(1);
         expect(screen.getByLabelText('Page 2 of 3')).toBeTruthy();
-        expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+        expect(scrollIntoView).not.toHaveBeenCalled();
         expect(document.activeElement).toBe(nextButton);
     });
 


### PR DESCRIPTION
## Summary

- remove the pager's automatic `scrollIntoView` behavior
- preserve the current app scroll position for next, previous, and page-size changes
- retain keyboard focus on the paging control

## Verification

- `npm run test:unit -- --run src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts` (4 passed)
- `npm run validate`
- focused Chromium Playwright pagination test (1 passed) against the local Aspire app
- `/next/` and `/api/v2/about` returned HTTP 200

## Breaking changes

None.