### PR TITLE
Compact runtime system settings

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/assistant-settings.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/assistant-settings.svelte
@@ -136,9 +136,22 @@
         <div class="flex flex-wrap items-center justify-end gap-2">
             <Switch id="assistant-enabled" bind:checked={assistantEnabled} disabled={updateEnabledSettings.isPending} />
             {#if settings?.is_enabled_overridden}
-                <Button type="button" size="sm" variant="outline" disabled={updateEnabledSettings.isPending} onclick={resetAvailability}>Reset</Button>
+                <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    aria-label="Reset Exie availability to deployment default"
+                    disabled={updateEnabledSettings.isPending}
+                    onclick={resetAvailability}>Reset</Button
+                >
             {/if}
-            <Button type="button" size="sm" disabled={updateEnabledSettings.isPending || assistantEnabled === settings?.enabled} onclick={saveAvailability}>
+            <Button
+                type="button"
+                size="sm"
+                aria-label="Save Exie availability"
+                disabled={updateEnabledSettings.isPending || assistantEnabled === settings?.enabled}
+                onclick={saveAvailability}
+            >
                 {updateEnabledSettings.isPending ? 'Saving...' : 'Save'}
             </Button>
         </div>
@@ -180,11 +193,18 @@
                             />
                             <div class="flex items-center justify-end gap-2">
                                 {#if settings?.is_overridden}
-                                    <Button type="button" size="sm" variant="outline" disabled={updateSettings.isPending} onclick={resetModel}>Reset</Button>
+                                    <Button
+                                        type="button"
+                                        size="sm"
+                                        variant="outline"
+                                        aria-label="Reset Exie model to deployment default"
+                                        disabled={updateSettings.isPending}
+                                        onclick={resetModel}>Reset</Button
+                                    >
                                 {/if}
                                 <settingsForm.Subscribe selector={(state) => state.isSubmitting}>
                                     {#snippet children(isSubmitting)}
-                                        <Button type="submit" size="sm" disabled={isSubmitting || updateSettings.isPending}>
+                                        <Button type="submit" size="sm" aria-label="Save Exie model" disabled={isSubmitting || updateSettings.isPending}>
                                             {isSubmitting || updateSettings.isPending ? 'Saving...' : 'Save'}
                                         </Button>
                                     {/snippet}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/assistant-settings.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/assistant-settings.svelte
@@ -1,19 +1,16 @@
 <script lang="ts">
     import ErrorMessage from '$comp/error-message.svelte';
-    import { Muted } from '$comp/typography';
     import { Badge } from '$comp/ui/badge';
     import { Button } from '$comp/ui/button';
-    import * as Card from '$comp/ui/card';
     import * as Field from '$comp/ui/field';
     import { Input } from '$comp/ui/input';
+    import { Separator } from '$comp/ui/separator';
     import { Spinner } from '$comp/ui/spinner';
     import { Switch } from '$comp/ui/switch';
     import { getAdminAssistantSettingsQuery, putAdminAssistantEnabledSettingsMutation, putAdminAssistantSettingsMutation } from '$features/admin/api.svelte';
     import { type AssistantSettingsFormData, AssistantSettingsSchema } from '$features/admin/schemas';
     import { ariaInvalid, getFormErrorMessages, mapFieldErrors, problemDetailsToFormErrors } from '$features/shared/validation';
     import { ProblemDetails } from '@foundatiofx/fetchclient';
-    import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
-    import Save from '@lucide/svelte/icons/save';
     import { createForm } from '@tanstack/svelte-form';
     import { toast } from 'svelte-sonner';
 
@@ -111,152 +108,98 @@
     }
 </script>
 
-<section class="space-y-4" aria-labelledby="exie-settings-heading">
-    <div class="space-y-1">
-        <h2 id="exie-settings-heading" class="text-lg font-semibold">Exie</h2>
-        <Muted>Manage Exie availability and provider configuration.</Muted>
+{#if settingsQuery.isPending}
+    <div class="flex items-center gap-2 p-4">
+        <Spinner />
+        <span class="text-muted-foreground text-sm">Loading Exie settings...</span>
     </div>
-
-    <Card.Root>
-        <Card.Header>
+{:else if settingsQuery.isError}
+    <div class="p-4">
+        <p class="text-destructive text-sm">Failed to load Exie settings.</p>
+    </div>
+{:else}
+    <Field.Field orientation="responsive" class="gap-4 p-4">
+        <Field.Content>
             <div class="flex flex-wrap items-center gap-2">
-                <Card.Title>Availability</Card.Title>
+                <Field.Label for="assistant-enabled">Exie availability</Field.Label>
                 {#if settings}
                     <Badge variant={settings.is_enabled_overridden ? 'secondary' : 'outline'}>
                         {settings.is_enabled_overridden ? 'Runtime override' : 'Deployment default'}
                     </Badge>
                 {/if}
             </div>
-            <Card.Description>Enable or disable Exie for all organizations without restarting the app.</Card.Description>
-        </Card.Header>
-        {#if settingsQuery.isPending}
-            <Card.Content class="flex items-center gap-2">
-                <Spinner />
-                <Muted>Loading Exie availability...</Muted>
-            </Card.Content>
-        {:else if settingsQuery.isError}
-            <Card.Content>
-                <p class="text-destructive text-sm">Failed to load Exie availability.</p>
-            </Card.Content>
-        {:else}
-            <Card.Content class="space-y-2">
-                <div class="flex items-center justify-between gap-6 rounded-lg border p-4">
-                    <div class="space-y-1">
-                        <label class="text-sm font-medium" for="assistant-enabled">Exie enabled</label>
-                        <Muted class="text-xs"
-                            >Disabled Exie requests are rejected immediately. The deployment default is {settings?.configured_enabled
-                                ? 'enabled'
-                                : 'disabled'}.</Muted
-                        >
-                    </div>
-                    <Switch id="assistant-enabled" bind:checked={assistantEnabled} disabled={updateEnabledSettings.isPending} />
-                </div>
-                {#if settings && !settings.is_configured}
-                    <p class="text-destructive text-sm">An OpenRouter API key must be configured before Exie can be used.</p>
-                {/if}
-            </Card.Content>
-            <Card.Footer class="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-                {#if settings?.is_enabled_overridden}
-                    <Button type="button" variant="outline" disabled={updateEnabledSettings.isPending} onclick={resetAvailability}>
-                        <RotateCcw data-icon="inline-start" />
-                        Reset to Deployment Default
-                    </Button>
-                {/if}
-                <Button type="button" disabled={updateEnabledSettings.isPending || assistantEnabled === settings?.enabled} onclick={saveAvailability}>
-                    {#if updateEnabledSettings.isPending}
-                        <Spinner data-icon="inline-start" />
-                        Saving...
-                    {:else}
-                        <Save data-icon="inline-start" />
-                        Save Availability
-                    {/if}
-                </Button>
-            </Card.Footer>
-        {/if}
-    </Card.Root>
+            <Field.Description>Enable or disable Exie for all organizations. Changes apply without restarting the app.</Field.Description>
+            {#if settings && !settings.is_configured}
+                <p class="text-destructive text-sm">An OpenRouter API key must be configured before Exie can be used.</p>
+            {/if}
+        </Field.Content>
+        <div class="flex flex-wrap items-center justify-end gap-2">
+            <Switch id="assistant-enabled" bind:checked={assistantEnabled} disabled={updateEnabledSettings.isPending} />
+            {#if settings?.is_enabled_overridden}
+                <Button type="button" size="sm" variant="outline" disabled={updateEnabledSettings.isPending} onclick={resetAvailability}>Reset</Button>
+            {/if}
+            <Button type="button" size="sm" disabled={updateEnabledSettings.isPending || assistantEnabled === settings?.enabled} onclick={saveAvailability}>
+                {updateEnabledSettings.isPending ? 'Saving...' : 'Save'}
+            </Button>
+        </div>
+    </Field.Field>
 
-    <Card.Root>
-        <Card.Header>
-            <div class="flex flex-wrap items-center gap-2">
-                <Card.Title>Model Configuration</Card.Title>
-                {#if settings}
-                    <Badge variant={settings.is_overridden ? 'secondary' : 'outline'}>
-                        {settings.is_overridden ? 'Runtime override' : 'Deployment default'}
-                    </Badge>
-                {/if}
-            </div>
-            <Card.Description>Choose the OpenRouter model used for new Exie conversations and turns. Changes apply without restarting the app.</Card.Description
-            >
-        </Card.Header>
-        {#if settingsQuery.isPending}
-            <Card.Content class="flex items-center gap-2">
-                <Spinner />
-                <Muted>Loading model configuration...</Muted>
-            </Card.Content>
-        {:else if settingsQuery.isError}
-            <Card.Content>
-                <p class="text-destructive text-sm">Failed to load the Exie model configuration.</p>
-            </Card.Content>
-        {:else}
-            <form
-                onsubmit={(event) => {
-                    event.preventDefault();
-                    void settingsForm.handleSubmit();
-                }}
-            >
-                <Card.Content>
-                    <Field.FieldGroup>
-                        <settingsForm.Field name="model">
-                            {#snippet children(field)}
-                                <Field.Field data-invalid={ariaInvalid(field)}>
-                                    <Field.Label for={field.name}>OpenRouter model ID</Field.Label>
-                                    <Input
-                                        id={field.name}
-                                        value={field.state.value}
-                                        onblur={field.handleBlur}
-                                        oninput={(event) => field.handleChange(event.currentTarget.value)}
-                                        aria-invalid={ariaInvalid(field)}
-                                        autocomplete="off"
-                                        placeholder="z-ai/glm-5.3-flash"
-                                    />
-                                    <Field.Description>
-                                        Enter a model slug such as
-                                        <a href="https://openrouter.ai/z-ai/glm-5.3-flash" target="_blank" rel="noopener noreferrer">z-ai/glm-5.3-flash</a>. The
-                                        deployment default is <code>{settings?.configured_model}</code>.
-                                    </Field.Description>
-                                    <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
-                                </Field.Field>
-                            {/snippet}
-                        </settingsForm.Field>
+    <Separator />
+
+    <form
+        onsubmit={(event) => {
+            event.preventDefault();
+            void settingsForm.handleSubmit();
+        }}
+    >
+        <settingsForm.Field name="model">
+            {#snippet children(field)}
+                <Field.Field orientation="responsive" class="gap-4 p-4" data-invalid={ariaInvalid(field)}>
+                    <Field.Content>
+                        <div class="flex flex-wrap items-center gap-2">
+                            <Field.Label for={field.name}>Exie model</Field.Label>
+                            {#if settings}
+                                <Badge variant={settings.is_overridden ? 'secondary' : 'outline'}>
+                                    {settings.is_overridden ? 'Runtime override' : 'Deployment default'}
+                                </Badge>
+                            {/if}
+                        </div>
+                        <Field.Description>OpenRouter model used for new Exie conversations and turns. Changes apply without restarting.</Field.Description>
+                    </Field.Content>
+                    <div class="flex w-full flex-col gap-2 @md/field-group:w-[32rem]">
+                        <div class="flex flex-col gap-2 sm:flex-row">
+                            <Input
+                                class="min-w-0 flex-1"
+                                id={field.name}
+                                value={field.state.value}
+                                onblur={field.handleBlur}
+                                oninput={(event) => field.handleChange(event.currentTarget.value)}
+                                aria-invalid={ariaInvalid(field)}
+                                autocomplete="off"
+                                placeholder="provider/model"
+                            />
+                            <div class="flex items-center justify-end gap-2">
+                                {#if settings?.is_overridden}
+                                    <Button type="button" size="sm" variant="outline" disabled={updateSettings.isPending} onclick={resetModel}>Reset</Button>
+                                {/if}
+                                <settingsForm.Subscribe selector={(state) => state.isSubmitting}>
+                                    {#snippet children(isSubmitting)}
+                                        <Button type="submit" size="sm" disabled={isSubmitting || updateSettings.isPending}>
+                                            {isSubmitting || updateSettings.isPending ? 'Saving...' : 'Save'}
+                                        </Button>
+                                    {/snippet}
+                                </settingsForm.Subscribe>
+                            </div>
+                        </div>
+                        <Field.Error errors={mapFieldErrors(field.state.meta.errors)} />
                         <settingsForm.Subscribe selector={(state) => state.errors}>
                             {#snippet children(errors)}
                                 <ErrorMessage message={getFormErrorMessages(errors)} />
                             {/snippet}
                         </settingsForm.Subscribe>
-                    </Field.FieldGroup>
-                </Card.Content>
-                <Card.Footer class="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-                    {#if settings?.is_overridden}
-                        <Button type="button" variant="outline" disabled={updateSettings.isPending} onclick={resetModel}>
-                            <RotateCcw data-icon="inline-start" />
-                            Reset to Deployment Default
-                        </Button>
-                    {/if}
-                    <settingsForm.Subscribe selector={(state) => state.isSubmitting}>
-                        {#snippet children(isSubmitting)}
-                            <Button type="submit" disabled={isSubmitting || updateSettings.isPending}>
-                                {#if isSubmitting || updateSettings.isPending}
-                                    <Spinner data-icon="inline-start" />
-                                    Saving...
-                                {:else}
-                                    <Save data-icon="inline-start" />
-                                    Save Model
-                                {/if}
-                            </Button>
-                        {/snippet}
-                    </settingsForm.Subscribe>
-                </Card.Footer>
-            </form>
-        {/if}
-    </Card.Root>
-</section>
+                    </div>
+                </Field.Field>
+            {/snippet}
+        </settingsForm.Field>
+    </form>
+{/if}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/settings/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/settings/+page.svelte
@@ -3,14 +3,13 @@
     import * as Alert from '$comp/ui/alert';
     import { Badge } from '$comp/ui/badge';
     import { Button } from '$comp/ui/button';
-    import * as Card from '$comp/ui/card';
+    import * as Field from '$comp/ui/field';
+    import { Separator } from '$comp/ui/separator';
     import { Spinner } from '$comp/ui/spinner';
     import { Switch } from '$comp/ui/switch';
     import { getEventSubmissionSettingsQuery, putEventSubmissionSettingsMutation } from '$features/admin/api.svelte';
     import AssistantSettings from '$features/admin/components/assistant-settings.svelte';
     import AlertTriangle from '@lucide/svelte/icons/alert-triangle';
-    import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
-    import Save from '@lucide/svelte/icons/save';
     import { toast } from 'svelte-sonner';
 
     const settingsQuery = getEventSubmissionSettingsQuery();
@@ -55,69 +54,56 @@
     }
 </script>
 
-<div class="space-y-8">
+<div class="flex flex-col gap-4">
     <Muted>Manage runtime system behavior</Muted>
 
-    <AssistantSettings />
+    <Field.FieldGroup class="gap-0 overflow-hidden rounded-lg border">
+        <AssistantSettings />
+        <Separator />
 
-    <Card.Root>
-        <Card.Header>
-            <div class="flex flex-wrap items-center gap-2">
-                <Card.Title>Event Submission</Card.Title>
-                {#if settings}
-                    <Badge variant={settings.is_overridden ? 'secondary' : 'outline'}>
-                        {settings.is_overridden ? 'Runtime override' : 'Deployment default'}
-                    </Badge>
-                {/if}
-            </div>
-            <Card.Description>Control whether Exceptionless accepts new events without restarting the app.</Card.Description>
-        </Card.Header>
-        {#if settingsQuery.isPending}
-            <Card.Content class="flex items-center gap-2">
-                <Spinner />
-                <Muted>Loading event submission settings...</Muted>
-            </Card.Content>
-        {:else if settingsQuery.isError}
-            <Card.Content>
-                <p class="text-destructive text-sm">Failed to load event submission settings.</p>
-            </Card.Content>
-        {:else}
-            <Card.Content class="space-y-4">
-                <div class="flex items-center justify-between gap-6 rounded-lg border p-4">
-                    <div class="space-y-1">
-                        <label class="text-sm font-medium" for="event-submission-enabled">Accept event submissions</label>
-                        <Muted class="text-xs">
-                            The deployment default is {settings?.configured_enabled ? 'enabled' : 'disabled'}. Changes apply to new requests immediately.
-                        </Muted>
-                    </div>
-                    <Switch id="event-submission-enabled" bind:checked={eventSubmissionEnabled} disabled={updateSettings.isPending} />
+        <Field.Field orientation="responsive" class="gap-4 p-4">
+            <Field.Content>
+                <div class="flex flex-wrap items-center gap-2">
+                    <Field.Label for="event-submission-enabled">Event submission</Field.Label>
+                    {#if settings}
+                        <Badge variant={settings.is_overridden ? 'secondary' : 'outline'}>
+                            {settings.is_overridden ? 'Runtime override' : 'Deployment default'}
+                        </Badge>
+                    {/if}
                 </div>
-
-                {#if !eventSubmissionEnabled}
+                <Field.Description>Control whether Exceptionless accepts new events. Changes apply to new requests immediately.</Field.Description>
+                {#if !settingsQuery.isPending && !settingsQuery.isError && !eventSubmissionEnabled}
                     <Alert.Root variant="destructive">
                         <AlertTriangle />
                         <Alert.Title>Incoming events will be rejected with HTTP 503.</Alert.Title>
-                        <Alert.Description>Session heartbeats remain successful but will not record activity while submission is disabled.</Alert.Description>
+                        <Alert.Description>Session heartbeats remain successful but will not record activity.</Alert.Description>
                     </Alert.Root>
                 {/if}
-            </Card.Content>
-            <Card.Footer class="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-                {#if settings?.is_overridden}
-                    <Button type="button" variant="outline" disabled={updateSettings.isPending} onclick={resetEventSubmission}>
-                        <RotateCcw data-icon="inline-start" />
-                        Reset to Deployment Default
-                    </Button>
-                {/if}
-                <Button type="button" disabled={updateSettings.isPending || eventSubmissionEnabled === settings?.enabled} onclick={saveEventSubmission}>
-                    {#if updateSettings.isPending}
-                        <Spinner data-icon="inline-start" />
-                        Saving...
-                    {:else}
-                        <Save data-icon="inline-start" />
-                        Save Setting
+            </Field.Content>
+
+            {#if settingsQuery.isPending}
+                <div class="flex items-center justify-end gap-2">
+                    <Spinner />
+                    <Muted>Loading...</Muted>
+                </div>
+            {:else if settingsQuery.isError}
+                <p class="text-destructive text-sm">Failed to load event submission settings.</p>
+            {:else}
+                <div class="flex flex-wrap items-center justify-end gap-2">
+                    <Switch id="event-submission-enabled" bind:checked={eventSubmissionEnabled} disabled={updateSettings.isPending} />
+                    {#if settings?.is_overridden}
+                        <Button type="button" size="sm" variant="outline" disabled={updateSettings.isPending} onclick={resetEventSubmission}>Reset</Button>
                     {/if}
-                </Button>
-            </Card.Footer>
-        {/if}
-    </Card.Root>
+                    <Button
+                        type="button"
+                        size="sm"
+                        disabled={updateSettings.isPending || eventSubmissionEnabled === settings?.enabled}
+                        onclick={saveEventSubmission}
+                    >
+                        {updateSettings.isPending ? 'Saving...' : 'Save'}
+                    </Button>
+                </div>
+            {/if}
+        </Field.Field>
+    </Field.FieldGroup>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/settings/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/system/settings/+page.svelte
@@ -92,11 +92,19 @@
                 <div class="flex flex-wrap items-center justify-end gap-2">
                     <Switch id="event-submission-enabled" bind:checked={eventSubmissionEnabled} disabled={updateSettings.isPending} />
                     {#if settings?.is_overridden}
-                        <Button type="button" size="sm" variant="outline" disabled={updateSettings.isPending} onclick={resetEventSubmission}>Reset</Button>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            aria-label="Reset event submission to deployment default"
+                            disabled={updateSettings.isPending}
+                            onclick={resetEventSubmission}>Reset</Button
+                        >
                     {/if}
                     <Button
                         type="button"
                         size="sm"
+                        aria-label="Save event submission"
                         disabled={updateSettings.isPending || eventSubmissionEnabled === settings?.enabled}
                         onclick={saveEventSubmission}
                     >


### PR DESCRIPTION
## Summary
- present Exie availability, Exie model, and event submission as compact rows in one settings list
- remove oversized per-setting cards and redundant Exie grouping
- replace model-specific helper text with stable generic guidance

Follow-up to #2545.

## Verification
- `npm run validate`
- `npm run build`

## Breaking changes
None.