### PR TITLE
Improve OAuth application administration

### DIFF
--- a/src/Exceptionless.Core/Migrations/008_PopulateOAuthApplicationOrganizationIds.cs
+++ b/src/Exceptionless.Core/Migrations/008_PopulateOAuthApplicationOrganizationIds.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics;
+using Exceptionless.Core.Repositories;
+using Foundatio.Repositories;
+using Foundatio.Repositories.Migrations;
+using Microsoft.Extensions.Logging;
+
+namespace Exceptionless.Core.Migrations;
+
+public sealed class PopulateOAuthApplicationOrganizationIds : MigrationBase
+{
+    private const int BatchSize = 500;
+    private readonly IOAuthApplicationRepository _oauthApplicationRepository;
+    private readonly IOAuthTokenRepository _oauthTokenRepository;
+
+    public PopulateOAuthApplicationOrganizationIds(
+        IOAuthApplicationRepository oauthApplicationRepository,
+        IOAuthTokenRepository oauthTokenRepository,
+        ILoggerFactory loggerFactory) : base(loggerFactory)
+    {
+        _oauthApplicationRepository = oauthApplicationRepository;
+        _oauthTokenRepository = oauthTokenRepository;
+
+        MigrationType = MigrationType.VersionedAndResumable;
+        Version = 8;
+    }
+
+    public override async Task RunAsync(MigrationContext context)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var tokens = await _oauthTokenRepository.FindAsync(
+            query => query
+                .SortAscending(token => token.ClientId)
+                .SortAscending(token => token.Id),
+            options => options.SearchAfterPaging().PageLimit(BatchSize));
+
+        int processedTokens = 0;
+        long updatedApplications = 0;
+        do
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            foreach (var clientTokens in tokens.Documents.GroupBy(token => token.ClientId, StringComparer.Ordinal))
+            {
+                string[] organizationIds = clientTokens
+                    .SelectMany(token => token.OrganizationIds)
+                    .Where(id => !String.IsNullOrWhiteSpace(id))
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+                updatedApplications += await _oauthApplicationRepository.AddOrganizationIdsAsync(
+                    clientTokens.Key,
+                    organizationIds,
+                    options => options.ImmediateConsistency().Notifications(false));
+            }
+
+            processedTokens += tokens.Documents.Count;
+            await context.Lock.RenewAsync();
+        } while (!context.CancellationToken.IsCancellationRequested && await tokens.NextPageAsync());
+
+        context.CancellationToken.ThrowIfCancellationRequested();
+        _logger.LogInformation(
+            "Populated OAuth application organization identifiers. ProcessedTokens={ProcessedTokens:N0} UpdatedApplications={UpdatedApplications:N0} Duration={Duration}",
+            processedTokens,
+            updatedApplications,
+            stopwatch.Elapsed);
+    }
+}

--- a/src/Exceptionless.Core/Models/OAuthApplication.cs
+++ b/src/Exceptionless.Core/Models/OAuthApplication.cs
@@ -28,6 +28,8 @@ public class OAuthApplication : IIdentity, IHaveDates, IValidatableObject
     [Length(1, 20)]
     public string[] Scopes { get; set; } = [];
 
+    public HashSet<string> OrganizationIds { get; set; } = new(StringComparer.Ordinal);
+
     [MaxLength(1000)]
     public string? Notes { get; set; }
 

--- a/src/Exceptionless.Core/Repositories/Configuration/Indexes/OAuthApplicationIndex.cs
+++ b/src/Exceptionless.Core/Repositories/Configuration/Indexes/OAuthApplicationIndex.cs
@@ -9,10 +9,9 @@ namespace Exceptionless.Core.Repositories.Configuration;
 
 public sealed class OAuthApplicationIndex : VersionedIndex<OAuthApplication>
 {
-    internal const string KEYWORD_LOWERCASE_ANALYZER = "keyword_lowercase";
     private readonly ExceptionlessElasticConfiguration _configuration;
 
-    public OAuthApplicationIndex(ExceptionlessElasticConfiguration configuration) : base(configuration, configuration.Options.ScopePrefix + "oauth-applications", 1)
+    public OAuthApplicationIndex(ExceptionlessElasticConfiguration configuration) : base(configuration, configuration.Options.ScopePrefix + "oauth-applications", 2)
     {
         _configuration = configuration;
     }
@@ -23,10 +22,11 @@ public sealed class OAuthApplicationIndex : VersionedIndex<OAuthApplication>
             .Dynamic(DynamicMapping.False)
             .Properties(p => p
                 .SetupDefaults()
-                .Text(e => e.Name, t => t.Analyzer(KEYWORD_LOWERCASE_ANALYZER).AddKeywordField())
+                .Text(e => e.Name, t => t.AddKeywordField())
                 .Keyword(e => e.ClientId)
                 .Keyword(e => e.RedirectUris)
                 .Keyword(e => e.Scopes)
+                .Keyword(e => e.OrganizationIds)
                 .Keyword(e => e.CreatedByUserId)
                 .Keyword(e => e.UpdatedByUserId)
                 .Boolean(e => e.IsDisabled));
@@ -36,7 +36,6 @@ public sealed class OAuthApplicationIndex : VersionedIndex<OAuthApplication>
     {
         base.ConfigureIndex(idx);
         idx.Settings(s => s
-            .Analysis(d => d.Analyzers(b => b.Custom(KEYWORD_LOWERCASE_ANALYZER, c => c.Filter("lowercase").Tokenizer("keyword"))))
             .NumberOfShards(_configuration.Options.NumberOfShards)
             .NumberOfReplicas(_configuration.Options.NumberOfReplicas)
             .Priority(5));

--- a/src/Exceptionless.Core/Repositories/Interfaces/IOAuthApplicationRepository.cs
+++ b/src/Exceptionless.Core/Repositories/Interfaces/IOAuthApplicationRepository.cs
@@ -6,5 +6,7 @@ namespace Exceptionless.Core.Repositories;
 
 public interface IOAuthApplicationRepository : ISearchableRepository<OAuthApplication>
 {
+    Task<long> AddOrganizationIdsAsync(string clientId, IReadOnlyCollection<string> organizationIds, CommandOptionsDescriptor<OAuthApplication>? options = null);
     Task<OAuthApplication?> GetByClientIdAsync(string clientId, CommandOptionsDescriptor<OAuthApplication>? options = null);
+    Task<FindResults<OAuthApplication>> GetByCriteriaAsync(string? criteria, IReadOnlyCollection<string>? organizationIds, CommandOptionsDescriptor<OAuthApplication>? options = null);
 }

--- a/src/Exceptionless.Core/Repositories/OAuthApplicationRepository.cs
+++ b/src/Exceptionless.Core/Repositories/OAuthApplicationRepository.cs
@@ -1,3 +1,4 @@
+using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories.Configuration;
 using Exceptionless.Core.Validation;
@@ -14,9 +15,64 @@ public class OAuthApplicationRepository : RepositoryBase<OAuthApplication>, IOAu
         DefaultConsistency = Consistency.Immediate;
     }
 
+    public Task<long> AddOrganizationIdsAsync(string clientId, IReadOnlyCollection<string> organizationIds, CommandOptionsDescriptor<OAuthApplication>? options = null)
+    {
+        if (organizationIds.Count == 0)
+            return Task.FromResult(0L);
+
+        const string script = """
+            if (ctx._source.organization_ids == null) {
+              ctx._source.organization_ids = [];
+            }
+            for (organizationId in params.organizationIds) {
+              if (!ctx._source.organization_ids.contains(organizationId)) {
+                ctx._source.organization_ids.add(organizationId);
+              }
+            }
+            """;
+        var patch = new ScriptPatch(script.TrimScript())
+        {
+            Params = new Dictionary<string, object>
+            {
+                ["organizationIds"] = organizationIds
+                    .Where(id => !String.IsNullOrWhiteSpace(id))
+                    .Select(id => id.Trim())
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray()
+            }
+        };
+
+        return PatchAllAsync(query => query.FieldEquals(application => application.ClientId, clientId.Trim()), patch, options);
+    }
+
     public async Task<OAuthApplication?> GetByClientIdAsync(string clientId, CommandOptionsDescriptor<OAuthApplication>? options = null)
     {
         var hit = await FindOneAsync(q => q.FieldEquals(a => a.ClientId, clientId.Trim()), options);
         return hit?.Document;
+    }
+
+    public Task<FindResults<OAuthApplication>> GetByCriteriaAsync(string? criteria, IReadOnlyCollection<string>? organizationIds, CommandOptionsDescriptor<OAuthApplication>? options = null)
+    {
+        var query = new RepositoryQuery<OAuthApplication>();
+
+        if (!String.IsNullOrWhiteSpace(criteria))
+        {
+            string normalizedCriteria = criteria.Trim();
+            query.FieldOr(group => group
+                .FieldContains(application => application.Name, normalizedCriteria)
+                .FieldEquals(application => application.ClientId, normalizedCriteria));
+        }
+
+        if (organizationIds is { Count: > 0 })
+        {
+            query.FieldOr(group =>
+            {
+                foreach (string organizationId in organizationIds)
+                    group.FieldEquals(application => application.OrganizationIds, organizationId);
+            });
+        }
+
+        query.SortDescending(application => application.UpdatedUtc).SortAscending(application => application.Name);
+        return FindAsync(q => query, options);
     }
 }

--- a/src/Exceptionless.Core/Repositories/OAuthApplicationRepository.cs
+++ b/src/Exceptionless.Core/Repositories/OAuthApplicationRepository.cs
@@ -64,15 +64,9 @@ public class OAuthApplicationRepository : RepositoryBase<OAuthApplication>, IOAu
         }
 
         if (organizationIds is { Count: > 0 })
-        {
-            query.FieldOr(group =>
-            {
-                foreach (string organizationId in organizationIds)
-                    group.FieldEquals(application => application.OrganizationIds, organizationId);
-            });
-        }
+            query.FieldEquals(application => application.OrganizationIds, organizationIds);
 
-        query.SortDescending(application => application.UpdatedUtc).SortAscending(application => application.Name);
+        query.SortAscending(application => application.Name);
         return FindAsync(q => query, options);
     }
 }

