### PR TITLE
Add persistent runtime system configuration

### DIFF
--- a/src/Exceptionless.Core/Bootstrapper.cs
+++ b/src/Exceptionless.Core/Bootstrapper.cs
@@ -151,6 +151,7 @@ public class Bootstrapper
         services.AddSingleton<IUserRepository, UserRepository>();
         services.AddSingleton<IWebHookRepository, WebHookRepository>();
         services.AddSingleton<ISavedViewRepository, SavedViewRepository>();
+        services.AddSingleton<ISystemSettingsRepository, SystemSettingsRepository>();
         services.AddSingleton<ITokenRepository, TokenRepository>();
 
         services.AddSingleton<IGeocodeService, NullGeocodeService>();

--- a/src/Exceptionless.Core/Bootstrapper.cs
+++ b/src/Exceptionless.Core/Bootstrapper.cs
@@ -191,6 +191,7 @@ public class Bootstrapper
         services.AddSingleton<UserAgentParser>();
         services.AddSingleton<ICoreLastReferenceIdManager, NullCoreLastReferenceIdManager>();
 
+        services.AddSingleton<SystemSettingsService>();
         services.AddSingleton<NotificationService>();
         services.AddSingleton<OrganizationService>();
         services.AddStartupAction<OrganizationService>();

--- a/src/Exceptionless.Core/Models/SystemSettings.cs
+++ b/src/Exceptionless.Core/Models/SystemSettings.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Exceptionless.Core.Attributes;
+using Exceptionless.Core.Messaging.Models;
 using Foundatio.Repositories.Models;
 
 namespace Exceptionless.Core.Models;
@@ -13,6 +14,12 @@ public sealed class SystemSettings : IIdentity, IHaveDates
 
     [MaxLength(200)]
     public string? AssistantModel { get; set; }
+
+    public bool? AssistantEnabled { get; set; }
+
+    public bool? EventSubmissionEnabled { get; set; }
+
+    public SystemNotification? SystemNotification { get; set; }
 
     [ObjectId]
     public string CreatedByUserId { get; set; } = null!;

--- a/src/Exceptionless.Core/Models/SystemSettings.cs
+++ b/src/Exceptionless.Core/Models/SystemSettings.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+using Exceptionless.Core.Attributes;
+using Foundatio.Repositories.Models;
+
+namespace Exceptionless.Core.Models;
+
+public sealed class SystemSettings : IIdentity, IHaveDates
+{
+    public const string DefaultId = "000000000000000000000001";
+
+    [ObjectId]
+    public string Id { get; set; } = DefaultId;
+
+    [MaxLength(200)]
+    public string? AssistantModel { get; set; }
+
+    [ObjectId]
+    public string CreatedByUserId { get; set; } = null!;
+
+    [ObjectId]
+    public string UpdatedByUserId { get; set; } = null!;
+
+    public DateTime CreatedUtc { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+}

--- a/src/Exceptionless.Core/Repositories/Configuration/ExceptionlessElasticConfiguration.cs
+++ b/src/Exceptionless.Core/Repositories/Configuration/ExceptionlessElasticConfiguration.cs
@@ -47,6 +47,7 @@ public sealed class ExceptionlessElasticConfiguration : ElasticConfiguration, IS
         AddIndex(OAuthTokens = new OAuthTokenIndex(this));
         AddIndex(Projects = new ProjectIndex(this));
         AddIndex(SavedViews = new SavedViewIndex(this));
+        AddIndex(SystemSettings = new SystemSettingsIndex(this));
         AddIndex(Tokens = new TokenIndex(this));
         AddIndex(Users = new UserIndex(this));
         AddIndex(WebHooks = new WebHookIndex(this));
@@ -77,6 +78,7 @@ public sealed class ExceptionlessElasticConfiguration : ElasticConfiguration, IS
     public OAuthTokenIndex OAuthTokens { get; }
     public ProjectIndex Projects { get; }
     public SavedViewIndex SavedViews { get; }
+    public SystemSettingsIndex SystemSettings { get; }
     public TokenIndex Tokens { get; }
     public UserIndex Users { get; }
     public WebHookIndex WebHooks { get; }

--- a/src/Exceptionless.Core/Repositories/Configuration/Indexes/SystemSettingsIndex.cs
+++ b/src/Exceptionless.Core/Repositories/Configuration/Indexes/SystemSettingsIndex.cs
@@ -23,6 +23,13 @@ public sealed class SystemSettingsIndex : VersionedIndex<SystemSettings>
             .Properties(properties => properties
                 .SetupDefaults()
                 .Keyword(settings => settings.AssistantModel)
+                .Boolean(settings => settings.AssistantEnabled)
+                .Boolean(settings => settings.EventSubmissionEnabled)
+                .Object(settings => settings.SystemNotification, notification => notification.Properties(properties => properties
+                    .Date("date")
+                    .Text("message")
+                    .Keyword("level")
+                    .Keyword("target")))
                 .Keyword(settings => settings.CreatedByUserId)
                 .Keyword(settings => settings.UpdatedByUserId));
     }

--- a/src/Exceptionless.Core/Repositories/Configuration/Indexes/SystemSettingsIndex.cs
+++ b/src/Exceptionless.Core/Repositories/Configuration/Indexes/SystemSettingsIndex.cs
@@ -1,0 +1,38 @@
+using Elastic.Clients.Elasticsearch.IndexManagement;
+using Elastic.Clients.Elasticsearch.Mapping;
+using Exceptionless.Core.Models;
+using Foundatio.Repositories.Elasticsearch.Configuration;
+using Foundatio.Repositories.Elasticsearch.Extensions;
+
+namespace Exceptionless.Core.Repositories.Configuration;
+
+public sealed class SystemSettingsIndex : VersionedIndex<SystemSettings>
+{
+    private readonly ExceptionlessElasticConfiguration _configuration;
+
+    public SystemSettingsIndex(ExceptionlessElasticConfiguration configuration)
+        : base(configuration, configuration.Options.ScopePrefix + "system-settings", 1)
+    {
+        _configuration = configuration;
+    }
+
+    public override void ConfigureIndexMapping(TypeMappingDescriptor<SystemSettings> map)
+    {
+        map
+            .Dynamic(DynamicMapping.False)
+            .Properties(properties => properties
+                .SetupDefaults()
+                .Keyword(settings => settings.AssistantModel)
+                .Keyword(settings => settings.CreatedByUserId)
+                .Keyword(settings => settings.UpdatedByUserId));
+    }
+
+    public override void ConfigureIndex(CreateIndexRequestDescriptor index)
+    {
+        base.ConfigureIndex(index);
+        index.Settings(settings => settings
+            .NumberOfShards(1)
+            .NumberOfReplicas(_configuration.Options.NumberOfReplicas)
+            .Priority(5));
+    }
+}

--- a/src/Exceptionless.Core/Repositories/Interfaces/ISystemSettingsRepository.cs
+++ b/src/Exceptionless.Core/Repositories/Interfaces/ISystemSettingsRepository.cs
@@ -1,0 +1,6 @@
+using Exceptionless.Core.Models;
+using Foundatio.Repositories;
+
+namespace Exceptionless.Core.Repositories;
+
+public interface ISystemSettingsRepository : IRepository<SystemSettings>;

--- a/src/Exceptionless.Core/Repositories/SystemSettingsRepository.cs
+++ b/src/Exceptionless.Core/Repositories/SystemSettingsRepository.cs
@@ -1,0 +1,15 @@
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Repositories.Configuration;
+using Exceptionless.Core.Validation;
+using Foundatio.Repositories;
+
+namespace Exceptionless.Core.Repositories;
+
+public sealed class SystemSettingsRepository : RepositoryBase<SystemSettings>, ISystemSettingsRepository
+{
+    public SystemSettingsRepository(ExceptionlessElasticConfiguration configuration, MiniValidationValidator validator, AppOptions options)
+        : base(configuration.SystemSettings, validator, options)
+    {
+        DefaultConsistency = Consistency.Immediate;
+    }
+}

