### PR TITLE
Relax Svelte runtime diagnostic compatibility check

### DIFF
--- a/src/Exceptionless.Web/ClientApp/vite.config.ts
+++ b/src/Exceptionless.Web/ClientApp/vite.config.ts
@@ -25,7 +25,6 @@ if (codespaceName && codespaceDomain) {
 }
 
 const SVELTE_RUNTIME_DIAGNOSTICS_GLOBAL = '__exceptionlessSvelteEffectDepthDiagnostics';
-const SUPPORTED_SVELTE_RUNTIME_VERSION = '5.56.10';
 
 // Svelte's useful effect-depth diagnostics are development-only. Preserve the
 // minimal state-write tracking needed to diagnose production-only loops.
@@ -45,14 +44,23 @@ function svelteEffectDepthDiagnostics(): Plugin {
     const effectDepthNeedle = '\t} catch (error) {\n\t\tif (DEV) {\n\t\t\t// stack contains no useful information, replace it\n';
     const effectDepthReplacement = `\t} catch (error) {\n\t\tglobalThis.${SVELTE_RUNTIME_DIAGNOSTICS_GLOBAL}?.attachEffectDepthError(error, last_scheduled_effect);\n\n\t\tif (DEV) {\n\t\t\t// stack contains no useful information, replace it\n`;
 
+    function findRuntimePatchTarget(code: string, id: string, needle: string) {
+        const start = code.indexOf(needle);
+        if (start < 0) {
+            throw new Error(`Unable to instrument ${id}; the expected Svelte runtime source was not found.`);
+        }
+
+        if (code.indexOf(needle, start + needle.length) >= 0) {
+            throw new Error(`Unable to instrument ${id}; the expected Svelte runtime source was found more than once.`);
+        }
+
+        return start;
+    }
+
     function instrumentRuntime(code: string, id: string, replacements: [needle: string, replacement: string][]) {
         const instrumented = new MagicString(code, { filename: id });
         for (const [needle, replacement] of replacements) {
-            const start = code.indexOf(needle);
-            if (start < 0) {
-                throw new Error(`Unable to instrument ${id}; the expected Svelte runtime source was not found.`);
-            }
-
+            const start = findRuntimePatchTarget(code, id, needle);
             instrumented.overwrite(start, start + needle.length, replacement);
         }
 
@@ -63,23 +71,12 @@ function svelteEffectDepthDiagnostics(): Plugin {
     }
 
     function assertRuntimeShape() {
-        const packageJson = JSON.parse(readFileSync(packagePath, 'utf8')) as { version?: string };
-        if (packageJson.version !== SUPPORTED_SVELTE_RUNTIME_VERSION) {
-            throw new Error(
-                `Svelte effect-depth diagnostics support ${SUPPORTED_SVELTE_RUNTIME_VERSION}, but ${packageJson.version ?? 'an unknown version'} is installed. Review Svelte's runtime before updating the supported version.`
-            );
-        }
-
         const sources = readFileSync(sourcesPath, 'utf8');
         const batch = readFileSync(batchPath, 'utf8');
-        if (
-            !sources.includes(stateUpdateNeedle) ||
-            !batch.includes(flushStartNeedle) ||
-            !batch.includes(flushEndNeedle) ||
-            !batch.includes(effectDepthNeedle)
-        ) {
-            throw new Error('Svelte runtime internals changed; update the effect-depth diagnostic instrumentation before building.');
-        }
+        findRuntimePatchTarget(sources, sourcesPath, stateUpdateNeedle);
+        findRuntimePatchTarget(batch, batchPath, flushStartNeedle);
+        findRuntimePatchTarget(batch, batchPath, flushEndNeedle);
+        findRuntimePatchTarget(batch, batchPath, effectDepthNeedle);
     }
 
     return {


### PR DESCRIPTION
## Summary

- remove the exact Svelte runtime version requirement from the production effect-depth diagnostic plugin
- validate that each runtime patch target exists exactly once before instrumenting it
- continue failing the build when Svelte runtime internals change incompatibly

## Validation

- `npm run validate`
- `npm run test:unit -- --run src/lib/telemetry/svelte-effect-depth-diagnostics.test.ts`
- `npm run build`
- production runtime probe confirmed diagnostic collection and Exceptionless serialization

## Breaking changes

None.