--- a/src/Exceptionless.Core/Services/OAuthService.cs
+++ b/src/Exceptionless.Core/Services/OAuthService.cs
@@ -378,6 +378,8 @@ public class OAuthService(OAuthServerOptions options, ICacheClient cacheClient, 
 
     public async Task<string> CreateAuthorizationCodeAsync(OAuthAuthorizeRequest request, string userId, IReadOnlyCollection<string> organizationIds)
     {
+        await oauthApplicationRepository.AddOrganizationIdsAsync(request.ClientId, organizationIds, o => o.ImmediateConsistency().Notifications(false));
+
         string code = StringExtensions.GetNewToken();
         var authorizationCode = new OAuthAuthorizationCode
         {

--- a/src/Exceptionless.Web/Api/Endpoints/OAuthApplicationEndpoints.cs
+++ b/src/Exceptionless.Web/Api/Endpoints/OAuthApplicationEndpoints.cs
@@ -18,8 +18,8 @@ public static class OAuthApplicationEndpoints
             .AddEndpointFilter<AutoValidationEndpointFilter>()
             .ExcludeFromDescription();
 
-        endpoints.MapGet("api/v2/admin/oauth-applications", async (IMediator mediator, IMediatorResultMapper<HttpIResult> resultMapper, string? criteria = null, string? organization = null, int page = 1, int limit = 20)
-            => (await mediator.InvokeAsync<Result<PagedResult<ViewOAuthApplication>>>(new GetOAuthApplications(criteria, organization, page, limit))).ToHttpResult(resultMapper))
+        endpoints.MapGet("api/v2/admin/oauth-applications", async (HttpContext httpContext, IMediator mediator, IMediatorResultMapper<HttpIResult> resultMapper, string? criteria = null, string? organization = null, int page = 1, int limit = 100)
+            => (await mediator.InvokeAsync<Result<PagedResult<ViewOAuthApplication>>>(new GetOAuthApplications(criteria, organization, page, limit, httpContext))).ToHttpResult(resultMapper))
             .RequireAuthorization(AuthorizationRoles.GlobalAdminPolicy)
             .AddEndpointFilter<AutoValidationEndpointFilter>()
             .Produces<IReadOnlyCollection<ViewOAuthApplication>>()

--- a/src/Exceptionless.Web/Api/Endpoints/OAuthApplicationEndpoints.cs
+++ b/src/Exceptionless.Web/Api/Endpoints/OAuthApplicationEndpoints.cs
@@ -18,10 +18,11 @@ public static class OAuthApplicationEndpoints
             .AddEndpointFilter<AutoValidationEndpointFilter>()
             .ExcludeFromDescription();
 
-        endpoints.MapGet("api/v2/admin/oauth-applications", async (IMediator mediator, IMediatorResultMapper<HttpIResult> resultMapper)
-            => (await mediator.InvokeAsync<Result<IReadOnlyCollection<ViewOAuthApplication>>>(new GetOAuthApplications())).ToHttpResult(resultMapper))
+        endpoints.MapGet("api/v2/admin/oauth-applications", async (IMediator mediator, IMediatorResultMapper<HttpIResult> resultMapper, string? criteria = null, string? organization = null, int page = 1, int limit = 20)
+            => (await mediator.InvokeAsync<Result<PagedResult<ViewOAuthApplication>>>(new GetOAuthApplications(criteria, organization, page, limit))).ToHttpResult(resultMapper))
             .RequireAuthorization(AuthorizationRoles.GlobalAdminPolicy)
             .AddEndpointFilter<AutoValidationEndpointFilter>()
+            .Produces<IReadOnlyCollection<ViewOAuthApplication>>()
             .ExcludeFromDescription();
 
         endpoints.MapPost("api/v2/admin/oauth-applications", async (HttpContext httpContext, IMediator mediator, IMediatorResultMapper<HttpIResult> resultMapper, [FromBody] NewOAuthApplication model)
@@ -31,6 +32,11 @@ public static class OAuthApplicationEndpoints
             .ExcludeFromDescription()
             .Produces<ViewOAuthApplication>(StatusCodes.Status201Created)
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity);
+
+        group.MapGet("{id:objectid}", async (string id, IMediator mediator, IMediatorResultMapper<HttpIResult> resultMapper)
+            => (await mediator.InvokeAsync<Result<ViewOAuthApplication>>(new GetOAuthApplication(id))).ToHttpResult(resultMapper))
+            .Produces<ViewOAuthApplication>()
+            .ProducesProblem(StatusCodes.Status404NotFound);
 
         group.MapPut("{id:objectid}", async (string id, HttpContext httpContext, IMediator mediator, IMediatorResultMapper<HttpIResult> resultMapper, [FromBody] UpdateOAuthApplication model)
             => (await mediator.InvokeAsync<Result<ViewOAuthApplication>>(new UpdateOAuthApplicationMessage(id, model, httpContext))).ToHttpResult(resultMapper))

--- a/src/Exceptionless.Web/Api/Handlers/OAuthApplicationHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/OAuthApplicationHandler.cs
@@ -24,7 +24,7 @@ public class OAuthApplicationHandler(
     {
         int page = Pagination.GetPage(message.Page);
         int limit = Pagination.GetLimit(message.Limit);
-        var organizationIds = await ResolveOrganizationIdsAsync(message.Organization);
+        var organizationIds = await ResolveOrganizationIdsAsync(message.Organization, message.Context.RequestAborted);
         if (!String.IsNullOrWhiteSpace(message.Organization) && organizationIds.Count == 0)
             return new PagedResult<ViewOAuthApplication>([], false, page, 0);
 
@@ -129,7 +129,7 @@ public class OAuthApplicationHandler(
         return existing is null;
     }
 
-    private async Task<IReadOnlyCollection<string>> ResolveOrganizationIdsAsync(string? organization)
+    private async Task<IReadOnlyCollection<string>> ResolveOrganizationIdsAsync(string? organization, CancellationToken cancellationToken)
     {
         if (String.IsNullOrWhiteSpace(organization))
             return [];
@@ -139,8 +139,14 @@ public class OAuthApplicationHandler(
             .FieldOr(group => group
                 .FieldEquals(item => item.Id, criteria)
                 .FieldContains(item => item.Name, criteria))
-            .SortAscending(item => item.Name), options => options.PageLimit(Pagination.MaximumLimit));
-        return results.Documents.Select(item => item.Id).ToArray();
+            .SortAscending(item => item.Name), options => options.SearchAfterPaging().PageLimit(Pagination.MaximumLimit));
+        var organizationIds = new List<string>();
+        do
+        {
+            organizationIds.AddRange(results.Documents.Select(item => item.Id));
+        } while (!cancellationToken.IsCancellationRequested && await results.NextPageAsync());
+
+        return organizationIds;
     }
 
     private async Task<IReadOnlyCollection<ViewOAuthApplication>> MapApplicationsAsync(IReadOnlyCollection<OAuthApplication> applications)

--- a/src/Exceptionless.Web/Api/Handlers/OAuthApplicationHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/OAuthApplicationHandler.cs
@@ -4,6 +4,8 @@ using Exceptionless.Core.Services;
 using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Validation;
 using Exceptionless.Web.Api.Messages;
+using Exceptionless.Web.Api.Infrastructure;
+using Exceptionless.Web.Api.Results;
 using Exceptionless.Web.Extensions;
 using Exceptionless.Web.Models.Admin;
 using Foundatio.Mediator;
@@ -14,13 +16,30 @@ namespace Exceptionless.Web.Api.Handlers;
 
 public class OAuthApplicationHandler(
     IOAuthApplicationRepository repository,
+    IOrganizationRepository organizationRepository,
     OAuthService oauthService,
     TimeProvider timeProvider)
 {
-    public async Task<Result<IReadOnlyCollection<ViewOAuthApplication>>> Handle(GetOAuthApplications message)
+    public async Task<Result<PagedResult<ViewOAuthApplication>>> Handle(GetOAuthApplications message)
     {
-        var results = await repository.FindAsync(q => q.SortAscending(a => a.Name), o => o.PageLimit(100));
-        return results.Documents.Select(ViewOAuthApplication.FromApplication).ToArray();
+        int page = Pagination.GetPage(message.Page);
+        int limit = Pagination.GetLimit(message.Limit);
+        var organizationIds = await ResolveOrganizationIdsAsync(message.Organization);
+        if (!String.IsNullOrWhiteSpace(message.Organization) && organizationIds.Count == 0)
+            return new PagedResult<ViewOAuthApplication>([], false, page, 0);
+
+        var results = await repository.GetByCriteriaAsync(message.Criteria, organizationIds, o => o.PageNumber(page).PageLimit(limit));
+        var applications = await MapApplicationsAsync(results.Documents);
+        return new PagedResult<ViewOAuthApplication>(applications, results.HasMore && !Pagination.NextPageExceedsSkipLimit(page, limit), page, results.Total);
+    }
+
+    public async Task<Result<ViewOAuthApplication>> Handle(GetOAuthApplication message)
+    {
+        var application = await repository.GetByIdAsync(message.Id);
+        if (application is null)
+            return Result.NotFound("OAuth application not found.");
+
+        return (await MapApplicationsAsync([application])).Single();
     }
 
     public async Task<Result<ViewOAuthApplication>> Handle(CreateOAuthApplicationMessage message)
@@ -108,6 +127,33 @@ public class OAuthApplicationHandler(
     {
         var existing = await repository.GetByClientIdAsync(clientId.Trim(), o => o.ImmediateConsistency());
         return existing is null;
+    }
+
+    private async Task<IReadOnlyCollection<string>> ResolveOrganizationIdsAsync(string? organization)
+    {
+        if (String.IsNullOrWhiteSpace(organization))
+            return [];
+
+        string criteria = organization.Trim();
+        var results = await organizationRepository.FindAsync(query => query
+            .FieldOr(group => group
+                .FieldEquals(item => item.Id, criteria)
+                .FieldContains(item => item.Name, criteria))
+            .SortAscending(item => item.Name), options => options.PageLimit(Pagination.MaximumLimit));
+        return results.Documents.Select(item => item.Id).ToArray();
+    }
+
+    private async Task<IReadOnlyCollection<ViewOAuthApplication>> MapApplicationsAsync(IReadOnlyCollection<OAuthApplication> applications)
+    {
+        string[] organizationIds = applications
+            .SelectMany(application => application.OrganizationIds)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        var organizations = organizationIds.Length > 0
+            ? await organizationRepository.GetByIdsAsync(organizationIds, options => options.Cache())
+            : [];
+        var organizationNames = organizations.ToDictionary(organization => organization.Id, organization => organization.Name, StringComparer.Ordinal);
+        return applications.Select(application => ViewOAuthApplication.FromApplication(application, organizationNames)).ToArray();
     }
 
     private static string[] NormalizeValues(IEnumerable<string> values, IEqualityComparer<string> comparer)

--- a/src/Exceptionless.Web/Api/Handlers/OAuthApplicationHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/OAuthApplicationHandler.cs
@@ -109,7 +109,7 @@ public class OAuthApplicationHandler(
 
         await oauthService.ClearAccessTokenClientValidityCacheAsync(previousClientId);
         await oauthService.ClearAccessTokenClientValidityCacheAsync(application.ClientId);
-        return ViewOAuthApplication.FromApplication(application);
+        return (await MapApplicationsAsync([application])).Single();
     }
 
     public async Task<Result> Handle(DeleteOAuthApplicationMessage message)

--- a/src/Exceptionless.Web/Api/Messages/OAuthApplicationMessages.cs
+++ b/src/Exceptionless.Web/Api/Messages/OAuthApplicationMessages.cs
@@ -2,7 +2,7 @@ using Exceptionless.Web.Models.Admin;
 
 namespace Exceptionless.Web.Api.Messages;
 
-public record GetOAuthApplications(string? Criteria, string? Organization, int Page, int Limit);
+public record GetOAuthApplications(string? Criteria, string? Organization, int Page, int Limit, HttpContext Context);
 public record GetOAuthApplication(string Id);
 public record CreateOAuthApplicationMessage(NewOAuthApplication Model, HttpContext Context);
 public record UpdateOAuthApplicationMessage(string Id, UpdateOAuthApplication Model, HttpContext Context);

--- a/src/Exceptionless.Web/Api/Messages/OAuthApplicationMessages.cs
+++ b/src/Exceptionless.Web/Api/Messages/OAuthApplicationMessages.cs
@@ -2,7 +2,8 @@ using Exceptionless.Web.Models.Admin;
 
 namespace Exceptionless.Web.Api.Messages;
 
-public record GetOAuthApplications;
+public record GetOAuthApplications(string? Criteria, string? Organization, int Page, int Limit);
+public record GetOAuthApplication(string Id);
 public record CreateOAuthApplicationMessage(NewOAuthApplication Model, HttpContext Context);
 public record UpdateOAuthApplicationMessage(string Id, UpdateOAuthApplication Model, HttpContext Context);
 public record DeleteOAuthApplicationMessage(string Id);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
@@ -1,5 +1,5 @@
 import { invalidateAssistantAccessQueries } from '$features/assistant/api.svelte';
-import { type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
+import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
 
 import type {
@@ -18,6 +18,17 @@ import type {
     UpdateEventSubmissionSettingsRequest
 } from './models';
 
+export type GetOAuthApplicationsParams = {
+    criteria?: string;
+    limit?: number;
+    organization?: string;
+    page?: number;
+};
+
+export type GetOAuthApplicationsRequest = {
+    params?: GetOAuthApplicationsParams;
+};
+
 export type RunMaintenanceJobParams = {
     name: string;
     organizationId?: string;
@@ -31,6 +42,7 @@ export const queryKeys = {
     elasticsearch: ['admin', 'elasticsearch'] as const,
     eventSubmissionSettings: ['admin', 'event-submission-settings'] as const,
     migrations: ['admin', 'migrations'] as const,
+    oauthApplication: (id: string | undefined) => [...queryKeys.oauthApplications, id] as const,
     oauthApplications: ['admin', 'oauth-applications'] as const,
     snapshots: ['admin', 'elasticsearch', 'snapshots'] as const,
     stats: ['admin', 'stats'] as const
@@ -177,11 +189,12 @@ export function getMigrationsQuery() {
     }));
 }
 
-export function getOAuthApplicationsQuery() {
-    return createQuery<OAuthApplication[], ProblemDetails>(() => ({
+export function getOAuthApplicationQuery(id: () => string | undefined) {
+    return createQuery<OAuthApplication, ProblemDetails>(() => ({
+        enabled: () => !!id(),
         queryFn: async ({ signal }: { signal: AbortSignal }) => {
             const client = useFetchClient();
-            const response = await client.getJSON<OAuthApplication[]>('admin/oauth-applications', {
+            const response = await client.getJSON<OAuthApplication>(`admin/oauth-applications/${id()}`, {
                 signal
             });
 
@@ -189,9 +202,38 @@ export function getOAuthApplicationsQuery() {
                 throw response.problem;
             }
 
-            return response.data ?? [];
+            return response.data!;
         },
-        queryKey: queryKeys.oauthApplications,
+        queryKey: queryKeys.oauthApplication(id()),
+        staleTime: 30 * 1000
+    }));
+}
+
+export function getOAuthApplicationsQuery(request: GetOAuthApplicationsRequest = {}) {
+    return createQuery<FetchClientResponse<OAuthApplication[]>, ProblemDetails>(() => ({
+        queryFn: async ({ signal }: { signal: AbortSignal }) => {
+            const client = useFetchClient();
+            const response = await client.getJSON<OAuthApplication[]>('admin/oauth-applications', {
+                params: {
+                    ...request.params
+                },
+                signal
+            });
+
+            if (!response.ok) {
+                throw response.problem;
+            }
+
+            return response;
+        },
+        queryKey: [
+            ...queryKeys.oauthApplications,
+            {
+                params: {
+                    ...request.params
+                }
+            }
+        ],
         staleTime: 30 * 1000
     }));
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/oauth-application-form.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/oauth-application-form.svelte
@@ -1,0 +1,265 @@
+<script lang="ts">
+    import type { OAuthApplication, OAuthApplicationRequest } from '$features/admin/models';
+
+    import { goto } from '$app/navigation';
+    import { resolve } from '$app/paths';
+    import ErrorMessage from '$comp/error-message.svelte';
+    import { Button } from '$comp/ui/button';
+    import * as Card from '$comp/ui/card';
+    import { Checkbox } from '$comp/ui/checkbox';
+    import * as Field from '$comp/ui/field';
+    import { Input } from '$comp/ui/input';
+    import { Label } from '$comp/ui/label';
+    import { Spinner } from '$comp/ui/spinner';
+    import { Textarea } from '$comp/ui/textarea';
+    import { postOAuthApplicationMutation, putOAuthApplicationMutation } from '$features/admin/api.svelte';
+    import { type OAuthApplicationFormData, OAuthApplicationSchema } from '$features/admin/schemas';
+    import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
+    import { ProblemDetails } from '@foundatiofx/fetchclient';
+    import Save from '@lucide/svelte/icons/save';
+    import { createForm } from '@tanstack/svelte-form';
+    import { toast } from 'svelte-sonner';
+
+    interface Props {
+        application?: null | OAuthApplication;
+    }
+
+    let { application = null }: Props = $props();
+
+    const supportedScopes = [
+        {
+            description: 'Allows connecting to the MCP endpoint.',
+            label: 'MCP',
+            value: 'mcp:read'
+        },
+        {
+            description: 'Allows reading project metadata.',
+            label: 'Projects',
+            value: 'projects:read'
+        },
+        {
+            description: 'Allows reading stack data.',
+            label: 'Stacks',
+            value: 'stacks:read'
+        },
+        {
+            description: 'Allows changing stack status, snooze, and critical settings.',
+            label: 'Stacks Write',
+            value: 'stacks:write'
+        },
+        {
+            description: 'Allows reading event details.',
+            label: 'Events',
+            value: 'events:read'
+        },
+        {
+            description: 'Allows refresh token issuance.',
+            label: 'Offline Access',
+            value: 'offline_access'
+        }
+    ] as const;
+
+    const createApplication = postOAuthApplicationMutation();
+    const updateApplication = putOAuthApplicationMutation();
+    const isEditing = $derived(application !== null);
+    const listHref = resolve('/(app)/system/oauth-applications');
+
+    const form = createForm(() => ({
+        defaultValues: getFormValues(application),
+        validators: {
+            onSubmit: OAuthApplicationSchema,
+            onSubmitAsync: async ({ value }) => {
+                try {
+                    const request = toRequest(value);
+                    if (application) {
+                        await updateApplication.mutateAsync({
+                            id: application.id,
+                            request
+                        });
+                    } else {
+                        await createApplication.mutateAsync(request);
+                    }
+
+                    toast.success(isEditing ? 'OAuth application updated.' : 'OAuth application created.');
+                    await goto(listHref);
+                    return null;
+                } catch (error: unknown) {
+                    if (error instanceof ProblemDetails) {
+                        return problemDetailsToFormErrors(error);
+                    }
+
+                    return {
+                        form: 'An unexpected error occurred, please try again.'
+                    };
+                }
+            }
+        }
+    }));
+
+    function getFormValues(value: null | OAuthApplication): OAuthApplicationFormData {
+        return {
+            client_id: value?.client_id ?? '',
+            is_disabled: value?.is_disabled ?? false,
+            name: value?.name ?? '',
+            notes: value?.notes ?? '',
+            redirect_uris: value?.redirect_uris.join('\n') ?? '',
+            scopes: value?.scopes ?? ['mcp:read', 'projects:read', 'stacks:read', 'events:read', 'offline_access']
+        };
+    }
+
+    function toRequest(value: OAuthApplicationFormData): OAuthApplicationRequest {
+        return {
+            client_id: value.client_id.trim(),
+            is_disabled: value.is_disabled,
+            name: value.name.trim(),
+            notes: value.notes?.trim() || null,
+            redirect_uris: value.redirect_uris
+                .split(/\r?\n/)
+                .map((item) => item.trim())
+                .filter(Boolean),
+            scopes: value.scopes
+        };
+    }
+
+    function isScopeChecked(scopes: string[], scope: string) {
+        return scopes.includes(scope);
+    }
+</script>
+
+<form
+    onsubmit={(event) => {
+        event.preventDefault();
+        form.handleSubmit();
+    }}
+>
+    <Card.Root>
+        <Card.Content class="space-y-5">
+            <form.Subscribe selector={(state) => state.errors}>
+                {#snippet children(errors)}
+                    <ErrorMessage message={getFormErrorMessages(errors)} />
+                {/snippet}
+            </form.Subscribe>
+
+            <form.Field name="name">
+                {#snippet children(field)}
+                    <Field.Field data-invalid={ariaInvalid(field)}>
+                        <Field.Label for={field.name}>Name</Field.Label>
+                        <Input
+                            id={field.name}
+                            value={field.state.value}
+                            onblur={field.handleBlur}
+                            oninput={(event) => field.handleChange(event.currentTarget.value)}
+                            aria-invalid={ariaInvalid(field)}
+                        />
+                        <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
+                    </Field.Field>
+                {/snippet}
+            </form.Field>
+
+            <form.Field name="client_id">
+                {#snippet children(field)}
+                    <Field.Field data-invalid={ariaInvalid(field)}>
+                        <Field.Label for={field.name}>Client ID</Field.Label>
+                        <Input
+                            id={field.name}
+                            value={field.state.value}
+                            onblur={field.handleBlur}
+                            oninput={(event) => field.handleChange(event.currentTarget.value)}
+                            aria-invalid={ariaInvalid(field)}
+                        />
+                        <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
+                    </Field.Field>
+                {/snippet}
+            </form.Field>
+
+            <form.Field name="redirect_uris">
+                {#snippet children(field)}
+                    <Field.Field data-invalid={ariaInvalid(field)}>
+                        <Field.Label for={field.name}>Redirect URIs</Field.Label>
+                        <Textarea
+                            id={field.name}
+                            class="min-h-24 font-mono text-xs"
+                            value={field.state.value}
+                            onblur={field.handleBlur}
+                            oninput={(event) => field.handleChange(event.currentTarget.value)}
+                            aria-invalid={ariaInvalid(field)}
+                        />
+                        <Field.Description>One exact redirect URI per line. Wildcards are not supported.</Field.Description>
+                        <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
+                    </Field.Field>
+                {/snippet}
+            </form.Field>
+
+            <form.Field name="scopes">
+                {#snippet children(field)}
+                    <Field.Field data-invalid={ariaInvalid(field)}>
+                        <Field.Label>Scopes</Field.Label>
+                        <div class="grid gap-3 sm:grid-cols-2">
+                            {#each supportedScopes as scope (scope.value)}
+                                {@const checked = isScopeChecked(field.state.value, scope.value)}
+                                <div class="flex items-start gap-3">
+                                    <Checkbox
+                                        {checked}
+                                        onCheckedChange={(value) => {
+                                            const current = field.state.value;
+                                            field.handleChange(value ? [...current, scope.value] : current.filter((item) => item !== scope.value));
+                                        }}
+                                    />
+                                    <div class="space-y-0.5">
+                                        <Label class="text-sm">{scope.label}</Label>
+                                        <p class="text-muted-foreground text-xs">{scope.description}</p>
+                                    </div>
+                                </div>
+                            {/each}
+                        </div>
+                        <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
+                    </Field.Field>
+                {/snippet}
+            </form.Field>
+
+            <form.Field name="notes">
+                {#snippet children(field)}
+                    <Field.Field data-invalid={ariaInvalid(field)}>
+                        <Field.Label for={field.name}>Notes</Field.Label>
+                        <Textarea
+                            id={field.name}
+                            value={field.state.value ?? ''}
+                            onblur={field.handleBlur}
+                            oninput={(event) => field.handleChange(event.currentTarget.value)}
+                            aria-invalid={ariaInvalid(field)}
+                        />
+                        <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
+                    </Field.Field>
+                {/snippet}
+            </form.Field>
+
+            <form.Field name="is_disabled">
+                {#snippet children(field)}
+                    <div class="flex items-start gap-3 rounded-md border p-3">
+                        <Checkbox checked={field.state.value} onCheckedChange={(value) => field.handleChange(!!value)} />
+                        <div class="space-y-1">
+                            <Label>Disabled</Label>
+                            <p class="text-muted-foreground text-xs">Disabled clients cannot authorize, refresh, or use existing OAuth access tokens.</p>
+                        </div>
+                    </div>
+                {/snippet}
+            </form.Field>
+        </Card.Content>
+        <Card.Footer class="flex justify-end gap-2">
+            <Button href={listHref} variant="outline">Cancel</Button>
+            <form.Subscribe selector={(state) => state.isSubmitting}>
+                {#snippet children(isSubmitting)}
+                    <Button type="submit" disabled={isSubmitting}>
+                        {#if isSubmitting}
+                            <Spinner />
+                            Saving...
+                        {:else}
+                            <Save class="size-4" aria-hidden="true" />
+                            {isEditing ? 'Save Changes' : 'Create App'}
+                        {/if}
+                    </Button>
+                {/snippet}
+            </form.Subscribe>
+        </Card.Footer>
+    </Card.Root>
+</form>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/table/oauth-application-actions-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/table/oauth-application-actions-cell.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+    import type { OAuthApplication } from '$features/admin/models';
+
+    import * as AlertDialog from '$comp/ui/alert-dialog';
+    import { Button, buttonVariants } from '$comp/ui/button';
+    import * as DropdownMenu from '$comp/ui/dropdown-menu';
+    import { deleteOAuthApplicationMutation } from '$features/admin/api.svelte';
+    import EllipsisIcon from '@lucide/svelte/icons/ellipsis';
+    import Trash2 from '@lucide/svelte/icons/trash-2';
+    import { toast } from 'svelte-sonner';
+
+    interface Props {
+        application: OAuthApplication;
+    }
+
+    let { application }: Props = $props();
+
+    const deleteApplication = deleteOAuthApplicationMutation();
+    let deleteDialogOpen = $state(false);
+
+    async function deleteOAuthApplication() {
+        try {
+            await deleteApplication.mutateAsync(application.id);
+            deleteDialogOpen = false;
+            toast.success('OAuth application deleted.');
+        } catch {
+            toast.error('Failed to delete OAuth application.');
+        }
+    }
+</script>
+
+<DropdownMenu.Root>
+    <DropdownMenu.Trigger>
+        {#snippet child({ props })}
+            <Button {...props} variant="ghost" size="icon" class="relative size-8 p-0">
+                <span class="sr-only">Open menu for {application.name}</span>
+                <EllipsisIcon class="size-4" aria-hidden="true" />
+            </Button>
+        {/snippet}
+    </DropdownMenu.Trigger>
+    <DropdownMenu.Content align="end">
+        <DropdownMenu.Item variant="destructive" onclick={() => (deleteDialogOpen = true)} disabled={deleteApplication.isPending}>
+            <Trash2 class="size-4" aria-hidden="true" />
+            Delete
+        </DropdownMenu.Item>
+    </DropdownMenu.Content>
+</DropdownMenu.Root>
+
+<AlertDialog.Root bind:open={deleteDialogOpen}>
+    <AlertDialog.Content>
+        <AlertDialog.Header>
+            <AlertDialog.Title>Delete OAuth Application</AlertDialog.Title>
+            <AlertDialog.Description>
+                Delete "{application.name}"? Disable the client instead when you only need to block OAuth access.
+            </AlertDialog.Description>
+        </AlertDialog.Header>
+        <AlertDialog.Footer>
+            <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                disabled={deleteApplication.isPending}
+                onclick={() => void deleteOAuthApplication()}
+            >
+                Delete
+            </AlertDialog.Action>
+        </AlertDialog.Footer>
+    </AlertDialog.Content>
+</AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/table/oauth-application-client-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/table/oauth-application-client-cell.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+    import CopyToClipboardButton from '$comp/copy-to-clipboard-button.svelte';
+
+    interface Props {
+        clientId: string;
+    }
+
+    let { clientId }: Props = $props();
+</script>
+
+<div class="flex min-w-0 items-center gap-1">
+    <code class="bg-muted min-w-0 truncate rounded px-1.5 py-0.5 text-xs" title={clientId}>{clientId}</code>
+    <CopyToClipboardButton value={clientId} variant="ghost" size="icon-sm" />
+</div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/table/oauth-application-organizations-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/table/oauth-application-organizations-cell.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+    import type { OAuthApplication } from '$features/admin/models';
+
+    import { Badge } from '$comp/ui/badge';
+    import * as Tooltip from '$comp/ui/tooltip';
+
+    interface Props {
+        application: OAuthApplication;
+    }
+
+    let { application }: Props = $props();
+</script>
+
+{#if application.organizations.length > 0}
+    <Tooltip.Root>
+        <Tooltip.Trigger>
+            {#snippet child({ props })}
+                <button
+                    {...props}
+                    type="button"
+                    class="focus-visible:ring-ring flex max-w-full items-center gap-1 rounded-sm text-left focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+                >
+                    <Badge class="max-w-44 truncate" variant="outline">{application.organizations[0]?.name}</Badge>
+                    {#if application.organizations.length > 1}
+                        <Badge variant="secondary">+{application.organizations.length - 1}</Badge>
+                    {/if}
+                </button>
+            {/snippet}
+        </Tooltip.Trigger>
+        <Tooltip.Content class="max-w-xs">
+            <div class="space-y-1">
+                {#each application.organizations as organization (organization.id)}
+                    <div class="truncate text-sm">{organization.name}</div>
+                {/each}
+            </div>
+        </Tooltip.Content>
+    </Tooltip.Root>
+{:else}
+    <span class="text-muted-foreground text-xs">Not authorized</span>
+{/if}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/table/oauth-application-scopes-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/table/oauth-application-scopes-cell.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+    import type { OAuthApplication } from '$features/admin/models';
+
+    import { Badge } from '$comp/ui/badge';
+    import * as Tooltip from '$comp/ui/tooltip';
+
+    interface Props {
+        application: OAuthApplication;
+    }
+
+    let { application }: Props = $props();
+</script>
+
+<Tooltip.Root>
+    <Tooltip.Trigger>
+        {#snippet child({ props })}
+            <button
+                {...props}
+                type="button"
+                class="focus-visible:ring-ring rounded-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
+                <Badge variant="secondary">{application.scopes.length} {application.scopes.length === 1 ? 'scope' : 'scopes'}</Badge>
+            </button>
+        {/snippet}
+    </Tooltip.Trigger>
+    <Tooltip.Content class="max-w-xs">
+        <div class="flex flex-wrap gap-1">
+            {#each application.scopes as scope (scope)}
+                <Badge variant={scope === 'stacks:write' ? 'amber' : 'secondary'}>{scope}</Badge>
+            {/each}
+        </div>
+    </Tooltip.Content>
+</Tooltip.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/table/oauth-application-summary-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/table/oauth-application-summary-cell.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+    import type { OAuthApplication } from '$features/admin/models';
+
+    import TimeAgo from '$comp/formatters/time-ago.svelte';
+    import { Badge } from '$comp/ui/badge';
+
+    interface Props {
+        application: OAuthApplication;
+    }
+
+    let { application }: Props = $props();
+</script>
+
+<div class="min-w-0 space-y-1 whitespace-normal">
+    <div class="truncate font-medium" title={application.name}>{application.name}</div>
+    <div class="text-muted-foreground text-xs">Updated <TimeAgo value={application.updated_utc} /></div>
+    {#if application.is_disabled}
+        <Badge variant="outline">Disabled</Badge>
+    {/if}
+</div>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/table/oauth-applications-data-table.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/table/oauth-applications-data-table.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+    import type { OAuthApplication } from '$features/admin/models';
+    import type { Snippet } from 'svelte';
+
+    import * as DataTable from '$comp/data-table';
+    import DelayedRender from '$comp/delayed-render.svelte';
+    import { type StockFeatures, type Table } from '@tanstack/svelte-table';
+
+    interface Props {
+        isLoading: boolean;
+        limit: number;
+        rowClick?: (row: OAuthApplication, event?: MouseEvent) => void;
+        rowHref?: (row: OAuthApplication) => string;
+        table: Table<StockFeatures, OAuthApplication>;
+        toolbarChildren?: Snippet;
+    }
+
+    let { isLoading, limit = $bindable(), rowClick, rowHref, table, toolbarChildren }: Props = $props();
+</script>
+
+<DataTable.Root>
+    {#if toolbarChildren}
+        <DataTable.Toolbar {table}>
+            {@render toolbarChildren()}
+        </DataTable.Toolbar>
+    {/if}
+    <DataTable.Footer {table} class="w-full">
+        <DataTable.Pager bind:value={limit} {table} />
+    </DataTable.Footer>
+    <DataTable.Body {rowClick} {rowHref} {table}>
+        {#if isLoading}
+            <DelayedRender>
+                <DataTable.Loading {table} />
+            </DelayedRender>
+        {:else}
+            <DataTable.Empty {table}>No OAuth applications found.</DataTable.Empty>
+        {/if}
+    </DataTable.Body>
+</DataTable.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/oauth-applications/table/options.svelte.ts
@@ -1,0 +1,100 @@
+import type { GetOAuthApplicationsParams } from '$features/admin/api.svelte';
+import type { OAuthApplication } from '$features/admin/models';
+import type { FetchClientResponse, ProblemDetails } from '@foundatiofx/fetchclient';
+import type { CreateQueryResult } from '@tanstack/svelte-query';
+
+import { getSharedTableOptions } from '$features/shared/table.svelte';
+import { type ColumnDef, renderComponent, type StockFeatures } from '@tanstack/svelte-table';
+
+import OAuthApplicationActionsCell from './oauth-application-actions-cell.svelte';
+import OAuthApplicationClientCell from './oauth-application-client-cell.svelte';
+import OAuthApplicationOrganizationsCell from './oauth-application-organizations-cell.svelte';
+import OAuthApplicationScopesCell from './oauth-application-scopes-cell.svelte';
+import OAuthApplicationSummaryCell from './oauth-application-summary-cell.svelte';
+
+export function getColumns(): ColumnDef<StockFeatures, OAuthApplication, unknown>[] {
+    return [
+        {
+            accessorKey: 'name',
+            cell: (info) =>
+                renderComponent(OAuthApplicationSummaryCell, {
+                    application: info.row.original
+                }),
+            enableHiding: false,
+            enableSorting: false,
+            header: 'Application',
+            meta: {
+                class: 'w-[28%] max-w-none whitespace-normal'
+            }
+        },
+        {
+            accessorKey: 'client_id',
+            cell: (info) =>
+                renderComponent(OAuthApplicationClientCell, {
+                    clientId: info.row.original.client_id
+                }),
+            enableSorting: false,
+            header: 'Client ID',
+            meta: {
+                class: 'w-[30%] max-w-none'
+            }
+        },
+        {
+            accessorKey: 'organizations',
+            cell: (info) =>
+                renderComponent(OAuthApplicationOrganizationsCell, {
+                    application: info.row.original
+                }),
+            enableSorting: false,
+            header: 'Authorized organizations',
+            meta: {
+                class: 'w-56 max-w-none whitespace-normal'
+            }
+        },
+        {
+            accessorKey: 'scopes',
+            cell: (info) =>
+                renderComponent(OAuthApplicationScopesCell, {
+                    application: info.row.original
+                }),
+            enableSorting: false,
+            header: 'Access',
+            meta: {
+                class: 'w-28 max-w-none'
+            }
+        },
+        {
+            cell: (info) =>
+                renderComponent(OAuthApplicationActionsCell, {
+                    application: info.row.original
+                }),
+            enableHiding: false,
+            enableSorting: false,
+            header: '',
+            id: 'actions',
+            meta: {
+                class: 'w-12 min-w-12 max-w-12 text-right'
+            }
+        }
+    ];
+}
+
+export function getTableOptions(
+    queryParameters: GetOAuthApplicationsParams,
+    queryResponse: CreateQueryResult<FetchClientResponse<OAuthApplication[]>, ProblemDetails>
+) {
+    return getSharedTableOptions<OAuthApplication, 'offset'>({
+        columnPersistenceKey: 'oauth-applications-compact',
+        columns: getColumns(),
+        paginationStrategy: 'offset',
+        get queryData() {
+            return queryResponse.data?.data ?? [];
+        },
+        get queryMeta() {
+            return queryResponse.data?.meta;
+        },
+        get queryParameters() {
+            return queryParameters;
+        }
+    });
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/models.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/models.ts
@@ -146,10 +146,16 @@ export type OAuthApplication = {
     is_disabled: boolean;
     name: string;
     notes?: null | string;
+    organizations: OAuthApplicationOrganization[];
     redirect_uris: string[];
     scopes: string[];
     updated_by_user_id?: null | string;
     updated_utc: string;
+};
+
+export type OAuthApplicationOrganization = {
+    id: string;
+    name: string;
 };
 
 export type OAuthApplicationRequest = {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/oauth-applications/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/oauth-applications/+page.svelte
@@ -1,423 +1,135 @@
 <script lang="ts">
-    import type { OAuthApplication, OAuthApplicationRequest } from '$features/admin/models';
+    import type { OAuthApplication } from '$features/admin/models';
 
-    import CopyToClipboardButton from '$comp/copy-to-clipboard-button.svelte';
-    import ErrorMessage from '$comp/error-message.svelte';
-    import DateTime from '$comp/formatters/date-time.svelte';
-    import { Muted } from '$comp/typography';
-    import { Badge } from '$comp/ui/badge';
+    import { goto } from '$app/navigation';
+    import { resolve } from '$app/paths';
+    import { Muted, P } from '$comp/typography';
     import { Button } from '$comp/ui/button';
-    import * as Card from '$comp/ui/card';
-    import { Checkbox } from '$comp/ui/checkbox';
-    import * as Field from '$comp/ui/field';
     import { Input } from '$comp/ui/input';
-    import { Label } from '$comp/ui/label';
-    import { Spinner } from '$comp/ui/spinner';
-    import * as Table from '$comp/ui/table';
-    import { Textarea } from '$comp/ui/textarea';
-    import {
-        deleteOAuthApplicationMutation,
-        getOAuthApplicationsQuery,
-        postOAuthApplicationMutation,
-        putOAuthApplicationMutation
-    } from '$features/admin/api.svelte';
-    import { type OAuthApplicationFormData, OAuthApplicationSchema } from '$features/admin/schemas';
-    import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
-    import { ProblemDetails } from '@foundatiofx/fetchclient';
-    import Check from '@lucide/svelte/icons/check';
-    import CircleSlash from '@lucide/svelte/icons/circle-slash';
+    import { type GetOAuthApplicationsParams, getOAuthApplicationsQuery } from '$features/admin/api.svelte';
+    import OAuthApplicationsDataTable from '$features/admin/components/oauth-applications/table/oauth-applications-data-table.svelte';
+    import { getTableOptions } from '$features/admin/components/oauth-applications/table/options.svelte';
+    import { DEFAULT_LIMIT } from '$features/shared/api/api.svelte';
+    import { createQueryParameters } from '$shared/query-params';
     import Plus from '@lucide/svelte/icons/plus';
-    import Save from '@lucide/svelte/icons/save';
-    import Trash2 from '@lucide/svelte/icons/trash-2';
-    import { createForm } from '@tanstack/svelte-form';
-    import { toast } from 'svelte-sonner';
+    import { createTable } from '@tanstack/svelte-table';
 
-    const supportedScopes = [
-        {
-            description: 'Allows connecting to the MCP endpoint.',
-            label: 'MCP',
-            value: 'mcp:read'
-        },
-        {
-            description: 'Allows reading project metadata.',
-            label: 'Projects',
-            value: 'projects:read'
-        },
-        {
-            description: 'Allows reading stack data.',
-            label: 'Stacks',
-            value: 'stacks:read'
-        },
-        {
-            description: 'Allows changing stack status, snooze, and critical settings.',
-            label: 'Stacks Write',
-            value: 'stacks:write'
-        },
-        {
-            description: 'Allows reading event details.',
-            label: 'Events',
-            value: 'events:read'
-        },
-        {
-            description: 'Allows refresh token issuance.',
-            label: 'Offline Access',
-            value: 'offline_access'
+    const DEFAULT_PARAMS = {
+        criteria: '',
+        limit: DEFAULT_LIMIT,
+        organization: '',
+        page: 1
+    };
+
+    const queryParams = createQueryParameters({
+        defaults: DEFAULT_PARAMS,
+        history: 'push',
+        schema: {
+            criteria: 'string',
+            limit: 'number',
+            organization: 'string',
+            page: 'number'
         }
-    ] as const;
+    });
 
-    const applicationsQuery = getOAuthApplicationsQuery();
-    const createApplication = postOAuthApplicationMutation();
-    const updateApplication = putOAuthApplicationMutation();
-    const deleteApplication = deleteOAuthApplicationMutation();
-
-    let selectedApplication = $state<null | OAuthApplication>(null);
-    let toastId = $state<number | string>();
-
-    const applications = $derived(applicationsQuery.data ?? []);
-    const isEditing = $derived(selectedApplication !== null);
-
-    const form = createForm(() => ({
-        defaultValues: getFormValues(null),
-        validators: {
-            onSubmit: OAuthApplicationSchema,
-            onSubmitAsync: async ({ value }) => {
-                const request = toRequest(value);
-
-                try {
-                    const saved = selectedApplication
-                        ? await updateApplication.mutateAsync({
-                              id: selectedApplication.id,
-                              request
-                          })
-                        : await createApplication.mutateAsync(request);
-
-                    selectedApplication = saved;
-                    setFormValues(saved);
-                    toast.dismiss(toastId);
-                    toastId = toast.success(selectedApplication ? 'OAuth application updated.' : 'OAuth application created.');
-                    return null;
-                } catch (error: unknown) {
-                    if (error instanceof ProblemDetails) {
-                        return problemDetailsToFormErrors(error);
-                    }
-
-                    return {
-                        form: 'An unexpected error occurred, please try again.'
-                    };
-                }
-            }
+    const applicationQueryParameters: GetOAuthApplicationsParams = $state({
+        get criteria() {
+            return queryParams.criteria!;
+        },
+        set criteria(value) {
+            queryParams.criteria = value;
+        },
+        get limit() {
+            return queryParams.limit!;
+        },
+        set limit(value) {
+            queryParams.limit = value;
+        },
+        get organization() {
+            return queryParams.organization!;
+        },
+        set organization(value) {
+            queryParams.organization = value;
+        },
+        get page() {
+            return queryParams.page!;
+        },
+        set page(value) {
+            queryParams.page = value;
         }
-    }));
+    });
 
-    function getFormValues(application: null | OAuthApplication): OAuthApplicationFormData {
-        return {
-            client_id: application?.client_id ?? '',
-            is_disabled: application?.is_disabled ?? false,
-            name: application?.name ?? '',
-            notes: application?.notes ?? '',
-            redirect_uris: application?.redirect_uris.join('\n') ?? '',
-            scopes: application?.scopes ?? ['mcp:read', 'projects:read', 'stacks:read', 'events:read', 'offline_access']
-        };
-    }
-
-    function setFormValues(application: null | OAuthApplication) {
-        const values = getFormValues(application);
-        form.setFieldValue('client_id', values.client_id);
-        form.setFieldValue('is_disabled', values.is_disabled);
-        form.setFieldValue('name', values.name);
-        form.setFieldValue('notes', values.notes);
-        form.setFieldValue('redirect_uris', values.redirect_uris);
-        form.setFieldValue('scopes', values.scopes);
-    }
-
-    function toRequest(value: OAuthApplicationFormData): OAuthApplicationRequest {
-        return {
-            client_id: value.client_id.trim(),
-            is_disabled: value.is_disabled,
-            name: value.name.trim(),
-            notes: value.notes?.trim() || null,
-            redirect_uris: value.redirect_uris
-                .split(/\r?\n/)
-                .map((v) => v.trim())
-                .filter(Boolean),
-            scopes: value.scopes
-        };
-    }
-
-    function selectApplication(application: OAuthApplication) {
-        selectedApplication = application;
-        setFormValues(application);
-    }
-
-    function createNewApplication() {
-        selectedApplication = null;
-        form.reset();
-        setFormValues(null);
-    }
-
-    async function handleDelete(application: OAuthApplication) {
-        if (!confirm(`Delete OAuth application "${application.name}"? Disable the client instead when you need to block OAuth access.`)) {
-            return;
+    const applicationsQuery = getOAuthApplicationsQuery({
+        get params() {
+            return applicationQueryParameters;
         }
+    });
+    const table = createTable(getTableOptions(applicationQueryParameters, applicationsQuery));
+    const newApplicationHref = resolve('/(app)/system/oauth-applications/new');
 
-        try {
-            await deleteApplication.mutateAsync(application.id);
-            if (selectedApplication?.id === application.id) {
-                createNewApplication();
-            }
+    $effect(() => {
+        queryParams.limit ??= DEFAULT_LIMIT;
+        queryParams.page ??= 1;
+    });
 
-            toast.success('OAuth application deleted.');
-        } catch {
-            toast.error('Failed to delete OAuth application.');
-        }
+    function setCriteria(value: string) {
+        applicationQueryParameters.page = 1;
+        applicationQueryParameters.criteria = value;
     }
 
-    function isScopeChecked(scopes: string[], scope: string) {
-        return scopes.includes(scope);
+    function setOrganization(value: string) {
+        applicationQueryParameters.page = 1;
+        applicationQueryParameters.organization = value;
+    }
+
+    function rowHref(application: OAuthApplication) {
+        return resolve('/(app)/system/oauth-applications/[id=objectid]', {
+            id: application.id
+        });
+    }
+
+    async function rowClick(application: OAuthApplication) {
+        await goto(rowHref(application));
     }
 </script>
 
-<div class="space-y-6">
+<div class="space-y-4">
     <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <Muted>Manage OAuth clients that can request access to the Exceptionless API and MCP tools.</Muted>
-        <Button variant="outline" onclick={createNewApplication}>
+        <div class="space-y-1">
+            <Muted>Manage public OAuth clients that can request access to the Exceptionless API and MCP tools.</Muted>
+            <P class="text-muted-foreground text-xs">
+                Dynamic clients are registered before consent. Organizations appear after a user authorizes access, and the historical associations are retained
+                for administration. One client may be authorized for several organizations.
+            </P>
+        </div>
+        <Button href={newApplicationHref} variant="outline">
             <Plus class="size-4" aria-hidden="true" />
             New OAuth App
         </Button>
     </div>
 
-    <div class="grid gap-6 xl:grid-cols-[minmax(0,1fr)_420px]">
-        <Card.Root>
-            <Card.Header>
-                <Card.Title class="text-sm font-medium">Applications</Card.Title>
-                <Card.Description>Registered public OAuth clients.</Card.Description>
-            </Card.Header>
-            <Card.Content>
-                {#if applicationsQuery.isPending}
-                    <div class="text-muted-foreground flex items-center gap-2 py-8 text-sm">
-                        <Spinner />
-                        Loading OAuth applications...
-                    </div>
-                {:else if applicationsQuery.isError}
-                    <p class="text-destructive py-8 text-sm">Failed to load OAuth applications.</p>
-                {:else if applications.length === 0}
-                    <p class="text-muted-foreground py-8 text-sm">No OAuth applications have been created.</p>
-                {:else}
-                    <div class="overflow-x-auto">
-                        <Table.Root>
-                            <Table.Header>
-                                <Table.Row>
-                                    <Table.Head>Name</Table.Head>
-                                    <Table.Head>Client ID</Table.Head>
-                                    <Table.Head>Scopes</Table.Head>
-                                    <Table.Head>Status</Table.Head>
-                                    <Table.Head class="w-16 text-right">Actions</Table.Head>
-                                </Table.Row>
-                            </Table.Header>
-                            <Table.Body>
-                                {#each applications as application (application.id)}
-                                    <Table.Row class={selectedApplication?.id === application.id ? 'bg-muted/60' : undefined}>
-                                        <Table.Cell>
-                                            <button type="button" class="text-left font-medium hover:underline" onclick={() => selectApplication(application)}>
-                                                {application.name}
-                                            </button>
-                                            <div class="text-muted-foreground mt-1 text-xs">
-                                                Updated <DateTime value={application.updated_utc} />
-                                            </div>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <div class="flex items-center gap-2">
-                                                <code class="bg-muted rounded px-1.5 py-0.5 text-xs break-all">{application.client_id}</code>
-                                                <CopyToClipboardButton value={application.client_id} variant="ghost" size="icon" />
-                                            </div>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            <div class="flex max-w-64 flex-wrap gap-1">
-                                                {#each application.scopes as scope (scope)}
-                                                    <Badge variant="secondary">{scope}</Badge>
-                                                {/each}
-                                            </div>
-                                        </Table.Cell>
-                                        <Table.Cell>
-                                            {#if application.is_disabled}
-                                                <Badge variant="outline" class="gap-1">
-                                                    <CircleSlash class="size-3" aria-hidden="true" />
-                                                    Disabled
-                                                </Badge>
-                                            {:else}
-                                                <Badge variant="secondary" class="gap-1">
-                                                    <Check class="size-3" aria-hidden="true" />
-                                                    Enabled
-                                                </Badge>
-                                            {/if}
-                                        </Table.Cell>
-                                        <Table.Cell class="text-right">
-                                            <Button
-                                                variant="ghost"
-                                                size="icon"
-                                                aria-label="Delete OAuth application"
-                                                title="Delete OAuth application"
-                                                disabled={deleteApplication.isPending}
-                                                onclick={() => {
-                                                    void handleDelete(application);
-                                                }}
-                                            >
-                                                <Trash2 class="size-4" aria-hidden="true" />
-                                            </Button>
-                                        </Table.Cell>
-                                    </Table.Row>
-                                {/each}
-                            </Table.Body>
-                        </Table.Root>
-                    </div>
-                {/if}
-            </Card.Content>
-        </Card.Root>
-
-        <Card.Root>
-            <Card.Header>
-                <Card.Title class="text-sm font-medium">{isEditing ? 'Edit OAuth App' : 'New OAuth App'}</Card.Title>
-                <Card.Description>Use exact redirect URIs. Wildcards are not supported.</Card.Description>
-            </Card.Header>
-            <form
-                onsubmit={(event) => {
-                    event.preventDefault();
-                    form.handleSubmit();
-                }}
-            >
-                <Card.Content class="space-y-5">
-                    <form.Subscribe selector={(state) => state.errors}>
-                        {#snippet children(errors)}
-                            <ErrorMessage message={getFormErrorMessages(errors)} />
-                        {/snippet}
-                    </form.Subscribe>
-
-                    <form.Field name="name">
-                        {#snippet children(field)}
-                            <Field.Field data-invalid={ariaInvalid(field)}>
-                                <Field.Label for={field.name}>Name</Field.Label>
-                                <Input
-                                    id={field.name}
-                                    value={field.state.value}
-                                    onblur={field.handleBlur}
-                                    oninput={(e) => field.handleChange(e.currentTarget.value)}
-                                    aria-invalid={ariaInvalid(field)}
-                                />
-                                <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
-                            </Field.Field>
-                        {/snippet}
-                    </form.Field>
-
-                    <form.Field name="client_id">
-                        {#snippet children(field)}
-                            <Field.Field data-invalid={ariaInvalid(field)}>
-                                <Field.Label for={field.name}>Client ID</Field.Label>
-                                <Input
-                                    id={field.name}
-                                    value={field.state.value}
-                                    onblur={field.handleBlur}
-                                    oninput={(e) => field.handleChange(e.currentTarget.value)}
-                                    aria-invalid={ariaInvalid(field)}
-                                />
-                                <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
-                            </Field.Field>
-                        {/snippet}
-                    </form.Field>
-
-                    <form.Field name="redirect_uris">
-                        {#snippet children(field)}
-                            <Field.Field data-invalid={ariaInvalid(field)}>
-                                <Field.Label for={field.name}>Redirect URIs</Field.Label>
-                                <Textarea
-                                    id={field.name}
-                                    class="min-h-24 font-mono text-xs"
-                                    value={field.state.value}
-                                    onblur={field.handleBlur}
-                                    oninput={(e) => field.handleChange(e.currentTarget.value)}
-                                    aria-invalid={ariaInvalid(field)}
-                                />
-                                <Field.Description>One redirect URI per line.</Field.Description>
-                                <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
-                            </Field.Field>
-                        {/snippet}
-                    </form.Field>
-
-                    <form.Field name="scopes">
-                        {#snippet children(field)}
-                            <Field.Field data-invalid={ariaInvalid(field)}>
-                                <Field.Label>Scopes</Field.Label>
-                                <div class="space-y-3">
-                                    {#each supportedScopes as scope (scope.value)}
-                                        {@const checked = isScopeChecked(field.state.value, scope.value)}
-                                        <div class="flex items-start gap-3">
-                                            <Checkbox
-                                                {checked}
-                                                onCheckedChange={(value) => {
-                                                    const current = field.state.value;
-                                                    field.handleChange(value ? [...current, scope.value] : current.filter((s) => s !== scope.value));
-                                                }}
-                                            />
-                                            <div class="space-y-0.5">
-                                                <Label class="text-sm">{scope.label}</Label>
-                                                <p class="text-muted-foreground text-xs">{scope.description}</p>
-                                            </div>
-                                        </div>
-                                    {/each}
-                                </div>
-                                <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
-                            </Field.Field>
-                        {/snippet}
-                    </form.Field>
-
-                    <form.Field name="notes">
-                        {#snippet children(field)}
-                            <Field.Field data-invalid={ariaInvalid(field)}>
-                                <Field.Label for={field.name}>Notes</Field.Label>
-                                <Textarea
-                                    id={field.name}
-                                    value={field.state.value ?? ''}
-                                    onblur={field.handleBlur}
-                                    oninput={(e) => field.handleChange(e.currentTarget.value)}
-                                    aria-invalid={ariaInvalid(field)}
-                                />
-                                <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
-                            </Field.Field>
-                        {/snippet}
-                    </form.Field>
-
-                    <form.Field name="is_disabled">
-                        {#snippet children(field)}
-                            <div class="flex items-start gap-3 rounded-md border p-3">
-                                <Checkbox checked={field.state.value} onCheckedChange={(value) => field.handleChange(!!value)} />
-                                <div class="space-y-1">
-                                    <Label>Disabled</Label>
-                                    <p class="text-muted-foreground text-xs">
-                                        Disabled clients cannot authorize, refresh, or use existing OAuth access tokens.
-                                    </p>
-                                </div>
-                            </div>
-                        {/snippet}
-                    </form.Field>
-                </Card.Content>
-                <Card.Footer class="flex justify-end gap-2">
-                    {#if isEditing}
-                        <Button type="button" variant="outline" onclick={createNewApplication}>Cancel</Button>
-                    {/if}
-                    <form.Subscribe selector={(state) => state.isSubmitting}>
-                        {#snippet children(isSubmitting)}
-                            <Button type="submit" disabled={isSubmitting}>
-                                {#if isSubmitting}
-                                    <Spinner />
-                                    Saving...
-                                {:else}
-                                    <Save class="size-4" aria-hidden="true" />
-                                    {isEditing ? 'Save Changes' : 'Create App'}
-                                {/if}
-                            </Button>
-                        {/snippet}
-                    </form.Subscribe>
-                </Card.Footer>
-            </form>
-        </Card.Root>
-    </div>
+    {#if applicationsQuery.isError}
+        <P class="text-destructive py-8 text-sm">Failed to load OAuth applications.</P>
+    {:else}
+        <OAuthApplicationsDataTable bind:limit={applicationQueryParameters.limit!} isLoading={applicationsQuery.isPending} {rowClick} {rowHref} {table}>
+            {#snippet toolbarChildren()}
+                <Input
+                    type="search"
+                    aria-label="Filter OAuth applications"
+                    placeholder="Filter by application name or exact client ID..."
+                    class="min-w-56 flex-1"
+                    value={applicationQueryParameters.criteria}
+                    oninput={(event) => setCriteria(event.currentTarget.value)}
+                />
+                <Input
+                    type="search"
+                    aria-label="Filter OAuth applications by organization"
+                    placeholder="Filter by organization name or ID..."
+                    class="min-w-56 flex-1"
+                    value={applicationQueryParameters.organization}
+                    oninput={(event) => setOrganization(event.currentTarget.value)}
+                />
+            {/snippet}
+        </OAuthApplicationsDataTable>
+    {/if}
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/oauth-applications/[id=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/oauth-applications/[id=objectid]/+page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+    import { page } from '$app/state';
+    import ErrorMessage from '$comp/error-message.svelte';
+    import { Muted } from '$comp/typography';
+    import { Spinner } from '$comp/ui/spinner';
+    import { getOAuthApplicationQuery } from '$features/admin/api.svelte';
+    import OAuthApplicationForm from '$features/admin/components/oauth-applications/oauth-application-form.svelte';
+
+    const applicationId = $derived(page.params.id);
+    const applicationQuery = getOAuthApplicationQuery(() => applicationId);
+</script>
+
+<div class="max-w-3xl space-y-6">
+    <Muted>Edit the registered OAuth client and its allowed access.</Muted>
+
+    {#if applicationQuery.isPending}
+        <div class="text-muted-foreground flex items-center gap-2 py-8 text-sm">
+            <Spinner />
+            Loading OAuth application...
+        </div>
+    {:else if applicationQuery.isError}
+        <ErrorMessage message="Failed to load the OAuth application." />
+    {:else if applicationQuery.data}
+        <OAuthApplicationForm application={applicationQuery.data} />
+    {/if}
+</div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/oauth-applications/new/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/oauth-applications/new/+page.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+    import { Muted } from '$comp/typography';
+    import OAuthApplicationForm from '$features/admin/components/oauth-applications/oauth-application-form.svelte';
+</script>
+
+<div class="max-w-3xl space-y-6">
+    <Muted>Create a manually managed public OAuth client.</Muted>
+    <OAuthApplicationForm />
+</div>

--- a/src/Exceptionless.Web/Models/Admin/ViewOAuthApplication.cs
+++ b/src/Exceptionless.Web/Models/Admin/ViewOAuthApplication.cs
@@ -9,6 +9,7 @@ public record ViewOAuthApplication
     public required string Name { get; init; }
     public required string[] RedirectUris { get; init; }
     public required string[] Scopes { get; init; }
+    public required IReadOnlyCollection<ViewOAuthApplicationOrganization> Organizations { get; init; }
     public string? Notes { get; init; }
     public bool IsDisabled { get; init; }
     public required string CreatedByUserId { get; init; }
@@ -16,7 +17,7 @@ public record ViewOAuthApplication
     public DateTime CreatedUtc { get; init; }
     public DateTime UpdatedUtc { get; init; }
 
-    public static ViewOAuthApplication FromApplication(OAuthApplication application)
+    public static ViewOAuthApplication FromApplication(OAuthApplication application, IReadOnlyDictionary<string, string>? organizationNames = null)
     {
         return new ViewOAuthApplication
         {
@@ -25,6 +26,10 @@ public record ViewOAuthApplication
             Name = application.Name,
             RedirectUris = application.RedirectUris,
             Scopes = application.Scopes,
+            Organizations = application.OrganizationIds
+                .Select(id => new ViewOAuthApplicationOrganization(id, organizationNames?.GetValueOrDefault(id) ?? id))
+                .OrderBy(organization => organization.Name)
+                .ToArray(),
             Notes = application.Notes,
             IsDisabled = application.IsDisabled,
             CreatedByUserId = application.CreatedByUserId,
@@ -34,3 +39,5 @@ public record ViewOAuthApplication
         };
     }
 }
+
+public sealed record ViewOAuthApplicationOrganization(string Id, string Name);

--- a/tests/Exceptionless.Tests/Api/Data/endpoint-manifest.json
+++ b/tests/Exceptionless.Tests/Api/Data/endpoint-manifest.json
@@ -470,6 +470,18 @@
     "authenticationSchemes": []
   },
   {
+    "method": "GET",
+    "route": "/api/v2/admin/oauth-applications/{id:objectid}",
+    "displayName": "HTTP: GET api/v2/admin/oauth-applications/{id:objectid}",
+    "tags": [],
+    "allowAnonymous": false,
+    "authorizationPolicies": [
+      "GlobalAdminPolicy"
+    ],
+    "authorizationRoles": [],
+    "authenticationSchemes": []
+  },
+  {
     "method": "PUT",
     "route": "/api/v2/admin/oauth-applications/{id:objectid}",
     "displayName": "HTTP: PUT api/v2/admin/oauth-applications/{id:objectid}",

--- a/tests/Exceptionless.Tests/Api/Endpoints/OAuthApplicationEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/OAuthApplicationEndpointTests.cs
@@ -3,6 +3,7 @@ using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Utility;
 using Exceptionless.Tests.Extensions;
 using Exceptionless.Web.Models.Admin;
+using Foundatio.Repositories;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
 
@@ -44,6 +45,7 @@ public sealed class OAuthApplicationEndpointTests : IntegrationTestsBase
         Assert.Equal(["mcp:read", "events:read"], created.Scopes);
         Assert.Equal("Dev OAuth app", created.Notes);
         Assert.False(created.IsDisabled);
+        Assert.Empty(created.Organizations);
         Assert.True(created.CreatedUtc > DateTime.MinValue);
         Assert.True(created.UpdatedUtc > DateTime.MinValue);
 
@@ -68,6 +70,71 @@ public sealed class OAuthApplicationEndpointTests : IntegrationTestsBase
         Assert.NotNull(applications);
         Assert.Contains(applications, a => a.Id == first.Id);
         Assert.Contains(applications, a => a.Id == second.Id);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithPagingAndFilters_ReturnsMatchingOrganizationDetails()
+    {
+        var first = await CreateApplicationAsync(CreateModel("paged-oauth-alpha", "Paged OAuth Alpha"));
+        var second = await CreateApplicationAsync(CreateModel("paged-oauth-beta", "Paged OAuth Beta"));
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+
+        var firstApplication = await _repository.GetByIdAsync(first.Id);
+        Assert.NotNull(firstApplication);
+        firstApplication.OrganizationIds.Add(SampleDataService.TEST_ORG_ID);
+        await _repository.SaveAsync(firstApplication, options => options.ImmediateConsistency());
+
+        var firstPage = await SendRequestAsAsync<IReadOnlyCollection<ViewOAuthApplication>>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "oauth-applications")
+            .QueryString("criteria", "Paged OAuth")
+            .QueryString("page", 1)
+            .QueryString("limit", 1)
+            .StatusCodeShouldBeOk());
+        var secondPage = await SendRequestAsAsync<IReadOnlyCollection<ViewOAuthApplication>>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "oauth-applications")
+            .QueryString("criteria", "Paged OAuth")
+            .QueryString("page", 2)
+            .QueryString("limit", 1)
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(firstPage);
+        Assert.NotNull(secondPage);
+        Assert.Single(firstPage);
+        Assert.Single(secondPage);
+        Assert.NotEqual(firstPage.Single().Id, secondPage.Single().Id);
+
+        var organizationMatches = await SendRequestAsAsync<IReadOnlyCollection<ViewOAuthApplication>>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "oauth-applications")
+            .QueryString("organization", "Acme")
+            .QueryString("criteria", "paged-oauth")
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(organizationMatches);
+        var match = Assert.Single(organizationMatches);
+        Assert.Equal(first.Id, match.Id);
+        var organization = Assert.Single(match.Organizations);
+        Assert.Equal(SampleDataService.TEST_ORG_ID, organization.Id);
+        Assert.Equal("Acme", organization.Name);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_AsGlobalAdmin_ReturnsOAuthApplication()
+    {
+        var created = await CreateApplicationAsync(CreateModel("oauth-by-id", "OAuth By Id"));
+        Assert.NotNull(created);
+
+        var application = await SendRequestAsAsync<ViewOAuthApplication>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "oauth-applications", created.Id)
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(application);
+        Assert.Equal(created.Id, application.Id);
+        Assert.Equal(created.ClientId, application.ClientId);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Api/Endpoints/OAuthApplicationEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/OAuthApplicationEndpointTests.cs
@@ -1,7 +1,10 @@
 using Exceptionless.Core.Authorization;
+using Exceptionless.Core.Billing;
+using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Utility;
 using Exceptionless.Tests.Extensions;
+using Exceptionless.Web.Api.Infrastructure;
 using Exceptionless.Web.Models.Admin;
 using Foundatio.Repositories;
 using Microsoft.AspNetCore.Mvc;
@@ -12,10 +15,14 @@ namespace Exceptionless.Tests.Api.Endpoints;
 public sealed class OAuthApplicationEndpointTests : IntegrationTestsBase
 {
     private readonly IOAuthApplicationRepository _repository;
+    private readonly IOrganizationRepository _organizationRepository;
+    private readonly BillingPlans _plans;
 
     public OAuthApplicationEndpointTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
     {
         _repository = GetService<IOAuthApplicationRepository>();
+        _organizationRepository = GetService<IOrganizationRepository>();
+        _plans = GetService<BillingPlans>();
     }
 
     protected override async Task ResetDataAsync()
@@ -73,6 +80,22 @@ public sealed class OAuthApplicationEndpointTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task GetAllAsync_WithoutLimit_PreservesLegacyPageSize()
+    {
+        for (int i = 0; i < 21; i++)
+            Assert.NotNull(await CreateApplicationAsync(CreateModel($"legacy-default-{i:D2}", $"Legacy Default {i:D2}")));
+
+        var applications = await SendRequestAsAsync<IReadOnlyCollection<ViewOAuthApplication>>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "oauth-applications")
+            .QueryString("criteria", "Legacy Default")
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(applications);
+        Assert.Equal(21, applications.Count);
+    }
+
+    [Fact]
     public async Task GetAllAsync_WithPagingAndFilters_ReturnsMatchingOrganizationDetails()
     {
         var first = await CreateApplicationAsync(CreateModel("paged-oauth-alpha", "Paged OAuth Alpha"));
@@ -119,6 +142,38 @@ public sealed class OAuthApplicationEndpointTests : IntegrationTestsBase
         var organization = Assert.Single(match.Organizations);
         Assert.Equal(SampleDataService.TEST_ORG_ID, organization.Id);
         Assert.Equal("Acme", organization.Name);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithOrganizationFilter_ResolvesMatchesBeyondFirstPage()
+    {
+        var organizations = Enumerable.Range(0, Pagination.MaximumLimit + 1)
+            .Select(index => new Organization
+            {
+                Name = $"OAuth Filter Organization {index:D3}",
+                PlanId = _plans.FreePlan.Id
+            })
+            .ToArray();
+        await _organizationRepository.AddAsync(organizations, options => options.ImmediateConsistency());
+
+        var created = await CreateApplicationAsync(CreateModel("deep-organization-filter", "Deep Organization Filter"));
+        Assert.NotNull(created);
+        var application = await _repository.GetByIdAsync(created.Id);
+        Assert.NotNull(application);
+        application.OrganizationIds.Add(organizations[^1].Id);
+        await _repository.SaveAsync(application, options => options.ImmediateConsistency());
+
+        var applications = await SendRequestAsAsync<IReadOnlyCollection<ViewOAuthApplication>>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "oauth-applications")
+            .QueryString("organization", "OAuth Filter Organization")
+            .QueryString("criteria", "deep-organization-filter")
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(applications);
+        var match = Assert.Single(applications);
+        Assert.Equal(created.Id, match.Id);
+        Assert.Contains(match.Organizations, organization => organization.Id == organizations[^1].Id);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Api/Endpoints/OAuthApplicationEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/OAuthApplicationEndpointTests.cs
@@ -93,6 +93,9 @@ public sealed class OAuthApplicationEndpointTests : IntegrationTestsBase
 
         Assert.NotNull(applications);
         Assert.Equal(21, applications.Count);
+        Assert.Equal(
+            Enumerable.Range(0, 21).Select(index => $"Legacy Default {index:D2}"),
+            applications.Select(application => application.Name));
     }
 
     [Fact]
@@ -147,7 +150,7 @@ public sealed class OAuthApplicationEndpointTests : IntegrationTestsBase
     [Fact]
     public async Task GetAllAsync_WithOrganizationFilter_ResolvesMatchesBeyondFirstPage()
     {
-        var organizations = Enumerable.Range(0, Pagination.MaximumLimit + 1)
+        var organizations = Enumerable.Range(0, Pagination.MaximumLimit * 11)
             .Select(index => new Organization
             {
                 Name = $"OAuth Filter Organization {index:D3}",
@@ -197,6 +200,10 @@ public sealed class OAuthApplicationEndpointTests : IntegrationTestsBase
     {
         var created = await CreateApplicationAsync(CreateModel("chatgpt-dev", "ChatGPT Dev"));
         Assert.NotNull(created);
+        var persistedApplication = await _repository.GetByIdAsync(created.Id);
+        Assert.NotNull(persistedApplication);
+        persistedApplication.OrganizationIds.Add(SampleDataService.TEST_ORG_ID);
+        await _repository.SaveAsync(persistedApplication, options => options.ImmediateConsistency());
 
         var updated = await SendRequestAsAsync<ViewOAuthApplication>(r => r
             .Put()
@@ -219,6 +226,9 @@ public sealed class OAuthApplicationEndpointTests : IntegrationTestsBase
         Assert.Equal("ChatGPT Production", updated.Name);
         Assert.Equal(["mcp:read", "projects:read"], updated.Scopes);
         Assert.True(updated.IsDisabled);
+        var organization = Assert.Single(updated.Organizations);
+        Assert.Equal(SampleDataService.TEST_ORG_ID, organization.Id);
+        Assert.Equal("Acme", organization.Name);
 
         var application = await _repository.GetByIdAsync(created.Id);
         Assert.NotNull(application);

--- a/tests/Exceptionless.Tests/Api/Endpoints/OAuthEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/OAuthEndpointTests.cs
@@ -601,7 +601,7 @@ public sealed class OAuthEndpointTests : IntegrationTestsBase
     [Fact]
     public async Task CompleteAuthorizeAsync_ClientMetadataDocument_PersistsObservedApplication()
     {
-        await CreateAuthorizationCodeAsync(PkceVerifier, MetadataRedirectUri, clientId: MetadataClientId);
+        await CreateAuthorizationCodeAsync(PkceVerifier, MetadataRedirectUri, clientId: MetadataClientId, organizationIds: [SampleDataService.TEST_ORG_ID]);
 
         var application = await _oauthApplicationRepository.GetByClientIdAsync(MetadataClientId, o => o.ImmediateConsistency());
 
@@ -610,6 +610,7 @@ public sealed class OAuthEndpointTests : IntegrationTestsBase
         Assert.Equal(OAuthApplication.SystemUserId, application.CreatedByUserId);
         Assert.Contains(MetadataRedirectUri, application.RedirectUris);
         Assert.Contains(AuthorizationRoles.McpRead, application.Scopes);
+        Assert.Contains(SampleDataService.TEST_ORG_ID, application.OrganizationIds);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Migrations/MigrateSavedViewColumnsIntegrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrateSavedViewColumnsIntegrationTests.cs
@@ -96,8 +96,8 @@ public sealed class MigrateSavedViewColumnsIntegrationTests : IntegrationTestsBa
         var migrationStateRepository = GetService<IMigrationStateRepository>();
         await migrationStateRepository.AddAsync(new MigrationState
         {
-            Id = "7",
-            Version = 7,
+            Id = "8",
+            Version = 8,
             MigrationType = MigrationType.VersionedAndResumable,
             StartedUtc = DateTime.UtcNow,
             CompletedUtc = DateTime.UtcNow

--- a/tests/Exceptionless.Tests/Migrations/MigrationRegistrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrationRegistrationTests.cs
@@ -39,4 +39,16 @@ public sealed class MigrationRegistrationTests : TestWithServices
         Assert.Equal(MigrationType.VersionedAndResumable, migration.MigrationType);
         Assert.Equal(7, migration.Version);
     }
+
+    [Fact]
+    public void MigrationRegistration_OAuthApplicationOrganizationMigration_IsRegisteredAsVersionedAndResumable()
+    {
+        var migration = GetService<IEnumerable<IMigration>>()
+            .DistinctBy(item => item.GetType())
+            .SingleOrDefault(item => item is PopulateOAuthApplicationOrganizationIds);
+
+        Assert.NotNull(migration);
+        Assert.Equal(MigrationType.VersionedAndResumable, migration.MigrationType);
+        Assert.Equal(8, migration.Version);
+    }
 }

--- a/tests/Exceptionless.Tests/Migrations/PopulateOAuthApplicationOrganizationIdsMigrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/PopulateOAuthApplicationOrganizationIdsMigrationTests.cs
@@ -1,0 +1,82 @@
+using Exceptionless.Core.Authorization;
+using Exceptionless.Core.Extensions;
+using Exceptionless.Core.Migrations;
+using Exceptionless.Core.Models;
+using Exceptionless.Core.Repositories;
+using Exceptionless.Tests.Utility;
+using Foundatio.Lock;
+using Foundatio.Repositories;
+using Foundatio.Repositories.Migrations;
+using Foundatio.Repositories.Utility;
+using Foundatio.Utility;
+using Xunit;
+
+namespace Exceptionless.Tests.Migrations;
+
+public sealed class PopulateOAuthApplicationOrganizationIdsMigrationTests : IntegrationTestsBase
+{
+    private readonly IOAuthApplicationRepository _oauthApplicationRepository;
+    private readonly IOAuthTokenRepository _oauthTokenRepository;
+
+    public PopulateOAuthApplicationOrganizationIdsMigrationTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
+    {
+        _oauthApplicationRepository = GetService<IOAuthApplicationRepository>();
+        _oauthTokenRepository = GetService<IOAuthTokenRepository>();
+    }
+
+    protected override void RegisterServices(IServiceCollection services)
+    {
+        services.AddTransient<PopulateOAuthApplicationOrganizationIds>();
+        services.AddSingleton<ILock>(EmptyLock.Empty);
+        base.RegisterServices(services);
+    }
+
+    [Fact]
+    public async Task RunAsync_LegacyOAuthTokens_PopulatesDistinctApplicationOrganizations()
+    {
+        string clientId = $"legacy-oauth-{ObjectId.GenerateNewId()}";
+        var utcNow = TimeProvider.GetUtcNow().UtcDateTime;
+        var application = await _oauthApplicationRepository.AddAsync(new OAuthApplication
+        {
+            ClientId = clientId,
+            Name = "Legacy OAuth Application",
+            RedirectUris = ["http://localhost/callback"],
+            Scopes = [AuthorizationRoles.McpRead],
+            CreatedByUserId = OAuthApplication.SystemUserId,
+            UpdatedByUserId = OAuthApplication.SystemUserId,
+            CreatedUtc = utcNow,
+            UpdatedUtc = utcNow
+        }, options => options.ImmediateConsistency());
+        await _oauthTokenRepository.AddAsync([
+            CreateToken(clientId, [TestConstants.OrganizationId, TestConstants.OrganizationId2], utcNow),
+            CreateToken(clientId, [TestConstants.OrganizationId], utcNow)
+        ], options => options.ImmediateConsistency());
+
+        var migration = GetService<PopulateOAuthApplicationOrganizationIds>();
+        await migration.RunAsync(new MigrationContext(GetService<ILock>(), _logger, TestCancellationToken));
+
+        var migrated = await _oauthApplicationRepository.GetByIdAsync(application.Id, options => options.ImmediateConsistency());
+        Assert.NotNull(migrated);
+        Assert.Equal(2, migrated.OrganizationIds.Count);
+        Assert.Contains(TestConstants.OrganizationId, migrated.OrganizationIds);
+        Assert.Contains(TestConstants.OrganizationId2, migrated.OrganizationIds);
+    }
+
+    private static OAuthToken CreateToken(string clientId, IReadOnlyCollection<string> organizationIds, DateTime utcNow)
+    {
+        return new OAuthToken
+        {
+            Id = ObjectId.GenerateNewId().ToString(),
+            UserId = TestConstants.UserId,
+            ClientId = clientId,
+            GrantId = StringExtensions.GetNewToken(),
+            Resource = "http://localhost/mcp",
+            AccessTokenHash = StringExtensions.GetNewToken(),
+            OrganizationIds = organizationIds.ToHashSet(StringComparer.Ordinal),
+            Scopes = [AuthorizationRoles.McpRead],
+            CreatedBy = TestConstants.UserId,
+            CreatedUtc = utcNow,
+            UpdatedUtc = utcNow
+        };
+    }
+}

--- a/tests/http/oauth.http
+++ b/tests/http/oauth.http
@@ -79,7 +79,11 @@ Content-Type: application/json
 }
 
 ### List OAuth Applications
-GET {{apiUrl}}/admin/oauth-applications
+GET {{apiUrl}}/admin/oauth-applications?page=1&limit=20&criteria=Codex&organization=Acme
+Authorization: Bearer {{login.response.body.token}}
+
+### Get OAuth Application
+GET {{apiUrl}}/admin/oauth-applications/{{oauthApplicationId}}
 Authorization: Bearer {{login.response.body.token}}
 
 ### Update OAuth Application


### PR DESCRIPTION
## Summary

- move OAuth application creation and editing to dedicated pages
- replace the large application list with a compact, server-paged table and application/organization filters
- record authorized organization associations during consent and display organization names in the admin list
- backfill existing application associations from OAuth tokens with a resumable migration

## API and behavior

- add paging and filtering parameters to the global-admin OAuth applications list
- add a global-admin OAuth application detail endpoint for the edit page
- preserve the existing list response body shape while adding standard pagination headers
- no breaking public API changes

## Verification

- `dotnet build tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-restore`
- `OAuthApplicationEndpointTests` — 9 passed
- `PopulateOAuthApplicationOrganizationIdsMigrationTests` — 1 passed
- `MigrationRegistrationTests` — 3 passed
- focused OAuth consent organization-association test — 1 passed
- `EndpointManifestTests` — 1 passed
- `npm run check`
- `npm run lint`
- `npm run build`
- local Aspire UI/API smoke testing with paged synthetic OAuth applications and organization filters

## Breaking changes

None.
