### PR TITLE
Fix event detail UI consistency

### DIFF
--- a/src/Exceptionless.Web/ClientApp/e2e/tests/session-investigation.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/session-investigation.e2e.ts
@@ -1,15 +1,45 @@
 import { createReferenceId, expect, test } from '../fixtures/e2e-test';
 import { getVisibleRow, getVisibleText } from '../support/page-helpers';
-import { createSessionEvent } from '../support/synthetic-event';
+import { createRepresentativeEvent, createSessionEvent } from '../support/synthetic-event';
 
 test('operator can find and inspect a user session', async ({ e2eApi, e2eScenario, page }) => {
     const sessionId = createReferenceId(e2eScenario.run, '-session');
+    const eventReferenceId = createReferenceId(e2eScenario.run, '-session-error');
     const identity = `session-${e2eScenario.run}@exceptionless.test`;
     const name = `Session User ${e2eScenario.run}`;
+    const longMessage = Array.from({ length: 42 }, (_, index) => `session-processing-failure-${String(index + 1).padStart(2, '0')}`).join(' ');
+    let relatedEventId = '';
+    let relatedStackId = '';
 
     await test.step('seed a representative session', async () => {
         await e2eApi.submitEvent(e2eScenario.projectId, e2eScenario.projectToken, createSessionEvent({ identity, name, sessionId }));
         await e2eApi.pollForEventByReference(e2eScenario.userToken, e2eScenario.projectId, sessionId);
+
+        const relatedEvent = createRepresentativeEvent({
+            appUrl: e2eApi.environment.appUrl,
+            message: longMessage,
+            referenceId: eventReferenceId,
+            runId: e2eApi.environment.runId
+        });
+        relatedEvent.data = {
+            ...(relatedEvent.data as Record<string, unknown>),
+            '@environment': {
+                ip_address: '10.42.0.25',
+                machine_name: 'session-worker-07',
+                process_name: 'Exceptionless.Worker'
+            },
+            '@ref:session': sessionId,
+            '@user': {
+                identity,
+                name
+            }
+        };
+
+        await e2eApi.submitEvent(e2eScenario.projectId, e2eScenario.projectToken, relatedEvent);
+        const persistedRelatedEvent = await e2eApi.pollForEventByReference(e2eScenario.userToken, e2eScenario.projectId, eventReferenceId);
+        expect(persistedRelatedEvent.stack_id).toBeTruthy();
+        relatedEventId = persistedRelatedEvent.id;
+        relatedStackId = persistedRelatedEvent.stack_id!;
     });
 
     await test.step('open the session from the Sessions table', async () => {
@@ -27,5 +57,59 @@ test('operator can find and inspect a user session', async ({ e2eApi, e2eScenari
 
         await expect(page).toHaveURL(/\/next\/(?:event|stack\/[^/]+\/event)\//);
         await expect(getVisibleText(page, identity)).toBeVisible();
+    });
+
+    await test.step('session events wrap summaries, show users, and open with the Events All view', async () => {
+        await page.getByRole('tab', { name: 'Session Events' }).click();
+        await expect(page.getByRole('tab', { name: 'Session Events' })).toHaveAttribute('aria-selected', 'true');
+        const summaryHeader = page.getByRole('columnheader', { name: 'Summary' });
+        await expect(summaryHeader).toBeVisible({ timeout: 30_000 });
+
+        const sessionEventsTable = summaryHeader.locator('xpath=ancestor::div[@data-slot="table-container"]');
+        await expect(sessionEventsTable.getByRole('columnheader')).toHaveText(['Summary', 'User', 'Session Time']);
+        await expect(sessionEventsTable.getByTitle(`${name} (${identity})`).first()).toBeVisible();
+        await expect.poll(() => sessionEventsTable.evaluate((element) => element.scrollWidth - element.clientWidth)).toBeLessThanOrEqual(1);
+
+        const eventsLink = page.getByRole('link', { name: 'Open events filtered to this session' });
+        await expect(eventsLink).toHaveAttribute('href', /\/next\/event\/all\?/);
+        const eventsHref = await eventsLink.getAttribute('href');
+        expect(new URL(eventsHref!, page.url()).searchParams.get('filter')).toContain('ref.session');
+    });
+
+    await test.step('event detail messages wrap and small alignment fixes render consistently', async () => {
+        await page.goto(`/next/stack/${relatedStackId}/event/${relatedEventId}`);
+        await expect(page.getByRole('tab', { name: 'Overview' })).toHaveAttribute('aria-selected', 'true');
+
+        const activePanel = () => page.getByRole('tabpanel').filter({ visible: true });
+        const activeTable = () => activePanel().locator('[data-slot="table-container"]').first();
+        const expectNoHorizontalOverflow = async () => {
+            await expect.poll(() => activeTable().evaluate((element) => element.scrollWidth - element.clientWidth)).toBeLessThanOrEqual(2);
+        };
+
+        await expectNoHorizontalOverflow();
+        await page.getByRole('tab', { name: 'Exception' }).click();
+        await expectNoHorizontalOverflow();
+
+        await page.getByRole('tab', { name: 'Environment' }).click();
+        const machineNameRow = activePanel().getByRole('row').filter({ hasText: 'Machine Name' });
+        await expect(machineNameRow).toBeVisible();
+        await expect
+            .poll(() =>
+                machineNameRow
+                    .locator('[data-slot="table-cell"]')
+                    .last()
+                    .evaluate((element) => getComputedStyle(element).display)
+            )
+            .toBe('table-cell');
+
+        await page.getByRole('button', { name: 'Stack options' }).click();
+        const stackingInformationItem = page.getByRole('menuitem', { name: 'View Stacking Information' });
+        await expect(stackingInformationItem).toBeVisible();
+        await expect.poll(() => stackingInformationItem.locator('svg').evaluate((element) => getComputedStyle(element).marginRight)).toBe('8px');
+        await page.keyboard.press('Escape');
+
+        const sidebarRail = page.locator('[data-slot="sidebar-rail"]');
+        await expect(sidebarRail).toBeVisible();
+        await expect.poll(() => sidebarRail.evaluate((element) => getComputedStyle(element).cursor)).toBe('pointer');
     });
 });

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/session-investigation.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/session-investigation.e2e.ts
@@ -83,7 +83,10 @@ test('operator can find and inspect a user session', async ({ e2eApi, e2eScenari
         const sessionEventsTable = summaryHeader.locator('xpath=ancestor::div[@data-slot="table-container"]');
         await expect(sessionEventsTable.getByRole('columnheader')).toHaveText(['Summary', 'User', 'Session Time']);
         await expect(sessionEventsTable.getByTitle(`${name} (${identity})`).first()).toBeVisible();
-        await expect.poll(() => sessionEventsTable.evaluate((element) => element.scrollWidth - element.offsetWidth)).toBeLessThanOrEqual(1);
+        const summaryCell = sessionEventsTable.getByRole('cell').first();
+        await expect(summaryCell).toHaveCSS('overflow-wrap', 'anywhere');
+        await expect(summaryCell).toHaveCSS('white-space', 'normal');
+        await expect.poll(() => sessionEventsTable.evaluate((element) => element.scrollWidth / element.offsetWidth)).toBeLessThanOrEqual(1.02);
 
         const eventsLink = page.getByRole('link', { name: 'Open events filtered to this session' });
         await expect(eventsLink).toHaveAttribute('href', /\/next\/event\/all\?/);

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/session-investigation.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/session-investigation.e2e.ts
@@ -100,13 +100,16 @@ test('operator can find and inspect a user session', async ({ e2eApi, e2eScenari
 
         const activePanel = () => page.getByRole('tabpanel').filter({ visible: true });
         const activeTable = () => activePanel().locator('[data-slot="table-container"]').first();
-        const expectNoHorizontalOverflow = async () => {
-            await expect.poll(() => activeTable().evaluate((element) => element.scrollWidth - element.clientWidth)).toBeLessThanOrEqual(2);
+        const expectWrappedMessageWithoutMeaningfulOverflow = async () => {
+            const messageCell = activePanel().getByRole('row').filter({ hasText: 'Message' }).first().locator('[data-slot="table-cell"]').last();
+            await expect(messageCell).toHaveCSS('overflow-wrap', 'anywhere');
+            await expect(messageCell).toHaveCSS('white-space', 'normal');
+            await expect.poll(() => activeTable().evaluate((element) => element.scrollWidth / element.offsetWidth)).toBeLessThanOrEqual(1.05);
         };
 
-        await expectNoHorizontalOverflow();
+        await expectWrappedMessageWithoutMeaningfulOverflow();
         await page.getByRole('tab', { name: 'Exception' }).click();
-        await expectNoHorizontalOverflow();
+        await expectWrappedMessageWithoutMeaningfulOverflow();
 
         await page.getByRole('tab', { name: 'Environment' }).click();
         const machineNameRow = activePanel().getByRole('row').filter({ hasText: 'Machine Name' });

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/session-investigation.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/session-investigation.e2e.ts
@@ -91,7 +91,11 @@ test('operator can find and inspect a user session', async ({ e2eApi, e2eScenari
         const eventsLink = page.getByRole('link', { name: 'Open events filtered to this session' });
         await expect(eventsLink).toHaveAttribute('href', /\/next\/event\/all\?/);
         const eventsHref = await eventsLink.getAttribute('href');
-        expect(new URL(eventsHref!, page.url()).searchParams.get('filter')).toContain('ref.session');
+        const eventsUrl = new URL(eventsHref!, page.url());
+        expect(eventsUrl.searchParams.get('session')).toBe(sessionId);
+        expect(eventsUrl.searchParams.get('filter')).toBe('');
+        expect(eventsUrl.searchParams.get('type')).toBe('');
+        expect(eventsUrl.searchParams.get('time')).toBe('all');
     });
 
     await test.step('event detail messages wrap and small alignment fixes render consistently', async () => {

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/session-investigation.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/session-investigation.e2e.ts
@@ -2,7 +2,7 @@ import { createReferenceId, expect, test } from '../fixtures/e2e-test';
 import { getVisibleRow, getVisibleText } from '../support/page-helpers';
 import { createRepresentativeEvent, createSessionEvent } from '../support/synthetic-event';
 
-test('operator can find and inspect a user session', async ({ e2eApi, e2eScenario, page }) => {
+test('operator can find and inspect a user session', async ({ e2eApi, e2eScenario, page, request }) => {
     const sessionId = createReferenceId(e2eScenario.run, '-session');
     const eventReferenceId = createReferenceId(e2eScenario.run, '-session-error');
     const identity = `session-${e2eScenario.run}@exceptionless.test`;
@@ -12,6 +12,21 @@ test('operator can find and inspect a user session', async ({ e2eApi, e2eScenari
     let relatedStackId = '';
 
     await test.step('seed a representative session', async () => {
+        const savedViewResponse = await request.post(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views`, {
+            data: {
+                columns: {
+                    date: { position: 1, visible: true },
+                    summary: { position: 0, visible: true, wrap: true }
+                },
+                name: 'All',
+                organization_id: e2eScenario.organizationId,
+                slug: 'all',
+                view_type: 'events'
+            },
+            headers: { Authorization: `Bearer ${e2eScenario.userToken}` }
+        });
+        expect(savedViewResponse.status(), await savedViewResponse.text()).toBe(201);
+
         await e2eApi.submitEvent(e2eScenario.projectId, e2eScenario.projectToken, createSessionEvent({ identity, name, sessionId }));
         await e2eApi.pollForEventByReference(e2eScenario.userToken, e2eScenario.projectId, sessionId);
 
@@ -68,7 +83,7 @@ test('operator can find and inspect a user session', async ({ e2eApi, e2eScenari
         const sessionEventsTable = summaryHeader.locator('xpath=ancestor::div[@data-slot="table-container"]');
         await expect(sessionEventsTable.getByRole('columnheader')).toHaveText(['Summary', 'User', 'Session Time']);
         await expect(sessionEventsTable.getByTitle(`${name} (${identity})`).first()).toBeVisible();
-        await expect.poll(() => sessionEventsTable.evaluate((element) => element.scrollWidth - element.clientWidth)).toBeLessThanOrEqual(1);
+        await expect.poll(() => sessionEventsTable.evaluate((element) => element.scrollWidth - element.offsetWidth)).toBeLessThanOrEqual(1);
 
         const eventsLink = page.getByRole('link', { name: 'Open events filtered to this session' });
         await expect(eventsLink).toHaveAttribute('href', /\/next\/event\/all\?/);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/environment.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/environment.svelte
@@ -27,7 +27,7 @@
                 <Table.Cell class="w-4 pr-0"
                     ><EventsFacetedFilter.StringTrigger changed={filterChanged} term="machine" value={environment.machine_name} /></Table.Cell
                 >
-                <Table.Cell class="flex items-center">{environment.machine_name}</Table.Cell>
+                <Table.Cell>{environment.machine_name}</Table.Cell>
             </Table.Row>
         {/if}
         {#if environment.ip_address}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/error.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/error.svelte
@@ -42,7 +42,7 @@
             <Table.Row class="group">
                 <Table.Head class="w-40 font-semibold whitespace-nowrap">Message</Table.Head>
                 <Table.Cell class="w-4 pr-0"><EventsFacetedFilter.StringTrigger changed={filterChanged} term="error.message" value={message} /></Table.Cell>
-                <Table.Cell>{message}</Table.Cell>
+                <Table.Cell class="wrap-anywhere whitespace-normal">{message}</Table.Cell>
             </Table.Row>
         {/if}
         {#if code}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/overview.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/overview.svelte
@@ -157,7 +157,7 @@
             <Table.Row class="group">
                 <Table.Head class="w-40 font-semibold whitespace-nowrap">Message</Table.Head>
                 <Table.Cell class="w-4 pr-0"><EventsFacetedFilter.StringTrigger changed={filterChanged} term="message" value={message} /></Table.Cell>
-                <Table.Cell>{message}</Table.Cell>
+                <Table.Cell class="wrap-anywhere whitespace-normal">{message}</Table.Cell>
             </Table.Row>
         {/if}
         {#if version}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.test.ts
@@ -2,7 +2,7 @@ import type { SavedView } from '$features/saved-views/models';
 
 import { describe, expect, it } from 'vitest';
 
-import { getSessionEventsPath } from './session-events-navigation';
+import { getSessionEventsHref, getSessionEventsPath } from './session-events-navigation';
 
 function createSavedView(overrides: Partial<SavedView> = {}): SavedView {
     return {
@@ -28,10 +28,6 @@ describe('getSessionEventsPath', () => {
         expect(getSessionEventsPath([createSavedView()])).toBe('/next/event/all');
     });
 
-    it('matches the resolved All slug even when the view name changes', () => {
-        expect(getSessionEventsPath([createSavedView({ name: 'Everything', slug: 'all' })])).toBe('/next/event/all');
-    });
-
     it('prefers the shared All view when a private view already owns the all slug', () => {
         const privateAll = createSavedView({ id: 'private-all', user_id: 'user-id' });
         const sharedAll = createSavedView({ id: 'shared-all', slug: 'all-2' });
@@ -47,7 +43,40 @@ describe('getSessionEventsPath', () => {
         expect(getSessionEventsPath([createSavedView({ name: 'Errors', slug: 'errors' })])).toBe('/next/event');
     });
 
+    it('does not mistake an unrelated all-N slug for the All view', () => {
+        expect(getSessionEventsPath([createSavedView({ name: 'Everything', slug: 'all-2' })])).toBe('/next/event');
+    });
+
     it('does not use an All view belonging to another resource', () => {
         expect(getSessionEventsPath([createSavedView({ view_type: 'stacks' })])).toBe('/next/event');
+    });
+});
+
+describe('getSessionEventsHref', () => {
+    it('keeps the saved view path while replacing every saved filter with the session', () => {
+        const href = getSessionEventsHref('/next/event/all-2', 'session-id');
+        const url = new URL(href!, 'https://example.test');
+
+        expect(url.pathname).toBe('/next/event/all-2');
+        expect(Object.fromEntries(url.searchParams)).toEqual({
+            bot: '',
+            filter: '',
+            first: '',
+            level: '',
+            project: '',
+            reference: '',
+            session: 'session-id',
+            stack: '',
+            status: '',
+            tag: '',
+            time: 'all',
+            type: '',
+            version: ''
+        });
+    });
+
+    it('does not enable navigation without both a path and session id', () => {
+        expect(getSessionEventsHref(undefined, 'session-id')).toBeUndefined();
+        expect(getSessionEventsHref('/next/event', undefined)).toBeUndefined();
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.test.ts
@@ -1,0 +1,38 @@
+import type { SavedView } from '$features/saved-views/models';
+
+import { describe, expect, it } from 'vitest';
+
+import { getSessionEventsPath } from './session-events-navigation';
+
+function createSavedView(overrides: Partial<SavedView> = {}): SavedView {
+    return {
+        created_by_user_id: 'user-id',
+        created_utc: '2026-08-29T00:00:00Z',
+        id: 'saved-view-id',
+        name: 'All',
+        organization_id: 'organization-id',
+        slug: 'all',
+        updated_utc: '2026-08-29T00:00:00Z',
+        version: 1,
+        view_type: 'events',
+        ...overrides
+    };
+}
+
+describe('getSessionEventsPath', () => {
+    it('uses the Events All saved view when it exists', () => {
+        expect(getSessionEventsPath([createSavedView()])).toBe('/next/event/all');
+    });
+
+    it('matches the resolved All slug even when the view name changes', () => {
+        expect(getSessionEventsPath([createSavedView({ name: 'Everything', slug: 'all' })])).toBe('/next/event/all');
+    });
+
+    it('falls back to the generic Events route when All is unavailable', () => {
+        expect(getSessionEventsPath([createSavedView({ name: 'Errors', slug: 'errors' })])).toBe('/next/event');
+    });
+
+    it('does not use an All view belonging to another resource', () => {
+        expect(getSessionEventsPath([createSavedView({ view_type: 'stacks' })])).toBe('/next/event');
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.test.ts
@@ -20,6 +20,10 @@ function createSavedView(overrides: Partial<SavedView> = {}): SavedView {
 }
 
 describe('getSessionEventsPath', () => {
+    it('waits for saved views before enabling navigation', () => {
+        expect(getSessionEventsPath(undefined, true)).toBeUndefined();
+    });
+
     it('uses the Events All saved view when it exists', () => {
         expect(getSessionEventsPath([createSavedView()])).toBe('/next/event/all');
     });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.test.ts
@@ -11,6 +11,7 @@ function createSavedView(overrides: Partial<SavedView> = {}): SavedView {
         id: 'saved-view-id',
         name: 'All',
         organization_id: 'organization-id',
+        predefined_key: 'events:all',
         slug: 'all',
         updated_utc: '2026-08-29T00:00:00Z',
         version: 1,
@@ -28,6 +29,10 @@ describe('getSessionEventsPath', () => {
         expect(getSessionEventsPath([createSavedView()])).toBe('/next/event/all');
     });
 
+    it('uses the immutable predefined key after the Events All view is renamed', () => {
+        expect(getSessionEventsPath([createSavedView({ name: 'Everything', slug: 'everything' })])).toBe('/next/event/everything');
+    });
+
     it('prefers the shared All view when a private view already owns the all slug', () => {
         const privateAll = createSavedView({ id: 'private-all', user_id: 'user-id' });
         const sharedAll = createSavedView({ id: 'shared-all', slug: 'all-2' });
@@ -40,11 +45,19 @@ describe('getSessionEventsPath', () => {
     });
 
     it('falls back to the generic Events route when All is unavailable', () => {
-        expect(getSessionEventsPath([createSavedView({ name: 'Errors', slug: 'errors' })])).toBe('/next/event');
+        expect(getSessionEventsPath([createSavedView({ name: 'Errors', predefined_key: 'events:errors', slug: 'errors' })])).toBe('/next/event');
     });
 
     it('does not mistake an unrelated all-N slug for the All view', () => {
-        expect(getSessionEventsPath([createSavedView({ name: 'Everything', slug: 'all-2' })])).toBe('/next/event');
+        expect(getSessionEventsPath([createSavedView({ name: 'Everything', predefined_key: undefined, slug: 'all-2' })])).toBe('/next/event');
+    });
+
+    it('supports a legacy unkeyed shared All view', () => {
+        expect(getSessionEventsPath([createSavedView({ predefined_key: undefined })])).toBe('/next/event/all');
+    });
+
+    it('does not use a differently keyed view that was renamed to All', () => {
+        expect(getSessionEventsPath([createSavedView({ predefined_key: 'events:errors' })])).toBe('/next/event');
     });
 
     it('does not use an All view belonging to another resource', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.test.ts
@@ -28,6 +28,17 @@ describe('getSessionEventsPath', () => {
         expect(getSessionEventsPath([createSavedView({ name: 'Everything', slug: 'all' })])).toBe('/next/event/all');
     });
 
+    it('prefers the shared All view when a private view already owns the all slug', () => {
+        const privateAll = createSavedView({ id: 'private-all', user_id: 'user-id' });
+        const sharedAll = createSavedView({ id: 'shared-all', slug: 'all-2' });
+
+        expect(getSessionEventsPath([privateAll, sharedAll])).toBe('/next/event/all-2');
+    });
+
+    it('does not use a private All view when no shared All view exists', () => {
+        expect(getSessionEventsPath([createSavedView({ user_id: 'user-id' })])).toBe('/next/event');
+    });
+
     it('falls back to the generic Events route when All is unavailable', () => {
         expect(getSessionEventsPath([createSavedView({ name: 'Errors', slug: 'errors' })])).toBe('/next/event');
     });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.ts
@@ -1,7 +1,22 @@
 import type { SavedView } from '$features/saved-views/models';
 
 import { resolve } from '$app/paths';
-import { savedViewHref, savedViewResolvedSlug } from '$features/saved-views/slugs';
+import { savedViewHref } from '$features/saved-views/slugs';
+
+const RESET_FILTER_QUERY_PARAMS = ['bot', 'filter', 'first', 'level', 'project', 'reference', 'stack', 'status', 'tag', 'type', 'version'] as const;
+
+export function getSessionEventsHref(eventsPath: string | undefined, sessionId: string | undefined): string | undefined {
+    if (!eventsPath || !sessionId) {
+        return undefined;
+    }
+
+    const query = new URLSearchParams({ session: sessionId, time: 'all' });
+    for (const name of RESET_FILTER_QUERY_PARAMS) {
+        query.set(name, '');
+    }
+
+    return `${eventsPath}?${query.toString()}`;
+}
 
 export function getSessionEventsPath(savedViews: SavedView[] | undefined, isPending = false): string | undefined {
     if (isPending) {
@@ -9,9 +24,7 @@ export function getSessionEventsPath(savedViews: SavedView[] | undefined, isPend
     }
 
     const sharedEventViews = (savedViews ?? []).filter((savedView) => savedView.view_type === 'events' && !savedView.user_id);
-    const allEventsView =
-        sharedEventViews.find((savedView) => savedView.name.trim().toLowerCase() === 'all') ??
-        sharedEventViews.find((savedView) => /^all(?:-\d+)?$/.test(savedViewResolvedSlug(savedView)));
+    const allEventsView = sharedEventViews.find((savedView) => savedView.name.trim().toLowerCase() === 'all');
 
     return allEventsView ? savedViewHref(allEventsView) : resolve('/(app)/event');
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.ts
@@ -4,6 +4,7 @@ import { resolve } from '$app/paths';
 import { savedViewHref } from '$features/saved-views/slugs';
 
 const RESET_FILTER_QUERY_PARAMS = ['bot', 'filter', 'first', 'level', 'project', 'reference', 'stack', 'status', 'tag', 'type', 'version'] as const;
+const EVENTS_ALL_PREDEFINED_KEY = 'events:all';
 
 export function getSessionEventsHref(eventsPath: string | undefined, sessionId: string | undefined): string | undefined {
     if (!eventsPath || !sessionId) {
@@ -24,7 +25,9 @@ export function getSessionEventsPath(savedViews: SavedView[] | undefined, isPend
     }
 
     const sharedEventViews = (savedViews ?? []).filter((savedView) => savedView.view_type === 'events' && !savedView.user_id);
-    const allEventsView = sharedEventViews.find((savedView) => savedView.name.trim().toLowerCase() === 'all');
+    const allEventsView =
+        sharedEventViews.find((savedView) => savedView.predefined_key?.trim().toLowerCase() === EVENTS_ALL_PREDEFINED_KEY) ??
+        sharedEventViews.find((savedView) => !savedView.predefined_key && savedView.name.trim().toLowerCase() === 'all');
 
     return allEventsView ? savedViewHref(allEventsView) : resolve('/(app)/event');
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.ts
@@ -1,0 +1,11 @@
+import type { SavedView } from '$features/saved-views/models';
+
+import { resolve } from '$app/paths';
+import { savedViewHref, savedViewResolvedSlug } from '$features/saved-views/slugs';
+
+export function getSessionEventsPath(savedViews: SavedView[] | undefined): string {
+    const eventViews = (savedViews ?? []).filter((savedView) => savedView.view_type === 'events');
+    const allEventsView = eventViews.find((savedView) => savedViewResolvedSlug(savedView) === 'all');
+
+    return allEventsView ? savedViewHref(allEventsView) : resolve('/(app)/event');
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.ts
@@ -4,8 +4,10 @@ import { resolve } from '$app/paths';
 import { savedViewHref, savedViewResolvedSlug } from '$features/saved-views/slugs';
 
 export function getSessionEventsPath(savedViews: SavedView[] | undefined): string {
-    const eventViews = (savedViews ?? []).filter((savedView) => savedView.view_type === 'events');
-    const allEventsView = eventViews.find((savedView) => savedViewResolvedSlug(savedView) === 'all');
+    const sharedEventViews = (savedViews ?? []).filter((savedView) => savedView.view_type === 'events' && !savedView.user_id);
+    const allEventsView =
+        sharedEventViews.find((savedView) => savedView.name.trim().toLowerCase() === 'all') ??
+        sharedEventViews.find((savedView) => /^all(?:-\d+)?$/.test(savedViewResolvedSlug(savedView)));
 
     return allEventsView ? savedViewHref(allEventsView) : resolve('/(app)/event');
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events-navigation.ts
@@ -3,7 +3,11 @@ import type { SavedView } from '$features/saved-views/models';
 import { resolve } from '$app/paths';
 import { savedViewHref, savedViewResolvedSlug } from '$features/saved-views/slugs';
 
-export function getSessionEventsPath(savedViews: SavedView[] | undefined): string {
+export function getSessionEventsPath(savedViews: SavedView[] | undefined, isPending = false): string | undefined {
+    if (isPending) {
+        return undefined;
+    }
+
     const sharedEventViews = (savedViews ?? []).filter((savedView) => savedView.view_type === 'events' && !savedView.user_id);
     const allEventsView =
         sharedEventViews.find((savedView) => savedView.name.trim().toLowerCase() === 'all') ??

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
@@ -7,8 +7,6 @@
     import { Skeleton } from '$comp/ui/skeleton';
     import * as Table from '$comp/ui/table';
     import { getSessionEventsQuery } from '$features/events/api.svelte';
-    import { SessionFilter } from '$features/events/components/filters';
-    import { buildFilterCacheKey, toFilter, updateFilterCache } from '$features/events/components/filters/helpers.svelte';
     import { buildEventDetailsHref } from '$features/events/components/summary';
     import Summary from '$features/events/components/summary/summary.svelte';
     import EventsUserIdentitySummaryCell from '$features/events/components/table/events-user-identity-summary-cell.svelte';
@@ -19,7 +17,7 @@
     import InfoIcon from '@lucide/svelte/icons/info';
 
     import SessionEventDuration from '../session-event-duration.svelte';
-    import { getSessionEventsPath } from './session-events-navigation';
+    import { getSessionEventsHref, getSessionEventsPath } from './session-events-navigation';
 
     interface Props {
         event: PersistentEvent;
@@ -45,18 +43,7 @@
             savedViewsQuery.isPending
         )
     );
-    const sessionEventsHref = $derived.by(() => {
-        const filter = getSessionFilter();
-        if (!filter || !eventsPath) {
-            return undefined;
-        }
-
-        const query = new URLSearchParams({
-            filter: filter.toFilter(),
-            time: 'all'
-        });
-        return `${eventsPath}?${query.toString()}`;
-    });
+    const sessionEventsHref = $derived(getSessionEventsHref(eventsPath, sessionId));
 
     const userInfo = $derived(event.data?.['@user']);
     const userIdentity = $derived(userInfo?.identity);
@@ -90,22 +77,7 @@
         return buildEventDetailsHref(eventId);
     }
 
-    function getSessionFilter(): SessionFilter | undefined {
-        return sessionId ? new SessionFilter(sessionId) : undefined;
-    }
-
-    function prepareSessionEventsFilter(): void {
-        const filter = getSessionFilter();
-        if (!filter || !eventsPath) {
-            return;
-        }
-
-        const filterQuery = toFilter([filter]);
-        updateFilterCache(buildFilterCacheKey(organization.current, eventsPath, filterQuery), [filter]);
-    }
-
     function handleSessionFilterClick(): void {
-        prepareSessionEventsFilter();
         onSessionFilter?.();
     }
 </script>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
@@ -39,10 +39,15 @@
             }
         }
     });
-    const eventsPath = $derived(getSessionEventsPath(savedViewsQuery.data?.filter((savedView) => !isSavedViewDeleted(savedView))));
+    const eventsPath = $derived(
+        getSessionEventsPath(
+            savedViewsQuery.data?.filter((savedView) => !isSavedViewDeleted(savedView)),
+            savedViewsQuery.isPending
+        )
+    );
     const sessionEventsHref = $derived.by(() => {
         const filter = getSessionFilter();
-        if (!filter) {
+        if (!filter || !eventsPath) {
             return undefined;
         }
 
@@ -91,7 +96,7 @@
 
     function prepareSessionEventsFilter(): void {
         const filter = getSessionFilter();
-        if (!filter) {
+        if (!filter || !eventsPath) {
             return;
         }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/views/session-events.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import type { PersistentEvent } from '$features/events/models';
 
-    import { resolve } from '$app/paths';
     import TimeAgo from '$comp/formatters/time-ago.svelte';
     import * as Alert from '$comp/ui/alert';
     import { Button } from '$comp/ui/button';
@@ -12,12 +11,15 @@
     import { buildFilterCacheKey, toFilter, updateFilterCache } from '$features/events/components/filters/helpers.svelte';
     import { buildEventDetailsHref } from '$features/events/components/summary';
     import Summary from '$features/events/components/summary/summary.svelte';
+    import EventsUserIdentitySummaryCell from '$features/events/components/table/events-user-identity-summary-cell.svelte';
     import { getSessionId } from '$features/events/utils/index';
     import { organization } from '$features/organizations/context.svelte';
+    import { getSavedViewsQuery, isSavedViewDeleted } from '$features/saved-views/api.svelte';
     import EventsIcon from '@lucide/svelte/icons/calendar-days';
     import InfoIcon from '@lucide/svelte/icons/info';
 
     import SessionEventDuration from '../session-event-duration.svelte';
+    import { getSessionEventsPath } from './session-events-navigation';
 
     interface Props {
         event: PersistentEvent;
@@ -30,7 +32,14 @@
 
     const sessionId = $derived(getSessionId(event));
     const isSessionStart = $derived(event.type === 'session');
-    const eventsPath = $derived(resolve('/(app)/event'));
+    const savedViewsQuery = getSavedViewsQuery({
+        route: {
+            get organizationId() {
+                return organization.current;
+            }
+        }
+    });
+    const eventsPath = $derived(getSessionEventsPath(savedViewsQuery.data?.filter((savedView) => !isSavedViewDeleted(savedView))));
     const sessionEventsHref = $derived.by(() => {
         const filter = getSessionFilter();
         if (!filter) {
@@ -104,7 +113,7 @@
     </Alert.Root>
 {/if}
 
-<div class="relative pr-10" class:opacity-60={!hasPremiumFeatures}>
+<div class:opacity-60={!hasPremiumFeatures}>
     {#if isSessionStart}
         <Table.Root class="mb-4">
             <Table.Body>
@@ -133,7 +142,7 @@
         </Table.Root>
     {/if}
 
-    <div class="absolute top-0 right-0 z-10">
+    <div class="mb-2 flex justify-end">
         <Button
             aria-label="Open events filtered to this session"
             disabled={!sessionEventsHref}
@@ -143,7 +152,7 @@
             title="Open events filtered to this session"
             variant="outline"
         >
-            <EventsIcon class="size-4" />
+            <EventsIcon aria-hidden="true" class="size-4" />
         </Button>
     </div>
 
@@ -160,10 +169,11 @@
             <Alert.Description>{sessionEventsQuery.error?.message ?? 'Unknown error'}</Alert.Description>
         </Alert.Root>
     {:else if (sessionEventsQuery.data ?? []).length > 0}
-        <Table.Root>
+        <Table.Root class="table-fixed">
             <Table.Header>
                 <Table.Row>
                     <Table.Head>Summary</Table.Head>
+                    <Table.Head class="w-56">User</Table.Head>
                     <Table.Head class="w-32">Session Time</Table.Head>
                 </Table.Row>
             </Table.Header>
@@ -171,9 +181,14 @@
                 {#each sessionEventsQuery.data ?? [] as sessionEvent (sessionEvent.id)}
                     {@const eventHref = getEventHref(sessionEvent.id)}
                     <Table.Row class="cursor-pointer">
+                        <Table.Cell class="p-0 wrap-anywhere whitespace-normal [&_.line-clamp-1]:line-clamp-none [&_.line-clamp-2]:line-clamp-none">
+                            <a class="text-foreground block p-2 wrap-anywhere whitespace-normal no-underline" href={eventHref} title="Open event details">
+                                <Summary linkToDetails={false} summary={sessionEvent} showType={true} showStatus={false} />
+                            </a>
+                        </Table.Cell>
                         <Table.Cell class="p-0">
                             <a class="text-foreground block p-2 no-underline" href={eventHref} title="Open event details">
-                                <Summary linkToDetails={false} summary={sessionEvent} showType={true} showStatus={false} />
+                                <EventsUserIdentitySummaryCell summary={sessionEvent} />
                             </a>
                         </Table.Cell>
                         <Table.Cell class="p-0">

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/sidebar/sidebar-rail.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/shared/components/ui/sidebar/sidebar-rail.svelte
@@ -23,8 +23,7 @@
 	title="Toggle Sidebar"
 	class={cn(
 		"hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
-		"in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
-		"[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+		"cursor-pointer",
 		"hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
 		"[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
 		"[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-options-dropdown-menu.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/stacks/components/stack-options-dropdown-menu.svelte
@@ -148,7 +148,7 @@
                 Add Reference Link
             </DropdownMenu.Item>
             <DropdownMenu.Item onclick={() => (openStackingInformationDialog = true)} title="View the values used to group events into this stack">
-                <ListTree />
+                <ListTree class="mr-2 size-4" />
                 View Stacking Information
             </DropdownMenu.Item>
             <DropdownMenu.Separator />

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
@@ -901,6 +901,7 @@ export interface ViewSavedView {
   created_by_user_id: string;
   /** @pattern ^[a-fA-F0-9]{24}$ */
   updated_by_user_id?: null | string;
+  predefined_key?: null | string;
   filter?: null | string;
   filter_definitions?: null | string;
   columns?: null | Record<string, SavedViewColumnSettings>;

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
@@ -1038,6 +1038,10 @@ export const ViewSavedViewSchema = object({
     .regex(/^[a-fA-F0-9]{24}$/, "Updated by user id has invalid format")
     .nullable()
     .optional(),
+  predefined_key: string()
+    .min(1, "Predefined key is required")
+    .nullable()
+    .optional(),
   filter: string().min(1, "Filter is required").nullable().optional(),
   filter_definitions: string()
     .min(1, "Filter definitions is required")

--- a/src/Exceptionless.Web/Models/SavedView/ViewSavedView.cs
+++ b/src/Exceptionless.Web/Models/SavedView/ViewSavedView.cs
@@ -21,6 +21,7 @@ public record ViewSavedView : IIdentity, IHaveDates
     [ObjectId]
     public string? UpdatedByUserId { get; set; }
 
+    public string? PredefinedKey { get; set; }
     public string? Filter { get; set; }
     public string? FilterDefinitions { get; set; }
     public Dictionary<string, SavedViewColumnSettings>? Columns { get; set; }

--- a/tests/Exceptionless.Tests/Api/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Api/Data/openapi.json
@@ -14435,6 +14435,12 @@
               "string"
             ]
           },
+          "predefined_key": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
           "filter": {
             "type": [
               "null",

--- a/tests/Exceptionless.Tests/Mapping/SavedViewMapperTests.cs
+++ b/tests/Exceptionless.Tests/Mapping/SavedViewMapperTests.cs
@@ -110,6 +110,7 @@ public sealed class SavedViewMapperTests
             UserId = "1ecd0826e447ad1e78822555",
             CreatedByUserId = "1ecd0826e447ad1e78822555",
             UpdatedByUserId = "1ecd0826e447ad1e78822666",
+            PredefinedKey = "events:all",
             Filter = "status:open",
             FilterDefinitions = "[{\"type\":\"status\",\"values\":[\"open\"]}]",
             Columns = new Dictionary<string, SavedViewColumnSettings>
@@ -135,6 +136,7 @@ public sealed class SavedViewMapperTests
         Assert.Equal("1ecd0826e447ad1e78822555", result.UserId);
         Assert.Equal("1ecd0826e447ad1e78822555", result.CreatedByUserId);
         Assert.Equal("1ecd0826e447ad1e78822666", result.UpdatedByUserId);
+        Assert.Equal("events:all", result.PredefinedKey);
         Assert.Equal("status:open", result.Filter);
         Assert.Equal("[{\"type\":\"status\",\"values\":[\"open\"]}]", result.FilterDefinitions);
         Assert.NotNull(result.Columns);
@@ -172,6 +174,7 @@ public sealed class SavedViewMapperTests
         // Assert
         Assert.Null(result.UserId);
         Assert.Null(result.UpdatedByUserId);
+        Assert.Null(result.PredefinedKey);
         Assert.Null(result.Filter);
         Assert.Null(result.FilterDefinitions);
         Assert.Null(result.Columns);


### PR DESCRIPTION
## Summary

- wrap long Overview, Exception, and Session Events messages without horizontal page-length scrolling
- add the missing Session Events user column and align its calendar action in normal layout
- open session-filtered events through the Events `All` saved view when available so column, wrapping, and width settings carry over
- correct the sidebar toggle cursor, Environment Machine Name cell layout, and stack-menu icon spacing

## Verification

- `npm run validate`
- `npm run test:unit -- --run src/lib/features/events/components/views/session-events-navigation.test.ts` (4 passed)
- `E2E_URL=https://localhost:33343 npx playwright test e2e/tests/session-investigation.e2e.ts --project=chromium --workers=1` (1 passed)
- local before/after Playwright capture at 1280 x 900: Overview and Exception scroll widths reduced from 8,337 px to 977 px; Session Events reduced from 8,590 px to 978 px within a 977 px container

## Breaking changes

None.
