### PR TITLE
Make regression pipeline test stacking deterministic

### DIFF
--- a/tests/Exceptionless.Tests/Pipeline/EventPipelineTests.cs
+++ b/tests/Exceptionless.Tests/Pipeline/EventPipelineTests.cs
@@ -816,16 +816,17 @@ public sealed class EventPipelineTests : IntegrationTestsBase
         var organization = _organizationData.GenerateSampleOrganization(_billingManager, _plans);
         var project = _projectData.GenerateSampleProject();
         var firstContext = await _pipeline.RunAsync(
-            _eventData.GenerateEvent(projectId: project.Id, organizationId: organization.Id, source: "first-stack", occurrenceDate: fixedAtUtc.AddMinutes(-2)),
+            _eventData.GenerateEvent(projectId: project.Id, organizationId: organization.Id, type: Event.KnownTypes.Log, source: "first-stack", occurrenceDate: fixedAtUtc.AddMinutes(-2)),
             organization,
             project);
         var secondContext = await _pipeline.RunAsync(
-            _eventData.GenerateEvent(projectId: project.Id, organizationId: organization.Id, source: "second-stack", occurrenceDate: fixedAtUtc.AddMinutes(-2)),
+            _eventData.GenerateEvent(projectId: project.Id, organizationId: organization.Id, type: Event.KnownTypes.Log, source: "second-stack", occurrenceDate: fixedAtUtc.AddMinutes(-2)),
             organization,
             project);
 
         Assert.NotNull(firstContext.Stack);
         Assert.NotNull(secondContext.Stack);
+        Assert.NotEqual(firstContext.Stack.Id, secondContext.Stack.Id);
         firstContext.Stack.MarkFixed(null, TimeProvider);
         secondContext.Stack.MarkFixed(null, TimeProvider);
         await _stackRepository.SaveAsync(firstContext.Stack, o => o.ImmediateConsistency().Cache());


### PR DESCRIPTION
## Summary
- generate the two setup events as logs so their distinct sources always produce separate stacks
- assert the setup stack IDs differ before exercising batch regression handling

## Why
The default error-event generator randomly selects from a 25-error pool. When both setup events selected the same error, they shared a stack and the test incorrectly observed the first context as regressed.

## Verification
- forced the two setup errors to match and reproduced `Expected: Fixed` / `Actual: Regressed`
- `dotnet test tests/Exceptionless.Tests/Exceptionless.Tests.csproj -- --filter-class Exceptionless.Tests.Pipeline.EventPipelineTests` (57 passed, 1 skipped)
- focused test passed 6 consecutive runs

## Breaking changes
None.