### PR TITLE
Refine table interactions and saved view draft persistence

### DIFF
--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -142,7 +142,7 @@ test('events saved view can be saved, renamed, loaded, and deleted', async ({ e2
         await expect(getVisibleText(page, journey.message)).toBeVisible();
     });
 
-    await test.step('updating a URL override clears the hidden browser-local draft', async () => {
+    await test.step('updating a URL override clears the hidden session-local draft', async () => {
         await page.goto(`/next/event/${viewSlug}?time=90d`);
         const dateFilter = page.getByRole('button', { name: /^Date/ }).filter({ visible: true }).first();
         await dateFilter.click();
@@ -618,7 +618,7 @@ test('save completion does not overwrite a newly active saved view', async ({ e2
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
 });
 
-test('stream switches to a browser-local saved view draft without mixing in-flight results', async ({ e2eApi, e2eScenario, page, request }) => {
+test('stream switches to a session-local saved view draft without mixing in-flight results', async ({ e2eApi, e2eScenario, page, request }) => {
     const failedApiRequests = captureFailedApiRequests(page);
     const suffix = e2eScenario.run.slice(-28);
     const viewName = `E2E Stream View ${suffix}`;
@@ -658,7 +658,7 @@ test('stream switches to a browser-local saved view draft without mixing in-flig
 
     await page.addInitScript(
         ({ draft, key }) => {
-            window.localStorage.setItem(key, JSON.stringify(draft));
+            window.sessionStorage.setItem(key, JSON.stringify(draft));
         },
         {
             draft: {
@@ -814,7 +814,7 @@ test('stream loads default results when its saved-view lookup fails', async ({ e
     await expect.poll(() => eventRequests.length, { timeout: 30_000 }).toBeGreaterThan(0);
 });
 
-test('reset clears a browser-local draft after delayed current-user identity resolves', async ({ e2eApi, e2eScenario, page, request }) => {
+test('reset clears a session-local draft after delayed current-user identity resolves', async ({ e2eApi, e2eScenario, page, request }) => {
     const suffix = e2eScenario.run.slice(-28);
     const viewName = `E2E Delayed Reset ${suffix}`;
     const viewSlug = savedViewSlug(viewName);
@@ -840,7 +840,7 @@ test('reset clears a browser-local draft after delayed current-user identity res
     const currentUser = await e2eApi.getCurrentUser(e2eScenario.userToken);
     expect(currentUser).toBeDefined();
 
-    await page.addInitScript(({ draft, key }) => window.localStorage.setItem(key, JSON.stringify(draft)), {
+    await page.addInitScript(({ draft, key }) => window.sessionStorage.setItem(key, JSON.stringify(draft)), {
         draft: {
             filterChanges: {
                 baselineDefinitions: '[{"term":"date","type":"date","value":"[now-15m TO now]"}]',
@@ -881,7 +881,7 @@ test('reset clears a browser-local draft after delayed current-user identity res
     await expect(page.getByLabel('Unsaved view changes')).toHaveCount(0);
 });
 
-test('filter edits made before current-user identity resolves become browser-local drafts', async ({ e2eApi, e2eScenario, page, request }) => {
+test('filter edits made before current-user identity resolves become session-local drafts', async ({ e2eApi, e2eScenario, page, request }) => {
     const suffix = e2eScenario.run.slice(-28);
     const viewName = `E2E Delayed Edit ${suffix}`;
     const viewSlug = savedViewSlug(viewName);
@@ -913,7 +913,7 @@ test('filter edits made before current-user identity resolves become browser-loc
                 return;
             }
 
-            window.localStorage.setItem(key, JSON.stringify({ showChart: false, version: 1 }));
+            window.sessionStorage.setItem(key, JSON.stringify({ showChart: false, version: 1 }));
             window.sessionStorage.setItem(marker, 'true');
         },
         { key: draftKey, marker: `${draftKey}:seeded` }
@@ -944,16 +944,16 @@ test('filter edits made before current-user identity resolves become browser-loc
 
     releaseCurrentUser();
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
-    await expect.poll(() => page.evaluate((key) => window.localStorage.getItem(key), draftKey)).not.toBeNull();
+    await expect.poll(() => page.evaluate((key) => window.sessionStorage.getItem(key), draftKey)).not.toBeNull();
     await openViewMenu(page);
     await expect(page.getByRole('menuitemcheckbox', { name: 'Chart' })).toBeChecked();
     await page.keyboard.press('Escape');
     await expect
-        .poll(async () => JSON.parse((await page.evaluate((key) => window.localStorage.getItem(key), draftKey)) ?? '{}') as { showChart?: boolean })
+        .poll(async () => JSON.parse((await page.evaluate((key) => window.sessionStorage.getItem(key), draftKey)) ?? '{}') as { showChart?: boolean })
         .not.toHaveProperty('showChart');
     await expect
         .poll(async () => {
-            const draft = JSON.parse((await page.evaluate((key) => window.localStorage.getItem(key), draftKey)) ?? '{}') as {
+            const draft = JSON.parse((await page.evaluate((key) => window.sessionStorage.getItem(key), draftKey)) ?? '{}') as {
                 filterChanges?: { upsertDefinitions?: string };
             };
             return draft.filterChanges?.upsertDefinitions;
@@ -964,7 +964,7 @@ test('filter edits made before current-user identity resolves become browser-loc
     await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
     await expect
         .poll(async () => {
-            const draft = JSON.parse((await page.evaluate((key) => window.localStorage.getItem(key), draftKey)) ?? '{}') as {
+            const draft = JSON.parse((await page.evaluate((key) => window.sessionStorage.getItem(key), draftKey)) ?? '{}') as {
                 filterChanges?: { upsertDefinitions?: string };
             };
             return draft.filterChanges?.upsertDefinitions;
@@ -1007,7 +1007,7 @@ test('saved view loads server state and protects drafts when the current-user lo
     const currentUser = await e2eApi.getCurrentUser(e2eScenario.userToken);
     expect(currentUser).toBeDefined();
     const draftKey = `exceptionless:saved-view-draft:v1:${currentUser!.id}:${e2eScenario.organizationId}:${savedView.id}`;
-    await page.addInitScript(({ draft, key }) => window.localStorage.setItem(key, JSON.stringify(draft)), {
+    await page.addInitScript(({ draft, key }) => window.sessionStorage.setItem(key, JSON.stringify(draft)), {
         draft: {
             filterChanges: {
                 baselineDefinitions: '[{"term":"date","type":"date","value":"[now-15m TO now]"}]',
@@ -1063,7 +1063,7 @@ test('saved view loads server state and protects drafts when the current-user lo
             .first()
     ).toBeVisible();
     await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
-    expect(await page.evaluate((key) => window.localStorage.getItem(key), draftKey)).not.toBeNull();
+    expect(await page.evaluate((key) => window.sessionStorage.getItem(key), draftKey)).not.toBeNull();
 });
 
 function captureFailedApiRequests(page: Page): { error: null | string; method: string; url: string }[] {

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/table-toolbar-pagination.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/table-toolbar-pagination.e2e.ts
@@ -52,6 +52,7 @@ test('table toolbar remains accessible while moving between different-height res
     await nextButton.click();
     await expect(pager.getByLabel('Page 2 of 2')).toBeVisible();
     await expect(pager.getByRole('button', { name: 'Go to next page' })).toBeFocused();
+    await expect(bulkActionsButton).toHaveAttribute('aria-disabled', 'true');
     await expect.poll(() => scrollContainer.evaluate((element) => element.scrollTop)).toBe(scrollTopBeforePaging);
 
     const secondToolbarBox = await toolbar.boundingBox();
@@ -85,4 +86,9 @@ test('table toolbar remains accessible while moving between different-height res
     if (process.env.E2E_CAPTURE_PAGER_TOOLBAR_SCREENSHOTS === 'true') {
         await page.screenshot({ path: resolve(process.cwd(), '../../../dogfood-output/pager-toolbar/narrow-page-2.png') });
     }
+
+    const firstPageButton = pager.getByRole('button', { name: 'Go to first page' });
+    await firstPageButton.click();
+    await expect(pager.getByLabel('Page 1 of 2')).toBeVisible();
+    await expect(page.locator('tbody').getByRole('checkbox').first()).not.toBeChecked();
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace-frame.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace-frame.svelte
@@ -15,8 +15,10 @@
     let { frame }: Props = $props();
 </script>
 
-{#if frame}<div class="flex flex-wrap bg-inherit pl-[10px] *:min-w-0" data-slot="stack-trace-frame">
-        at <StackTraceFrameNamespace {frame} /><StackTraceFrameMethodName {frame} /><StackTraceFrameGenericArguments {frame} />(<StackTraceFrameParameters
-            {frame}
-        />)<StackTraceFrameOffset {frame} /><StackTraceFrameFileName {frame} />
+{#if frame}<div class="flex flex-wrap bg-inherit pl-[10px]" data-slot="stack-trace-frame">
+        <span class="min-w-0" data-slot="stack-trace-frame-content"
+            >at <StackTraceFrameNamespace {frame} /><StackTraceFrameMethodName {frame} /><StackTraceFrameGenericArguments {frame} />(<StackTraceFrameParameters
+                {frame}
+            />)<StackTraceFrameOffset {frame} /><StackTraceFrameFileName {frame} /></span
+        >
     </div>{:else}&lt;null&gt;{/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace-frame.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace-frame.svelte
@@ -15,7 +15,7 @@
     let { frame }: Props = $props();
 </script>
 
-{#if frame}<div class="bg-inherit pl-[10px]">
+{#if frame}<div class="flex flex-wrap bg-inherit pl-[10px]" data-slot="stack-trace-frame">
         at <StackTraceFrameNamespace {frame} /><StackTraceFrameMethodName {frame} /><StackTraceFrameGenericArguments {frame} />(<StackTraceFrameParameters
             {frame}
         />)<StackTraceFrameOffset {frame} /><StackTraceFrameFileName {frame} />

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace-frame.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace-frame.svelte
@@ -15,7 +15,7 @@
     let { frame }: Props = $props();
 </script>
 
-{#if frame}<div class="flex flex-wrap bg-inherit pl-[10px]" data-slot="stack-trace-frame">
+{#if frame}<div class="flex flex-wrap bg-inherit pl-[10px] *:min-w-0" data-slot="stack-trace-frame">
         at <StackTraceFrameNamespace {frame} /><StackTraceFrameMethodName {frame} /><StackTraceFrameGenericArguments {frame} />(<StackTraceFrameParameters
             {frame}
         />)<StackTraceFrameOffset {frame} /><StackTraceFrameFileName {frame} />

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace-frames.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace-frames.svelte
@@ -10,6 +10,6 @@
     let { error }: Props = $props();
 </script>
 
-{#if error.stack_trace}<div class="bg-inherit pl-[10px]">
+{#if error.stack_trace}<div class="flex flex-col bg-inherit pl-[10px]" data-slot="stack-trace-frames">
         {#each error.stack_trace as frame, index (index)}<StackTraceFrame {frame} />{/each}
     </div>{/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace.svelte.test.ts
@@ -46,6 +46,7 @@ describe('StackTrace', () => {
         expect(frames?.classList.contains('flex-col')).toBe(true);
         expect(frameRows).toHaveLength(2);
         expect([...frameRows].every((frame) => frame.classList.contains('flex') && frame.classList.contains('flex-wrap'))).toBe(true);
+        expect([...frameRows].every((frame) => frame.classList.contains('*:min-w-0'))).toBe(true);
         expect(frameRows[0]?.textContent).toContain('TransformManyBlock`2.Initialize');
         expect(frameRows[1]?.textContent).toContain('CancellationTokenSource.ThrowObjectDisposedException');
     });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace.svelte.test.ts
@@ -41,13 +41,15 @@ describe('StackTrace', () => {
 
         const { container } = render(StackTrace, { error });
         const frames = container.querySelector<HTMLElement>('[data-slot="stack-trace-frames"]');
+        const frameContents = container.querySelectorAll<HTMLElement>('[data-slot="stack-trace-frame-content"]');
         const frameRows = container.querySelectorAll<HTMLElement>('[data-slot="stack-trace-frame"]');
 
         expect(frames?.classList.contains('flex-col')).toBe(true);
         expect(frameRows).toHaveLength(2);
+        expect(frameContents).toHaveLength(2);
         expect([...frameRows].every((frame) => frame.classList.contains('flex') && frame.classList.contains('flex-wrap'))).toBe(true);
-        expect([...frameRows].every((frame) => frame.classList.contains('*:min-w-0'))).toBe(true);
-        expect(frameRows[0]?.textContent).toContain('TransformManyBlock`2.Initialize');
-        expect(frameRows[1]?.textContent).toContain('CancellationTokenSource.ThrowObjectDisposedException');
+        expect([...frameContents].every((frame) => frame.classList.contains('min-w-0'))).toBe(true);
+        expect(frameContents[0]?.textContent).toContain('at System.Threading.Tasks.Dataflow.TransformManyBlock`2.Initialize');
+        expect(frameContents[1]?.textContent).toContain('at System.Threading.CancellationTokenSource.ThrowObjectDisposedException');
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/stack-trace/stack-trace.svelte.test.ts
@@ -1,0 +1,52 @@
+import type { ErrorInfo } from '$features/events/models/event-data';
+
+import { cleanup, render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import StackTrace from './stack-trace.svelte';
+
+afterEach(cleanup);
+
+describe('StackTrace', () => {
+    it('keeps frames on separate rows while allowing structured frame content to wrap', () => {
+        const error: ErrorInfo = {
+            message: 'The CancellationTokenSource has been disposed.',
+            stack_trace: [
+                {
+                    data: { ILOffset: 363 },
+                    declaring_namespace: 'System.Threading.Tasks.Dataflow',
+                    declaring_type: 'TransformManyBlock`2',
+                    name: 'Initialize',
+                    parameters: [
+                        {
+                            name: 'processMessageAction',
+                            type: 'Action`1',
+                            type_namespace: 'System'
+                        },
+                        {
+                            name: 'dataflowBlockOptions',
+                            type: 'ExecutionDataflowBlockOptions',
+                            type_namespace: 'System.Threading.Tasks.Dataflow'
+                        }
+                    ]
+                },
+                {
+                    declaring_namespace: 'System.Threading',
+                    declaring_type: 'CancellationTokenSource',
+                    name: 'ThrowObjectDisposedException'
+                }
+            ],
+            type: 'ObjectDisposedException'
+        };
+
+        const { container } = render(StackTrace, { error });
+        const frames = container.querySelector<HTMLElement>('[data-slot="stack-trace-frames"]');
+        const frameRows = container.querySelectorAll<HTMLElement>('[data-slot="stack-trace-frame"]');
+
+        expect(frames?.classList.contains('flex-col')).toBe(true);
+        expect(frameRows).toHaveLength(2);
+        expect([...frameRows].every((frame) => frame.classList.contains('flex') && frame.classList.contains('flex-wrap'))).toBe(true);
+        expect(frameRows[0]?.textContent).toContain('TransformManyBlock`2.Initialize');
+        expect(frameRows[1]?.textContent).toContain('CancellationTokenSource.ThrowObjectDisposedException');
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.test.ts
@@ -15,6 +15,7 @@ import {
     clearSavedViewDraft,
     getMatchingFilterOverrideKeys,
     getSavedViewDraft,
+    getSavedViewDraftStorageKey,
     mergeFilterOverrides,
     mergePendingSavedViewDraftEdits,
     saveSavedViewDraft
@@ -205,7 +206,7 @@ describe('saved view drafts', () => {
         expect(mergedFilters.map((filter) => (filter as KeywordFilter).value)).toEqual(['baz']);
     });
 
-    it('continues to apply key removals from legacy browser-local drafts', () => {
+    it('continues to apply key removals from legacy saved-view drafts', () => {
         const mergedFilters = applyFilterChanges([new StatusFilter([StackStatus.Open])], {
             removedKeys: ['status'],
             upsertDefinitions: '[]'
@@ -367,5 +368,21 @@ describe('saved view drafts', () => {
         clearSavedViewDraft(identity, storage);
 
         expect(getSavedViewDraft(identity, storage)).toBeUndefined();
+    });
+
+    it('removes a legacy persistent draft without restoring it into the current session', () => {
+        const sessionStorage = createStorage();
+        const legacyLocalStorage = createStorage();
+        const key = getSavedViewDraftStorageKey(identity);
+        legacyLocalStorage.setItem(key, JSON.stringify({ showChart: false, version: 1 }));
+
+        expect(getSavedViewDraft(identity, sessionStorage, legacyLocalStorage)).toBeUndefined();
+        expect(legacyLocalStorage.getItem(key)).toBeNull();
+
+        saveSavedViewDraft(identity, { showStats: false, version: 1 }, sessionStorage, legacyLocalStorage);
+        expect(getSavedViewDraft(identity, sessionStorage, legacyLocalStorage)).toEqual({ showStats: false, version: 1 });
+
+        clearSavedViewDraft(identity, sessionStorage, legacyLocalStorage);
+        expect(getSavedViewDraft(identity, sessionStorage, legacyLocalStorage)).toBeUndefined();
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/saved-view-drafts.ts
@@ -235,11 +235,14 @@ export function buildWrappedColumnChanges(serverValue: string[], currentValue: s
     return Object.keys(changes).length > 0 ? changes : undefined;
 }
 
-export function clearSavedViewDraft(identity: SavedViewDraftIdentity, storage: DraftStorage | undefined = getLocalStorage()): void {
-    try {
-        storage?.removeItem(getSavedViewDraftStorageKey(identity));
-    } catch {
-        // Storage can be unavailable by browser policy; the saved view still works without a local draft.
+export function clearSavedViewDraft(
+    identity: SavedViewDraftIdentity,
+    storage: DraftStorage | undefined = getSessionStorage(),
+    legacyStorage: DraftStorage | undefined = getLocalStorage()
+): void {
+    removeSavedViewDraftFromStorage(identity, storage);
+    if (legacyStorage !== storage) {
+        removeSavedViewDraftFromStorage(identity, legacyStorage);
     }
 }
 
@@ -249,7 +252,15 @@ export function getMatchingFilterOverrideKeys(filters: IFilter[], baselines: Rec
         .map(([key]) => key);
 }
 
-export function getSavedViewDraft(identity: SavedViewDraftIdentity, storage: DraftStorage | undefined = getLocalStorage()): SavedViewDraft | undefined {
+export function getSavedViewDraft(
+    identity: SavedViewDraftIdentity,
+    storage: DraftStorage | undefined = getSessionStorage(),
+    legacyStorage: DraftStorage | undefined = getLocalStorage()
+): SavedViewDraft | undefined {
+    if (legacyStorage !== storage) {
+        removeSavedViewDraftFromStorage(identity, legacyStorage);
+    }
+
     try {
         const value = storage?.getItem(getSavedViewDraftStorageKey(identity));
         if (!value) {
@@ -334,11 +345,20 @@ export function mergePendingSavedViewDraftEdits(
     return Object.entries(merged).some(([key, value]) => key !== 'version' && value !== undefined) ? merged : undefined;
 }
 
-export function saveSavedViewDraft(identity: SavedViewDraftIdentity, draft: SavedViewDraft, storage: DraftStorage | undefined = getLocalStorage()): void {
+export function saveSavedViewDraft(
+    identity: SavedViewDraftIdentity,
+    draft: SavedViewDraft,
+    storage: DraftStorage | undefined = getSessionStorage(),
+    legacyStorage: DraftStorage | undefined = getLocalStorage()
+): void {
     try {
         storage?.setItem(getSavedViewDraftStorageKey(identity), JSON.stringify(draft));
     } catch {
         // Storage can be unavailable or full; the current in-memory edits remain usable.
+    }
+
+    if (legacyStorage !== storage) {
+        removeSavedViewDraftFromStorage(identity, legacyStorage);
     }
 }
 
@@ -398,6 +418,14 @@ function getMissingDuplicateUpserts(upserts: IFilter[], targetCounts: Map<string
         missingCounts.set(serialized, remaining - 1);
         return true;
     });
+}
+
+function getSessionStorage(): DraftStorage | undefined {
+    try {
+        return typeof sessionStorage === 'undefined' ? undefined : sessionStorage;
+    } catch {
+        return undefined;
+    }
 }
 
 function getUnmatchedFilters(filters: IFilter[], comparison: IFilter[]): IFilter[] {
@@ -480,6 +508,14 @@ function isSavedViewDraft(value: unknown): value is SavedViewDraft {
 
 function isStringArray(value: unknown): value is string[] {
     return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function removeSavedViewDraftFromStorage(identity: SavedViewDraftIdentity, storage: DraftStorage | undefined): void {
+    try {
+        storage?.removeItem(getSavedViewDraftStorageKey(identity));
+    } catch {
+        // Storage can be unavailable by browser policy; the saved view still works without a stored draft.
+    }
 }
 
 function supportsMultipleDefinitions(filter: IFilter): boolean {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -163,7 +163,7 @@ describe('useSavedViews', () => {
     });
 
     describe('expression filter overrides', () => {
-        it('includes saved and browser-local expression filters without typed query parameter filters', () => {
+        it('includes saved and session-local expression filters without typed query parameter filters', () => {
             const draft = {
                 filterChanges: {
                     removedKeys: [],

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte
@@ -11,6 +11,7 @@
     import { cn } from '$lib/utils';
     import ChevronLeftIcon from '@lucide/svelte/icons/chevron-left';
     import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
+    import ChevronsLeftIcon from '@lucide/svelte/icons/chevrons-left';
 
     import DataTablePageSize from './data-table-page-size.svelte';
 
@@ -26,6 +27,12 @@
     const totalPages = $derived(Math.max(1, table.getPageCount() || 1));
     const canGoNext = $derived(currentPage < totalPages);
     const canGoPrevious = $derived(currentPage > 1);
+
+    function goToFirstPage(): void {
+        if (canGoPrevious) {
+            table.setPageIndex(0);
+        }
+    }
 
     function goToNextPage(): void {
         if (canGoNext) {
@@ -50,6 +57,17 @@
         >
             <Number value={currentPage} /> / <Number value={totalPages} />
         </ButtonGroup.Text>
+        <Button
+            aria-label="Go to first page"
+            aria-disabled={!canGoPrevious}
+            class={cn('aria-disabled:pointer-events-none aria-disabled:opacity-50', variant === 'floating' && 'rounded-none border-y-0')}
+            onclick={goToFirstPage}
+            size="icon"
+            title="First page"
+            variant="outline"
+        >
+            <ChevronsLeftIcon />
+        </Button>
         <Button
             aria-label="Go to previous page"
             aria-disabled={!canGoPrevious}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/data-table/data-table-pager.svelte.test.ts
@@ -52,6 +52,10 @@ describe('DataTablePager', () => {
         expect(pageLabel.classList.contains('select-none')).toBe(true);
         expect(pageLabel.classList.contains('rounded-none')).toBe(true);
         expect(pageLabel.classList.contains('border-y-0')).toBe(true);
+        const firstButton = screen.getByRole('button', { name: 'Go to first page' });
+        expect(firstButton.getAttribute('aria-disabled')).toBe('true');
+        expect(firstButton.classList.contains('rounded-none')).toBe(true);
+        expect(firstButton.classList.contains('border-y-0')).toBe(true);
         const nextButton = screen.getByRole('button', { name: 'Go to next page' });
         expect(nextButton.classList.contains('rounded-r-lg!')).toBe(true);
         expect(nextButton.classList.contains('rounded-l-none!')).toBe(true);
@@ -100,6 +104,21 @@ describe('DataTablePager', () => {
         expect(screen.getByLabelText('Page 2 of 3')).toBeTruthy();
         expect(scrollIntoView).not.toHaveBeenCalled();
         expect(document.activeElement).toBe(nextButton);
+    });
+
+    it('returns directly to the first page without moving the controls', async () => {
+        const onPageIndexChange = vi.fn();
+        render(DataTablePagerTestHarness, { onPageIndexChange, onPageSizeChange: vi.fn() });
+
+        await fireEvent.click(screen.getByRole('button', { name: 'Go to next page' }));
+        const firstButton = screen.getByRole('button', { name: 'Go to first page' });
+        firstButton.focus();
+        await fireEvent.click(firstButton);
+
+        expect(onPageIndexChange).toHaveBeenLastCalledWith(0);
+        expect(screen.getByLabelText('Page 1 of 3')).toBeTruthy();
+        expect(firstButton.getAttribute('aria-disabled')).toBe('true');
+        expect(document.activeElement).toBe(firstButton);
     });
 
     it('keeps an unavailable paging target focused without changing pages', async () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table-selection.svelte.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table-selection.svelte.test.ts
@@ -1,0 +1,40 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import TableSelectionTestHarness from './table-selection.test-harness.svelte';
+
+afterEach(cleanup);
+
+describe('shared table selection scope', () => {
+    it('clears selection when moving to another page', async () => {
+        render(TableSelectionTestHarness);
+
+        await fireEvent.click(screen.getByRole('button', { name: 'Select row' }));
+        expect(screen.getByLabelText('Selected rows').textContent).toBe('1');
+
+        await fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
+        expect(screen.getByLabelText('Selected rows').textContent).toBe('0');
+    });
+
+    it('clears selection when the result sort changes', async () => {
+        render(TableSelectionTestHarness);
+
+        await fireEvent.click(screen.getByRole('button', { name: 'Select row' }));
+        expect(screen.getByLabelText('Selected rows').textContent).toBe('1');
+
+        await fireEvent.click(screen.getByRole('button', { name: 'Sort descending' }));
+        expect(screen.getByLabelText('Selected rows').textContent).toBe('0');
+    });
+
+    it('clears selection when browser history restores another page or sort', async () => {
+        render(TableSelectionTestHarness);
+
+        await fireEvent.click(screen.getByRole('button', { name: 'Select row' }));
+        await fireEvent.click(screen.getByRole('button', { name: 'Restore page from URL' }));
+        expect(screen.getByLabelText('Selected rows').textContent).toBe('0');
+
+        await fireEvent.click(screen.getByRole('button', { name: 'Select row' }));
+        await fireEvent.click(screen.getByRole('button', { name: 'Restore sort from URL' }));
+        expect(screen.getByLabelText('Selected rows').textContent).toBe('0');
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table-selection.test-harness.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table-selection.test-harness.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+    import { createTable } from '@tanstack/svelte-table';
+
+    import { getSharedTableOptions } from './table.svelte';
+
+    const queryParameters = $state({
+        limit: 1,
+        page: 1,
+        sort: 'name'
+    });
+
+    const table = createTable(
+        getSharedTableOptions<{ id: string; name: string }>({
+            columnPersistenceKey: 'table-selection-test',
+            columns: [
+                {
+                    accessorKey: 'name',
+                    id: 'name'
+                }
+            ],
+            paginationStrategy: 'offset',
+            queryData: [
+                {
+                    id: 'row-1',
+                    name: 'First row'
+                }
+            ],
+            queryMeta: {
+                links: {
+                    next: {
+                        page: '2',
+                        rel: 'next',
+                        url: '/rows?page=2'
+                    }
+                },
+                total: 2
+            },
+            queryParameters
+        })
+    );
+
+    const selectedCount = $derived(Object.keys(table.store.state.rowSelection).length);
+</script>
+
+<button onclick={() => table.getRowModel().rows[0]?.toggleSelected()} type="button">Select row</button>
+<button onclick={() => table.setPageIndex(1)} type="button">Next page</button>
+<button
+    onclick={() =>
+        table.setSorting([
+            {
+                desc: true,
+                id: 'name'
+            }
+        ])}
+    type="button">Sort descending</button
+>
+<button onclick={() => (queryParameters.page = 2)} type="button">Restore page from URL</button>
+<button onclick={() => (queryParameters.sort = '-name')} type="button">Restore sort from URL</button>
+<span aria-label="Selected rows">{selectedCount}</span>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/table.svelte.ts
@@ -135,6 +135,13 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
         const previousPageInfo = pagination();
         const requestedPageInfo = resolveUpdater(previousPageInfo, updaterOrValue);
         const paginationChange = resolvePaginationChange(previousPageInfo, requestedPageInfo);
+        if (
+            previousPageInfo.pageIndex !== paginationChange.currentPageInfo.pageIndex ||
+            previousPageInfo.pageSize !== paginationChange.currentPageInfo.pageSize
+        ) {
+            setRowSelection({});
+        }
+
         setPagination(paginationChange.currentPageInfo);
 
         const currentPageInfo = paginationChange.currentPageInfo;
@@ -154,8 +161,12 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
     };
 
     const onSortingChange = (updaterOrValue: Updater<ColumnSort[]>) => {
+        const previousSorting = sorting();
         setSorting(updaterOrValue);
         const newSorting = sorting();
+        if (serializeSortState(previousSorting) !== serializeSortState(newSorting)) {
+            setRowSelection({});
+        }
 
         if (isCursorPaging) {
             const parameters = configuration.queryParameters as TableCursorPagingParameters;
@@ -233,6 +244,7 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
         const currentPageInfo = pagination();
 
         if (currentPageInfo.pageSize !== nextPageSize || currentPageInfo.pageIndex !== nextPageIndex) {
+            setRowSelection({});
             setPagination({
                 pageIndex: nextPageIndex,
                 pageSize: nextPageSize
@@ -246,6 +258,7 @@ export function getSharedTableOptions<TData extends RowData, TPaginationStrategy
 
         const parsedSort = parseSortString(configuration.queryParameters.sort);
         if (serializeSortState(parsedSort) !== serializeSortState(sorting())) {
+            setRowSelection({});
             setSorting(parsedSort);
         }
     });

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/+page.svelte
@@ -431,8 +431,13 @@
     let isInternalFilterUpdate = false;
     watch(
         [() => page.url.pathname, () => getListFilterQueryParams(queryParams), () => savedViewsState.activeSavedView],
-        ([pathname, currentQueryParams, activeSavedView], [previousPathname, , previousSavedView]) => {
+        ([pathname, currentQueryParams, activeSavedView], [previousPathname, previousQueryParams, previousSavedView]) => {
             const savedViewChanged = pathname !== previousPathname || activeSavedView?.id !== previousSavedView?.id;
+            const queryChanged = JSON.stringify(currentQueryParams) !== JSON.stringify(previousQueryParams);
+            if (savedViewChanged || queryChanged) {
+                table.resetRowSelection();
+            }
+
             if (isInternalFilterUpdate && !savedViewChanged) {
                 isInternalFilterUpdate = false;
                 return;
@@ -448,6 +453,7 @@
 
     function handleResetToSaved(): void {
         isInternalFilterUpdate = false;
+        table.resetRowSelection();
         queryParams.update(LIST_FILTER_QUERY_PARAM_RESET);
         savedViewsState.handleResetToSaved();
         filters = getCurrentFilters();
@@ -509,6 +515,10 @@
         const effectiveQueryWillChange = (filter || null) !== getEffectiveFilter() || time !== getQueryTime();
         const shouldClearPaginationForFilter = shouldClearPagination && effectiveQueryWillChange;
         const paginationWillChange = shouldClearPaginationForFilter && (queryParams.after != null || queryParams.before != null || queryParams.page != null);
+
+        if (effectiveQueryWillChange) {
+            table.resetRowSelection();
+        }
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
 

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/+page.svelte
@@ -125,6 +125,7 @@
     watch(
         [() => queryParams.filter],
         ([filter]) => {
+            table.resetRowSelection();
             filters = sanitizeStackFilters(getFiltersFromCache(filterCacheKey(filter), filter), true);
         },
         {
@@ -167,6 +168,10 @@
     function updateFilters(updatedFilters: FacetedFilter.IFilter[]): void {
         const sanitizedFilters = sanitizeStackFilters(updatedFilters);
         const filter = toFilter(sanitizedFilters);
+        if (queryParams.filter !== filter) {
+            table.resetRowSelection();
+        }
+
         updateFilterCache(filterCacheKey(filter), sanitizedFilters);
         queryParams.page = 1;
         queryParams.filter = filter;

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
@@ -110,6 +110,7 @@
     watch(
         [() => queryParams.filter, () => queryParams.time],
         ([filter, time]) => {
+            table.resetRowSelection();
             filters = applyTimeFilter(getFiltersFromCache(filterCacheKey(filter), filter), time);
         },
         {
@@ -140,9 +141,14 @@
 
     function updateFilters(updatedFilters: FacetedFilter.IFilter[]): void {
         const filter = toFilter(updatedFilters.filter((f) => f.type !== 'date'));
+        const time = ((updatedFilters.find((f) => f.type === 'date') as DateFilter | undefined)?.value as string | undefined) ?? null;
+
+        if (queryParams.filter !== filter || queryParams.time !== time) {
+            table.resetRowSelection();
+        }
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
-        queryParams.time = ((updatedFilters.find((f) => f.type === 'date') as DateFilter | undefined)?.value as string | undefined) ?? null;
+        queryParams.time = time;
         queryParams.filter = filter;
     }
 
@@ -202,6 +208,14 @@
                 return eventsQueryParameters;
             }
         })
+    );
+
+    watch(
+        () => viewActive,
+        () => reset(),
+        {
+            lazy: true
+        }
     );
 
     function reset() {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/+page.svelte
@@ -422,9 +422,10 @@
     let isInternalFilterUpdate = false;
     watch(
         [() => page.url.pathname, () => getListFilterQueryParams(queryParams), () => savedViewsState.activeSavedView],
-        ([pathname, currentQueryParams, activeSavedView], [previousPathname, , previousSavedView]) => {
+        ([pathname, currentQueryParams, activeSavedView], [previousPathname, previousQueryParams, previousSavedView]) => {
             const savedViewChanged = pathname !== previousPathname || activeSavedView?.id !== previousSavedView?.id;
-            if (savedViewChanged) {
+            const queryChanged = JSON.stringify(currentQueryParams) !== JSON.stringify(previousQueryParams);
+            if (savedViewChanged || queryChanged) {
                 table.resetRowSelection();
             }
 
@@ -446,6 +447,7 @@
 
     function handleResetToSaved(): void {
         isInternalFilterUpdate = false;
+        table.resetRowSelection();
         queryParams.update(LIST_FILTER_QUERY_PARAM_RESET);
         savedViewsState.handleResetToSaved();
         filters = getCurrentFilters();
@@ -509,6 +511,10 @@
         const effectiveQueryWillChange = (filter || null) !== getEffectiveFilter() || time !== getQueryTime();
         const shouldClearPaginationForFilter = shouldClearPagination && effectiveQueryWillChange;
         const paginationWillChange = shouldClearPaginationForFilter && queryParams.page != null;
+
+        if (effectiveQueryWillChange) {
+            table.resetRowSelection();
+        }
 
         updateFilterCache(filterCacheKey(filter), updatedFilters);
 


### PR DESCRIPTION
## Summary

- clear table selections when pagination, sorting, filters, time ranges, or saved-view context changes
- add first-page navigation and restore wrapping for structured stack trace frames
- scope unsaved saved-view drafts to the browser session and remove legacy local-storage drafts
- extend unit and browser coverage for selection, paging, stack wrapping, and draft persistence

## Verification

- npm run validate
- focused Vitest suite: 36 tests passed
- Playwright table-toolbar-pagination scenario passed
- Playwright session-local saved-view scenarios: 3 passed

## Breaking changes

None.