--- a/src/Exceptionless.Core/Services/NotificationService.cs
+++ b/src/Exceptionless.Core/Services/NotificationService.cs
@@ -10,17 +10,32 @@ namespace Exceptionless.Core.Services;
 public class NotificationService(ICacheClient cacheClient, IMessagePublisher messagePublisher, TimeProvider timeProvider, CacheLockProvider lockProvider, SystemSettingsService systemSettingsService)
 {
     private const string SystemNotificationCacheKey = "system-notification";
+    private const string SystemNotificationCompatibilityCacheKey = "system-notification-compatibility";
     private static readonly TimeSpan OrganizationNotificationLockTimeout = TimeSpan.FromMinutes(90);
 
     public async Task<SystemNotification?> GetSystemNotificationAsync()
     {
         var settings = await systemSettingsService.GetAsync();
-        if (settings?.SystemNotification is not null)
-            return settings.SystemNotification;
+        var durableNotification = settings?.SystemNotification;
+        var legacyNotification = await cacheClient.GetAsync<SystemNotification>(SystemNotificationCacheKey);
 
-        // Preserve an active notification created before notifications became durable.
-        var result = await cacheClient.GetAsync<SystemNotification>(SystemNotificationCacheKey);
-        return result.HasValue ? result.Value : null;
+        // Reconcile a newer notification written by an older instance during a rolling deployment.
+        if (legacyNotification.HasValue && (durableNotification is null || legacyNotification.Value.Date > durableNotification.Date))
+            return legacyNotification.Value;
+
+        if (durableNotification is null)
+            return legacyNotification.HasValue ? legacyNotification.Value : null;
+
+        // Older instances clear only the legacy key. A separate marker distinguishes that targeted
+        // removal from a full cache restart, where Elasticsearch must remain authoritative.
+        if (!legacyNotification.HasValue)
+        {
+            var compatibilityDate = await cacheClient.GetAsync<DateTime>(SystemNotificationCompatibilityCacheKey);
+            if (compatibilityDate.HasValue && compatibilityDate.Value >= durableNotification.Date)
+                return null;
+        }
+
+        return durableNotification;
     }
 
     public async Task<SystemNotification> SetSystemNotificationAsync(string message, string userId, SystemNotificationLevel level = SystemNotificationLevel.Info, SystemNotificationTarget target = SystemNotificationTarget.Both, bool publish = true)
@@ -29,6 +44,7 @@ public class NotificationService(ICacheClient cacheClient, IMessagePublisher mes
         await systemSettingsService.UpdateAsync(userId, settings => settings.SystemNotification = notification);
         // Keep older instances in a rolling deployment synchronized until they all read durable settings.
         await cacheClient.SetAsync(SystemNotificationCacheKey, notification);
+        await cacheClient.SetAsync(SystemNotificationCompatibilityCacheKey, notification.Date);
         if (publish)
             await messagePublisher.PublishAsync(notification);
         return notification;
@@ -38,6 +54,7 @@ public class NotificationService(ICacheClient cacheClient, IMessagePublisher mes
     {
         await systemSettingsService.UpdateAsync(userId, settings => settings.SystemNotification = null);
         await cacheClient.RemoveAsync(SystemNotificationCacheKey);
+        await cacheClient.RemoveAsync(SystemNotificationCompatibilityCacheKey);
         if (publish)
             await messagePublisher.PublishAsync(new SystemNotification { Date = timeProvider.GetUtcNow().UtcDateTime });
     }

--- a/src/Exceptionless.Core/Services/NotificationService.cs
+++ b/src/Exceptionless.Core/Services/NotificationService.cs
@@ -7,28 +7,35 @@ using Foundatio.Messaging;
 
 namespace Exceptionless.Core.Services;
 
-public class NotificationService(ICacheClient cacheClient, IMessagePublisher messagePublisher, TimeProvider timeProvider, CacheLockProvider lockProvider)
+public class NotificationService(ICacheClient cacheClient, IMessagePublisher messagePublisher, TimeProvider timeProvider, CacheLockProvider lockProvider, SystemSettingsService systemSettingsService)
 {
     private const string SystemNotificationCacheKey = "system-notification";
     private static readonly TimeSpan OrganizationNotificationLockTimeout = TimeSpan.FromMinutes(90);
 
     public async Task<SystemNotification?> GetSystemNotificationAsync()
     {
+        var settings = await systemSettingsService.GetAsync();
+        if (settings?.SystemNotification is not null)
+            return settings.SystemNotification;
+
+        // Preserve an active notification created before notifications became durable.
         var result = await cacheClient.GetAsync<SystemNotification>(SystemNotificationCacheKey);
         return result.HasValue ? result.Value : null;
     }
 
-    public async Task<SystemNotification> SetSystemNotificationAsync(string message, SystemNotificationLevel level = SystemNotificationLevel.Info, SystemNotificationTarget target = SystemNotificationTarget.Both, bool publish = true)
+    public async Task<SystemNotification> SetSystemNotificationAsync(string message, string userId, SystemNotificationLevel level = SystemNotificationLevel.Info, SystemNotificationTarget target = SystemNotificationTarget.Both, bool publish = true)
     {
         var notification = new SystemNotification { Date = timeProvider.GetUtcNow().UtcDateTime, Message = message, Level = level, Target = target };
-        await cacheClient.SetAsync(SystemNotificationCacheKey, notification);
+        await systemSettingsService.UpdateAsync(userId, settings => settings.SystemNotification = notification);
+        await cacheClient.RemoveAsync(SystemNotificationCacheKey);
         if (publish)
             await messagePublisher.PublishAsync(notification);
         return notification;
     }
 
-    public async Task ClearSystemNotificationAsync(bool publish = true)
+    public async Task ClearSystemNotificationAsync(string userId, bool publish = true)
     {
+        await systemSettingsService.UpdateAsync(userId, settings => settings.SystemNotification = null);
         await cacheClient.RemoveAsync(SystemNotificationCacheKey);
         if (publish)
             await messagePublisher.PublishAsync(new SystemNotification { Date = timeProvider.GetUtcNow().UtcDateTime });

--- a/src/Exceptionless.Core/Services/NotificationService.cs
+++ b/src/Exceptionless.Core/Services/NotificationService.cs
@@ -27,7 +27,8 @@ public class NotificationService(ICacheClient cacheClient, IMessagePublisher mes
     {
         var notification = new SystemNotification { Date = timeProvider.GetUtcNow().UtcDateTime, Message = message, Level = level, Target = target };
         await systemSettingsService.UpdateAsync(userId, settings => settings.SystemNotification = notification);
-        await cacheClient.RemoveAsync(SystemNotificationCacheKey);
+        // Keep older instances in a rolling deployment synchronized until they all read durable settings.
+        await cacheClient.SetAsync(SystemNotificationCacheKey, notification);
         if (publish)
             await messagePublisher.PublishAsync(notification);
         return notification;

--- a/src/Exceptionless.Core/Services/SystemSettingsService.cs
+++ b/src/Exceptionless.Core/Services/SystemSettingsService.cs
@@ -1,0 +1,95 @@
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Repositories;
+using Foundatio.Lock;
+using Foundatio.Repositories;
+
+namespace Exceptionless.Core.Services;
+
+public sealed class SystemSettingsService
+{
+    private readonly AppOptions _appOptions;
+    private readonly Func<Task<SystemSettings?>> _getSettingsAsync;
+    private readonly ILockProvider? _lockProvider;
+    private readonly Func<SystemSettings, Task> _saveSettingsAsync;
+    private readonly TimeProvider _timeProvider;
+
+    public SystemSettingsService(
+        ISystemSettingsRepository repository,
+        ILockProvider lockProvider,
+        AppOptions appOptions,
+        TimeProvider timeProvider)
+        : this(
+            () => repository.GetByIdAsync(SystemSettings.DefaultId, options => options.Cache()),
+            async settings => await repository.SaveAsync(settings, options => options.Cache().ImmediateConsistency()),
+            lockProvider,
+            appOptions,
+            timeProvider)
+    {
+    }
+
+    internal SystemSettingsService(
+        Func<Task<SystemSettings?>> getSettingsAsync,
+        Func<SystemSettings, Task> saveSettingsAsync,
+        AppOptions appOptions,
+        TimeProvider timeProvider)
+        : this(getSettingsAsync, saveSettingsAsync, null, appOptions, timeProvider)
+    {
+    }
+
+    private SystemSettingsService(
+        Func<Task<SystemSettings?>> getSettingsAsync,
+        Func<SystemSettings, Task> saveSettingsAsync,
+        ILockProvider? lockProvider,
+        AppOptions appOptions,
+        TimeProvider timeProvider)
+    {
+        _getSettingsAsync = getSettingsAsync;
+        _saveSettingsAsync = saveSettingsAsync;
+        _lockProvider = lockProvider;
+        _appOptions = appOptions;
+        _timeProvider = timeProvider;
+    }
+
+    public Task<SystemSettings?> GetAsync() => _getSettingsAsync();
+
+    public async Task<SystemSettings> UpdateAsync(string userId, Action<SystemSettings> update)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        ArgumentNullException.ThrowIfNull(update);
+
+        if (_lockProvider is null)
+            return await UpdateCoreAsync(userId, update);
+
+        await using var settingsLock = await _lockProvider.AcquireAsync("system-settings:update", TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(15));
+        return await UpdateCoreAsync(userId, update);
+    }
+
+    private async Task<SystemSettings> UpdateCoreAsync(string userId, Action<SystemSettings> update)
+    {
+        var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
+        var settings = await _getSettingsAsync() ?? new SystemSettings
+        {
+            CreatedByUserId = userId,
+            CreatedUtc = utcNow
+        };
+
+        update(settings);
+        settings.UpdatedByUserId = userId;
+        settings.UpdatedUtc = utcNow;
+        await _saveSettingsAsync(settings);
+
+        return settings;
+    }
+
+    public async Task<bool> IsAssistantEnabledAsync()
+    {
+        var settings = await _getSettingsAsync();
+        return settings?.AssistantEnabled ?? _appOptions.AssistantOptions.Enabled;
+    }
+
+    public async Task<bool> IsEventSubmissionEnabledAsync()
+    {
+        var settings = await _getSettingsAsync();
+        return settings?.EventSubmissionEnabled ?? !_appOptions.EventSubmissionDisabled;
+    }
+}

--- a/src/Exceptionless.Web/Api/Endpoints/AdminEndpoints.cs
+++ b/src/Exceptionless.Web/Api/Endpoints/AdminEndpoints.cs
@@ -24,11 +24,27 @@ public static class AdminEndpoints
         group.MapGet("echo", async (HttpContext httpContext, IMediator mediator, IMediatorResultMapper<HttpIResult> resultMapper)
             => (await mediator.InvokeAsync<Result<object>>(new GetAdminEcho(httpContext))).ToHttpResult(resultMapper));
 
-        group.MapGet("assistant-settings", async (AssistantModelSettingsService settingsService)
-            => HttpResults.Ok(await settingsService.GetAsync()));
+        endpoints.MapGet("api/v2/admin/assistant-settings", async (AssistantModelSettingsService settingsService)
+            => HttpResults.Ok(await settingsService.GetAsync()))
+            .RequireAuthorization(AuthorizationRoles.GlobalAdminPolicy)
+            .AddEndpointFilter<AutoValidationEndpointFilter>()
+            .Produces<AssistantModelSettings>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .WithTags(nameof(AdminEndpoints))
+            .WithSummary("Get Exie assistant settings");
 
-        group.MapPut("assistant-settings", async (HttpContext httpContext, [FromBody] UpdateAssistantSettings request, AssistantModelSettingsService settingsService)
-            => HttpResults.Ok(await settingsService.SetModelAsync(request.Model, httpContext.Request.GetUser().Id)));
+        endpoints.MapPut("api/v2/admin/assistant-settings", async (HttpContext httpContext, [FromBody] UpdateAssistantSettings request, AssistantModelSettingsService settingsService)
+            => HttpResults.Ok(await settingsService.SetModelAsync(request.Model, httpContext.Request.GetUser().Id)))
+            .RequireAuthorization(AuthorizationRoles.GlobalAdminPolicy)
+            .AddEndpointFilter<AutoValidationEndpointFilter>()
+            .Accepts<UpdateAssistantSettings>("application/json", "application/*+json")
+            .Produces<AssistantModelSettings>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .WithTags(nameof(AdminEndpoints))
+            .WithSummary("Update Exie assistant settings");
 
         endpoints.MapGet("api/v2/admin/assistant-usage", GetAssistantUsageAsync)
             .RequireAuthorization(AuthorizationRoles.GlobalAdminPolicy)

--- a/src/Exceptionless.Web/Api/Endpoints/AdminEndpoints.cs
+++ b/src/Exceptionless.Web/Api/Endpoints/AdminEndpoints.cs
@@ -2,8 +2,12 @@ using Exceptionless.Core.Authorization;
 using Exceptionless.Web.Api.Filters;
 using Exceptionless.Web.Api.Messages;
 using Exceptionless.Web.Api.Results;
+using Exceptionless.Web.Assistant;
+using Exceptionless.Web.Extensions;
 using Exceptionless.Web.Models.Admin;
 using Foundatio.Mediator;
+using Microsoft.AspNetCore.Mvc;
+using HttpResults = Microsoft.AspNetCore.Http.Results;
 using HttpIResult = Microsoft.AspNetCore.Http.IResult;
 
 namespace Exceptionless.Web.Api.Endpoints;
@@ -19,6 +23,12 @@ public static class AdminEndpoints
 
         group.MapGet("echo", async (HttpContext httpContext, IMediator mediator, IMediatorResultMapper<HttpIResult> resultMapper)
             => (await mediator.InvokeAsync<Result<object>>(new GetAdminEcho(httpContext))).ToHttpResult(resultMapper));
+
+        group.MapGet("assistant-settings", async (AssistantModelSettingsService settingsService)
+            => HttpResults.Ok(await settingsService.GetAsync()));
+
+        group.MapPut("assistant-settings", async (HttpContext httpContext, [FromBody] UpdateAssistantSettings request, AssistantModelSettingsService settingsService)
+            => HttpResults.Ok(await settingsService.SetModelAsync(request.Model, httpContext.Request.GetUser().Id)));
 
         endpoints.MapGet("api/v2/admin/assistant-usage", GetAssistantUsageAsync)
             .RequireAuthorization(AuthorizationRoles.GlobalAdminPolicy)

--- a/src/Exceptionless.Web/Api/Endpoints/AdminEndpoints.cs
+++ b/src/Exceptionless.Web/Api/Endpoints/AdminEndpoints.cs
@@ -1,4 +1,6 @@
+using Exceptionless.Core;
 using Exceptionless.Core.Authorization;
+using Exceptionless.Core.Services;
 using Exceptionless.Web.Api.Filters;
 using Exceptionless.Web.Api.Messages;
 using Exceptionless.Web.Api.Results;
@@ -46,6 +48,37 @@ public static class AdminEndpoints
             .WithTags(nameof(AdminEndpoints))
             .WithSummary("Update Exie assistant settings");
 
+        endpoints.MapPut("api/v2/admin/assistant-settings/enabled", async (HttpContext httpContext, [FromBody] UpdateAssistantEnabledSettings request, AssistantModelSettingsService settingsService)
+            => HttpResults.Ok(await settingsService.SetEnabledAsync(request.Enabled, httpContext.Request.GetUser().Id)))
+            .RequireAuthorization(AuthorizationRoles.GlobalAdminPolicy)
+            .AddEndpointFilter<AutoValidationEndpointFilter>()
+            .Accepts<UpdateAssistantEnabledSettings>("application/json", "application/*+json")
+            .Produces<AssistantModelSettings>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .WithTags(nameof(AdminEndpoints))
+            .WithSummary("Update Exie assistant availability");
+
+        endpoints.MapGet("api/v2/admin/event-submission-settings", GetEventSubmissionSettingsAsync)
+            .RequireAuthorization(AuthorizationRoles.GlobalAdminPolicy)
+            .Produces<EventSubmissionSettings>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .WithTags(nameof(AdminEndpoints))
+            .WithSummary("Get event submission settings");
+
+        endpoints.MapPut("api/v2/admin/event-submission-settings", UpdateEventSubmissionSettingsAsync)
+            .RequireAuthorization(AuthorizationRoles.GlobalAdminPolicy)
+            .AddEndpointFilter<AutoValidationEndpointFilter>()
+            .Accepts<UpdateEventSubmissionSettings>("application/json", "application/*+json")
+            .Produces<EventSubmissionSettings>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .WithTags(nameof(AdminEndpoints))
+            .WithSummary("Update event submission settings");
+
         endpoints.MapGet("api/v2/admin/assistant-usage", GetAssistantUsageAsync)
             .RequireAuthorization(AuthorizationRoles.GlobalAdminPolicy)
             .AddEndpointFilter<AutoValidationEndpointFilter>()
@@ -73,4 +106,28 @@ public static class AdminEndpoints
         DateTime? month = null,
         int limit = 100)
         => (await mediator.InvokeAsync<Result<object>>(new GetAdminAssistantUsage(month, limit, httpContext))).ToHttpResult(resultMapper);
+
+    private static async Task<HttpIResult> GetEventSubmissionSettingsAsync(SystemSettingsService settingsService, AppOptions appOptions)
+    {
+        var settings = await settingsService.GetAsync();
+        return HttpResults.Ok(CreateEventSubmissionSettings(settings?.EventSubmissionEnabled, appOptions));
+    }
+
+    private static async Task<HttpIResult> UpdateEventSubmissionSettingsAsync(
+        HttpContext httpContext,
+        [FromBody] UpdateEventSubmissionSettings request,
+        SystemSettingsService settingsService,
+        AppOptions appOptions)
+    {
+        bool configuredEnabled = !appOptions.EventSubmissionDisabled;
+        bool? enabledOverride = request.Enabled == configuredEnabled ? null : request.Enabled;
+        var settings = await settingsService.UpdateAsync(httpContext.Request.GetUser().Id, value => value.EventSubmissionEnabled = enabledOverride);
+        return HttpResults.Ok(CreateEventSubmissionSettings(settings.EventSubmissionEnabled, appOptions));
+    }
+
+    private static EventSubmissionSettings CreateEventSubmissionSettings(bool? enabledOverride, AppOptions appOptions)
+    {
+        bool configuredEnabled = !appOptions.EventSubmissionDisabled;
+        return new EventSubmissionSettings(enabledOverride ?? configuredEnabled, configuredEnabled, enabledOverride.HasValue);
+    }
 }

--- a/src/Exceptionless.Web/Api/Endpoints/StatusEndpoints.cs
+++ b/src/Exceptionless.Web/Api/Endpoints/StatusEndpoints.cs
@@ -2,6 +2,7 @@ using Exceptionless.Core.Authorization;
 using Exceptionless.Core.Messaging.Models;
 using Exceptionless.Web.Api.Filters;
 using Exceptionless.Web.Api.Messages;
+using Exceptionless.Web.Extensions;
 using Exceptionless.Web.Models;
 using Foundatio.Mediator;
 using Microsoft.AspNetCore.Mvc;
@@ -39,19 +40,19 @@ public static class StatusEndpoints
             return result.Date == DateTime.MinValue ? HttpResults.NoContent() : HttpResults.Ok(result);
         });
 
-        group.MapPost("notifications/system", async (IMediator mediator, [FromBody] SetSystemNotificationRequest request, bool publish = true) =>
+        group.MapPost("notifications/system", async (HttpContext httpContext, IMediator mediator, [FromBody] SetSystemNotificationRequest request, bool publish = true) =>
         {
             if (String.IsNullOrWhiteSpace(request.Message))
                 return HttpResults.NotFound();
 
-            var result = await mediator.InvokeAsync<object>(new PostSystemNotification(request.Message, request.Level, request.Target, publish));
+            var result = await mediator.InvokeAsync<object>(new PostSystemNotification(request.Message, httpContext.Request.GetUser().Id, request.Level, request.Target, publish));
             return HttpResults.Ok(result);
         })
         .RequireAuthorization(AuthorizationRoles.GlobalAdminPolicy);
 
-        group.MapDelete("notifications/system", async (IMediator mediator, bool publish = true) =>
+        group.MapDelete("notifications/system", async (HttpContext httpContext, IMediator mediator, bool publish = true) =>
         {
-            await mediator.InvokeAsync(new RemoveSystemNotification(publish));
+            await mediator.InvokeAsync(new RemoveSystemNotification(httpContext.Request.GetUser().Id, publish));
             return HttpResults.Ok();
         })
         .RequireAuthorization(AuthorizationRoles.GlobalAdminPolicy);

--- a/src/Exceptionless.Web/Api/Handlers/EventHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/EventHandler.cs
@@ -47,6 +47,7 @@ public class EventHandler(
     PersistentEventQueryValidator validator,
     EventStackQueryValidator stackModeValidator,
     AppOptions appOptions,
+    SystemSettingsService systemSettingsService,
     UsageService usageService,
     TimeProvider timeProvider,
     LinkGenerator linkGenerator,
@@ -395,7 +396,7 @@ public class EventHandler(
     public async Task<Result> Handle(RecordEventHeartbeat message)
     {
         var httpContext = message.Context;
-        if (appOptions.EventSubmissionDisabled || String.IsNullOrEmpty(message.Id))
+        if (!await systemSettingsService.IsEventSubmissionEnabledAsync() || String.IsNullOrEmpty(message.Id))
             return Result.Success();
 
         string? projectId = httpContext.Request.GetDefaultProjectId();

--- a/src/Exceptionless.Web/Api/Handlers/StatusHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/StatusHandler.cs
@@ -89,11 +89,11 @@ public class StatusHandler(
         if (String.IsNullOrWhiteSpace(message.Message))
             return new SystemNotification { Date = DateTime.MinValue };
 
-        return await notificationService.SetSystemNotificationAsync(message.Message, message.Level, message.Target, message.Publish);
+        return await notificationService.SetSystemNotificationAsync(message.Message, message.UserId, message.Level, message.Target, message.Publish);
     }
 
     public Task Handle(RemoveSystemNotification message)
     {
-        return notificationService.ClearSystemNotificationAsync(message.Publish);
+        return notificationService.ClearSystemNotificationAsync(message.UserId, message.Publish);
     }
 }

--- a/src/Exceptionless.Web/Api/Messages/StatusMessages.cs
+++ b/src/Exceptionless.Web/Api/Messages/StatusMessages.cs
@@ -6,8 +6,8 @@ public record GetAboutInfo;
 public record GetQueueStats;
 public record PostReleaseNotification(string Message, bool Critical);
 public record GetSystemNotification;
-public record PostSystemNotification(string Message, SystemNotificationLevel Level = SystemNotificationLevel.Info, SystemNotificationTarget Target = SystemNotificationTarget.Both, bool Publish = true);
-public record RemoveSystemNotification(bool Publish = true);
+public record PostSystemNotification(string Message, string UserId, SystemNotificationLevel Level = SystemNotificationLevel.Info, SystemNotificationTarget Target = SystemNotificationTarget.Both, bool Publish = true);
+public record RemoveSystemNotification(string UserId, bool Publish = true);
 public record ValidateSearchQuery(string Query);
 
 public record SetSystemNotificationRequest

--- a/src/Exceptionless.Web/Assistant/AssistantAccessService.cs
+++ b/src/Exceptionless.Web/Assistant/AssistantAccessService.cs
@@ -2,6 +2,7 @@ using Exceptionless.Core;
 using Exceptionless.Core.Billing;
 using Exceptionless.Core.Models.Billing;
 using Exceptionless.Core.Repositories;
+using Exceptionless.Core.Services;
 using Exceptionless.Web.Extensions;
 using Foundatio.Repositories;
 using Foundatio.Repositories.Options;
@@ -11,13 +12,15 @@ namespace Exceptionless.Web.Assistant;
 public sealed class AssistantAccessService(
     AppOptions appOptions,
     BillingPlans billingPlans,
-    IOrganizationRepository organizationRepository)
+    IOrganizationRepository organizationRepository,
+    SystemSettingsService systemSettingsService)
 {
     public async Task<AssistantAccessDecision> GetAccessAsync(HttpRequest request, string? organizationId)
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var configurationDecision = EvaluateConfiguration(appOptions);
+        bool enabled = await systemSettingsService.IsAssistantEnabledAsync();
+        var configurationDecision = EvaluateConfiguration(appOptions, enabled);
         if (configurationDecision is not null)
             return configurationDecision;
 
@@ -41,9 +44,9 @@ public sealed class AssistantAccessService(
         return EvaluatePlan(billingPlans.GetPlan(organization.PlanId)?.Assistant, billingPlans.MediumPlan.Id);
     }
 
-    internal static AssistantAccessDecision? EvaluateConfiguration(AppOptions appOptions)
+    internal static AssistantAccessDecision? EvaluateConfiguration(AppOptions appOptions, bool? enabled = null)
     {
-        if (!appOptions.AssistantOptions.Enabled)
+        if (!(enabled ?? appOptions.AssistantOptions.Enabled))
             return AssistantAccessDecision.Unavailable(AssistantAccessReason.Disabled, "Exie is disabled.", enabled: false);
 
         if (!appOptions.AssistantOptions.IsConfigured)

--- a/src/Exceptionless.Web/Assistant/AssistantModelSettingsService.cs
+++ b/src/Exceptionless.Web/Assistant/AssistantModelSettingsService.cs
@@ -1,42 +1,23 @@
 using Exceptionless.Core;
 using Exceptionless.Core.Models;
-using Exceptionless.Core.Repositories;
-using Foundatio.Repositories;
+using Exceptionless.Core.Services;
 
 namespace Exceptionless.Web.Assistant;
 
 public sealed class AssistantModelSettingsService
 {
     private readonly AppOptions _appOptions;
-    private readonly Func<Task<SystemSettings?>> _getSettingsAsync;
-    private readonly Func<SystemSettings, Task> _saveSettingsAsync;
-    private readonly TimeProvider _timeProvider;
+    private readonly SystemSettingsService _systemSettingsService;
 
     public AssistantModelSettingsService(
-        ISystemSettingsRepository repository,
-        AppOptions appOptions,
-        TimeProvider timeProvider)
-        : this(
-            () => repository.GetByIdAsync(SystemSettings.DefaultId, options => options.Cache()),
-            async settings => await repository.SaveAsync(settings, options => options.Cache().ImmediateConsistency()),
-            appOptions,
-            timeProvider)
+        SystemSettingsService systemSettingsService,
+        AppOptions appOptions)
     {
-    }
-
-    internal AssistantModelSettingsService(
-        Func<Task<SystemSettings?>> getSettingsAsync,
-        Func<SystemSettings, Task> saveSettingsAsync,
-        AppOptions appOptions,
-        TimeProvider timeProvider)
-    {
-        _getSettingsAsync = getSettingsAsync;
-        _saveSettingsAsync = saveSettingsAsync;
+        _systemSettingsService = systemSettingsService;
         _appOptions = appOptions;
-        _timeProvider = timeProvider;
     }
 
-    public async Task<AssistantModelSettings> GetAsync() => CreateResponse(await _getSettingsAsync());
+    public async Task<AssistantModelSettings> GetAsync() => CreateResponse(await _systemSettingsService.GetAsync());
 
     public async Task<AssistantModelSettings> SetModelAsync(string? model, string userId)
     {
@@ -47,18 +28,18 @@ public sealed class AssistantModelSettingsService
             || String.Equals(normalizedModel, _appOptions.AssistantOptions.Model, StringComparison.Ordinal))
             normalizedModel = null;
 
-        var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
-        var settings = await _getSettingsAsync() ?? new SystemSettings
-        {
-            CreatedByUserId = userId,
-            CreatedUtc = utcNow
-        };
-        settings.AssistantModel = normalizedModel;
-        settings.UpdatedByUserId = userId;
-        settings.UpdatedUtc = utcNow;
+        var settings = await _systemSettingsService.UpdateAsync(userId, value => value.AssistantModel = normalizedModel);
 
-        await _saveSettingsAsync(settings);
+        return CreateResponse(settings);
+    }
 
+    public async Task<AssistantModelSettings> SetEnabledAsync(bool? enabled, string userId)
+    {
+        bool? normalizedEnabled = enabled;
+        if (normalizedEnabled == _appOptions.AssistantOptions.Enabled)
+            normalizedEnabled = null;
+
+        var settings = await _systemSettingsService.UpdateAsync(userId, value => value.AssistantEnabled = normalizedEnabled);
         return CreateResponse(settings);
     }
 
@@ -66,13 +47,26 @@ public sealed class AssistantModelSettingsService
     {
         string configuredModel = _appOptions.AssistantOptions.Model;
         string? modelOverride = settings?.AssistantModel;
-        bool isOverridden = !String.IsNullOrWhiteSpace(modelOverride);
+        bool isModelOverridden = !String.IsNullOrWhiteSpace(modelOverride);
+        bool configuredEnabled = _appOptions.AssistantOptions.Enabled;
+        bool? enabledOverride = settings?.AssistantEnabled;
 
         return new AssistantModelSettings(
-            isOverridden ? modelOverride! : configuredModel,
+            isModelOverridden ? modelOverride! : configuredModel,
             configuredModel,
-            isOverridden);
+            isModelOverridden,
+            enabledOverride ?? configuredEnabled,
+            configuredEnabled,
+            enabledOverride.HasValue,
+            _appOptions.AssistantOptions.IsConfigured);
     }
 }
 
-public sealed record AssistantModelSettings(string Model, string ConfiguredModel, bool IsOverridden);
+public sealed record AssistantModelSettings(
+    string Model,
+    string ConfiguredModel,
+    bool IsOverridden,
+    bool Enabled,
+    bool ConfiguredEnabled,
+    bool IsEnabledOverridden,
+    bool IsConfigured);

--- a/src/Exceptionless.Web/Assistant/AssistantModelSettingsService.cs
+++ b/src/Exceptionless.Web/Assistant/AssistantModelSettingsService.cs
@@ -1,0 +1,78 @@
+using Exceptionless.Core;
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Repositories;
+using Foundatio.Repositories;
+
+namespace Exceptionless.Web.Assistant;
+
+public sealed class AssistantModelSettingsService
+{
+    private readonly AppOptions _appOptions;
+    private readonly Func<Task<SystemSettings?>> _getSettingsAsync;
+    private readonly Func<SystemSettings, Task> _saveSettingsAsync;
+    private readonly TimeProvider _timeProvider;
+
+    public AssistantModelSettingsService(
+        ISystemSettingsRepository repository,
+        AppOptions appOptions,
+        TimeProvider timeProvider)
+        : this(
+            () => repository.GetByIdAsync(SystemSettings.DefaultId, options => options.Cache()),
+            async settings => await repository.SaveAsync(settings, options => options.Cache().ImmediateConsistency()),
+            appOptions,
+            timeProvider)
+    {
+    }
+
+    internal AssistantModelSettingsService(
+        Func<Task<SystemSettings?>> getSettingsAsync,
+        Func<SystemSettings, Task> saveSettingsAsync,
+        AppOptions appOptions,
+        TimeProvider timeProvider)
+    {
+        _getSettingsAsync = getSettingsAsync;
+        _saveSettingsAsync = saveSettingsAsync;
+        _appOptions = appOptions;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<AssistantModelSettings> GetAsync() => CreateResponse(await _getSettingsAsync());
+
+    public async Task<AssistantModelSettings> SetModelAsync(string? model, string userId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+
+        string? normalizedModel = model?.Trim();
+        if (String.IsNullOrWhiteSpace(normalizedModel)
+            || String.Equals(normalizedModel, _appOptions.AssistantOptions.Model, StringComparison.Ordinal))
+            normalizedModel = null;
+
+        var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
+        var settings = await _getSettingsAsync() ?? new SystemSettings
+        {
+            CreatedByUserId = userId,
+            CreatedUtc = utcNow
+        };
+        settings.AssistantModel = normalizedModel;
+        settings.UpdatedByUserId = userId;
+        settings.UpdatedUtc = utcNow;
+
+        await _saveSettingsAsync(settings);
+
+        return CreateResponse(settings);
+    }
+
+    private AssistantModelSettings CreateResponse(SystemSettings? settings)
+    {
+        string configuredModel = _appOptions.AssistantOptions.Model;
+        string? modelOverride = settings?.AssistantModel;
+        bool isOverridden = !String.IsNullOrWhiteSpace(modelOverride);
+
+        return new AssistantModelSettings(
+            isOverridden ? modelOverride! : configuredModel,
+            configuredModel,
+            isOverridden);
+    }
+}
+
+public sealed record AssistantModelSettings(string Model, string ConfiguredModel, bool IsOverridden);

--- a/src/Exceptionless.Web/Assistant/AssistantService.cs
+++ b/src/Exceptionless.Web/Assistant/AssistantService.cs
@@ -17,6 +17,7 @@ public sealed class AssistantService(
     ExceptionlessMcpTools tools,
     AssistantToolContext assistantToolContext,
     AssistantConversationService assistantConversationService,
+    AssistantModelSettingsService assistantModelSettingsService,
     AssistantUsageService assistantUsageService,
     TimeProvider timeProvider,
     ILogger<AssistantService> logger)
@@ -42,6 +43,7 @@ public sealed class AssistantService(
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var options = appOptions.AssistantOptions;
+        string model = (await assistantModelSettingsService.GetAsync()).Model;
         AssistantConversationState? conversationState = null;
         if (!String.IsNullOrWhiteSpace(request.OrganizationId) && !String.IsNullOrWhiteSpace(request.ConversationId))
         {
@@ -112,7 +114,7 @@ public sealed class AssistantService(
             }
 
             await using var providerRequest = await assistantUsageService.StartProviderRequestAsync(request.OrganizationId, providerInputCharacters);
-            using var response = await SendRequestAsync(messages, options, allowTools, request, cancellationToken);
+            using var response = await SendRequestAsync(messages, options, model, allowTools, request, cancellationToken);
             providerRequest.MarkAccepted();
             await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
             using var reader = new StreamReader(stream);
@@ -382,7 +384,7 @@ public sealed class AssistantService(
         }
     }
 
-    private async Task<HttpResponseMessage> SendRequestAsync(List<object> messages, AssistantOptions options, bool allowTools, AssistantChatRequest chatRequest, CancellationToken cancellationToken)
+    private async Task<HttpResponseMessage> SendRequestAsync(List<object> messages, AssistantOptions options, string model, bool allowTools, AssistantChatRequest chatRequest, CancellationToken cancellationToken)
     {
         var client = httpClientFactory.CreateClient(nameof(AssistantService));
         using var providerRequest = new HttpRequestMessage(HttpMethod.Post, options.Endpoint);
@@ -391,7 +393,7 @@ public sealed class AssistantService(
         providerRequest.Headers.TryAddWithoutValidation("X-OpenRouter-Title", "Exceptionless");
         var payload = new Dictionary<string, object?>
         {
-            ["model"] = options.Model,
+            ["model"] = model,
             ["messages"] = messages,
             ["stream"] = true,
             ["max_tokens"] = AssistantLimits.MaximumOutputTokens,

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
@@ -4,6 +4,7 @@ import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-qu
 import type {
     AdminAssistantSettings,
     AdminAssistantUsage,
+    AdminEventSubmissionSettings,
     AdminStats,
     ElasticsearchInfo,
     ElasticsearchSnapshotsResponse,
@@ -11,7 +12,9 @@ import type {
     OAuthApplication,
     OAuthApplicationRequest,
     PredefinedSavedViewDefinition,
-    UpdateAssistantSettingsRequest
+    UpdateAssistantEnabledSettingsRequest,
+    UpdateAssistantSettingsRequest,
+    UpdateEventSubmissionSettingsRequest
 } from './models';
 
 export type RunMaintenanceJobParams = {
@@ -25,6 +28,7 @@ export const queryKeys = {
     assistantSettings: ['admin', 'assistant-settings'] as const,
     assistantUsage: (month: string) => ['admin', 'assistant-usage', month] as const,
     elasticsearch: ['admin', 'elasticsearch'] as const,
+    eventSubmissionSettings: ['admin', 'event-submission-settings'] as const,
     migrations: ['admin', 'migrations'] as const,
     oauthApplications: ['admin', 'oauth-applications'] as const,
     snapshots: ['admin', 'elasticsearch', 'snapshots'] as const,
@@ -138,6 +142,25 @@ export function getElasticsearchSnapshotsQuery() {
     }));
 }
 
+export function getEventSubmissionSettingsQuery() {
+    return createQuery<AdminEventSubmissionSettings, ProblemDetails>(() => ({
+        queryFn: async ({ signal }: { signal: AbortSignal }) => {
+            const client = useFetchClient();
+            const response = await client.getJSON<AdminEventSubmissionSettings>('admin/event-submission-settings', {
+                signal
+            });
+
+            if (!response.ok) {
+                throw response.problem;
+            }
+
+            return response.data!;
+        },
+        queryKey: queryKeys.eventSubmissionSettings,
+        staleTime: 30 * 1000
+    }));
+}
+
 export function getMigrationsQuery() {
     return createQuery<MigrationsResponse, ProblemDetails>(() => ({
         queryFn: async ({ signal }: { signal: AbortSignal }) => {
@@ -229,6 +252,26 @@ export function postOAuthApplicationMutation() {
     }));
 }
 
+export function putAdminAssistantEnabledSettingsMutation() {
+    const queryClient = useQueryClient();
+
+    return createMutation<AdminAssistantSettings, ProblemDetails, UpdateAssistantEnabledSettingsRequest>(() => ({
+        mutationFn: async (request) => {
+            const client = useFetchClient();
+            const response = await client.putJSON<AdminAssistantSettings>('admin/assistant-settings/enabled', request);
+
+            if (!response.ok) {
+                throw response.problem;
+            }
+
+            return response.data!;
+        },
+        onSuccess: (settings) => {
+            queryClient.setQueryData(queryKeys.assistantSettings, settings);
+        }
+    }));
+}
+
 export function putAdminAssistantSettingsMutation() {
     const queryClient = useQueryClient();
 
@@ -245,6 +288,26 @@ export function putAdminAssistantSettingsMutation() {
         },
         onSuccess: (settings) => {
             queryClient.setQueryData(queryKeys.assistantSettings, settings);
+        }
+    }));
+}
+
+export function putEventSubmissionSettingsMutation() {
+    const queryClient = useQueryClient();
+
+    return createMutation<AdminEventSubmissionSettings, ProblemDetails, UpdateEventSubmissionSettingsRequest>(() => ({
+        mutationFn: async (request) => {
+            const client = useFetchClient();
+            const response = await client.putJSON<AdminEventSubmissionSettings>('admin/event-submission-settings', request);
+
+            if (!response.ok) {
+                throw response.problem;
+            }
+
+            return response.data!;
+        },
+        onSuccess: (settings) => {
+            queryClient.setQueryData(queryKeys.eventSubmissionSettings, settings);
         }
     }));
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
@@ -1,3 +1,4 @@
+import { invalidateAssistantAccessQueries } from '$features/assistant/api.svelte';
 import { type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
 
@@ -266,8 +267,9 @@ export function putAdminAssistantEnabledSettingsMutation() {
 
             return response.data!;
         },
-        onSuccess: (settings) => {
+        onSuccess: async (settings) => {
             queryClient.setQueryData(queryKeys.assistantSettings, settings);
+            await invalidateAssistantAccessQueries(queryClient);
         }
     }));
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
@@ -2,6 +2,7 @@ import { type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
 
 import type {
+    AdminAssistantSettings,
     AdminAssistantUsage,
     AdminStats,
     ElasticsearchInfo,
@@ -9,7 +10,8 @@ import type {
     MigrationsResponse,
     OAuthApplication,
     OAuthApplicationRequest,
-    PredefinedSavedViewDefinition
+    PredefinedSavedViewDefinition,
+    UpdateAssistantSettingsRequest
 } from './models';
 
 export type RunMaintenanceJobParams = {
@@ -20,6 +22,7 @@ export type RunMaintenanceJobParams = {
 };
 
 export const queryKeys = {
+    assistantSettings: ['admin', 'assistant-settings'] as const,
     assistantUsage: (month: string) => ['admin', 'assistant-usage', month] as const,
     elasticsearch: ['admin', 'elasticsearch'] as const,
     migrations: ['admin', 'migrations'] as const,
@@ -45,6 +48,25 @@ export function deleteOAuthApplicationMutation() {
                 queryKey: queryKeys.oauthApplications
             });
         }
+    }));
+}
+
+export function getAdminAssistantSettingsQuery() {
+    return createQuery<AdminAssistantSettings, ProblemDetails>(() => ({
+        queryFn: async ({ signal }: { signal: AbortSignal }) => {
+            const client = useFetchClient();
+            const response = await client.getJSON<AdminAssistantSettings>('admin/assistant-settings', {
+                signal
+            });
+
+            if (!response.ok) {
+                throw response.problem;
+            }
+
+            return response.data!;
+        },
+        queryKey: queryKeys.assistantSettings,
+        staleTime: 30 * 1000
     }));
 }
 
@@ -203,6 +225,26 @@ export function postOAuthApplicationMutation() {
             queryClient.invalidateQueries({
                 queryKey: queryKeys.oauthApplications
             });
+        }
+    }));
+}
+
+export function putAdminAssistantSettingsMutation() {
+    const queryClient = useQueryClient();
+
+    return createMutation<AdminAssistantSettings, ProblemDetails, UpdateAssistantSettingsRequest>(() => ({
+        mutationFn: async (request) => {
+            const client = useFetchClient();
+            const response = await client.putJSON<AdminAssistantSettings>('admin/assistant-settings', request);
+
+            if (!response.ok) {
+                throw response.problem;
+            }
+
+            return response.data!;
+        },
+        onSuccess: (settings) => {
+            queryClient.setQueryData(queryKeys.assistantSettings, settings);
         }
     }));
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/models.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/models.ts
@@ -30,6 +30,12 @@ export type AdminAssistantOrganizationUsage = {
     turns: number;
 };
 
+export type AdminAssistantSettings = {
+    configured_model: string;
+    is_overridden: boolean;
+    model: string;
+};
+
 export type AdminAssistantUsage = {
     active_organizations: number;
     completion_tokens: number;
@@ -169,6 +175,10 @@ export type ShardMetric = {
     id: string;
     label: string;
     value: number;
+};
+
+export type UpdateAssistantSettingsRequest = {
+    model: null | string;
 };
 
 export const maintenanceActions: MaintenanceAction[] = [

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/models.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/models.ts
@@ -1,4 +1,4 @@
-import type { CountResult } from '$generated/api';
+import type { AssistantModelSettings, CountResult, UpdateAssistantSettings } from '$generated/api';
 
 export enum MigrationType {
     Versioned = 0,
@@ -30,11 +30,7 @@ export type AdminAssistantOrganizationUsage = {
     turns: number;
 };
 
-export type AdminAssistantSettings = {
-    configured_model: string;
-    is_overridden: boolean;
-    model: string;
-};
+export type AdminAssistantSettings = AssistantModelSettings;
 
 export type AdminAssistantUsage = {
     active_organizations: number;
@@ -177,9 +173,7 @@ export type ShardMetric = {
     value: number;
 };
 
-export type UpdateAssistantSettingsRequest = {
-    model: null | string;
-};
+export type UpdateAssistantSettingsRequest = UpdateAssistantSettings;
 
 export const maintenanceActions: MaintenanceAction[] = [
     {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/models.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/models.ts
@@ -1,4 +1,11 @@
-import type { AssistantModelSettings, CountResult, UpdateAssistantSettings } from '$generated/api';
+import type {
+    AssistantModelSettings,
+    CountResult,
+    EventSubmissionSettings,
+    UpdateAssistantEnabledSettings,
+    UpdateAssistantSettings,
+    UpdateEventSubmissionSettings
+} from '$generated/api';
 
 export enum MigrationType {
     Versioned = 0,
@@ -41,6 +48,8 @@ export type AdminAssistantUsage = {
     prompt_tokens: number;
     turns: number;
 };
+
+export type AdminEventSubmissionSettings = EventSubmissionSettings;
 
 export type AdminStats = {
     events: CountResult;
@@ -173,7 +182,9 @@ export type ShardMetric = {
     value: number;
 };
 
+export type UpdateAssistantEnabledSettingsRequest = UpdateAssistantEnabledSettings;
 export type UpdateAssistantSettingsRequest = UpdateAssistantSettings;
+export type UpdateEventSubmissionSettingsRequest = UpdateEventSubmissionSettings;
 
 export const maintenanceActions: MaintenanceAction[] = [
     {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/schemas.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/schemas.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { AssistantSettingsSchema } from './schemas';
+
+describe('assistant settings schema', () => {
+    it('accepts the GLM 5.3 Flash OpenRouter model ID', () => {
+        const result = AssistantSettingsSchema.safeParse({ model: 'z-ai/glm-5.3-flash' });
+
+        expect(result.success).toBe(true);
+    });
+
+    it('rejects an empty model ID', () => {
+        const result = AssistantSettingsSchema.safeParse({ model: '   ' });
+
+        expect(result.success).toBe(false);
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/schemas.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/schemas.ts
@@ -1,5 +1,10 @@
 import { array, boolean, date, type infer as Infer, object, string } from 'zod';
 
+export const AssistantSettingsSchema = object({
+    model: string().trim().min(1, 'Enter an OpenRouter model ID.').max(200)
+});
+export type AssistantSettingsFormData = Infer<typeof AssistantSettingsSchema>;
+
 export const RunMaintenanceJobSchema = object({
     confirmText: string().min(1),
     organizationId: string().optional(),

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
@@ -15,6 +15,94 @@ export enum BillingStatus {
   Unpaid = 4,
 }
 
+export interface AdminAssistantOrganizationUsage {
+  organization_id: string;
+  organization_name: string;
+  plan_id: string;
+  /** @format date-time */
+  last_used_utc: string;
+  /** @format int64 */
+  turns: number;
+  /** @format int64 */
+  completed: number;
+  /** @format int64 */
+  failed: number;
+  /** @format int64 */
+  cancelled: number;
+  /** @format int64 */
+  provider_requests: number;
+  /** @format int64 */
+  tool_calls: number;
+  /** @format int64 */
+  prompt_tokens: number;
+  /** @format int64 */
+  completion_tokens: number;
+  /** @format double */
+  cost_usd: number;
+  /** @format int64 */
+  blocked_by_concurrency: number;
+  /** @format int64 */
+  blocked_by_rate_limit: number;
+  /** @format int64 */
+  blocked_by_token_limit: number;
+  /** @format int64 */
+  blocked_by_cost_limit: number;
+  /** @format int64 */
+  monthly_token_limit?: null | number;
+  /** @format double */
+  monthly_cost_limit_usd?: null | number;
+  /** @format double */
+  token_utilization?: null | number;
+  /** @format double */
+  cost_utilization?: null | number;
+}
+
+export interface AdminAssistantUsageResponse {
+  /** @format date-time */
+  month: string;
+  /** @format int64 */
+  active_organizations: number;
+  /** @format int64 */
+  turns: number;
+  /** @format int64 */
+  prompt_tokens: number;
+  /** @format int64 */
+  completion_tokens: number;
+  /** @format double */
+  cost_usd: number;
+  organizations: AdminAssistantOrganizationUsage[];
+}
+
+export interface AssistantAccessResponse {
+  enabled: boolean;
+  has_access: boolean;
+  upgrade_required: boolean;
+  message?: null | string;
+  minimum_plan_id?: null | string;
+}
+
+export interface AssistantChatMessage {
+  role: string;
+  content: string;
+  is_suggested_action?: null | boolean;
+  suggested_action_label?: null | string;
+  suggested_action_path?: null | string;
+}
+
+export interface AssistantChatRequest {
+  messages: AssistantChatMessage[];
+  organization_id?: null | string;
+  project_id?: null | string;
+  path?: null | string;
+  conversation_id?: null | string;
+}
+
+export interface AssistantModelSettings {
+  model: string;
+  configured_model: string;
+  is_overridden: boolean;
+}
+
 export interface BillingPlan {
   id: string;
   name: string;
@@ -69,6 +157,16 @@ export interface ExternalAuthInfo {
   /** @format uri */
   redirectUri: string;
   inviteToken?: null | string;
+}
+
+export interface HttpValidationProblemDetails {
+  type?: null | string;
+  title?: null | string;
+  /** @format int32 */
+  status?: null | number;
+  detail?: null | string;
+  instance?: null | string;
+  errors: Record<string, string[]>;
 }
 
 /** Base interface for aggregation results. Concrete types include ValueAggregate, BucketAggregate, StatsAggregate, etc. See client-side type definitions for full type information. */
@@ -515,6 +613,10 @@ export interface StringValueFromBody {
 
 export interface TokenResult {
   token: string;
+}
+
+export interface UpdateAssistantSettings {
+  model?: null | string;
 }
 
 export interface UpdateEmailAddressResult {

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
@@ -101,6 +101,10 @@ export interface AssistantModelSettings {
   model: string;
   configured_model: string;
   is_overridden: boolean;
+  enabled: boolean;
+  configured_enabled: boolean;
+  is_enabled_overridden: boolean;
+  is_configured: boolean;
 }
 
 export interface BillingPlan {
@@ -149,6 +153,12 @@ export interface CountResult {
   total: number;
   aggregations?: null | Record<string, IAggregate>;
   data?: null | object;
+}
+
+export interface EventSubmissionSettings {
+  enabled: boolean;
+  configured_enabled: boolean;
+  is_overridden: boolean;
 }
 
 export interface ExternalAuthInfo {
@@ -615,6 +625,10 @@ export interface TokenResult {
   token: string;
 }
 
+export interface UpdateAssistantEnabledSettings {
+  enabled?: null | boolean;
+}
+
 export interface UpdateAssistantSettings {
   model?: null | string;
 }
@@ -628,6 +642,10 @@ export interface UpdateEvent {
   /** @format email */
   email_address?: null | string;
   description?: null | string;
+}
+
+export interface UpdateEventSubmissionSettings {
+  enabled?: null | boolean;
 }
 
 /** A class the tracks changes (i.e. the Delta) for a particular TEntityType. */

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
@@ -127,6 +127,10 @@ export const AssistantModelSettingsSchema = object({
   model: string().min(1, "Model is required"),
   configured_model: string().min(1, "Configured model is required"),
   is_overridden: boolean(),
+  enabled: boolean(),
+  configured_enabled: boolean(),
+  is_enabled_overridden: boolean(),
+  is_configured: boolean(),
 });
 export type AssistantModelSettingsFormData = Infer<
   typeof AssistantModelSettingsSchema
@@ -192,6 +196,15 @@ export const CountResultSchema = object({
   data: record(string(), unknown()).nullable(),
 });
 export type CountResultFormData = Infer<typeof CountResultSchema>;
+
+export const EventSubmissionSettingsSchema = object({
+  enabled: boolean(),
+  configured_enabled: boolean(),
+  is_overridden: boolean(),
+});
+export type EventSubmissionSettingsFormData = Infer<
+  typeof EventSubmissionSettingsSchema
+>;
 
 export const ExternalAuthInfoSchema = object({
   clientId: string().min(1, "Client id is required"),
@@ -717,6 +730,13 @@ export const TokenResultSchema = object({
 });
 export type TokenResultFormData = Infer<typeof TokenResultSchema>;
 
+export const UpdateAssistantEnabledSettingsSchema = object({
+  enabled: boolean().nullable().optional(),
+});
+export type UpdateAssistantEnabledSettingsFormData = Infer<
+  typeof UpdateAssistantEnabledSettingsSchema
+>;
+
 export const UpdateAssistantSettingsSchema = object({
   model: string()
     .min(1, "Model is required")
@@ -740,6 +760,13 @@ export const UpdateEventSchema = object({
   description: string().min(1, "Description is required").nullable().optional(),
 });
 export type UpdateEventFormData = Infer<typeof UpdateEventSchema>;
+
+export const UpdateEventSubmissionSettingsSchema = object({
+  enabled: boolean().nullable().optional(),
+});
+export type UpdateEventSubmissionSettingsFormData = Infer<
+  typeof UpdateEventSubmissionSettingsSchema
+>;
 
 export const UpdateProjectSchema = object({
   name: string().min(1, "Name is required").optional(),

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
@@ -35,6 +35,103 @@ export const BillingStatusSchema = union([
   literal(4),
 ]);
 
+export const AdminAssistantOrganizationUsageSchema = object({
+  organization_id: string().min(1, "Organization id is required"),
+  organization_name: string().min(1, "Organization name is required"),
+  plan_id: string().min(1, "Plan id is required"),
+  last_used_utc: iso.datetime(),
+  turns: int(),
+  completed: int(),
+  failed: int(),
+  cancelled: int(),
+  provider_requests: int(),
+  tool_calls: int(),
+  prompt_tokens: int(),
+  completion_tokens: int(),
+  cost_usd: number(),
+  blocked_by_concurrency: int(),
+  blocked_by_rate_limit: int(),
+  blocked_by_token_limit: int(),
+  blocked_by_cost_limit: int(),
+  monthly_token_limit: int().nullable(),
+  monthly_cost_limit_usd: number().nullable(),
+  token_utilization: number().nullable(),
+  cost_utilization: number().nullable(),
+});
+export type AdminAssistantOrganizationUsageFormData = Infer<
+  typeof AdminAssistantOrganizationUsageSchema
+>;
+
+export const AdminAssistantUsageResponseSchema = object({
+  month: iso.datetime(),
+  active_organizations: int(),
+  turns: int(),
+  prompt_tokens: int(),
+  completion_tokens: int(),
+  cost_usd: number(),
+  organizations: array(lazy(() => AdminAssistantOrganizationUsageSchema)),
+});
+export type AdminAssistantUsageResponseFormData = Infer<
+  typeof AdminAssistantUsageResponseSchema
+>;
+
+export const AssistantAccessResponseSchema = object({
+  enabled: boolean(),
+  has_access: boolean(),
+  upgrade_required: boolean(),
+  message: string().min(1, "Message is required").nullable().optional(),
+  minimum_plan_id: string()
+    .min(1, "Minimum plan id is required")
+    .nullable()
+    .optional(),
+});
+export type AssistantAccessResponseFormData = Infer<
+  typeof AssistantAccessResponseSchema
+>;
+
+export const AssistantChatMessageSchema = object({
+  role: string().min(1, "Role is required"),
+  content: string().min(1, "Content is required"),
+  is_suggested_action: boolean().nullable().optional(),
+  suggested_action_label: string()
+    .min(1, "Suggested action label is required")
+    .nullable()
+    .optional(),
+  suggested_action_path: string()
+    .min(1, "Suggested action path is required")
+    .nullable()
+    .optional(),
+});
+export type AssistantChatMessageFormData = Infer<
+  typeof AssistantChatMessageSchema
+>;
+
+export const AssistantChatRequestSchema = object({
+  messages: array(lazy(() => AssistantChatMessageSchema)),
+  organization_id: string()
+    .min(1, "Organization id is required")
+    .nullable()
+    .optional(),
+  project_id: string().min(1, "Project id is required").nullable().optional(),
+  path: string().min(1, "Path is required").nullable().optional(),
+  conversation_id: string()
+    .min(1, "Conversation id is required")
+    .nullable()
+    .optional(),
+});
+export type AssistantChatRequestFormData = Infer<
+  typeof AssistantChatRequestSchema
+>;
+
+export const AssistantModelSettingsSchema = object({
+  model: string().min(1, "Model is required"),
+  configured_model: string().min(1, "Configured model is required"),
+  is_overridden: boolean(),
+});
+export type AssistantModelSettingsFormData = Infer<
+  typeof AssistantModelSettingsSchema
+>;
+
 export const BillingPlanSchema = object({
   id: string().min(1, "Id is required"),
   name: string().min(1, "Name is required"),
@@ -106,6 +203,18 @@ export const ExternalAuthInfoSchema = object({
     .optional(),
 });
 export type ExternalAuthInfoFormData = Infer<typeof ExternalAuthInfoSchema>;
+
+export const HttpValidationProblemDetailsSchema = object({
+  type: string().min(1, "Type is required").nullable().optional(),
+  title: string().min(1, "Title is required").nullable().optional(),
+  status: int32().nullable().optional(),
+  detail: string().min(1, "Detail is required").nullable().optional(),
+  instance: string().min(1, "Instance is required").nullable().optional(),
+  errors: record(string(), array(string())),
+});
+export type HttpValidationProblemDetailsFormData = Infer<
+  typeof HttpValidationProblemDetailsSchema
+>;
 
 export const IAggregateSchema = object({
   data: record(string(), unknown()).optional(),
@@ -608,6 +717,17 @@ export const TokenResultSchema = object({
 });
 export type TokenResultFormData = Infer<typeof TokenResultSchema>;
 
+export const UpdateAssistantSettingsSchema = object({
+  model: string()
+    .min(1, "Model is required")
+    .max(200, "Model must be at most 200 characters")
+    .nullable()
+    .optional(),
+});
+export type UpdateAssistantSettingsFormData = Infer<
+  typeof UpdateAssistantSettingsSchema
+>;
+
 export const UpdateEmailAddressResultSchema = object({
   is_verified: boolean(),
 });
@@ -706,9 +826,7 @@ export const UserSchema = object({
     .optional(),
   password_reset_token_expiration: iso.datetime(),
   o_auth_accounts: array(lazy(() => OAuthAccountSchema)),
-  organization_preferences: array(
-    lazy(() => UserOrganizationPreferenceSchema),
-  ),
+  organization_preferences: array(lazy(() => UserOrganizationPreferenceSchema)),
   full_name: string().min(1, "Full name is required"),
   email_address: email(),
   avatar_file_name: string()
@@ -753,9 +871,7 @@ export const ViewCurrentUserSchema = object({
   hash: string().min(1, "Hash is required").nullable().optional(),
   has_local_account: boolean(),
   o_auth_accounts: array(lazy(() => OAuthAccountSchema)),
-  organization_preferences: array(
-    lazy(() => UserOrganizationPreferenceSchema),
-  ),
+  organization_preferences: array(lazy(() => UserOrganizationPreferenceSchema)),
   id: string()
     .length(24, "Id must be exactly 24 characters")
     .regex(/^[a-fA-F0-9]{24}$/, "Id has invalid format"),

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/exie/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/exie/+page.svelte
@@ -13,8 +13,14 @@
     import { Input } from '$comp/ui/input';
     import { Skeleton } from '$comp/ui/skeleton';
     import { Spinner } from '$comp/ui/spinner';
+    import { Switch } from '$comp/ui/switch';
     import * as Table from '$comp/ui/table';
-    import { getAdminAssistantSettingsQuery, getAdminAssistantUsageQuery, putAdminAssistantSettingsMutation } from '$features/admin/api.svelte';
+    import {
+        getAdminAssistantSettingsQuery,
+        getAdminAssistantUsageQuery,
+        putAdminAssistantEnabledSettingsMutation,
+        putAdminAssistantSettingsMutation
+    } from '$features/admin/api.svelte';
     import { getBlockedCount, getTotalTokens, getUsageRisk, getUtcMonthKey, type UsageRisk } from '$features/admin/assistant-usage';
     import { type AssistantSettingsFormData, AssistantSettingsSchema } from '$features/admin/schemas';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
@@ -44,11 +50,17 @@
 
     const currentMonth = getUtcMonthKey();
     const settingsQuery = getAdminAssistantSettingsQuery();
+    const updateEnabledSettings = putAdminAssistantEnabledSettingsMutation();
     const updateSettings = putAdminAssistantSettingsMutation();
+    let assistantEnabled = $state(false);
+    let loadedAvailabilityKey = $state<null | string>(null);
     let selectedMonth = $state(currentMonth);
     let loadedSettingsKey = $state<null | string>(null);
     const usageQuery = getAdminAssistantUsageQuery(() => selectedMonth);
     const settings = $derived(settingsQuery.data);
+    const availabilityKey = $derived(
+        settings ? JSON.stringify([settings.enabled, settings.configured_enabled, settings.is_enabled_overridden, settings.is_configured]) : null
+    );
     const settingsKey = $derived(settings ? JSON.stringify([settings.model, settings.configured_model, settings.is_overridden]) : null);
     const usage = $derived(usageQuery.data);
     const totalTokens = $derived((usage?.prompt_tokens ?? 0) + (usage?.completion_tokens ?? 0));
@@ -83,6 +95,15 @@
     }));
 
     $effect(() => {
+        if (!settings || loadedAvailabilityKey === availabilityKey) {
+            return;
+        }
+
+        loadedAvailabilityKey = availabilityKey;
+        assistantEnabled = settings.enabled;
+    });
+
+    $effect(() => {
         if (!settings || loadedSettingsKey === settingsKey) {
             return;
         }
@@ -100,6 +121,30 @@
             toast.success('Exie model reset to the deployment default.');
         } catch {
             toast.error('Failed to reset the Exie model.');
+        }
+    }
+
+    async function saveAvailability() {
+        try {
+            const saved = await updateEnabledSettings.mutateAsync({
+                enabled: assistantEnabled
+            });
+            assistantEnabled = saved.enabled;
+            toast.success(saved.enabled ? 'Exie is enabled.' : 'Exie is disabled.');
+        } catch {
+            toast.error('Failed to update Exie availability.');
+        }
+    }
+
+    async function resetAvailability() {
+        try {
+            const saved = await updateEnabledSettings.mutateAsync({
+                enabled: null
+            });
+            assistantEnabled = saved.enabled;
+            toast.success('Exie availability reset to the deployment default.');
+        } catch {
+            toast.error('Failed to reset Exie availability.');
         }
     }
 
@@ -146,6 +191,64 @@
 </script>
 
 <div class="flex flex-col gap-6">
+    <Card.Root>
+        <Card.Header>
+            <div class="flex flex-wrap items-center gap-2">
+                <Card.Title>Availability</Card.Title>
+                {#if settings}
+                    <Badge variant={settings.is_enabled_overridden ? 'secondary' : 'outline'}>
+                        {settings.is_enabled_overridden ? 'Runtime override' : 'Deployment default'}
+                    </Badge>
+                {/if}
+            </div>
+            <Card.Description>Enable or disable Exie for all organizations without restarting the app.</Card.Description>
+        </Card.Header>
+        {#if settingsQuery.isPending}
+            <Card.Content class="flex items-center gap-2">
+                <Spinner />
+                <Muted>Loading Exie availability...</Muted>
+            </Card.Content>
+        {:else if settingsQuery.isError}
+            <Card.Content>
+                <p class="text-destructive text-sm">Failed to load Exie availability.</p>
+            </Card.Content>
+        {:else}
+            <Card.Content class="space-y-2">
+                <div class="flex items-center justify-between gap-6 rounded-lg border p-4">
+                    <div class="space-y-1">
+                        <label class="text-sm font-medium" for="assistant-enabled">Exie enabled</label>
+                        <Muted class="text-xs"
+                            >Disabled Exie requests are rejected immediately. The deployment default is {settings?.configured_enabled
+                                ? 'enabled'
+                                : 'disabled'}.</Muted
+                        >
+                    </div>
+                    <Switch id="assistant-enabled" bind:checked={assistantEnabled} disabled={updateEnabledSettings.isPending} />
+                </div>
+                {#if settings && !settings.is_configured}
+                    <p class="text-destructive text-sm">An OpenRouter API key must be configured before Exie can be used.</p>
+                {/if}
+            </Card.Content>
+            <Card.Footer class="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                {#if settings?.is_enabled_overridden}
+                    <Button type="button" variant="outline" disabled={updateEnabledSettings.isPending} onclick={resetAvailability}>
+                        <RotateCcw data-icon="inline-start" />
+                        Reset to Deployment Default
+                    </Button>
+                {/if}
+                <Button type="button" disabled={updateEnabledSettings.isPending || assistantEnabled === settings?.enabled} onclick={saveAvailability}>
+                    {#if updateEnabledSettings.isPending}
+                        <Spinner data-icon="inline-start" />
+                        Saving...
+                    {:else}
+                        <Save data-icon="inline-start" />
+                        Save Availability
+                    {/if}
+                </Button>
+            </Card.Footer>
+        {/if}
+    </Card.Root>
+
     <Card.Root>
         <Card.Header>
             <div class="flex flex-wrap items-center gap-2">

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/exie/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/exie/+page.svelte
@@ -1,23 +1,34 @@
 <script lang="ts">
     import { resolve } from '$app/paths';
+    import ErrorMessage from '$comp/error-message.svelte';
     import Currency from '$comp/formatters/currency.svelte';
     import NumberCompact from '$comp/formatters/number-compact.svelte';
     import Number from '$comp/formatters/number.svelte';
     import TimeAgo from '$comp/formatters/time-ago.svelte';
     import { Muted } from '$comp/typography';
     import { Badge } from '$comp/ui/badge';
+    import { Button } from '$comp/ui/button';
     import * as Card from '$comp/ui/card';
+    import * as Field from '$comp/ui/field';
     import { Input } from '$comp/ui/input';
     import { Skeleton } from '$comp/ui/skeleton';
+    import { Spinner } from '$comp/ui/spinner';
     import * as Table from '$comp/ui/table';
-    import { getAdminAssistantUsageQuery } from '$features/admin/api.svelte';
+    import { getAdminAssistantSettingsQuery, getAdminAssistantUsageQuery, putAdminAssistantSettingsMutation } from '$features/admin/api.svelte';
     import { getBlockedCount, getTotalTokens, getUsageRisk, getUtcMonthKey, type UsageRisk } from '$features/admin/assistant-usage';
+    import { type AssistantSettingsFormData, AssistantSettingsSchema } from '$features/admin/schemas';
+    import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
     import Bot from '@lucide/svelte/icons/bot';
     import Building2 from '@lucide/svelte/icons/building-2';
     import Coins from '@lucide/svelte/icons/coins';
     import Gauge from '@lucide/svelte/icons/gauge';
     import MessagesSquare from '@lucide/svelte/icons/messages-square';
+    import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
+    import Save from '@lucide/svelte/icons/save';
     import Wrench from '@lucide/svelte/icons/wrench';
+    import { createForm } from '@tanstack/svelte-form';
+    import { toast } from 'svelte-sonner';
 
     function riskBadgeVariant(risk: UsageRisk): 'destructive' | 'outline' | 'yellow' {
         if (risk === 'critical') {
@@ -32,12 +43,65 @@
     }
 
     const currentMonth = getUtcMonthKey();
+    const settingsQuery = getAdminAssistantSettingsQuery();
+    const updateSettings = putAdminAssistantSettingsMutation();
     let selectedMonth = $state(currentMonth);
+    let loadedSettingsKey = $state<null | string>(null);
     const usageQuery = getAdminAssistantUsageQuery(() => selectedMonth);
+    const settings = $derived(settingsQuery.data);
+    const settingsKey = $derived(settings ? JSON.stringify([settings.model, settings.configured_model, settings.is_overridden]) : null);
     const usage = $derived(usageQuery.data);
     const totalTokens = $derived((usage?.prompt_tokens ?? 0) + (usage?.completion_tokens ?? 0));
     const averageCost = $derived(usage && usage.active_organizations > 0 ? usage.cost_usd / usage.active_organizations : 0);
     const tokensPerTurn = $derived(usage && usage.turns > 0 ? totalTokens / usage.turns : 0);
+
+    const settingsForm = createForm(() => ({
+        defaultValues: {
+            model: ''
+        } as AssistantSettingsFormData,
+        validators: {
+            onSubmit: AssistantSettingsSchema,
+            onSubmitAsync: async ({ value }) => {
+                try {
+                    const saved = await updateSettings.mutateAsync({
+                        model: value.model.trim()
+                    });
+                    settingsForm.setFieldValue('model', saved.model);
+                    toast.success(saved.is_overridden ? 'Exie model override saved.' : 'Exie is using the deployment-configured model.');
+                    return null;
+                } catch (error: unknown) {
+                    if (error instanceof ProblemDetails) {
+                        return problemDetailsToFormErrors(error);
+                    }
+
+                    return {
+                        form: 'Failed to update the Exie model.'
+                    };
+                }
+            }
+        }
+    }));
+
+    $effect(() => {
+        if (!settings || loadedSettingsKey === settingsKey) {
+            return;
+        }
+
+        loadedSettingsKey = settingsKey;
+        settingsForm.setFieldValue('model', settings.model);
+    });
+
+    async function resetModel() {
+        try {
+            const saved = await updateSettings.mutateAsync({
+                model: null
+            });
+            settingsForm.setFieldValue('model', saved.model);
+            toast.success('Exie model reset to the deployment default.');
+        } catch {
+            toast.error('Failed to reset the Exie model.');
+        }
+    }
 
     const statCards = $derived([
         {
@@ -81,7 +145,92 @@
     ]);
 </script>
 
-<div class="space-y-6">
+<div class="flex flex-col gap-6">
+    <Card.Root>
+        <Card.Header>
+            <div class="flex flex-wrap items-center gap-2">
+                <Card.Title>Model Configuration</Card.Title>
+                {#if settings}
+                    <Badge variant={settings.is_overridden ? 'secondary' : 'outline'}>
+                        {settings.is_overridden ? 'Runtime override' : 'Deployment default'}
+                    </Badge>
+                {/if}
+            </div>
+            <Card.Description>Choose the OpenRouter model used for new Exie conversations and turns. Changes apply without restarting the app.</Card.Description
+            >
+        </Card.Header>
+        {#if settingsQuery.isPending}
+            <Card.Content class="flex items-center gap-2">
+                <Spinner />
+                <Muted>Loading model configuration...</Muted>
+            </Card.Content>
+        {:else if settingsQuery.isError}
+            <Card.Content>
+                <p class="text-destructive text-sm">Failed to load the Exie model configuration.</p>
+            </Card.Content>
+        {:else}
+            <form
+                onsubmit={(event) => {
+                    event.preventDefault();
+                    void settingsForm.handleSubmit();
+                }}
+            >
+                <Card.Content>
+                    <Field.FieldGroup>
+                        <settingsForm.Field name="model">
+                            {#snippet children(field)}
+                                <Field.Field data-invalid={ariaInvalid(field)}>
+                                    <Field.Label for={field.name}>OpenRouter model ID</Field.Label>
+                                    <Input
+                                        id={field.name}
+                                        value={field.state.value}
+                                        onblur={field.handleBlur}
+                                        oninput={(event) => field.handleChange(event.currentTarget.value)}
+                                        aria-invalid={ariaInvalid(field)}
+                                        autocomplete="off"
+                                        placeholder="z-ai/glm-5.3-flash"
+                                    />
+                                    <Field.Description>
+                                        Enter a model slug such as
+                                        <a href="https://openrouter.ai/z-ai/glm-5.3-flash" target="_blank" rel="noopener noreferrer">z-ai/glm-5.3-flash</a>. The
+                                        deployment default is <code>{settings?.configured_model}</code>.
+                                    </Field.Description>
+                                    <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
+                                </Field.Field>
+                            {/snippet}
+                        </settingsForm.Field>
+                        <settingsForm.Subscribe selector={(state) => state.errors}>
+                            {#snippet children(errors)}
+                                <ErrorMessage message={getFormErrorMessages(errors)} />
+                            {/snippet}
+                        </settingsForm.Subscribe>
+                    </Field.FieldGroup>
+                </Card.Content>
+                <Card.Footer class="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                    {#if settings?.is_overridden}
+                        <Button type="button" variant="outline" disabled={updateSettings.isPending} onclick={resetModel}>
+                            <RotateCcw data-icon="inline-start" />
+                            Reset to Deployment Default
+                        </Button>
+                    {/if}
+                    <settingsForm.Subscribe selector={(state) => state.isSubmitting}>
+                        {#snippet children(isSubmitting)}
+                            <Button type="submit" disabled={isSubmitting || updateSettings.isPending}>
+                                {#if isSubmitting || updateSettings.isPending}
+                                    <Spinner data-icon="inline-start" />
+                                    Saving...
+                                {:else}
+                                    <Save data-icon="inline-start" />
+                                    Save Model
+                                {/if}
+                            </Button>
+                        {/snippet}
+                    </settingsForm.Subscribe>
+                </Card.Footer>
+            </form>
+        {/if}
+    </Card.Root>
+
     <div class="flex flex-wrap items-end justify-between gap-4">
         <Muted>Monthly Exie usage, provider cost, and plan-limit health across all organizations</Muted>
         <label class="flex flex-col gap-1 text-sm font-medium">

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/routes.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/routes.svelte.ts
@@ -7,6 +7,7 @@ import DatabaseZap from '@lucide/svelte/icons/database-zap';
 import KeyRound from '@lucide/svelte/icons/key-round';
 import LayoutDashboard from '@lucide/svelte/icons/layout-dashboard';
 import Play from '@lucide/svelte/icons/play';
+import Settings from '@lucide/svelte/icons/settings';
 
 import type { NavigationItem } from '../../routes.svelte';
 
@@ -32,6 +33,13 @@ export function routes(): NavigationItem[] {
             icon: Bot,
             show: (context) => context.user?.roles?.includes('global') ?? false,
             title: 'Exie'
+        },
+        {
+            group: 'System',
+            href: resolve('/(app)/system/settings'),
+            icon: Settings,
+            show: (context) => context.user?.roles?.includes('global') ?? false,
+            title: 'Settings'
         },
         {
             group: 'System',

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/settings/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/settings/+page.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+    import { Muted } from '$comp/typography';
+    import * as Alert from '$comp/ui/alert';
+    import { Badge } from '$comp/ui/badge';
+    import { Button } from '$comp/ui/button';
+    import * as Card from '$comp/ui/card';
+    import { Spinner } from '$comp/ui/spinner';
+    import { Switch } from '$comp/ui/switch';
+    import { getEventSubmissionSettingsQuery, putEventSubmissionSettingsMutation } from '$features/admin/api.svelte';
+    import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
+    import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
+    import Save from '@lucide/svelte/icons/save';
+    import { toast } from 'svelte-sonner';
+
+    const settingsQuery = getEventSubmissionSettingsQuery();
+    const updateSettings = putEventSubmissionSettingsMutation();
+    let eventSubmissionEnabled = $state(false);
+    let loadedSettingsKey = $state<null | string>(null);
+
+    const settings = $derived(settingsQuery.data);
+    const settingsKey = $derived(settings ? JSON.stringify([settings.enabled, settings.configured_enabled, settings.is_overridden]) : null);
+
+    $effect(() => {
+        if (!settings || loadedSettingsKey === settingsKey) {
+            return;
+        }
+
+        loadedSettingsKey = settingsKey;
+        eventSubmissionEnabled = settings.enabled;
+    });
+
+    async function saveEventSubmission() {
+        try {
+            const saved = await updateSettings.mutateAsync({
+                enabled: eventSubmissionEnabled
+            });
+            eventSubmissionEnabled = saved.enabled;
+            toast.success(saved.enabled ? 'Event submission is enabled.' : 'Event submission is disabled.');
+        } catch {
+            toast.error('Failed to update event submission.');
+        }
+    }
+
+    async function resetEventSubmission() {
+        try {
+            const saved = await updateSettings.mutateAsync({
+                enabled: null
+            });
+            eventSubmissionEnabled = saved.enabled;
+            toast.success('Event submission reset to the deployment default.');
+        } catch {
+            toast.error('Failed to reset event submission.');
+        }
+    }
+</script>
+
+<div class="space-y-6">
+    <Muted>Manage runtime system behavior</Muted>
+
+    <Card.Root>
+        <Card.Header>
+            <div class="flex flex-wrap items-center gap-2">
+                <Card.Title>Event Submission</Card.Title>
+                {#if settings}
+                    <Badge variant={settings.is_overridden ? 'secondary' : 'outline'}>
+                        {settings.is_overridden ? 'Runtime override' : 'Deployment default'}
+                    </Badge>
+                {/if}
+            </div>
+            <Card.Description>Control whether Exceptionless accepts new events without restarting the app.</Card.Description>
+        </Card.Header>
+        {#if settingsQuery.isPending}
+            <Card.Content class="flex items-center gap-2">
+                <Spinner />
+                <Muted>Loading event submission settings...</Muted>
+            </Card.Content>
+        {:else if settingsQuery.isError}
+            <Card.Content>
+                <p class="text-destructive text-sm">Failed to load event submission settings.</p>
+            </Card.Content>
+        {:else}
+            <Card.Content class="space-y-4">
+                <div class="flex items-center justify-between gap-6 rounded-lg border p-4">
+                    <div class="space-y-1">
+                        <label class="text-sm font-medium" for="event-submission-enabled">Accept event submissions</label>
+                        <Muted class="text-xs">
+                            The deployment default is {settings?.configured_enabled ? 'enabled' : 'disabled'}. Changes apply to new requests immediately.
+                        </Muted>
+                    </div>
+                    <Switch id="event-submission-enabled" bind:checked={eventSubmissionEnabled} disabled={updateSettings.isPending} />
+                </div>
+
+                {#if !eventSubmissionEnabled}
+                    <Alert.Root variant="destructive">
+                        <AlertTriangle />
+                        <Alert.Title>Incoming events will be rejected with HTTP 503.</Alert.Title>
+                        <Alert.Description>Session heartbeats remain successful but will not record activity while submission is disabled.</Alert.Description>
+                    </Alert.Root>
+                {/if}
+            </Card.Content>
+            <Card.Footer class="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                {#if settings?.is_overridden}
+                    <Button type="button" variant="outline" disabled={updateSettings.isPending} onclick={resetEventSubmission}>
+                        <RotateCcw data-icon="inline-start" />
+                        Reset to Deployment Default
+                    </Button>
+                {/if}
+                <Button type="button" disabled={updateSettings.isPending || eventSubmissionEnabled === settings?.enabled} onclick={saveEventSubmission}>
+                    {#if updateSettings.isPending}
+                        <Spinner data-icon="inline-start" />
+                        Saving...
+                    {:else}
+                        <Save data-icon="inline-start" />
+                        Save Setting
+                    {/if}
+                </Button>
+            </Card.Footer>
+        {/if}
+    </Card.Root>
+</div>

--- a/src/Exceptionless.Web/Models/Admin/UpdateAssistantEnabledSettings.cs
+++ b/src/Exceptionless.Web/Models/Admin/UpdateAssistantEnabledSettings.cs
@@ -1,0 +1,6 @@
+namespace Exceptionless.Web.Models.Admin;
+
+public sealed record UpdateAssistantEnabledSettings
+{
+    public bool? Enabled { get; init; }
+}

--- a/src/Exceptionless.Web/Models/Admin/UpdateAssistantSettings.cs
+++ b/src/Exceptionless.Web/Models/Admin/UpdateAssistantSettings.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Exceptionless.Web.Models.Admin;
+
+public sealed record UpdateAssistantSettings
+{
+    [MaxLength(200)]
+    public string? Model { get; init; }
+}

--- a/src/Exceptionless.Web/Models/Admin/UpdateEventSubmissionSettings.cs
+++ b/src/Exceptionless.Web/Models/Admin/UpdateEventSubmissionSettings.cs
@@ -1,0 +1,8 @@
+namespace Exceptionless.Web.Models.Admin;
+
+public sealed record UpdateEventSubmissionSettings
+{
+    public bool? Enabled { get; init; }
+}
+
+public sealed record EventSubmissionSettings(bool Enabled, bool ConfiguredEnabled, bool IsOverridden);

--- a/src/Exceptionless.Web/Program.cs
+++ b/src/Exceptionless.Web/Program.cs
@@ -194,6 +194,7 @@ public partial class Program
             builder.Services.AddScoped<AssistantToolContext>();
             builder.Services.AddScoped<AssistantAccessService>();
             builder.Services.AddScoped<AssistantConversationService>();
+            builder.Services.AddSingleton<AssistantModelSettingsService>();
             builder.Services.AddScoped<AssistantUsageService>();
             builder.Services.AddScoped<ExceptionlessMcpTools>();
             builder.Services.AddScoped<AssistantService>();

--- a/src/Exceptionless.Web/Utility/Handlers/OverageMiddleware.cs
+++ b/src/Exceptionless.Web/Utility/Handlers/OverageMiddleware.cs
@@ -12,15 +12,17 @@ public sealed class OverageMiddleware
     private readonly UsageService _usageService;
     private readonly IOrganizationRepository _organizationRepository;
     private readonly AppOptions _appOptions;
+    private readonly SystemSettingsService _systemSettingsService;
     private readonly ILogger _logger;
     private readonly RequestDelegate _next;
 
-    public OverageMiddleware(RequestDelegate next, UsageService usageService, IOrganizationRepository organizationRepository, AppOptions appOptions, ILogger<OverageMiddleware> logger)
+    public OverageMiddleware(RequestDelegate next, UsageService usageService, IOrganizationRepository organizationRepository, AppOptions appOptions, SystemSettingsService systemSettingsService, ILogger<OverageMiddleware> logger)
     {
         _next = next;
         _usageService = usageService;
         _organizationRepository = organizationRepository;
         _appOptions = appOptions;
+        _systemSettingsService = systemSettingsService;
         _logger = logger;
     }
 
@@ -39,7 +41,7 @@ public sealed class OverageMiddleware
             return;
         }
 
-        if (_appOptions.EventSubmissionDisabled)
+        if (!await _systemSettingsService.IsEventSubmissionEnabledAsync())
         {
             context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
             return;

--- a/src/Exceptionless.Web/Utility/Handlers/RecordSessionHeartbeatMiddleware.cs
+++ b/src/Exceptionless.Web/Utility/Handlers/RecordSessionHeartbeatMiddleware.cs
@@ -1,5 +1,6 @@
 ﻿using Exceptionless.Core;
 using Exceptionless.Core.Extensions;
+using Exceptionless.Core.Services;
 using Exceptionless.Web.Extensions;
 using Foundatio.Caching;
 
@@ -9,17 +10,19 @@ public sealed class RecordSessionHeartbeatMiddleware
 {
     private readonly ICacheClient _cache;
     private readonly AppOptions _appOptions;
+    private readonly SystemSettingsService _systemSettingsService;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger _logger;
     private readonly RequestDelegate _next;
     private static readonly PathString _heartbeatPath = new("/api/v2/events/session/heartbeat");
 
-    public RecordSessionHeartbeatMiddleware(RequestDelegate next, ICacheClient cache, AppOptions appOptions,
+    public RecordSessionHeartbeatMiddleware(RequestDelegate next, ICacheClient cache, AppOptions appOptions, SystemSettingsService systemSettingsService,
         TimeProvider timeProvider, ILogger<ProjectConfigMiddleware> logger)
     {
         _next = next;
         _cache = cache;
         _appOptions = appOptions;
+        _systemSettingsService = systemSettingsService;
         _timeProvider = timeProvider;
         _logger = logger;
     }
@@ -47,7 +50,7 @@ public sealed class RecordSessionHeartbeatMiddleware
             return;
         }
 
-        if (_appOptions.EventSubmissionDisabled || !context.Request.Query.TryGetValue("id", out var id) || String.IsNullOrEmpty(id))
+        if (!await _systemSettingsService.IsEventSubmissionEnabledAsync() || !context.Request.Query.TryGetValue("id", out var id) || String.IsNullOrEmpty(id))
         {
             context.Response.StatusCode = StatusCodes.Status200OK;
             return;

--- a/tests/Exceptionless.Tests/Api/Data/endpoint-manifest.json
+++ b/tests/Exceptionless.Tests/Api/Data/endpoint-manifest.json
@@ -261,6 +261,30 @@
   },
   {
     "method": "GET",
+    "route": "/api/v2/admin/assistant-settings",
+    "displayName": "HTTP: GET api/v2/admin/assistant-settings",
+    "tags": [],
+    "allowAnonymous": false,
+    "authorizationPolicies": [
+      "GlobalAdminPolicy"
+    ],
+    "authorizationRoles": [],
+    "authenticationSchemes": []
+  },
+  {
+    "method": "PUT",
+    "route": "/api/v2/admin/assistant-settings",
+    "displayName": "HTTP: PUT api/v2/admin/assistant-settings",
+    "tags": [],
+    "allowAnonymous": false,
+    "authorizationPolicies": [
+      "GlobalAdminPolicy"
+    ],
+    "authorizationRoles": [],
+    "authenticationSchemes": []
+  },
+  {
+    "method": "GET",
     "route": "/api/v2/admin/assistant-usage",
     "displayName": "HTTP: GET api/v2/admin/assistant-usage =\u003E GetAssistantUsageAsync",
     "tags": [],

--- a/tests/Exceptionless.Tests/Api/Data/endpoint-manifest.json
+++ b/tests/Exceptionless.Tests/Api/Data/endpoint-manifest.json
@@ -288,6 +288,20 @@
     "authenticationSchemes": []
   },
   {
+    "method": "PUT",
+    "route": "/api/v2/admin/assistant-settings/enabled",
+    "displayName": "HTTP: PUT api/v2/admin/assistant-settings/enabled",
+    "tags": [
+      "AdminEndpoints"
+    ],
+    "allowAnonymous": false,
+    "authorizationPolicies": [
+      "GlobalAdminPolicy"
+    ],
+    "authorizationRoles": [],
+    "authenticationSchemes": []
+  },
+  {
     "method": "GET",
     "route": "/api/v2/admin/assistant-usage",
     "displayName": "HTTP: GET api/v2/admin/assistant-usage =\u003E GetAssistantUsageAsync",
@@ -343,6 +357,34 @@
     "displayName": "HTTP: GET /api/v2/admin/elasticsearch/snapshots",
     "tags": [
       "Admin"
+    ],
+    "allowAnonymous": false,
+    "authorizationPolicies": [
+      "GlobalAdminPolicy"
+    ],
+    "authorizationRoles": [],
+    "authenticationSchemes": []
+  },
+  {
+    "method": "GET",
+    "route": "/api/v2/admin/event-submission-settings",
+    "displayName": "HTTP: GET api/v2/admin/event-submission-settings =\u003E GetEventSubmissionSettingsAsync",
+    "tags": [
+      "AdminEndpoints"
+    ],
+    "allowAnonymous": false,
+    "authorizationPolicies": [
+      "GlobalAdminPolicy"
+    ],
+    "authorizationRoles": [],
+    "authenticationSchemes": []
+  },
+  {
+    "method": "PUT",
+    "route": "/api/v2/admin/event-submission-settings",
+    "displayName": "HTTP: PUT api/v2/admin/event-submission-settings =\u003E UpdateEventSubmissionSettingsAsync",
+    "tags": [
+      "AdminEndpoints"
     ],
     "allowAnonymous": false,
     "authorizationPolicies": [

--- a/tests/Exceptionless.Tests/Api/Data/endpoint-manifest.json
+++ b/tests/Exceptionless.Tests/Api/Data/endpoint-manifest.json
@@ -263,7 +263,9 @@
     "method": "GET",
     "route": "/api/v2/admin/assistant-settings",
     "displayName": "HTTP: GET api/v2/admin/assistant-settings",
-    "tags": [],
+    "tags": [
+      "AdminEndpoints"
+    ],
     "allowAnonymous": false,
     "authorizationPolicies": [
       "GlobalAdminPolicy"
@@ -275,7 +277,9 @@
     "method": "PUT",
     "route": "/api/v2/admin/assistant-settings",
     "displayName": "HTTP: PUT api/v2/admin/assistant-settings",
-    "tags": [],
+    "tags": [
+      "AdminEndpoints"
+    ],
     "allowAnonymous": false,
     "authorizationPolicies": [
       "GlobalAdminPolicy"

--- a/tests/Exceptionless.Tests/Api/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Api/Data/openapi.json
@@ -248,6 +248,132 @@
         }
       }
     },
+    "/api/v2/admin/assistant-settings/enabled": {
+      "put": {
+        "tags": [
+          "AdminEndpoints"
+        ],
+        "summary": "Update Exie assistant availability",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAssistantEnabledSettings"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAssistantEnabledSettings"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantModelSettings"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/admin/event-submission-settings": {
+      "get": {
+        "tags": [
+          "AdminEndpoints"
+        ],
+        "summary": "Get event submission settings",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventSubmissionSettings"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "AdminEndpoints"
+        ],
+        "summary": "Update event submission settings",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateEventSubmissionSettings"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateEventSubmissionSettings"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventSubmissionSettings"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/admin/assistant-usage": {
       "get": {
         "tags": [
@@ -11570,7 +11696,11 @@
         "required": [
           "model",
           "configured_model",
-          "is_overridden"
+          "is_overridden",
+          "enabled",
+          "configured_enabled",
+          "is_enabled_overridden",
+          "is_configured"
         ],
         "type": "object",
         "properties": {
@@ -11581,6 +11711,18 @@
             "type": "string"
           },
           "is_overridden": {
+            "type": "boolean"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "configured_enabled": {
+            "type": "boolean"
+          },
+          "is_enabled_overridden": {
+            "type": "boolean"
+          },
+          "is_configured": {
             "type": "boolean"
           }
         }
@@ -11769,6 +11911,25 @@
               "null",
               "object"
             ]
+          }
+        }
+      },
+      "EventSubmissionSettings": {
+        "required": [
+          "enabled",
+          "configured_enabled",
+          "is_overridden"
+        ],
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "configured_enabled": {
+            "type": "boolean"
+          },
+          "is_overridden": {
+            "type": "boolean"
           }
         }
       },
@@ -13305,6 +13466,17 @@
           }
         }
       },
+      "UpdateAssistantEnabledSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          }
+        }
+      },
       "UpdateAssistantSettings": {
         "type": "object",
         "properties": {
@@ -13346,6 +13518,17 @@
           }
         },
         "description": "A class the tracks changes (i.e. the Delta) for a particular TEntityType."
+      },
+      "UpdateEventSubmissionSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          }
+        }
       },
       "UpdateProject": {
         "type": "object",

--- a/tests/Exceptionless.Tests/Api/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Api/Data/openapi.json
@@ -173,6 +173,81 @@
         "deprecated": true
       }
     },
+    "/api/v2/admin/assistant-settings": {
+      "get": {
+        "tags": [
+          "AdminEndpoints"
+        ],
+        "summary": "Get Exie assistant settings",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantModelSettings"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "AdminEndpoints"
+        ],
+        "summary": "Update Exie assistant settings",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAssistantSettings"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAssistantSettings"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantModelSettings"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/admin/assistant-usage": {
       "get": {
         "tags": [
@@ -11491,6 +11566,25 @@
           }
         }
       },
+      "AssistantModelSettings": {
+        "required": [
+          "model",
+          "configured_model",
+          "is_overridden"
+        ],
+        "type": "object",
+        "properties": {
+          "model": {
+            "type": "string"
+          },
+          "configured_model": {
+            "type": "string"
+          },
+          "is_overridden": {
+            "type": "boolean"
+          }
+        }
+      },
       "BillingPlan": {
         "required": [
           "id",
@@ -13208,6 +13302,18 @@
         "properties": {
           "token": {
             "type": "string"
+          }
+        }
+      },
+      "UpdateAssistantSettings": {
+        "type": "object",
+        "properties": {
+          "model": {
+            "maxLength": 200,
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },

--- a/tests/Exceptionless.Tests/Api/Endpoints/AdminEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/AdminEndpointTests.cs
@@ -101,6 +101,8 @@ public class AdminEndpointTests : IntegrationTestsBase
         Assert.NotNull(initial);
         Assert.Equal(initial.ConfiguredModel, initial.Model);
         Assert.False(initial.IsOverridden);
+        Assert.Equal(initial.ConfiguredEnabled, initial.Enabled);
+        Assert.False(initial.IsEnabledOverridden);
 
         var updated = await SendRequestAsAsync<AssistantModelSettingsResponse>(request => request
             .Put()
@@ -130,6 +132,24 @@ public class AdminEndpointTests : IntegrationTestsBase
         Assert.Equal("z-ai/glm-5.3-flash", afterCacheClear.Model);
         Assert.True(afterCacheClear.IsOverridden);
 
+        var restoredDefault = await SendRequestAsAsync<AssistantModelSettingsResponse>(request => request
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "assistant-settings")
+            .Content(new UpdateAssistantSettings { Model = initial.ConfiguredModel })
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(restoredDefault);
+        Assert.Equal(initial.ConfiguredModel, restoredDefault.Model);
+        Assert.False(restoredDefault.IsOverridden);
+
+        await SendRequestAsAsync<AssistantModelSettingsResponse>(request => request
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "assistant-settings")
+            .Content(new UpdateAssistantSettings { Model = "z-ai/glm-5.3-flash" })
+            .StatusCodeShouldBeOk());
+
         var cleared = await SendRequestAsAsync<AssistantModelSettingsResponse>(request => request
             .Put()
             .AsGlobalAdminUser()
@@ -140,6 +160,159 @@ public class AdminEndpointTests : IntegrationTestsBase
         Assert.NotNull(cleared);
         Assert.Equal(initial.ConfiguredModel, cleared.Model);
         Assert.False(cleared.IsOverridden);
+    }
+
+    [Fact]
+    public async Task AssistantSettingsAsync_AsGlobalAdmin_UpdatesAndClearsRuntimeEnabledOverride()
+    {
+        var initial = await SendRequestAsAsync<AssistantModelSettingsResponse>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "assistant-settings")
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(initial);
+
+        var updated = await SendRequestAsAsync<AssistantModelSettingsResponse>(request => request
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "assistant-settings", "enabled")
+            .Content(new UpdateAssistantEnabledSettings { Enabled = !initial.ConfiguredEnabled })
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(updated);
+        Assert.Equal(!initial.ConfiguredEnabled, updated.Enabled);
+        Assert.True(updated.IsEnabledOverridden);
+
+        await GetService<ICacheClient>().RemoveAllAsync();
+        var afterCacheClear = await SendRequestAsAsync<AssistantModelSettingsResponse>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "assistant-settings")
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(afterCacheClear);
+        Assert.Equal(updated.Enabled, afterCacheClear.Enabled);
+        Assert.True(afterCacheClear.IsEnabledOverridden);
+
+        var restoredDefault = await SendRequestAsAsync<AssistantModelSettingsResponse>(request => request
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "assistant-settings", "enabled")
+            .Content(new UpdateAssistantEnabledSettings { Enabled = initial.ConfiguredEnabled })
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(restoredDefault);
+        Assert.Equal(initial.ConfiguredEnabled, restoredDefault.Enabled);
+        Assert.False(restoredDefault.IsEnabledOverridden);
+
+        await SendRequestAsAsync<AssistantModelSettingsResponse>(request => request
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "assistant-settings", "enabled")
+            .Content(new UpdateAssistantEnabledSettings { Enabled = !initial.ConfiguredEnabled })
+            .StatusCodeShouldBeOk());
+
+        var cleared = await SendRequestAsAsync<AssistantModelSettingsResponse>(request => request
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "assistant-settings", "enabled")
+            .Content(new UpdateAssistantEnabledSettings { Enabled = null })
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(cleared);
+        Assert.Equal(initial.ConfiguredEnabled, cleared.Enabled);
+        Assert.False(cleared.IsEnabledOverridden);
+    }
+
+    [Fact]
+    public async Task EventSubmissionSettingsAsync_AsGlobalAdmin_UpdatesAndClearsRuntimeOverride()
+    {
+        var initial = await SendRequestAsAsync<EventSubmissionSettings>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "event-submission-settings")
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(initial);
+        Assert.Equal(initial.ConfiguredEnabled, initial.Enabled);
+        Assert.False(initial.IsOverridden);
+
+        var updated = await SendRequestAsAsync<EventSubmissionSettings>(request => request
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "event-submission-settings")
+            .Content(new UpdateEventSubmissionSettings { Enabled = !initial.ConfiguredEnabled })
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(updated);
+        Assert.Equal(!initial.ConfiguredEnabled, updated.Enabled);
+        Assert.True(updated.IsOverridden);
+
+        await GetService<ICacheClient>().RemoveAllAsync();
+        var afterCacheClear = await SendRequestAsAsync<EventSubmissionSettings>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "event-submission-settings")
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(afterCacheClear);
+        Assert.Equal(updated.Enabled, afterCacheClear.Enabled);
+        Assert.True(afterCacheClear.IsOverridden);
+
+        var restoredDefault = await SendRequestAsAsync<EventSubmissionSettings>(request => request
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "event-submission-settings")
+            .Content(new UpdateEventSubmissionSettings { Enabled = initial.ConfiguredEnabled })
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(restoredDefault);
+        Assert.Equal(initial.ConfiguredEnabled, restoredDefault.Enabled);
+        Assert.False(restoredDefault.IsOverridden);
+
+        await SendRequestAsAsync<EventSubmissionSettings>(request => request
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "event-submission-settings")
+            .Content(new UpdateEventSubmissionSettings { Enabled = !initial.ConfiguredEnabled })
+            .StatusCodeShouldBeOk());
+
+        var cleared = await SendRequestAsAsync<EventSubmissionSettings>(request => request
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "event-submission-settings")
+            .Content(new UpdateEventSubmissionSettings { Enabled = null })
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(cleared);
+        Assert.Equal(initial.ConfiguredEnabled, cleared.Enabled);
+        Assert.False(cleared.IsOverridden);
+    }
+
+    [Fact]
+    public async Task RuntimeSettingsAsync_LegacyDocumentUsesDeploymentDefaults()
+    {
+        await GetService<ISystemSettingsRepository>().SaveAsync(new SystemSettings
+        {
+            AssistantModel = "legacy/model",
+            CreatedByUserId = TestConstants.UserId,
+            CreatedUtc = TimeProvider.GetUtcNow().UtcDateTime,
+            UpdatedByUserId = TestConstants.UserId,
+            UpdatedUtc = TimeProvider.GetUtcNow().UtcDateTime
+        }, options => options.ImmediateConsistency());
+
+        var assistantSettings = await SendRequestAsAsync<AssistantModelSettingsResponse>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "assistant-settings")
+            .StatusCodeShouldBeOk());
+        var eventSubmissionSettings = await SendRequestAsAsync<EventSubmissionSettings>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "event-submission-settings")
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(assistantSettings);
+        Assert.Equal(assistantSettings.ConfiguredEnabled, assistantSettings.Enabled);
+        Assert.False(assistantSettings.IsEnabledOverridden);
+        Assert.NotNull(eventSubmissionSettings);
+        Assert.Equal(eventSubmissionSettings.ConfiguredEnabled, eventSubmissionSettings.Enabled);
+        Assert.False(eventSubmissionSettings.IsOverridden);
     }
 
     [Fact]
@@ -1031,6 +1204,13 @@ public class AdminEndpointTests : IntegrationTestsBase
             .StatusCodeShouldBeForbidden());
     }
 
-    private sealed record AssistantModelSettingsResponse(string Model, string ConfiguredModel, bool IsOverridden);
+    private sealed record AssistantModelSettingsResponse(
+        string Model,
+        string ConfiguredModel,
+        bool IsOverridden,
+        bool Enabled,
+        bool ConfiguredEnabled,
+        bool IsEnabledOverridden,
+        bool IsConfigured);
     private sealed record RequeueResult([property: JsonPropertyName("enqueued")] int Enqueued);
 }

--- a/tests/Exceptionless.Tests/Api/Endpoints/AdminEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/AdminEndpointTests.cs
@@ -8,6 +8,7 @@ using Exceptionless.Tests.Extensions;
 using Exceptionless.Tests.Utility;
 using Exceptionless.Web.Api.Handlers;
 using Exceptionless.Web.Models.Admin;
+using Foundatio.Caching;
 using Foundatio.Jobs;
 using Foundatio.Queues;
 using Foundatio.Repositories;
@@ -87,6 +88,78 @@ public class AdminEndpointTests : IntegrationTestsBase
         Assert.Equal(5m, usage.MonthlyCostLimitUsd);
         Assert.Equal(0.0005m, usage.TokenUtilization);
         Assert.Equal(0.0005m, usage.CostUtilization);
+    }
+
+    [Fact]
+    public async Task AssistantSettingsAsync_AsGlobalAdmin_UpdatesAndClearsRuntimeModelOverride()
+    {
+        var initial = await SendRequestAsAsync<AssistantModelSettingsResponse>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "assistant-settings")
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(initial);
+        Assert.Equal(initial.ConfiguredModel, initial.Model);
+        Assert.False(initial.IsOverridden);
+
+        var updated = await SendRequestAsAsync<AssistantModelSettingsResponse>(request => request
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "assistant-settings")
+            .Content(new UpdateAssistantSettings { Model = "  z-ai/glm-5.3-flash  " })
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(updated);
+        Assert.Equal("z-ai/glm-5.3-flash", updated.Model);
+        Assert.Equal(initial.ConfiguredModel, updated.ConfiguredModel);
+        Assert.True(updated.IsOverridden);
+
+        var persistedSettings = await GetService<ISystemSettingsRepository>().GetByIdAsync(SystemSettings.DefaultId, options => options.ImmediateConsistency());
+        Assert.NotNull(persistedSettings);
+        Assert.Equal("z-ai/glm-5.3-flash", persistedSettings.AssistantModel);
+        Assert.False(String.IsNullOrWhiteSpace(persistedSettings.CreatedByUserId));
+        Assert.False(String.IsNullOrWhiteSpace(persistedSettings.UpdatedByUserId));
+
+        await GetService<ICacheClient>().RemoveAllAsync();
+        var afterCacheClear = await SendRequestAsAsync<AssistantModelSettingsResponse>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "assistant-settings")
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(afterCacheClear);
+        Assert.Equal("z-ai/glm-5.3-flash", afterCacheClear.Model);
+        Assert.True(afterCacheClear.IsOverridden);
+
+        var cleared = await SendRequestAsAsync<AssistantModelSettingsResponse>(request => request
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "assistant-settings")
+            .Content(new UpdateAssistantSettings { Model = null })
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(cleared);
+        Assert.Equal(initial.ConfiguredModel, cleared.Model);
+        Assert.False(cleared.IsOverridden);
+    }
+
+    [Fact]
+    public Task AssistantSettingsAsync_AsOrganizationUser_ReturnsForbidden()
+    {
+        return SendRequestAsync(request => request
+            .AsTestOrganizationUser()
+            .AppendPaths("admin", "assistant-settings")
+            .StatusCodeShouldBeForbidden());
+    }
+
+    [Fact]
+    public Task AssistantSettingsAsync_ModelIsTooLong_ReturnsUnprocessableEntity()
+    {
+        return SendRequestAsync(request => request
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "assistant-settings")
+            .Content(new UpdateAssistantSettings { Model = new string('m', 201) })
+            .StatusCodeShouldBeUnprocessableEntity());
     }
 
     protected override async Task ResetDataAsync()
@@ -958,5 +1031,6 @@ public class AdminEndpointTests : IntegrationTestsBase
             .StatusCodeShouldBeForbidden());
     }
 
+    private sealed record AssistantModelSettingsResponse(string Model, string ConfiguredModel, bool IsOverridden);
     private sealed record RequeueResult([property: JsonPropertyName("enqueued")] int Enqueued);
 }

--- a/tests/Exceptionless.Tests/Api/Endpoints/StatusEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/StatusEndpointTests.cs
@@ -1,9 +1,13 @@
 using System.Text.Json;
 using Exceptionless.Core.Messaging.Models;
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Utility;
 using Exceptionless.DateTimeExtensions;
 using Exceptionless.Tests.Extensions;
 using Exceptionless.Web.Models;
+using Foundatio.Caching;
+using Foundatio.Repositories;
 using FluentRest;
 using Xunit;
 
@@ -122,6 +126,22 @@ public class StatusEndpointTests : IntegrationTestsBase
         Assert.Equal(SystemNotificationLevel.Info, notification.Level);
         Assert.Equal(SystemNotificationTarget.Both, notification.Target);
         Assert.True(notification.Date.IsAfterOrEqual(utcNow));
+
+        var settings = await GetService<ISystemSettingsRepository>().GetByIdAsync(SystemSettings.DefaultId, options => options.ImmediateConsistency());
+        Assert.NotNull(settings?.SystemNotification);
+        Assert.Equal(notification.Message, settings.SystemNotification.Message);
+        Assert.Equal(notification.Level, settings.SystemNotification.Level);
+        Assert.Equal(notification.Target, settings.SystemNotification.Target);
+
+        await GetService<ICacheClient>().RemoveAllAsync();
+        var afterCacheClear = await SendRequestAsAsync<SystemNotification>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("notifications/system")
+            .StatusCodeShouldBeOk());
+        Assert.NotNull(afterCacheClear);
+        Assert.Equal(notification.Message, afterCacheClear.Message);
+        Assert.Equal(notification.Level, afterCacheClear.Level);
+        Assert.Equal(notification.Target, afterCacheClear.Target);
     }
 
     [Fact]
@@ -198,12 +218,15 @@ public class StatusEndpointTests : IntegrationTestsBase
         Assert.NotNull(notification);
         Assert.Equal("Silent notification", notification.Message);
 
-        // Verify it was actually persisted to cache
+        // Verify it was actually persisted to durable system settings.
         var persisted = await SendRequestAsAsync<SystemNotification>(r => r
             .AsGlobalAdminUser()
             .AppendPath("notifications/system")
             .StatusCodeShouldBeOk());
         Assert.NotNull(persisted);
         Assert.Equal("Silent notification", persisted.Message);
+
+        var settings = await GetService<ISystemSettingsRepository>().GetByIdAsync(SystemSettings.DefaultId, options => options.ImmediateConsistency());
+        Assert.Equal("Silent notification", settings?.SystemNotification?.Message);
     }
 }

--- a/tests/Exceptionless.Tests/Api/Endpoints/StatusEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/StatusEndpointTests.cs
@@ -233,4 +233,51 @@ public class StatusEndpointTests : IntegrationTestsBase
         var settings = await GetService<ISystemSettingsRepository>().GetByIdAsync(SystemSettings.DefaultId, options => options.ImmediateConsistency());
         Assert.Equal("Silent notification", settings?.SystemNotification?.Message);
     }
+
+    [Fact]
+    public async Task GetSystemNotificationAsync_LegacyUpdateIsReconciledDuringRollingDeployment()
+    {
+        var durableNotification = await SendRequestAsAsync<SystemNotification>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("notifications/system")
+            .Content(new { message = "Durable notification", level = "Info", target = "Both" })
+            .StatusCodeShouldBeOk());
+        Assert.NotNull(durableNotification);
+
+        var legacyNotification = durableNotification with
+        {
+            Date = durableNotification.Date.AddMinutes(1),
+            Message = "Legacy notification"
+        };
+        await GetService<ICacheClient>().SetAsync("system-notification", legacyNotification);
+
+        var response = await SendRequestAsAsync<SystemNotification>(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("notifications/system")
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(response);
+        Assert.Equal(legacyNotification.Message, response.Message);
+        Assert.Equal(legacyNotification.Date, response.Date);
+    }
+
+    [Fact]
+    public async Task GetSystemNotificationAsync_LegacyClearIsReconciledDuringRollingDeployment()
+    {
+        await SendRequestAsAsync<SystemNotification>(r => r
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPath("notifications/system")
+            .Content(new { message = "Durable notification", level = "Info", target = "Both" })
+            .StatusCodeShouldBeOk());
+
+        // Older instances remove only this key when clearing a notification.
+        await GetService<ICacheClient>().RemoveAsync("system-notification");
+
+        await SendRequestAsync(r => r
+            .AsGlobalAdminUser()
+            .AppendPath("notifications/system")
+            .StatusCodeShouldBeNoContent());
+    }
 }

--- a/tests/Exceptionless.Tests/Api/Endpoints/StatusEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/StatusEndpointTests.cs
@@ -133,6 +133,10 @@ public class StatusEndpointTests : IntegrationTestsBase
         Assert.Equal(notification.Level, settings.SystemNotification.Level);
         Assert.Equal(notification.Target, settings.SystemNotification.Target);
 
+        var cachedNotification = await GetService<ICacheClient>().GetAsync<SystemNotification>("system-notification");
+        Assert.True(cachedNotification.HasValue);
+        Assert.Equal(notification.Message, cachedNotification.Value.Message);
+
         await GetService<ICacheClient>().RemoveAllAsync();
         var afterCacheClear = await SendRequestAsAsync<SystemNotification>(r => r
             .AsGlobalAdminUser()

--- a/tests/Exceptionless.Tests/Assistant/AssistantAccessServiceTests.cs
+++ b/tests/Exceptionless.Tests/Assistant/AssistantAccessServiceTests.cs
@@ -5,6 +5,7 @@ using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Models.Billing;
 using Exceptionless.Core.Repositories;
+using Exceptionless.Core.Services;
 using Exceptionless.Web.Assistant;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
@@ -74,6 +75,23 @@ public sealed class AssistantAccessServiceTests
         Assert.NotNull(access);
         Assert.False(access.Enabled);
         Assert.Equal(AssistantAccessReason.NotConfigured, access.Reason);
+    }
+
+    [Fact]
+    public async Task GetAccessAsync_RuntimeOverrideDisabled_HidesAssistant()
+    {
+        var options = CreateOptions(new Dictionary<string, string?> { ["Assistant:ApiKey"] = "test-key" });
+        var repository = DispatchProxy.Create<IOrganizationRepository, OrganizationRepositoryProxy>();
+        var proxy = (OrganizationRepositoryProxy)(object)repository;
+        var settings = new SystemSettings { AssistantEnabled = false };
+        var service = new AssistantAccessService(options, new BillingPlans(options), repository, CreateSystemSettingsService(options, settings));
+
+        var access = await service.GetAccessAsync(CreateRequest("organization-id"), "organization-id");
+
+        Assert.False(access.Enabled);
+        Assert.False(access.HasAccess);
+        Assert.Equal(AssistantAccessReason.Disabled, access.Reason);
+        Assert.Equal(0, proxy.GetByIdCallCount);
     }
 
     [Fact]
@@ -162,7 +180,7 @@ public sealed class AssistantAccessServiceTests
         var repository = DispatchProxy.Create<IOrganizationRepository, OrganizationRepositoryProxy>();
         var proxy = (OrganizationRepositoryProxy)(object)repository;
         proxy.Organization = new Organization { Id = "organization-id", Name = "Test", PlanId = "EX_FREE" };
-        var service = new AssistantAccessService(options, new BillingPlans(options), repository);
+        var service = new AssistantAccessService(options, new BillingPlans(options), repository, CreateSystemSettingsService(options));
         var request = CreateRequest("different-organization-id");
 
         var access = await service.GetAccessAsync(request, "organization-id");
@@ -183,7 +201,7 @@ public sealed class AssistantAccessServiceTests
         var repository = DispatchProxy.Create<IOrganizationRepository, OrganizationRepositoryProxy>();
         var proxy = (OrganizationRepositoryProxy)(object)repository;
         proxy.Organization = new Organization { Id = "organization-id", Name = "Test", PlanId = "EX_FREE", IsSuspended = true };
-        var service = new AssistantAccessService(options, new BillingPlans(options), repository);
+        var service = new AssistantAccessService(options, new BillingPlans(options), repository, CreateSystemSettingsService(options));
         var request = CreateRequest("organization-id");
 
         var access = await service.GetAccessAsync(request, "organization-id");
@@ -205,7 +223,7 @@ public sealed class AssistantAccessServiceTests
         var proxy = (OrganizationRepositoryProxy)(object)repository;
         proxy.Organization = new Organization { Id = "organization-id", Name = "Test", PlanId = "EX_FREE" };
         var billingPlans = new BillingPlans(options);
-        var service = new AssistantAccessService(options, billingPlans, repository);
+        var service = new AssistantAccessService(options, billingPlans, repository, CreateSystemSettingsService(options));
         var request = CreateRequest("organization-id");
 
         var access = await service.GetAccessAsync(request, "organization-id");
@@ -222,6 +240,15 @@ public sealed class AssistantAccessServiceTests
         Assert.Equal(turnsPerMinute, options.MaximumTurnsPerMinute);
         Assert.Equal(monthlyTokens, options.MaximumMonthlyTokens);
         Assert.Equal(monthlyCost, options.MaximumMonthlyCostUsd);
+    }
+
+    private static SystemSettingsService CreateSystemSettingsService(AppOptions appOptions, SystemSettings? settings = null)
+    {
+        return new SystemSettingsService(
+            () => Task.FromResult(settings),
+            _ => Task.CompletedTask,
+            appOptions,
+            TimeProvider.System);
     }
 
     private static AppOptions CreateOptions(Dictionary<string, string?>? values = null)

--- a/tests/Exceptionless.Tests/Assistant/AssistantServiceTests.cs
+++ b/tests/Exceptionless.Tests/Assistant/AssistantServiceTests.cs
@@ -169,6 +169,44 @@ public sealed class AssistantServiceTests
     }
 
     [Fact]
+    public async Task StreamAsync_RuntimeModelOverride_UsesOverride()
+    {
+        var handler = new StubHttpMessageHandler(
+            """
+            data: {"choices":[{"delta":{"content":"Hello"}}]}
+
+            data: [DONE]
+
+            """);
+        var appOptions = AppOptions.ReadFromConfiguration(new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["BaseURL"] = "https://localhost",
+                ["Assistant:ApiKey"] = "test-key"
+            })
+            .Build());
+        using var cache = new InMemoryCacheClient(new InMemoryCacheClientOptions
+        {
+            LoggerFactory = NullLoggerFactory.Instance,
+            TimeProvider = TimeProvider.System
+        });
+        var settingsService = CreateAssistantModelSettingsService(appOptions);
+        await settingsService.SetModelAsync("z-ai/glm-5.3-flash", "000000000000000000000001");
+        var service = CreateAssistantService(handler, appOptions, cache, modelSettingsService: settingsService);
+
+        await foreach (var _ in service.StreamAsync(
+            new AssistantChatRequest([new AssistantChatMessage("user", "Say hello")]),
+            "user-id",
+            CreatePlanOptions(),
+            TestContext.Current.CancellationToken))
+        {
+        }
+
+        using var providerRequest = JsonDocument.Parse(handler.RequestBody);
+        Assert.Equal("z-ai/glm-5.3-flash", providerRequest.RootElement.GetProperty("model").GetString());
+    }
+
+    [Fact]
     public async Task StreamAsync_ExplicitWriteRequest_ExecutesToolWithoutConfirmationGate()
     {
         string toolCallPayload = JsonSerializer.Serialize(new
@@ -1189,7 +1227,8 @@ public sealed class AssistantServiceTests
         AppOptions appOptions,
         ICacheClient? cache = null,
         ILockProvider? lockProvider = null,
-        AssistantUsageService? usageService = null)
+        AssistantUsageService? usageService = null,
+        AssistantModelSettingsService? modelSettingsService = null)
     {
         cache ??= new InMemoryCacheClient(new InMemoryCacheClientOptions
         {
@@ -1204,6 +1243,7 @@ public sealed class AssistantServiceTests
             appOptions,
             TimeProvider.System,
             NullLogger<AssistantUsageService>.Instance);
+        modelSettingsService ??= CreateAssistantModelSettingsService(appOptions);
 
         var assistantToolContext = new AssistantToolContext();
         return new AssistantService(
@@ -1212,9 +1252,24 @@ public sealed class AssistantServiceTests
             CreateMcpTools(assistantToolContext),
             assistantToolContext,
             new AssistantConversationService(cache, lockProvider, NullLogger<AssistantConversationService>.Instance),
+            modelSettingsService,
             usageService,
             TimeProvider.System,
             NullLogger<AssistantService>.Instance);
+    }
+
+    private static AssistantModelSettingsService CreateAssistantModelSettingsService(AppOptions appOptions)
+    {
+        SystemSettings? settings = null;
+        return new AssistantModelSettingsService(
+            () => Task.FromResult(settings),
+            value =>
+            {
+                settings = value;
+                return Task.CompletedTask;
+            },
+            appOptions,
+            TimeProvider.System);
     }
 
     private static ILockProvider CreateLockProvider(ICacheClient cache, TimeProvider timeProvider)

--- a/tests/Exceptionless.Tests/Assistant/AssistantServiceTests.cs
+++ b/tests/Exceptionless.Tests/Assistant/AssistantServiceTests.cs
@@ -6,6 +6,7 @@ using Exceptionless.Core.Authorization;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Models.Billing;
 using Exceptionless.Core.Serialization;
+using Exceptionless.Core.Services;
 using Exceptionless.Web.Assistant;
 using Exceptionless.Web.Mcp;
 using Foundatio.Caching;
@@ -1261,7 +1262,7 @@ public sealed class AssistantServiceTests
     private static AssistantModelSettingsService CreateAssistantModelSettingsService(AppOptions appOptions)
     {
         SystemSettings? settings = null;
-        return new AssistantModelSettingsService(
+        var systemSettingsService = new SystemSettingsService(
             () => Task.FromResult(settings),
             value =>
             {
@@ -1270,6 +1271,7 @@ public sealed class AssistantServiceTests
             },
             appOptions,
             TimeProvider.System);
+        return new AssistantModelSettingsService(systemSettingsService, appOptions);
     }
 
     private static ILockProvider CreateLockProvider(ICacheClient cache, TimeProvider timeProvider)

--- a/tests/Exceptionless.Tests/Utility/Handlers/OverageMiddlewareTests.cs
+++ b/tests/Exceptionless.Tests/Utility/Handlers/OverageMiddlewareTests.cs
@@ -5,8 +5,11 @@ using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Services;
 using Exceptionless.Core.Utility;
+using Exceptionless.Tests.Extensions;
 using Exceptionless.Tests.Utility;
 using Exceptionless.Web.Utility;
+using Exceptionless.Web.Models.Admin;
+using FluentRest;
 using Xunit;
 
 namespace Exceptionless.Tests.Utility.Handlers;
@@ -208,6 +211,32 @@ public sealed class OverageMiddlewareTests : IntegrationTestsBase
         }
     }
 
+    [Fact]
+    public async Task Invoke_RuntimeEventSubmissionOverrideDisabled_ReturnsServiceUnavailable()
+    {
+        await SendRequestAsync(request => request
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "event-submission-settings")
+            .Content(new UpdateEventSubmissionSettings { Enabled = false })
+            .StatusCodeShouldBeOk());
+
+        bool nextCalled = false;
+        var middleware = CreateMiddleware(context =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+        var context = CreateEventPostContext(
+            CreateTokenPrincipal(SampleDataService.TEST_API_KEY, SampleDataService.TEST_ORG_ID, SampleDataService.TEST_PROJECT_ID),
+            128);
+
+        await middleware.Invoke(context);
+
+        Assert.False(nextCalled);
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, context.Response.StatusCode);
+    }
+
     private OverageMiddleware CreateMiddleware(RequestDelegate next)
     {
         return new OverageMiddleware(
@@ -215,6 +244,7 @@ public sealed class OverageMiddlewareTests : IntegrationTestsBase
             _usageService,
             _organizationRepository,
             GetService<AppOptions>(),
+            GetService<SystemSettingsService>(),
             GetService<ILogger<OverageMiddleware>>());
     }
 

--- a/tests/Exceptionless.Tests/Utility/Handlers/RecordSessionHeartbeatMiddlewareTests.cs
+++ b/tests/Exceptionless.Tests/Utility/Handlers/RecordSessionHeartbeatMiddlewareTests.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Exceptionless.Core;
 using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Models;
+using Exceptionless.Core.Services;
 using Exceptionless.Tests.Utility;
 using Exceptionless.Web.Utility;
 using Foundatio.Caching;
@@ -98,6 +99,7 @@ public sealed class RecordSessionHeartbeatMiddlewareTests : TestWithServices
             next,
             GetService<ICacheClient>(),
             GetService<AppOptions>(),
+            GetService<SystemSettingsService>(),
             TimeProvider,
             GetService<ILogger<ProjectConfigMiddleware>>());
     }

--- a/tests/http/admin.http
+++ b/tests/http/admin.http
@@ -54,6 +54,28 @@ Authorization: Bearer {{token}}
 GET {{apiUrl}}/admin/assistant-usage
 Authorization: Bearer {{token}}
 
+### Get Exie Settings
+GET {{apiUrl}}/admin/assistant-settings
+Authorization: Bearer {{token}}
+
+### Set Exie Model Override
+PUT {{apiUrl}}/admin/assistant-settings
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "model": "z-ai/glm-5.3-flash"
+}
+
+### Reset Exie Model Override
+PUT {{apiUrl}}/admin/assistant-settings
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "model": null
+}
+
 ### Suspend
 POST {{apiUrl}}/organizations/{{organizationId}}/suspend?code=1
 Authorization: Bearer {{token}}

--- a/tests/http/admin.http
+++ b/tests/http/admin.http
@@ -76,6 +76,46 @@ Content-Type: application/json
     "model": null
 }
 
+### Disable Exie at Runtime
+PUT {{apiUrl}}/admin/assistant-settings/enabled
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "enabled": false
+}
+
+### Reset Exie Availability to Deployment Default
+PUT {{apiUrl}}/admin/assistant-settings/enabled
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "enabled": null
+}
+
+### Get Event Submission Settings
+GET {{apiUrl}}/admin/event-submission-settings
+Authorization: Bearer {{token}}
+
+### Disable Event Submission at Runtime
+PUT {{apiUrl}}/admin/event-submission-settings
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "enabled": false
+}
+
+### Reset Event Submission to Deployment Default
+PUT {{apiUrl}}/admin/event-submission-settings
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "enabled": null
+}
+
 ### Suspend
 POST {{apiUrl}}/organizations/{{organizationId}}/suspend?code=1
 Authorization: Bearer {{token}}


### PR DESCRIPTION
## Summary

- add a durable, typed system-settings document in Elasticsearch with repository caching, serialized updates, and audit metadata
- let global administrators change Exie's OpenRouter model and availability without restarting the app
- add a runtime event-submission switch under System > Settings
- persist system notification banners while preserving live message-bus updates and legacy cached notifications

## API and behavior

- extend `/api/v2/admin/assistant-settings` and add `/api/v2/admin/assistant-settings/enabled`
- add global-admin `GET` and `PUT` endpoints at `/api/v2/admin/event-submission-settings`
- use deployment configuration as the fallback for nullable runtime overrides; resetting or selecting the configured value removes the override
- apply Exie availability on every access decision and event-submission availability to new event and heartbeat requests
- return HTTP 503 for event posts while submission is disabled; session heartbeats remain successful without recording activity
- retain API keys, provider readiness, and startup topology as deployment-owned configuration

## Verification

- `dotnet build tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-restore` (0 warnings, 0 errors)
- `dotnet test --project tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-build --no-restore` (2,893 passed, 3 intentional skips)
- `npm run validate`
- `npm run build`
- `npm run test:unit` (714 passed; one unrelated existing command-palette expectation fails because unchanged code navigates to `/next/` while the test expects `/next/stack`)

## Breaking changes

None. Existing deployment settings remain the defaults, and existing SystemSettings documents without the new fields retain current behavior.
