### PR TITLE
Limit floating pagers to activity pages

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/table/events-data-table.svelte
@@ -42,12 +42,12 @@
             {@render toolbarChildren()}
         </DataTable.Toolbar>
     {/if}
-    <DataTable.Footer {table} class="w-full">
+    <DataTable.Footer {table} class="w-full" variant="floating">
         {#if footerChildren}
             {@render footerChildren()}
         {:else}
             <DataTable.Selection {table} />
-            <DataTable.Pager bind:value={limit} {table} />
+            <DataTable.Pager bind:value={limit} {table} variant="floating" />
         {/if}
     </DataTable.Footer>
     <DataTable.Body {autoFillColumnId} {onAutoFillColumnResized} {rowClick} {rowHref} {table} {wrappedColumnIds}>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/table/organizations-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/organizations/components/table/organizations-data-table.svelte
@@ -27,13 +27,11 @@
     {:else}
         <DataTable.Toolbar {table} />
     {/if}
-    <DataTable.Footer {table} class="gap-6 lg:gap-8">
-        {#if footerChildren}
+    {#if footerChildren}
+        <DataTable.Footer {table} class="gap-6 lg:gap-8">
             {@render footerChildren()}
-        {:else}
-            <DataTable.Selection {table} />
-        {/if}
-    </DataTable.Footer>
+        </DataTable.Footer>
+    {/if}
     <DataTable.Body {rowClick} {rowHref} {table}>
         {#if isLoading}
             <DelayedRender>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-footer.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-footer.svelte
@@ -15,18 +15,23 @@
     type Props = HTMLAttributes<Element> & {
         children?: Snippet;
         table: Table<StockFeatures, TData>;
+        variant?: 'floating' | 'simple';
     };
 
-    let { children, class: className, table }: Props = $props();
+    let { children, class: className, table, variant = 'simple' }: Props = $props();
 </script>
 
 <div
     aria-label="Table controls"
     class={[
-        'border-border bg-background/95 sticky top-2 z-30 flex w-full flex-wrap items-center justify-between gap-0 rounded-lg border backdrop-blur-sm',
+        'flex w-full items-center',
+        variant === 'floating'
+            ? 'border-border bg-background/95 sticky top-2 z-30 flex-wrap justify-between gap-0 rounded-lg border backdrop-blur-sm'
+            : 'justify-end gap-2',
         className
     ]}
     data-slot="data-table-footer"
+    data-variant={variant}
     role="toolbar"
 >
     {#if children}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-page-size.svelte
@@ -11,11 +11,12 @@
     interface Props {
         joined?: boolean;
         onPageSizeChange?: () => void;
+        size?: 'default' | 'sm';
         table: Table<StockFeatures, TData>;
         value: number;
     }
 
-    let { joined = false, onPageSizeChange, table, value = $bindable() }: Props = $props();
+    let { joined = false, onPageSizeChange, size = 'sm', table, value = $bindable() }: Props = $props();
 
     type Item = { label: string; value: string };
     const items: Item[] = [
@@ -56,12 +57,7 @@
 </script>
 
 <Select.Root type="single" {items} value={valueString} {onValueChange}>
-    <Select.Trigger
-        aria-label="Rows per page"
-        class={cn('min-w-14 sm:min-w-18', joined && 'rounded-none border-y-0')}
-        size={joined ? 'default' : 'sm'}
-        title="Rows per page"
-    >
+    <Select.Trigger aria-label="Rows per page" class={cn('min-w-14 sm:min-w-18', joined && 'rounded-none border-y-0')} {size} title="Rows per page">
         {selected.label} <span class="hidden sm:inline">rows</span>
     </Select.Trigger>
     <Select.Content>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
@@ -8,6 +8,7 @@
     import Number from '$comp/formatters/number.svelte';
     import { Button } from '$comp/ui/button';
     import * as ButtonGroup from '$comp/ui/button-group';
+    import { cn } from '$lib/utils';
     import ChevronLeftIcon from '@lucide/svelte/icons/chevron-left';
     import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 
@@ -16,9 +17,10 @@
     interface Props {
         table: Table<StockFeatures, TData>;
         value: number;
+        variant?: 'floating' | 'simple';
     }
 
-    let { table, value = $bindable() }: Props = $props();
+    let { table, value = $bindable(), variant = 'simple' }: Props = $props();
 
     const currentPage = $derived((table.options.state?.pagination?.pageIndex ?? table.store.state.pagination.pageIndex) + 1);
     const totalPages = $derived(Math.max(1, table.getPageCount() || 1));
@@ -38,12 +40,12 @@
     }
 </script>
 
-<nav aria-label="Table pagination" class="ml-auto shrink-0">
+<nav aria-label="Table pagination" class="ml-auto shrink-0" data-variant={variant}>
     <ButtonGroup.Root aria-label="Pagination controls">
-        <DataTablePageSize bind:value joined {table} />
+        <DataTablePageSize bind:value joined={variant === 'floating'} size="default" {table} />
         <ButtonGroup.Text
             aria-label={`Page ${currentPage} of ${totalPages}`}
-            class="min-w-14 justify-center rounded-none border-y-0 select-none"
+            class={cn('min-w-14 justify-center select-none', variant === 'floating' && 'rounded-none border-y-0')}
             title={`Page ${currentPage} of ${totalPages}`}
         >
             <Number value={currentPage} /> / <Number value={totalPages} />
@@ -51,7 +53,7 @@
         <Button
             aria-label="Go to previous page"
             aria-disabled={!canGoPrevious}
-            class="rounded-none border-y-0 aria-disabled:pointer-events-none aria-disabled:opacity-50"
+            class={cn('aria-disabled:pointer-events-none aria-disabled:opacity-50', variant === 'floating' && 'rounded-none border-y-0')}
             onclick={goToPreviousPage}
             size="icon"
             title="Previous page"
@@ -62,7 +64,10 @@
         <Button
             aria-label="Go to next page"
             aria-disabled={!canGoNext}
-            class="rounded-l-none! rounded-r-lg! border-y-0 border-r-0 aria-disabled:pointer-events-none aria-disabled:opacity-50"
+            class={cn(
+                'aria-disabled:pointer-events-none aria-disabled:opacity-50',
+                variant === 'floating' && 'rounded-l-none! rounded-r-lg! border-y-0 border-r-0'
+            )}
             onclick={goToNextPage}
             size="icon"
             title="Next page"

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
@@ -17,7 +17,7 @@ describe('DataTablePager', () => {
     });
 
     it('joins bulk actions and pagination in one full-width sticky toolbar', () => {
-        render(DataTablePagerTestHarness, { onPageIndexChange: vi.fn(), onPageSizeChange: vi.fn() });
+        render(DataTablePagerTestHarness, { onPageIndexChange: vi.fn(), onPageSizeChange: vi.fn(), variant: 'floating' });
 
         const toolbar = document.querySelector('[data-slot="data-table-footer"]');
         const pager = screen.getByRole('navigation', { name: 'Table pagination' });
@@ -56,6 +56,26 @@ describe('DataTablePager', () => {
         expect(nextButton.classList.contains('rounded-r-lg!')).toBe(true);
         expect(nextButton.classList.contains('rounded-l-none!')).toBe(true);
         expect(nextButton.classList.contains('border-r-0')).toBe(true);
+    });
+
+    it('shows a simple standalone pager on the right by default', () => {
+        render(DataTablePagerTestHarness, { onPageIndexChange: vi.fn(), onPageSizeChange: vi.fn() });
+
+        const toolbar = document.querySelector('[data-slot="data-table-footer"]');
+        const pager = screen.getByRole('navigation', { name: 'Table pagination' });
+
+        expect(toolbar?.getAttribute('data-variant')).toBe('simple');
+        expect(toolbar?.classList.contains('sticky')).toBe(false);
+        expect(toolbar?.classList.contains('border')).toBe(false);
+        expect(toolbar?.classList.contains('justify-end')).toBe(true);
+        expect(pager.getAttribute('data-variant')).toBe('simple');
+
+        const pageSize = screen.getByLabelText('Rows per page');
+        expect(pageSize.getAttribute('data-size')).toBe('default');
+        expect(pageSize.classList.contains('rounded-none')).toBe(false);
+        expect(pageSize.classList.contains('border-y-0')).toBe(false);
+        expect(screen.getByLabelText('Page 1 of 3').classList.contains('border-y-0')).toBe(false);
+        expect(screen.getByRole('button', { name: 'Go to next page' }).classList.contains('border-r-0')).toBe(false);
     });
 
     it('keeps a standalone page-size selector fully bordered', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.test-harness.svelte
@@ -6,9 +6,10 @@
     interface Props {
         onPageIndexChange: (pageIndex: number) => void;
         onPageSizeChange: (pageSize: number) => void;
+        variant?: 'floating' | 'simple';
     }
 
-    let { onPageIndexChange, onPageSizeChange }: Props = $props();
+    let { onPageIndexChange, onPageSizeChange, variant = 'simple' }: Props = $props();
 
     let limit = $state(10);
     let pageIndex = $state(0);
@@ -45,8 +46,8 @@
 </script>
 
 <DataTableRoot>
-    <DataTableFooter {table}>
+    <DataTableFooter {table} {variant}>
         <button type="button">Actions</button>
-        <DataTablePager bind:value={limit} {table} />
+        <DataTablePager bind:value={limit} {table} {variant} />
     </DataTableFooter>
 </DataTableRoot>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/table/stacks-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/table/stacks-data-table.svelte
@@ -19,12 +19,12 @@
 </script>
 
 <DataTable.Root>
-    <DataTable.Footer {table} class="w-full">
+    <DataTable.Footer {table} class="w-full" variant="floating">
         {#if footerChildren}
             {@render footerChildren()}
         {:else}
             <DataTable.Selection {table} />
-            <DataTable.Pager bind:value={limit} {table} />
+            <DataTable.Pager bind:value={limit} {table} variant="floating" />
         {/if}
     </DataTable.Footer>
     <DataTable.Body {rowClick} {rowHref} {table}>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -1024,7 +1024,7 @@
                     <DataTable.Selection {table} />
                 </div>
 
-                <DataTable.Pager bind:value={eventsQueryParameters.limit!} {table} />
+                <DataTable.Pager bind:value={eventsQueryParameters.limit!} {table} variant="floating" />
             {/snippet}
         </EventsDataTable>
     </div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
@@ -286,7 +286,7 @@
                 <DataTable.Selection {table} />
             </div>
 
-            <DataTable.Pager bind:value={queryParams.limit!} {table} />
+            <DataTable.Pager bind:value={queryParams.limit!} {table} variant="floating" />
         {/snippet}
     </StacksDataTable>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
@@ -382,7 +382,7 @@
         <EventsDataTable bind:limit={queryParams.limit!} isLoading={clientStatus.isLoading} rowClick={rowclick} {rowHref} {table}>
             {#snippet footerChildren()}
                 <DataTable.Selection {table} />
-                <DataTable.Pager bind:value={queryParams.limit!} {table} />
+                <DataTable.Pager bind:value={queryParams.limit!} {table} variant="floating" />
             {/snippet}
         </EventsDataTable>
     </div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -930,7 +930,7 @@
                     <DataTable.Selection {table} />
                 </div>
 
-                <DataTable.Pager bind:value={eventsQueryParameters.limit!} {table} />
+                <DataTable.Pager bind:value={eventsQueryParameters.limit!} {table} variant="floating" />
             {/snippet}
         </EventsDataTable>
     </div>


### PR DESCRIPTION
## Summary

- make the simple right-aligned pager the default for table lists
- retain the full-width sticky pager only for Events, Stacks, project Stacks, and Sessions
- keep standalone pager borders and rounding intact outside the floating toolbar

## Why

Admin and configuration lists do not have bulk controls that justify a full-width floating pager. Those pages should use a normal pager aligned to the right without sticky-on-scroll behavior.

## Verification

- `npm run test:unit -- --run src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts` (5 passed)
- `npm run validate`

## Breaking changes

None.
