### PR TITLE
Add saved views to Sessions

### DIFF
--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/ForcePredefinedSavedViewsWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/ForcePredefinedSavedViewsWorkItemHandler.cs
@@ -13,7 +13,7 @@ namespace Exceptionless.Core.Jobs.WorkItemHandlers;
 public class ForcePredefinedSavedViewsWorkItemHandler : WorkItemHandlerBase
 {
     private const int SavedViewPageLimit = 1000;
-    private static readonly string[] ValidViewTypes = ["events", "stacks", "stream"];
+    private static readonly string[] ValidViewTypes = ["events", "sessions", "stacks", "stream"];
 
     private readonly ISavedViewRepository _savedViewRepository;
     private readonly ILockProvider _lockProvider;

--- a/src/Exceptionless.Core/Migrations/009_AddSessionsPredefinedSavedView.cs
+++ b/src/Exceptionless.Core/Migrations/009_AddSessionsPredefinedSavedView.cs
@@ -1,3 +1,4 @@
+using Exceptionless.Core.Jobs.WorkItemHandlers;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Seed;
 using Foundatio.Repositories;
@@ -8,13 +9,17 @@ namespace Exceptionless.Core.Migrations;
 
 public sealed class AddSessionsPredefinedSavedView : MigrationBase
 {
+    private const int PageLimit = 500;
     internal const string PredefinedKey = "sessions:all";
+    private readonly IOrganizationRepository _organizationRepository;
     private readonly ISavedViewRepository _savedViewRepository;
 
     public AddSessionsPredefinedSavedView(
+        IOrganizationRepository organizationRepository,
         ISavedViewRepository savedViewRepository,
         ILoggerFactory loggerFactory) : base(loggerFactory)
     {
+        _organizationRepository = organizationRepository;
         _savedViewRepository = savedViewRepository;
 
         MigrationType = MigrationType.VersionedAndResumable;
@@ -29,17 +34,53 @@ public sealed class AddSessionsPredefinedSavedView : MigrationBase
 
         // A fresh installation has no system definitions yet; the data seed creates the complete
         // set after migrations finish. This migration only upgrades an existing nonempty seed.
-        if (existingResults.Total == 0 || existingResults.Documents.Any(view =>
-            String.Equals(view.PredefinedKey, PredefinedKey, StringComparison.OrdinalIgnoreCase)))
-        {
+        if (existingResults.Total == 0)
             return;
-        }
 
         var definitions = await PredefinedSavedViewsDataSeed.ReadDefaultSavedViewsAsync(context.CancellationToken);
         var definition = definitions.Single(view => String.Equals(view.Key, PredefinedKey, StringComparison.OrdinalIgnoreCase));
-        var savedView = PredefinedSavedViewsDataSeed.CreateSavedView(definition);
+        if (!existingResults.Documents.Any(view => String.Equals(view.PredefinedKey, PredefinedKey, StringComparison.OrdinalIgnoreCase)))
+        {
+            var savedView = PredefinedSavedViewsDataSeed.CreateSavedView(definition);
+            await _savedViewRepository.AddAsync(savedView, options => options.Cache().ImmediateConsistency());
+        }
 
-        await _savedViewRepository.AddAsync(savedView, options => options.Cache().ImmediateConsistency());
-        _logger.LogInformation("Added the Sessions predefined saved view to the existing system definitions");
+        int organizationsUpdated = 0;
+        var organizations = await _organizationRepository.FindAsync(
+            query => query.SortAscending(organization => organization.Id),
+            options => options.SearchAfterPaging().PageLimit(PageLimit));
+        do
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            foreach (var organization in organizations.Documents.Where(PredefinedSavedViewsDataSeed.HasCreatedPredefinedSavedViews))
+            {
+                var existingSessionsViews = await _savedViewRepository.GetByViewAsync(
+                    organization.Id,
+                    "sessions",
+                    options => options.PageLimit(1000));
+                if (existingSessionsViews.Documents.Any(view =>
+                    view.UserId is null && String.Equals(view.PredefinedKey, PredefinedKey, StringComparison.OrdinalIgnoreCase)))
+                {
+                    continue;
+                }
+
+                string slug = ForcePredefinedSavedViewsWorkItemHandler.GetUniqueSlug(definition.Slug, existingSessionsViews.Documents, null);
+                var savedView = PredefinedSavedViewsDataSeed.CreateSavedView(
+                    definition,
+                    organization.Id,
+                    PredefinedSavedViewsDataSeed.SystemUserId,
+                    slug);
+                await _savedViewRepository.AddAsync(savedView, options => options.Cache().ImmediateConsistency());
+                organizationsUpdated++;
+            }
+
+            await context.Lock.RenewAsync();
+        } while (!context.CancellationToken.IsCancellationRequested && await organizations.NextPageAsync());
+
+        context.CancellationToken.ThrowIfCancellationRequested();
+        _logger.LogInformation(
+            "Added the Sessions predefined saved view to the system definitions and {OrganizationCount} existing organizations",
+            organizationsUpdated);
     }
 }

--- a/src/Exceptionless.Core/Migrations/009_AddSessionsPredefinedSavedView.cs
+++ b/src/Exceptionless.Core/Migrations/009_AddSessionsPredefinedSavedView.cs
@@ -1,0 +1,45 @@
+using Exceptionless.Core.Repositories;
+using Exceptionless.Core.Seed;
+using Foundatio.Repositories;
+using Foundatio.Repositories.Migrations;
+using Microsoft.Extensions.Logging;
+
+namespace Exceptionless.Core.Migrations;
+
+public sealed class AddSessionsPredefinedSavedView : MigrationBase
+{
+    internal const string PredefinedKey = "sessions:all";
+    private readonly ISavedViewRepository _savedViewRepository;
+
+    public AddSessionsPredefinedSavedView(
+        ISavedViewRepository savedViewRepository,
+        ILoggerFactory loggerFactory) : base(loggerFactory)
+    {
+        _savedViewRepository = savedViewRepository;
+
+        MigrationType = MigrationType.VersionedAndResumable;
+        Version = 9;
+    }
+
+    public override async Task RunAsync(MigrationContext context)
+    {
+        var existingResults = await _savedViewRepository.GetByOrganizationIdAsync(
+            PredefinedSavedViewsDataSeed.SystemOrganizationId,
+            options => options.PageLimit(1000).ImmediateConsistency());
+
+        // A fresh installation has no system definitions yet; the data seed creates the complete
+        // set after migrations finish. This migration only upgrades an existing nonempty seed.
+        if (existingResults.Total == 0 || existingResults.Documents.Any(view =>
+            String.Equals(view.PredefinedKey, PredefinedKey, StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        var definitions = await PredefinedSavedViewsDataSeed.ReadDefaultSavedViewsAsync(context.CancellationToken);
+        var definition = definitions.Single(view => String.Equals(view.Key, PredefinedKey, StringComparison.OrdinalIgnoreCase));
+        var savedView = PredefinedSavedViewsDataSeed.CreateSavedView(definition);
+
+        await _savedViewRepository.AddAsync(savedView, options => options.Cache().ImmediateConsistency());
+        _logger.LogInformation("Added the Sessions predefined saved view to the existing system definitions");
+    }
+}

--- a/src/Exceptionless.Core/Models/SavedView.cs
+++ b/src/Exceptionless.Core/Models/SavedView.cs
@@ -84,9 +84,9 @@ public partial record SavedView : IOwnedByOrganizationWithIdentity, IHaveDates
     /// <summary>Schema version for future filter definition migrations.</summary>
     public int Version { get; set; } = 1;
 
-    /// <summary>Dashboard page identifier: "events", "stacks", or "stream".</summary>
+    /// <summary>Dashboard page identifier: "events", "sessions", "stacks", or "stream".</summary>
     [Required]
-    [RegularExpression("^(events|stacks|stream)$")]
+    [RegularExpression("^(events|sessions|stacks|stream)$")]
     public string ViewType { get; set; } = null!;
 
     // Timestamps

--- a/src/Exceptionless.Core/Seed/PredefinedSavedViewsDataSeed.cs
+++ b/src/Exceptionless.Core/Seed/PredefinedSavedViewsDataSeed.cs
@@ -170,7 +170,7 @@ public class PredefinedSavedViewsDataSeed : IDataSeed
         return Path.Combine(AppContext.BaseDirectory, "Seed", seedFileName);
     }
 
-    private static SavedView CreateSavedView(PredefinedSavedViewDefinition definition)
+    internal static SavedView CreateSavedView(PredefinedSavedViewDefinition definition)
     {
         var savedView = new SavedView
         {

--- a/src/Exceptionless.Core/Seed/PredefinedSavedViewsDataSeed.cs
+++ b/src/Exceptionless.Core/Seed/PredefinedSavedViewsDataSeed.cs
@@ -10,6 +10,8 @@ namespace Exceptionless.Core.Seed;
 
 public class PredefinedSavedViewsDataSeed : IDataSeed
 {
+    public const string PredefinedSavedViewsContentHashDataKey = "@@PredefinedSavedViewsContentHash";
+    public const string PredefinedSavedViewsDataKey = "@@PredefinedSavedViewsVersion";
     public const string SystemOrganizationId = "000000000000000000000001";
     public const string SystemUserId = "000000000000000000000001";
     public const string SeedFileName = "predefined-saved-views.json";
@@ -46,7 +48,7 @@ public class PredefinedSavedViewsDataSeed : IDataSeed
             if (existingResults.Total == 0)
             {
                 // First-time seed: create all views from definitions.
-                var savedViews = definitions.Select(CreateSavedView).ToList();
+                var savedViews = definitions.Select(definition => CreateSavedView(definition)).ToList();
                 await _savedViewRepository.AddAsync(savedViews, o => o.Cache().ImmediateConsistency());
                 _logger.LogInformation("Seeded {Count} predefined saved views", savedViews.Count);
                 return;
@@ -170,15 +172,30 @@ public class PredefinedSavedViewsDataSeed : IDataSeed
         return Path.Combine(AppContext.BaseDirectory, "Seed", seedFileName);
     }
 
-    internal static SavedView CreateSavedView(PredefinedSavedViewDefinition definition)
+    public static bool HasCreatedPredefinedSavedViews(Organization organization)
+    {
+        if (organization.Data is null)
+            return false;
+
+        return organization.Data.ContainsKey(PredefinedSavedViewsContentHashDataKey)
+            || organization.Data.TryGetValue(PredefinedSavedViewsDataKey, out object? versionValue)
+                && Int32.TryParse(versionValue?.ToString(), out int version)
+                && version > 0;
+    }
+
+    internal static SavedView CreateSavedView(
+        PredefinedSavedViewDefinition definition,
+        string organizationId = SystemOrganizationId,
+        string createdByUserId = SystemUserId,
+        string? slug = null)
     {
         var savedView = new SavedView
         {
-            OrganizationId = SystemOrganizationId,
-            CreatedByUserId = SystemUserId,
+            OrganizationId = organizationId,
+            CreatedByUserId = createdByUserId,
             PredefinedKey = definition.Key,
             Name = definition.Name,
-            Slug = definition.Slug,
+            Slug = slug ?? definition.Slug,
             ViewType = definition.ViewType,
             Filter = definition.Filter,
             Time = definition.Time,

--- a/src/Exceptionless.Core/Seed/predefined-saved-views.json
+++ b/src/Exceptionless.Core/Seed/predefined-saved-views.json
@@ -110,6 +110,36 @@
         "showChart": true
     },
     {
+        "key": "sessions:all",
+        "name": "All",
+        "slug": "all",
+        "viewType": "sessions",
+        "filter": "type:session",
+        "time": "[now-7d TO now]",
+        "sort": "-date",
+        "filterDefinitions": [
+            {
+                "type": "date",
+                "term": "date",
+                "value": "[now-7d TO now]"
+            },
+            {
+                "type": "project",
+                "value": []
+            },
+            {
+                "type": "type",
+                "value": ["session"],
+                "hidden": true
+            }
+        ],
+        "columns": {
+            "summary": { "autoFill": true }
+        },
+        "showStats": true,
+        "showChart": true
+    },
+    {
         "key": "stacks:all",
         "name": "All",
         "slug": "all",

--- a/src/Exceptionless.Core/Seed/predefined-saved-views.json
+++ b/src/Exceptionless.Core/Seed/predefined-saved-views.json
@@ -114,7 +114,6 @@
         "name": "All",
         "slug": "all",
         "viewType": "sessions",
-        "filter": "type:session",
         "time": "[now-7d TO now]",
         "sort": "-date",
         "filterDefinitions": [
@@ -126,11 +125,6 @@
             {
                 "type": "project",
                 "value": []
-            },
-            {
-                "type": "type",
-                "value": ["session"],
-                "hidden": true
             }
         ],
         "columns": {

--- a/src/Exceptionless.Web/Api/Handlers/SavedViewHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/SavedViewHandler.cs
@@ -34,8 +34,6 @@ public partial class SavedViewHandler(
     IHttpContextAccessor httpContextAccessor)
 {
     private const int MaxViewsPerOrganization = 100;
-    private const string PredefinedSavedViewsContentHashDataKey = "@@PredefinedSavedViewsContentHash";
-    private const string PredefinedSavedViewsDataKey = "@@PredefinedSavedViewsVersion";
 
     private HttpContext HttpContext => httpContextAccessor.HttpContext ?? throw new InvalidOperationException("HttpContext is unavailable.");
 
@@ -618,14 +616,14 @@ public partial class SavedViewHandler(
                 return;
             }
 
-            bool createMissing = forceCreateMissing || !HasCreatedPredefinedSavedViews(organization);
+            bool createMissing = forceCreateMissing || !PredefinedSavedViewsDataSeed.HasCreatedPredefinedSavedViews(organization);
             var upsertResult = await UpsertPredefinedSavedViewsForOrganizationAsync(organizationId, definitions, createMissing);
             savedViews = upsertResult.SavedViews;
 
             if (!upsertResult.HasSkippedCustomizations)
             {
                 organization.Data ??= new DataDictionary();
-                organization.Data[PredefinedSavedViewsContentHashDataKey] = definitionsContentHash;
+                organization.Data[PredefinedSavedViewsDataSeed.PredefinedSavedViewsContentHashDataKey] = definitionsContentHash;
                 await organizationRepository.SaveAsync(organization, o => o.Cache().ImmediateConsistency());
             }
         }, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(15));
@@ -716,21 +714,10 @@ public partial class SavedViewHandler(
             ?? existingViews.FirstOrDefault(view => view.UserId is null && String.IsNullOrWhiteSpace(view.PredefinedKey) && String.Equals(view.Name.Trim(), definition.Name, StringComparison.OrdinalIgnoreCase));
     }
 
-    private static bool HasCreatedPredefinedSavedViews(Organization organization)
-    {
-        if (organization.Data is null)
-            return false;
-
-        return organization.Data.ContainsKey(PredefinedSavedViewsContentHashDataKey)
-            || organization.Data.TryGetValue(PredefinedSavedViewsDataKey, out object? versionValue)
-                && Int32.TryParse(versionValue?.ToString(), out int version)
-                && version > 0;
-    }
-
     private static bool HasSynchronizedPredefinedSavedViews(Organization organization, string definitionsContentHash)
     {
         return organization.Data is not null
-            && organization.Data.TryGetValue(PredefinedSavedViewsContentHashDataKey, out object? contentHash)
+            && organization.Data.TryGetValue(PredefinedSavedViewsDataSeed.PredefinedSavedViewsContentHashDataKey, out object? contentHash)
             && String.Equals(contentHash?.ToString(), definitionsContentHash, StringComparison.Ordinal);
     }
 

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/sessions-saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/sessions-saved-views.e2e.ts
@@ -31,8 +31,15 @@ test('Sessions saved views persist active state, display settings, filters, and 
 
         await page.goto('/next/sessions?time=all');
         await expect(page.getByRole('heading', { name: 'Sessions' })).toBeVisible();
+        await expect(page.getByRole('button', { name: /^Type\b/ })).toHaveCount(0);
         await expect(getVisibleRow(page, name, identity)).toBeVisible({ timeout: 30_000 });
         await expect(page.getByRole('columnheader')).toHaveText(['', 'Summary', 'Duration', 'User', 'Date']);
+
+        await page.getByRole('button', { name: /^Manage filters/ }).click();
+        const filterSearch = page.getByPlaceholder('Search...').filter({ visible: true });
+        await filterSearch.fill('Type');
+        await expect(page.getByText('Type', { exact: true })).toHaveCount(0);
+        await page.keyboard.press('Escape');
     });
 
     await test.step('represent View Active as a reload-safe URL override', async () => {
@@ -139,11 +146,13 @@ test('Sessions saved views persist active state, display settings, filters, and 
         });
         const savedViews = (await savedViewsResponse.json()) as { filter_definitions?: string; name: string }[];
         const savedView = savedViews.find((view) => view.name === viewName);
-        expect(JSON.parse(savedView?.filter_definitions ?? '[]')).toContainEqual({
+        const savedFilterDefinitions = JSON.parse(savedView?.filter_definitions ?? '[]') as { hidden?: boolean; term?: string; type: string }[];
+        expect(savedFilterDefinitions).toContainEqual({
             hidden: true,
             term: 'data.sessionend',
             type: 'boolean'
         });
+        expect(savedFilterDefinitions).not.toContainEqual(expect.objectContaining({ type: 'type' }));
     });
 
     await test.step('temporary changes remain in the URL and Reset to Saved restores active state', async () => {
@@ -218,6 +227,48 @@ test('Sessions legacy raw-filter views keep URL removals and session-scoped stat
     await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
     await expect(rawFilterButton).toHaveCount(0);
     await expect(page).toHaveURL(/[?&]filters=(?:&|$)/);
+});
+
+test('Sessions ignore legacy structured Type filters and Type URL parameters', async ({ e2eScenario, page, request }) => {
+    const suffix = e2eScenario.run.slice(-32);
+    const viewName = `E2E Structured Sessions ${suffix}`;
+    const viewSlug = savedViewSlug(viewName);
+    const sessionFilters: string[] = [];
+    const sessionsPath = `/api/v2/organizations/${e2eScenario.organizationId}/events/sessions`;
+
+    page.on('request', (eventRequest) => {
+        const url = new URL(eventRequest.url());
+        if (url.pathname === sessionsPath) {
+            sessionFilters.push(url.searchParams.get('filter') ?? '');
+        }
+    });
+
+    const response = await request.post(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views`, {
+        data: {
+            filter: 'type:error',
+            filter_definitions: JSON.stringify([{ hidden: true, type: 'type', value: ['error'] }]),
+            name: viewName,
+            organization_id: e2eScenario.organizationId,
+            show_chart: true,
+            show_stats: true,
+            slug: viewSlug,
+            time: '[now-7d TO now]',
+            view_type: 'sessions'
+        },
+        headers: { Authorization: `Bearer ${e2eScenario.userToken}` }
+    });
+    expect(response.status(), await response.text()).toBe(201);
+
+    await page.goto(`/next/sessions/${viewSlug}?type=log`);
+    await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await expect(page.getByRole('button', { name: /^Type\b/ })).toHaveCount(0);
+    await expect(page.getByLabel('Unsaved view changes')).toHaveCount(0);
+    await expect.poll(() => sessionFilters).toContain('type:session');
+
+    await page.getByRole('button', { name: /^Manage filters/ }).click();
+    const filterSearch = page.getByPlaceholder('Search...').filter({ visible: true });
+    await filterSearch.fill('Type');
+    await expect(page.getByText('Type', { exact: true })).toHaveCount(0);
 });
 
 async function captureEvidence(page: Page, fileName: string): Promise<void> {

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/sessions-saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/sessions-saved-views.e2e.ts
@@ -1,0 +1,204 @@
+import type { Page } from '@playwright/test';
+
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+import { createReferenceId, expect, test } from '../fixtures/e2e-test';
+import { getVisibleRow } from '../support/page-helpers';
+import { createSessionEvent } from '../support/synthetic-event';
+
+test('Sessions saved views persist active state, display settings, filters, and columns', async ({ e2eApi, e2eScenario, page, request }) => {
+    const failedApiRequests: string[] = [];
+    page.on('response', (response) => {
+        const url = new URL(response.url());
+        if (url.pathname.startsWith('/api/') && response.status() >= 400) {
+            failedApiRequests.push(`${response.status()} ${url.pathname}`);
+        }
+    });
+    await page.setViewportSize({ height: 900, width: 1280 });
+
+    const sessionId = createReferenceId(e2eScenario.run, '-saved-session');
+    const identity = `saved-session-${e2eScenario.run}@exceptionless.test`;
+    const name = `Saved Session User ${e2eScenario.run}`;
+    const viewName = `E2E Sessions ${e2eScenario.run.slice(-32)}`;
+    const viewSlug = savedViewSlug(viewName);
+    const authorizationHeaders = { Authorization: `Bearer ${e2eScenario.userToken}` };
+    let savedSummaryWidth = 0;
+
+    await test.step('seed and open an active session', async () => {
+        await e2eApi.submitEvent(e2eScenario.projectId, e2eScenario.projectToken, createSessionEvent({ identity, name, sessionId }));
+        await e2eApi.pollForEventByReference(e2eScenario.userToken, e2eScenario.projectId, sessionId);
+
+        await page.goto('/next/sessions?time=all');
+        await expect(page.getByRole('heading', { name: 'Sessions' })).toBeVisible();
+        await expect(getVisibleRow(page, name, identity)).toBeVisible({ timeout: 30_000 });
+        await expect(page.getByRole('columnheader')).toHaveText(['', 'Summary', 'Duration', 'User', 'Date']);
+    });
+
+    await test.step('represent View Active as a reload-safe URL override', async () => {
+        const viewActive = page.getByRole('switch', { name: 'View Active' });
+        await viewActive.click();
+        await expect(viewActive).toBeChecked();
+        await expect(page).toHaveURL(/[?&]filters=/);
+        await expect(getVisibleRow(page, name, identity)).toBeVisible();
+
+        await page.reload();
+        await expect(viewActive).toBeChecked();
+        await expect(getVisibleRow(page, name, identity)).toBeVisible({ timeout: 30_000 });
+    });
+
+    await test.step('configure display and columns, then save the complete view', async () => {
+        await openViewMenu(page);
+        await page.getByRole('menuitemcheckbox', { name: 'Chart' }).click();
+        await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
+
+        const columnDialog = page.getByRole('dialog', { name: 'Column Picker' });
+        await columnDialog.getByRole('button', { name: 'Remove Duration column' }).click();
+        await columnDialog.getByRole('checkbox', { name: 'User wrap text' }).click();
+        await columnDialog.getByRole('button', { name: 'Move Date up' }).click();
+        await columnDialog.getByRole('button', { name: 'Done' }).click();
+
+        await expect(page.getByRole('columnheader', { name: 'Duration' })).toHaveCount(0);
+        await expectColumnBefore(page, 'Date', 'User');
+
+        const summaryHeader = page.getByRole('columnheader', { name: 'Summary' });
+        const originalSummaryWidth = (await summaryHeader.boundingBox())?.width ?? 0;
+        await page.getByRole('button', { name: 'Resize summary column' }).focus();
+        await page.keyboard.press('ArrowRight');
+        await page.keyboard.press('ArrowRight');
+        savedSummaryWidth = (await summaryHeader.boundingBox())?.width ?? 0;
+        expect(savedSummaryWidth).toBeGreaterThanOrEqual(originalSummaryWidth + 30);
+
+        await openViewMenu(page);
+        await page.getByRole('menuitem', { name: 'Save As...' }).click();
+        const saveDialog = page.getByRole('dialog', { name: 'Save View' });
+        await saveDialog.getByLabel('Name', { exact: true }).fill(viewName);
+        await saveDialog.getByRole('button', { name: 'Save' }).click();
+        await expect(saveDialog).toBeHidden({ timeout: 30_000 });
+
+        await expect(page).toHaveURL(new RegExp(`/next/sessions/${escapeRegExp(viewSlug)}(?:[?#]|$)`));
+        await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+        await expect
+            .poll(
+                async () => {
+                    const response = await request.get(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views/sessions`, {
+                        headers: authorizationHeaders
+                    });
+                    const views = response.ok() ? ((await response.json()) as { name: string }[]) : [];
+                    return views.some((view) => view.name === viewName);
+                },
+                { timeout: 30_000 }
+            )
+            .toBe(true);
+    });
+
+    await test.step('reload the saved route and verify the complete server representation', async () => {
+        await page.reload();
+        await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+        await expect(page.getByRole('switch', { name: 'View Active' })).toBeChecked();
+        await expect(page.getByRole('columnheader', { name: 'Duration' })).toHaveCount(0);
+        await expectColumnBefore(page, 'Date', 'User');
+        await expect.poll(async () => (await page.getByRole('columnheader', { name: 'Summary' }).boundingBox())?.width ?? 0).toBeCloseTo(savedSummaryWidth, 0);
+
+        await captureEvidence(page, '01-sessions-saved-view.png');
+
+        await openViewMenu(page);
+        await expect(page.getByRole('menuitemcheckbox', { name: 'Chart' })).not.toBeChecked();
+        await page.getByRole('menuitem', { name: 'Manage Columns...' }).click();
+        const columnDialog = page.getByRole('dialog', { name: 'Column Picker' });
+        await expect(columnDialog.getByRole('checkbox', { name: 'User wrap text' })).toBeChecked();
+        await captureEvidence(page, '02-sessions-column-management.png');
+        await columnDialog.getByRole('button', { name: 'Done' }).click();
+
+        await expect
+            .poll(async () => {
+                const response = await request.get(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views/sessions`, {
+                    headers: authorizationHeaders
+                });
+                const views = (await response.json()) as {
+                    columns?: Record<string, { position?: number; visible?: boolean; wrap?: boolean }>;
+                    filter_definitions?: string;
+                    name: string;
+                    show_chart?: boolean;
+                    time?: string;
+                    view_type: string;
+                }[];
+                return views.find((view) => view.name === viewName);
+            })
+            .toMatchObject({
+                columns: {
+                    duration: { visible: false },
+                    user: { wrap: true }
+                },
+                show_chart: false,
+                view_type: 'sessions'
+            });
+
+        const savedViewsResponse = await request.get(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views/sessions`, {
+            headers: authorizationHeaders
+        });
+        const savedViews = (await savedViewsResponse.json()) as { filter_definitions?: string; name: string }[];
+        const savedView = savedViews.find((view) => view.name === viewName);
+        expect(JSON.parse(savedView?.filter_definitions ?? '[]')).toContainEqual({
+            hidden: true,
+            term: 'data.sessionend',
+            type: 'boolean'
+        });
+    });
+
+    await test.step('temporary changes remain in the URL and Reset to Saved restores active state', async () => {
+        const viewActive = page.getByRole('switch', { name: 'View Active' });
+        await viewActive.click();
+        await expect(viewActive).not.toBeChecked();
+        await expect(page).toHaveURL(/[?&]filters=(?:&|$)/);
+        await expect(page.getByLabel('Unsaved view changes')).toBeVisible();
+
+        await page.reload();
+        await expect(viewActive).not.toBeChecked();
+        await openViewMenu(page);
+        await page.getByRole('menuitem', { name: 'Reset to Saved' }).click();
+        await expect(page).not.toHaveURL(/[?&]filters=/);
+        await expect(viewActive).toBeChecked();
+        await expect(page.getByLabel('Unsaved view changes')).toHaveCount(0);
+        await captureEvidence(page, '03-sessions-reset-to-saved.png');
+    });
+
+    expect(failedApiRequests).toEqual([]);
+});
+
+async function captureEvidence(page: Page, fileName: string): Promise<void> {
+    const outputDirectory = process.env.DOGFOOD_OUTPUT;
+    if (!outputDirectory) return;
+
+    const resolvedDirectory = path.resolve(outputDirectory);
+    mkdirSync(resolvedDirectory, { recursive: true });
+    await page.screenshot({ path: path.join(resolvedDirectory, fileName) });
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function expectColumnBefore(page: Page, firstColumn: string, secondColumn: string): Promise<void> {
+    await expect
+        .poll(async () => {
+            const headings = await page.getByRole('columnheader').allTextContents();
+            const firstIndex = headings.findIndex((heading) => heading.trim().startsWith(firstColumn));
+            const secondIndex = headings.findIndex((heading) => heading.trim().startsWith(secondColumn));
+            return firstIndex >= 0 && secondIndex >= 0 && firstIndex < secondIndex;
+        })
+        .toBe(true);
+}
+
+async function openViewMenu(page: Page): Promise<void> {
+    await page.getByRole('button', { name: /^View/ }).filter({ visible: true }).first().click();
+}
+
+function savedViewSlug(value: string): string {
+    return value
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .replace(/-+/g, '-');
+}

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/sessions-saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/sessions-saved-views.e2e.ts
@@ -166,6 +166,60 @@ test('Sessions saved views persist active state, display settings, filters, and 
     expect(failedApiRequests).toEqual([]);
 });
 
+test('Sessions legacy raw-filter views keep URL removals and session-scoped statistics', async ({ e2eScenario, page, request }) => {
+    await page.setViewportSize({ height: 900, width: 1600 });
+
+    const suffix = e2eScenario.run.slice(-32);
+    const viewName = `E2E Legacy Sessions ${suffix}`;
+    const viewSlug = savedViewSlug(viewName);
+    const rawFilter = 'type:error';
+    const statisticsFilters: string[] = [];
+    const statisticsPath = `/api/v2/organizations/${e2eScenario.organizationId}/events/count`;
+
+    page.on('request', (eventRequest) => {
+        const url = new URL(eventRequest.url());
+        if (url.pathname === statisticsPath && url.searchParams.get('aggregations')?.includes('avg:value')) {
+            statisticsFilters.push(url.searchParams.get('filter') ?? '');
+        }
+    });
+
+    const response = await request.post(`/api/v2/organizations/${e2eScenario.organizationId}/saved-views`, {
+        data: {
+            filter: rawFilter,
+            name: viewName,
+            organization_id: e2eScenario.organizationId,
+            show_chart: true,
+            show_stats: true,
+            slug: viewSlug,
+            time: '[now-7d TO now]',
+            view_type: 'sessions'
+        },
+        headers: { Authorization: `Bearer ${e2eScenario.userToken}` }
+    });
+    expect(response.status(), await response.text()).toBe(201);
+
+    await page.goto(`/next/sessions/${viewSlug}`);
+    await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    const rawFilterButton = page
+        .getByRole('button', { name: new RegExp(`^Raw Filter\\s+${escapeRegExp(rawFilter)}`) })
+        .filter({ visible: true })
+        .first();
+    await expect(rawFilterButton).toBeVisible();
+    await expect.poll(() => statisticsFilters).toContain(`type:session AND (${rawFilter})`);
+
+    await rawFilterButton.focus();
+    await page.keyboard.press('Enter');
+    await page.getByRole('button', { name: 'Remove filter' }).click();
+    await expect(page).toHaveURL(/[?&]filters=(?:&|$)/);
+    await expect(rawFilterButton).toHaveCount(0);
+    await expect.poll(() => statisticsFilters).toContain('type:session');
+
+    await page.reload();
+    await expect(page.getByRole('heading', { name: viewName })).toBeVisible();
+    await expect(rawFilterButton).toHaveCount(0);
+    await expect(page).toHaveURL(/[?&]filters=(?:&|$)/);
+});
+
 async function captureEvidence(page: Page, fileName: string): Promise<void> {
     const outputDirectory = process.env.DOGFOOD_OUTPUT;
     if (!outputDirectory) return;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
@@ -103,12 +103,14 @@ export const queryKeys = {
     organizations: (id: string | undefined) => [...queryKeys.type, 'organizations', id] as const,
     organizationsCount: (id: string | undefined, params?: GetOrganizationCountRequest['params']) => [...queryKeys.organizations(id), 'count', params] as const,
     organizationsEvents: (id: string | undefined, params?: GetEventsParams) => [...queryKeys.organizations(id), 'events', params] as const,
+    organizationsSessions: (id: string | undefined, params?: GetEventsParams) => [...queryKeys.organizations(id), 'sessions', 'list', params] as const,
     projects: (id: string | undefined) => [...queryKeys.type, 'projects', id] as const,
     projectsCount: (id: string | undefined, params?: GetProjectCountRequest['params']) => [...queryKeys.projects(id), 'count', params] as const,
     sessionEvents: (id: string | undefined, projectId?: string | undefined, params?: GetSessionEventsRequest['params']) =>
         [...queryKeys.type, 'sessions', 'session', id, projectId, params] as const,
     sessions: (id: string | undefined) => [...queryKeys.type, 'sessions', 'organizations', id] as const,
-    sessionsCount: (id: string | undefined, params?: GetOrganizationSessionsCountRequest['params']) => [...queryKeys.sessions(id), 'count', params] as const,
+    sessionsCount: (id: string | undefined, params?: GetOrganizationSessionsCountRequest['params']) =>
+        [...queryKeys.organizations(id), 'sessions', 'count', params] as const,
     stackEvents: (id: string | undefined, params?: GetStackEventsRequest['params']) => [...queryKeys.stacks(id), 'events', params] as const,
     stacks: (id: string | undefined) => [...queryKeys.type, 'stacks', id] as const,
     stacksCount: (id: string | undefined, params?: GetStackCountRequest['params']) => [...queryKeys.stacks(id), 'count', params] as const,
@@ -201,12 +203,21 @@ export interface GetOrganizationEventsRequest {
 }
 
 export interface GetOrganizationSessionsCountRequest {
+    enabled?: () => boolean;
     params?: {
         aggregations?: string;
         filter?: string;
         offset?: string;
         time?: string;
     };
+    route: {
+        organizationId: string | undefined;
+    };
+}
+
+export interface GetOrganizationSessionsRequest {
+    enabled?: () => boolean;
+    params?: GetEventsParams;
     route: {
         organizationId: string | undefined;
     };
@@ -466,7 +477,7 @@ export function getOrganizationSessionsCountQuery(request: GetOrganizationSessio
     const queryClient = useQueryClient();
 
     return createQuery<CountResult, ProblemDetails>(() => ({
-        enabled: () => !!accessToken.current && !!request.route.organizationId,
+        enabled: () => !!accessToken.current && !!request.route.organizationId && (request.enabled?.() ?? true),
         queryClient,
         queryFn: async () => {
             const client = useFetchClient();
@@ -483,8 +494,33 @@ export function getOrganizationSessionsCountQuery(request: GetOrganizationSessio
 
             return response.data!;
         },
-        queryKey: queryKeys.sessionsCount(request.route.organizationId, request.params)
+        queryKey: queryKeys.sessionsCount(request.route.organizationId, request.params),
+        staleTime: ORGANIZATION_EVENT_QUERY_STALE_TIME_MS
     }));
+}
+
+export function getOrganizationSessionsQuery(request: GetOrganizationSessionsRequest) {
+    return createQuery<FetchClientResponse<EventSummaryModel<SummaryTemplateKeys>[]>, ProblemDetails>(() => {
+        const organizationId = request.route.organizationId;
+        const params = request.params
+            ? {
+                  ...request.params
+              }
+            : undefined;
+
+        return {
+            enabled: () => !!accessToken.current && !!organizationId && (request.enabled?.() ?? true),
+            placeholderData: keepPreviousData,
+            queryFn: async () => {
+                const client = useFetchClient();
+                return await client.getJSON<EventSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organizationId}/events/sessions`, {
+                    params: params as Record<string, unknown>
+                });
+            },
+            queryKey: queryKeys.organizationsSessions(organizationId, params),
+            staleTime: ORGANIZATION_EVENT_QUERY_STALE_TIME_MS
+        };
+    });
 }
 
 export function getProjectCountQuery(request: GetProjectCountRequest) {
@@ -636,7 +672,11 @@ export function schedulePersistentEventDeleteReconciliation(queryClient: QueryCl
 }
 
 function isOrganizationEventDashboardQueryKey(queryKey: readonly unknown[]): boolean {
-    return queryKey[0] === queryKeys.type[0] && queryKey[1] === 'organizations' && (queryKey[3] === 'count' || queryKey[3] === 'events');
+    return (
+        queryKey[0] === queryKeys.type[0] &&
+        queryKey[1] === 'organizations' &&
+        (queryKey[3] === 'count' || queryKey[3] === 'events' || queryKey[3] === 'sessions')
+    );
 }
 
 function isOrganizationEventsQueryKey(queryKey: readonly unknown[]): boolean {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.svelte.ts
@@ -502,6 +502,7 @@ export function getOrganizationSessionsCountQuery(request: GetOrganizationSessio
 export function getOrganizationSessionsQuery(request: GetOrganizationSessionsRequest) {
     return createQuery<FetchClientResponse<EventSummaryModel<SummaryTemplateKeys>[]>, ProblemDetails>(() => {
         const organizationId = request.route.organizationId;
+        const enabled = !!accessToken.current && !!organizationId && (request.enabled?.() ?? true);
         const params = request.params
             ? {
                   ...request.params
@@ -509,8 +510,9 @@ export function getOrganizationSessionsQuery(request: GetOrganizationSessionsReq
             : undefined;
 
         return {
-            enabled: () => !!accessToken.current && !!organizationId && (request.enabled?.() ?? true),
-            placeholderData: keepPreviousData,
+            enabled,
+            placeholderData: (previousData, previousQuery) =>
+                retainPreviousOrganizationQueryData(previousData, previousQuery?.queryKey, organizationId, enabled),
             queryFn: async () => {
                 const client = useFetchClient();
                 return await client.getJSON<EventSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organizationId}/events/sessions`, {
@@ -643,6 +645,15 @@ export function getStackEventsQuery(request: GetStackEventsRequest) {
         },
         queryKey: queryKeys.stackEvents(request.route.stackId, request.params)
     }));
+}
+
+export function retainPreviousOrganizationQueryData<T>(
+    previousData: T | undefined,
+    previousQueryKey: readonly unknown[] | undefined,
+    organizationId: string | undefined,
+    enabled: boolean
+): T | undefined {
+    return enabled && previousQueryKey?.[2] === organizationId ? previousData : undefined;
 }
 
 export function schedulePersistentEventDeleteReconciliation(queryClient: QueryClient, eventTarget: EventTarget = document) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.test.ts
@@ -15,6 +15,7 @@ import {
     PERSISTENT_EVENT_DELETE_RECONCILE_EVENT,
     PERSISTENT_EVENT_DELETE_RECONCILE_RETRY_DELAY,
     queryKeys,
+    retainPreviousOrganizationQueryData,
     schedulePersistentEventDeleteReconciliation
 } from './api.svelte';
 
@@ -26,6 +27,17 @@ vi.mock('@foundatiofx/fetchclient', () => ({
 
 afterEach(() => {
     vi.useRealTimers();
+});
+
+describe('retainPreviousOrganizationQueryData', () => {
+    const previousData = { data: [{ id: 'session-id' }] };
+    const previousQueryKey = queryKeys.organizationsSessions('organization-a', { page: 1 });
+
+    it('retains data only for enabled query changes within the same organization', () => {
+        expect(retainPreviousOrganizationQueryData(previousData, previousQueryKey, 'organization-a', true)).toBe(previousData);
+        expect(retainPreviousOrganizationQueryData(previousData, previousQueryKey, 'organization-b', true)).toBeUndefined();
+        expect(retainPreviousOrganizationQueryData(previousData, previousQueryKey, 'organization-a', false)).toBeUndefined();
+    });
 });
 
 describe('createOrganizationEventNotificationRefresher', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/api.test.ts
@@ -87,6 +87,8 @@ describe('createOrganizationEventNotificationRefresher', () => {
         expect(firstInvalidation?.refetchType).toBe('active');
         expect(firstInvalidation?.predicate?.({ queryKey: queryKeys.organizationsEvents('organization-id') } as never)).toBe(true);
         expect(firstInvalidation?.predicate?.({ queryKey: queryKeys.organizationsCount('organization-id') } as never)).toBe(true);
+        expect(firstInvalidation?.predicate?.({ queryKey: queryKeys.organizationsSessions('organization-id') } as never)).toBe(true);
+        expect(firstInvalidation?.predicate?.({ queryKey: queryKeys.sessionsCount('organization-id') } as never)).toBe(true);
         expect(firstInvalidation?.predicate?.({ queryKey: queryKeys.organizationsEvents('other-organization-id') } as never)).toBe(false);
         expect(firstInvalidation?.predicate?.({ queryKey: queryKeys.id('event-id') } as never)).toBe(false);
 
@@ -195,6 +197,8 @@ describe('invalidatePersistentEventQueries', () => {
         const broadInvalidation = invalidateSpy.mock.calls.find(([filters]) => filters?.queryKey === queryKeys.type)?.[0];
         expect(broadInvalidation?.predicate?.({ queryKey: queryKeys.organizationsEvents('organization-id') } as never)).toBe(false);
         expect(broadInvalidation?.predicate?.({ queryKey: queryKeys.organizationsCount('organization-id') } as never)).toBe(false);
+        expect(broadInvalidation?.predicate?.({ queryKey: queryKeys.organizationsSessions('organization-id') } as never)).toBe(false);
+        expect(broadInvalidation?.predicate?.({ queryKey: queryKeys.sessionsCount('organization-id') } as never)).toBe(false);
         expect(broadInvalidation?.predicate?.({ queryKey: queryKeys.id('event-id') } as never)).toBe(true);
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/organization-defaults-faceted-filter-builder.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/filters/organization-defaults-faceted-filter-builder.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
     interface Props {
         includeDateFacets?: boolean;
+        includeTypeFacet?: boolean;
     }
 
-    const { includeDateFacets = true }: Props = $props();
+    const { includeDateFacets = true, includeTypeFacet = true }: Props = $props();
     import * as FacetedFilter from './index';
 
     type KnownTermsFilterConfig = {
@@ -238,7 +239,9 @@
 {/each}
 
 <FacetedFilter.TagBuilder priority={70} />
-<FacetedFilter.TypeBuilder priority={50} />
+{#if includeTypeFacet}
+    <FacetedFilter.TypeBuilder priority={50} />
+{/if}
 
 {#each eventsVersionFilters as { priority, term, title } (term)}
     <FacetedFilter.VersionBuilder {priority} {term} {title} />

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/defaults.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/defaults.test.ts
@@ -100,6 +100,17 @@ describe('getSavedViewDefaultHref', () => {
 
         expect(getSavedViewDefaultHref(defaults, savedViews)).toBe('/next/stream?saved=stream-default');
     });
+
+    it('builds Sessions saved view links for a configured home view', () => {
+        const savedViews = [savedView({ id: 'sessions-default', slug: 'active', view_type: 'sessions' })];
+        const defaults = resolveSavedViewDefaults({
+            organizationId: 'organization-id',
+            organizationPreferences: [preference('sessions-default')],
+            savedViews
+        });
+
+        expect(getSavedViewDefaultHref(defaults, savedViews)).toBe('/next/sessions/active');
+    });
 });
 
 function preference(defaultSavedViewId: string): UserOrganizationPreference {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/slugs.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/slugs.ts
@@ -41,7 +41,8 @@ export function savedViewHref(savedView: SavedViewLink): string {
         return `${resolve('/(app)/stream')}?saved=${savedView.id}`;
     }
 
-    const base = savedView.view_type === 'events' ? resolve('/(app)/event') : resolve('/(app)/stack');
+    const base =
+        savedView.view_type === 'events' ? resolve('/(app)/event') : savedView.view_type === 'sessions' ? resolve('/(app)/sessions') : resolve('/(app)/stack');
     return `${base}/${savedViewResolvedSlug(savedView)}`;
 }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.svelte.ts
@@ -82,6 +82,7 @@ export interface UseSavedViewsOptions {
     getShowStats?: () => boolean;
     getSort?: () => null | string | undefined;
     getTime?: () => null | string | undefined;
+    normalizeSavedView?: (view: SavedView) => SavedView;
     queryParams: SavedViewQueryParams;
     setColumnOrder?: (order: ColumnOrderState) => void;
     setColumnSizing?: (sizing: ColumnSizingState) => void;
@@ -466,8 +467,17 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
         }
     });
 
-    const activeSavedView = $derived.by(() => {
+    const savedViews = $derived.by(() => {
         const views = savedViewsListQuery.data;
+        if (!views || !options.normalizeSavedView) {
+            return views;
+        }
+
+        return views.map((view) => options.normalizeSavedView!(view));
+    });
+
+    const activeSavedView = $derived.by(() => {
+        const views = savedViews;
         if (!views) {
             return undefined;
         }
@@ -1195,7 +1205,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             activeSavedView,
             isLoading: savedViewsListQuery.isLoading,
             savedViewKey: options.slug ?? options.queryParams.saved,
-            savedViews: savedViewsListQuery.data
+            savedViews
         })
     );
 
@@ -1274,20 +1284,21 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
     }
 
     function handleSavedViewUpdated(view: SavedView) {
+        const normalizedView = options.normalizeSavedView?.(view) ?? view;
         const identity =
-            getDraftIdentity(view) ??
-            (view.organization_id && view.updated_by_user_id
+            getDraftIdentity(normalizedView) ??
+            (normalizedView.organization_id && normalizedView.updated_by_user_id
                 ? {
-                      organizationId: view.organization_id,
-                      savedViewId: view.id,
-                      userId: view.updated_by_user_id
+                      organizationId: normalizedView.organization_id,
+                      savedViewId: normalizedView.id,
+                      userId: normalizedView.updated_by_user_id
                   }
                 : undefined);
         if (identity) {
             clearSavedViewDraft(identity);
         }
 
-        if (activeSavedView?.id !== view.id) {
+        if (activeSavedView?.id !== normalizedView.id) {
             return;
         }
 
@@ -1298,11 +1309,11 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
 
         activeFilterOverrideBaselines = {};
         activeSortOverride = undefined;
-        hydratedColumnOrder = options.getColumnOrder ? resolveSavedViewColumnOrder(view, options.getColumnOrder()) : undefined;
-        hydratedSavedView = view;
-        hydratedSavedViewSignature = getSavedViewStateSignature(view);
-        hydratedSavedViewId = view.id;
-        serverHydratedSavedViewId = view.id;
+        hydratedColumnOrder = options.getColumnOrder ? resolveSavedViewColumnOrder(normalizedView, options.getColumnOrder()) : undefined;
+        hydratedSavedView = normalizedView;
+        hydratedSavedViewSignature = getSavedViewStateSignature(normalizedView);
+        hydratedSavedViewId = normalizedView.id;
+        serverHydratedSavedViewId = normalizedView.id;
     }
 
     async function handleClearSavedView(): Promise<void> {
@@ -1348,7 +1359,7 @@ export function useSavedViews(options: UseSavedViewsOptions): UseSavedViewsRetur
             return isModified;
         },
         get savedViews() {
-            return savedViewsListQuery.data ?? [];
+            return savedViews ?? [];
         },
         setAutoFillColumnId(columnId: AutoFillColumnSelection) {
             autoFillColumnId = columnId;

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/use-saved-views.test.ts
@@ -201,6 +201,12 @@ describe('useSavedViews', () => {
             // Assert
             expect(href).toBe('/next/event/legacy-saved-view');
         });
+
+        it('builds Sessions saved-view URLs on the Sessions route', () => {
+            const savedView = buildSavedView({ id: 'view-1', name: 'Active Sessions', slug: 'active', view_type: 'sessions' });
+
+            expect(savedViewHref(savedView)).toBe('/next/sessions/active');
+        });
     });
 
     describe('saved view slug resolution', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/sessions/components/session-table-columns.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/sessions/components/session-table-columns.ts
@@ -4,9 +4,11 @@ import TimeAgo from '$comp/formatters/time-ago.svelte';
 import { Checkbox } from '$comp/ui/checkbox';
 import Summary from '$features/events/components/summary/summary.svelte';
 import EventsUserIdentitySummaryCell from '$features/events/components/table/events-user-identity-summary-cell.svelte';
-import { type ColumnDef, renderComponent, type StockFeatures } from '@tanstack/svelte-table';
+import { type ColumnDef, type ColumnVisibilityState, renderComponent, type StockFeatures } from '@tanstack/svelte-table';
 
 import SessionDurationCell from './session-duration-cell.svelte';
+
+export const defaultSessionColumnVisibility: ColumnVisibilityState = {};
 
 export function getSessionColumns(): ColumnDef<StockFeatures, EventSummaryModel<SummaryTemplateKeys>, unknown>[] {
     return [
@@ -21,6 +23,7 @@ export function getSessionColumns(): ColumnDef<StockFeatures, EventSummaryModel<
                     onCheckedChange: (checked: 'indeterminate' | boolean) => props.row.getToggleSelectedHandler()({ target: { checked } })
                 }),
             enableHiding: false,
+            enableResizing: false,
             enableSorting: false,
             header: ({ table }) =>
                 renderComponent(Checkbox, {
@@ -35,39 +38,53 @@ export function getSessionColumns(): ColumnDef<StockFeatures, EventSummaryModel<
         },
         {
             cell: (prop) => renderComponent(Summary, { showStatus: false, showType: false, summary: prop.row.original }),
-            enableHiding: false,
+            enableSorting: false,
             header: 'Summary',
             id: 'summary',
+            maxSize: 1200,
             meta: {
-                class: 'w-full'
-            }
+                class: 'w-full',
+                enableWrapping: true
+            },
+            minSize: 240,
+            size: 480
         },
         {
             cell: (prop) => renderComponent(SessionDurationCell, { summary: prop.row.original }),
             enableSorting: false,
             header: 'Duration',
             id: 'duration',
+            maxSize: 320,
             meta: {
                 class: 'w-40'
-            }
+            },
+            minSize: 96,
+            size: 160
         },
         {
             cell: (prop) => renderComponent(EventsUserIdentitySummaryCell, { summary: prop.row.original }),
             enableSorting: false,
             header: 'User',
             id: 'user',
+            maxSize: 480,
             meta: {
-                class: 'w-56'
-            }
+                class: 'w-56',
+                enableWrapping: true
+            },
+            minSize: 112,
+            size: 224
         },
         {
             accessorFn: (row) => row.date,
             cell: (prop) => renderComponent(TimeAgo, { value: prop.getValue<string>() }),
             header: 'Date',
             id: 'date',
+            maxSize: 240,
             meta: {
                 class: 'w-36'
-            }
+            },
+            minSize: 100,
+            size: 144
         }
     ];
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/sessions/saved-view-invariants.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/sessions/saved-view-invariants.test.ts
@@ -1,0 +1,66 @@
+import type { SavedView } from '$features/saved-views/models';
+
+import { describe, expect, it } from 'vitest';
+
+import { getSessionQueryFilter, normalizeSessionSavedView, SESSION_EVENT_FILTER } from './saved-view-invariants';
+
+function buildSavedView(overrides: Partial<SavedView> = {}): SavedView {
+    return {
+        columns: {},
+        created_by_user_id: '507f1f77bcf86cd799439011',
+        created_utc: new Date().toISOString(),
+        filter: null,
+        filter_definitions: null,
+        id: '507f1f77bcf86cd799439012',
+        name: 'Sessions',
+        organization_id: '507f1f77bcf86cd799439013',
+        slug: 'sessions',
+        sort: '-date',
+        time: '[now-7d TO now]',
+        updated_by_user_id: null,
+        updated_utc: new Date().toISOString(),
+        user_id: null,
+        version: 1,
+        view_type: 'sessions',
+        ...overrides
+    };
+}
+
+describe('Sessions saved-view invariants', () => {
+    it('applies the session event predicate independently of editable filters', () => {
+        expect(getSessionQueryFilter(null)).toBe(SESSION_EVENT_FILTER);
+        expect(getSessionQueryFilter('project:abc')).toBe('type:session AND (project:abc)');
+    });
+
+    it('removes a structured Type filter and recomputes the editable filter', () => {
+        const view = buildSavedView({
+            filter: 'project:abc type:error',
+            filter_definitions: JSON.stringify([
+                { type: 'project', value: ['abc'] },
+                { hidden: true, type: 'type', value: ['error'] },
+                { term: 'date', type: 'date', value: '[now-7d TO now]' }
+            ])
+        });
+
+        const normalized = normalizeSessionSavedView(view);
+
+        expect(normalized.filter).toBe('project:abc');
+        expect(JSON.parse(normalized.filter_definitions ?? '[]')).toEqual([
+            { type: 'project', value: ['abc'] },
+            { term: 'date', type: 'date', value: '[now-7d TO now]' }
+        ]);
+    });
+
+    it('removes the legacy raw session-only predicate', () => {
+        const normalized = normalizeSessionSavedView(buildSavedView({ filter: ' TYPE:SESSION ' }));
+
+        expect(normalized.filter).toBeNull();
+        expect(normalized.filter_definitions).toBeNull();
+    });
+
+    it('preserves an advanced raw filter that is not the route invariant', () => {
+        const view = buildSavedView({ filter: 'type:error' });
+
+        expect(normalizeSessionSavedView(view)).toBe(view);
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/sessions/saved-view-invariants.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/sessions/saved-view-invariants.ts
@@ -1,0 +1,41 @@
+import type { IFilter } from '$comp/faceted-filter';
+import type { SavedView } from '$features/saved-views/models';
+
+import { deserializeFilters, serializeFilters, toFilter } from '$features/events/components/filters/helpers.svelte';
+
+export const SESSION_EVENT_FILTER = 'type:session';
+
+export function getSessionQueryFilter(filter: null | string | undefined): string {
+    return filter ? `${SESSION_EVENT_FILTER} AND (${filter})` : SESSION_EVENT_FILTER;
+}
+
+export function getSessionViewFilters(filters: IFilter[]): IFilter[] {
+    return filters.filter((filter) => filter.type !== 'type');
+}
+
+export function normalizeSessionSavedView(view: SavedView): SavedView {
+    if (view.filter_definitions) {
+        const filters = getSessionViewFilters(deserializeFilters(view.filter_definitions));
+        const filterDefinitions = serializeFilters(filters);
+        const filter = toFilter(filters.filter((candidate) => candidate.type !== 'date')) || null;
+
+        if (view.filter === filter && view.filter_definitions === filterDefinitions) {
+            return view;
+        }
+
+        return {
+            ...view,
+            filter,
+            filter_definitions: filterDefinitions
+        };
+    }
+
+    if (view.filter?.trim().toLowerCase() !== SESSION_EVENT_FILTER) {
+        return view;
+    }
+
+    return {
+        ...view,
+        filter: null
+    };
+}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
@@ -563,6 +563,7 @@
 
     const viewToHref: Record<string, string> = {
         events: resolve('/(app)/event'),
+        sessions: resolve('/(app)/sessions'),
         stacks: resolve('/(app)/stack'),
         stream: resolve('/(app)/stream')
     };

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
@@ -781,10 +781,16 @@
     onDestroy(() => debouncedRefetch.cancel());
 
     function onPersistentEventChanged(message: WebSocketMessageValue<'PersistentEventChanged'>) {
-        if (message.id && message.change_type === ChangeType.Removed) {
+        if (message.change_type !== ChangeType.Removed || (message.organization_id && message.organization_id !== organization.current)) {
+            return;
+        }
+
+        if (message.id) {
             removeTableSelection(table, message.id);
             removeTableData(table, (document) => document.id === message.id);
         }
+
+        debouncedRefetch();
     }
 
     useEventListener(document, PERSISTENT_EVENT_DELETE_RECONCILE_EVENT, () => debouncedRefetch());

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
@@ -126,6 +126,10 @@
         return buildFilterCacheKey(organization.current, page.url.pathname, filter);
     }
 
+    function getSessionsStatsFilter(filter: null | string | undefined): string {
+        return filter ? `${DEFAULT_FILTER} AND (${filter})` : DEFAULT_FILTER;
+    }
+
     function getQueryTime(params: ListFilterQueryParams = queryParams): null | string {
         if (params.time != null) {
             if (params.time === ALL_TIME_QUERY_VALUE) {
@@ -363,7 +367,16 @@
 
     function getSavedViewFilters(): FacetedFilter.IFilter[] | null {
         const savedView = savedViewsState.activeSavedView;
-        return savedView?.filter_definitions ? deserializeFilters(savedView.filter_definitions) : null;
+        if (!savedView) {
+            return null;
+        }
+
+        if (savedView.filter_definitions) {
+            return deserializeFilters(savedView.filter_definitions);
+        }
+
+        const filter = savedView.filter ?? DEFAULT_FILTER;
+        return getFiltersFromCache(filterCacheKey(filter), filter);
     }
 
     function getQueryFilterRemovalKeys(savedViewFilters: FacetedFilter.IFilter[], params: SessionListFilterQueryParams): string[] {
@@ -834,7 +847,7 @@
                 return `avg:value cardinality:user date:(date${DEFAULT_OFFSET ? `^${DEFAULT_OFFSET}` : ''} cardinality:user)`;
             },
             get filter() {
-                return eventsQueryParameters.filter;
+                return getSessionsStatsFilter(eventsQueryParameters.filter);
             },
             get time() {
                 return eventsQueryParameters.time;

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
@@ -1,24 +1,38 @@
 <script lang="ts">
     import type { GetEventsParams } from '$features/events/api.svelte';
 
+    import { resolve } from '$app/paths';
     import { page } from '$app/state';
     import * as DataTable from '$comp/data-table';
-    import DataTableViewOptions from '$comp/data-table/data-table-view-options.svelte';
     import * as FacetedFilter from '$comp/faceted-filter';
     import RefreshButton from '$comp/refresh-button.svelte';
     import { H3 } from '$comp/typography';
     import { Label } from '$comp/ui/label';
     import { Switch } from '$comp/ui/switch';
     import { showBillingDialogOnUpgradeProblem } from '$features/billing/upgrade-required.svelte';
-    import { getOrganizationSessionsCountQuery, PERSISTENT_EVENT_DELETE_RECONCILE_EVENT } from '$features/events/api.svelte';
+    import { getOrganizationSessionsCountQuery, getOrganizationSessionsQuery, PERSISTENT_EVENT_DELETE_RECONCILE_EVENT } from '$features/events/api.svelte';
     import EventDetailSheet from '$features/events/components/event-detail-sheet.svelte';
-    import { DateFilter, ProjectFilter, TypeFilter } from '$features/events/components/filters';
+    import {
+        BooleanFilter,
+        DateFilter,
+        LevelFilter,
+        ProjectFilter,
+        ReferenceFilter,
+        SessionFilter,
+        StatusFilter,
+        StringFilter,
+        TagFilter,
+        TypeFilter,
+        VersionFilter
+    } from '$features/events/components/filters';
     import {
         applyTimeFilter,
         buildFilterCacheKey,
+        deserializeFilters,
         filterChanged,
         filterRemoved,
         getFiltersFromCache,
+        serializeFilters,
         toFilter,
         updateFilterCache
     } from '$features/events/components/filters/helpers.svelte';
@@ -28,24 +42,68 @@
     import { getOrganizationQuery } from '$features/organizations/api.svelte';
     import { organization } from '$features/organizations/context.svelte';
     import { premiumPage } from '$features/organizations/premium-page.svelte';
-    import { getSessionColumns } from '$features/sessions/components/session-table-columns';
+    import SavedViewPicker from '$features/saved-views/components/saved-view-picker.svelte';
+    import { isSavedViewHydrationPending, isSavedViewUnavailable, useSavedViews } from '$features/saved-views/use-saved-views.svelte';
+    import { defaultSessionColumnVisibility, getSessionColumns } from '$features/sessions/components/session-table-columns';
     import SessionsDashboardChart from '$features/sessions/components/sessions-dashboard-chart.svelte';
     import SessionsStatsDashboard from '$features/sessions/components/sessions-stats-dashboard.svelte';
     import * as agg from '$features/shared/api/aggregations';
-    import { getSharedTableOptions, removeTableData, removeTableSelection } from '$features/shared/table.svelte';
+    import { createPageSizePreference, getSharedTableOptions, removeTableData, removeTableSelection } from '$features/shared/table.svelte';
     import { fillDateSeries } from '$features/shared/utils/charts.js';
     import { parseDateMathRange, toDateMathRange } from '$features/shared/utils/datemath';
     import { ChangeType, type WebSocketMessageValue } from '$features/websockets/models';
-    import { DEFAULT_LIMIT, DEFAULT_OFFSET, useFetchClientStatus } from '$shared/api/api.svelte';
+    import { DEFAULT_OFFSET } from '$shared/api/api.svelte';
     import { createQueryParameters } from '$shared/query-params';
-    import { type FetchClientResponse, useFetchClient } from '@foundatiofx/fetchclient';
+    import { error } from '@sveltejs/kit';
     import { createTable } from '@tanstack/svelte-table';
     import { useEventListener, watch } from 'runed';
-    import { onDestroy } from 'svelte';
+    import { onDestroy, untrack } from 'svelte';
     import { debounce } from 'throttle-debounce';
 
+    import {
+        ALL_TIME_QUERY_VALUE,
+        deserializeTimeQueryParam,
+        getListFilterQueryParams,
+        LIST_FILTER_QUERY_PARAM_RESET,
+        type ListFilterQueryParams,
+        serializeTimeQueryParam
+    } from '../redirect-to-events.svelte';
+
+    type SessionListFilterQueryParams = ListFilterQueryParams & {
+        filters?: null | string;
+    };
+
+    const ACTIVE_SESSION_END_TERM = 'data.sessionend';
+    const DEFAULT_FILTER = 'type:session';
+    const DEFAULT_TIME_RANGE = '[now-7d TO now]';
+    const DEFAULT_FILTERS = [new DateFilter('date', DEFAULT_TIME_RANGE), new ProjectFilter([]), new TypeFilter(['session'])];
+    const PAGE_SIZE_PREFERENCE_KEY = 'event-stack-list-page-size';
+    const pageSizePreference = createPageSizePreference(PAGE_SIZE_PREFERENCE_KEY);
+    const DEFAULT_PARAMS = {
+        after: undefined as string | undefined,
+        before: undefined as string | undefined,
+        bot: undefined as string | undefined,
+        filter: undefined as string | undefined,
+        filters: undefined as string | undefined,
+        first: undefined as string | undefined,
+        level: undefined as string | undefined,
+        limit: undefined as number | undefined,
+        page: undefined as number | undefined,
+        project: undefined as string | undefined,
+        reference: undefined as string | undefined,
+        session: undefined as string | undefined,
+        sort: undefined as string | undefined,
+        stack: undefined as string | undefined,
+        status: undefined as string | undefined,
+        tag: undefined as string | undefined,
+        time: undefined as string | undefined,
+        type: undefined as string | undefined,
+        version: undefined as string | undefined
+    };
+
     let selectedEventId: null | string = $state(null);
-    function rowclick(row: EventSummaryModel<SummaryTemplateKeys>) {
+
+    function rowClick(row: EventSummaryModel<SummaryTemplateKeys>) {
         selectedEventId = row.id;
     }
 
@@ -53,10 +111,8 @@
         return buildEventDetailsHref(row.id);
     }
 
-    // Register this page as requiring premium features (layout auto-resets on navigation)
     premiumPage.current = 'Sessions';
 
-    // Organization query to check premium features
     const organizationQuery = getOrganizationQuery({
         route: {
             get id() {
@@ -64,40 +120,202 @@
             }
         }
     });
-
     const hasPremiumFeatures = $derived(organizationQuery.isSuccess && !!organizationQuery.data?.has_premium_features);
-
-    // View Active toggle state
-    let viewActive = $state(false);
-
-    const DEFAULT_TIME_RANGE = '[now-7d TO now]';
-    const DEFAULT_FILTERS = [new DateFilter('date', DEFAULT_TIME_RANGE), new ProjectFilter([]), new TypeFilter(['session'])];
-    const DEFAULT_PARAMS = {
-        filter: 'type:session',
-        limit: DEFAULT_LIMIT,
-        time: DEFAULT_TIME_RANGE
-    };
 
     function filterCacheKey(filter: null | string): string {
         return buildFilterCacheKey(organization.current, page.url.pathname, filter);
     }
 
-    updateFilterCache(filterCacheKey(DEFAULT_PARAMS.filter), DEFAULT_FILTERS);
+    function getQueryTime(params: ListFilterQueryParams = queryParams): null | string {
+        if (params.time != null) {
+            if (params.time === ALL_TIME_QUERY_VALUE) {
+                return null;
+            }
+
+            return params.time ? deserializeTimeQueryParam(params.time) : null;
+        }
+
+        return savedViewsState.activeSavedView?.time ?? DEFAULT_TIME_RANGE;
+    }
+
+    function getEffectiveFilter(): null | string {
+        const filter = toFilter(getCurrentFiltersWithoutTime());
+        return filter || null;
+    }
+
+    function getQueryFilters(params: ListFilterQueryParams = queryParams): FacetedFilter.IFilter[] | null {
+        const queryFilters: FacetedFilter.IFilter[] = [];
+
+        if (params.project) {
+            queryFilters.push(new ProjectFilter(splitQueryParam(params.project)));
+        }
+
+        if (params.stack) {
+            queryFilters.push(new StringFilter('stack', params.stack));
+        }
+
+        const bot = parseBooleanQueryParam(params.bot);
+        if (bot !== undefined) {
+            queryFilters.push(new BooleanFilter('bot', bot));
+        }
+
+        const first = parseBooleanQueryParam(params.first);
+        if (first !== undefined) {
+            queryFilters.push(new BooleanFilter('first', first));
+        }
+
+        if (params.level) {
+            queryFilters.push(new LevelFilter(splitQueryParam(params.level) as never[]));
+        }
+
+        if (params.reference) {
+            queryFilters.push(new ReferenceFilter(params.reference));
+        }
+
+        if (params.session) {
+            queryFilters.push(new SessionFilter(params.session));
+        }
+
+        if (params.status) {
+            queryFilters.push(new StatusFilter(splitQueryParam(params.status) as never[]));
+        }
+
+        if (params.tag) {
+            queryFilters.push(new TagFilter(splitQueryParam(params.tag) as never[]));
+        }
+
+        if (params.type) {
+            queryFilters.push(new TypeFilter(splitQueryParam(params.type) as never[]));
+        }
+
+        if (params.version) {
+            queryFilters.push(new VersionFilter('version', params.version));
+        }
+
+        return queryFilters.length > 0 ? queryFilters : null;
+    }
+
+    function parseBooleanQueryParam(value: null | string | undefined): boolean | undefined {
+        if (value === 'true') {
+            return true;
+        }
+
+        if (value === 'false') {
+            return false;
+        }
+        return undefined;
+    }
+
+    function splitQueryParam(value: string): string[] {
+        return value
+            .split(',')
+            .map((item) => item.trim())
+            .filter((item) => item);
+    }
+
+    function getEffectiveSort(): null | string | undefined {
+        if (queryParams.sort != null) {
+            return queryParams.sort || undefined;
+        }
+        return savedViewsState.activeSavedView?.sort ?? undefined;
+    }
+
+    updateFilterCache(filterCacheKey(DEFAULT_FILTER), DEFAULT_FILTERS);
     const queryParams = createQueryParameters({
         defaults: DEFAULT_PARAMS,
         history: 'push',
         schema: {
+            after: 'string',
+            before: 'string',
+            bot: 'string',
             filter: 'string',
+            filters: 'string',
+            first: 'string',
+            level: 'string',
             limit: 'number',
-            time: 'string'
+            page: 'number',
+            project: 'string',
+            reference: 'string',
+            session: 'string',
+            sort: 'string',
+            stack: 'string',
+            status: 'string',
+            tag: 'string',
+            time: 'string',
+            type: 'string',
+            version: 'string'
         }
     });
 
+    const VIEW = 'sessions';
+    let showStats = $state(true);
+    let showChart = $state(true);
+    const savedViewsState = useSavedViews({
+        applyFilters: (draftFilters, options) => {
+            updateFilters(draftFilters, {
+                clearPagination: false,
+                history: options?.history
+            });
+            filters = draftFilters;
+        },
+        baseHref: resolve('/(app)/sessions'),
+        defaultAutoFillColumnId: 'summary',
+        defaultColumnVisibility: defaultSessionColumnVisibility,
+        defaultFilter: DEFAULT_FILTER,
+        defaultTime: DEFAULT_TIME_RANGE,
+        filterCacheKey,
+        getAvailableColumnIds: () =>
+            table
+                .getAllFlatColumns()
+                .filter((column) => column.columns.length === 0)
+                .map((column) => column.id),
+        getColumnOrder: () => table.store.state.columnOrder,
+        getColumnSizing: () => table.store.state.columnSizing,
+        getColumnVisibility: () => table.store.state.columnVisibility,
+        getFilter: getEffectiveFilter,
+        getFilterDefinitions: () => serializeFilters(filters ?? []),
+        getShowChart: () => showChart,
+        getShowStats: () => showStats,
+        getSort: getEffectiveSort,
+        getTime: getQueryTime,
+        queryParams,
+        setColumnOrder: (value) => table.setColumnOrder(value),
+        setColumnSizing: (value) => table.setColumnSizing(value),
+        setColumnVisibility: (value) => table.setColumnVisibility(value),
+        setShowChart: (value) => (showChart = value),
+        setShowStats: (value) => (showStats = value),
+        get slug() {
+            return page.params.slug;
+        },
+        updateFilterCache,
+        view: VIEW
+    });
+    const pageTitle = $derived(savedViewsState.activeSavedView?.name ?? 'Sessions');
+    let normalizedSavedViewId = $state<string>();
+    const isSavedViewRoutePending = $derived(
+        isSavedViewHydrationPending(
+            page.params.slug,
+            savedViewsState.activeSavedView?.id,
+            normalizedSavedViewId,
+            isSavedViewUnavailable(savedViewsState.activeSavedView?.id, savedViewsState.isMissing, savedViewsState.isError)
+        )
+    );
+
+    $effect(() => {
+        document.title = `${pageTitle} - Exceptionless`;
+    });
+
+    function throwSavedViewNotFound(): never {
+        throw error(404, `The saved Sessions view "${page.params.slug}" could not be found.`);
+    }
+
     watch(
         () => organization.current,
-        () => {
-            viewActive = false;
-            updateFilterCache(filterCacheKey(DEFAULT_PARAMS.filter), DEFAULT_FILTERS);
+        (_currentOrganizationId, previousOrganizationId) => {
+            if (previousOrganizationId === undefined) {
+                return;
+            }
+            updateFilterCache(filterCacheKey(DEFAULT_FILTER), DEFAULT_FILTERS);
             queryParams.update(DEFAULT_PARAMS);
             reset();
         },
@@ -106,30 +324,156 @@
         }
     );
 
-    let filters = $state(applyTimeFilter(getFiltersFromCache(filterCacheKey(queryParams.filter), queryParams.filter), queryParams.time));
+    function getSessionListFilterQueryParams(params: typeof queryParams = queryParams): SessionListFilterQueryParams {
+        return {
+            ...getListFilterQueryParams(params),
+            filters: params.filters
+        };
+    }
+
+    function getCurrentFilters(params: SessionListFilterQueryParams = getSessionListFilterQueryParams()): FacetedFilter.IFilter[] {
+        return applyTimeFilter(getCurrentFiltersWithoutTime(params), getQueryTime(params));
+    }
+
+    function getCurrentFiltersWithoutTime(params: SessionListFilterQueryParams = getSessionListFilterQueryParams()): FacetedFilter.IFilter[] {
+        const savedViewFilters = getSavedViewFilters();
+        const queryFilters = getQueryFilters(params) ?? [];
+        const serializedExpressionFilters = params.filters != null && params.filters ? deserializeFilters(params.filters) : [];
+        const rawExpressionFilters =
+            params.filter != null && params.filter
+                ? getFiltersFromCache(filterCacheKey(params.filter), params.filter).filter((filter) => filter.type !== 'date')
+                : [];
+        const expressionFilters = [...rawExpressionFilters, ...serializedExpressionFilters];
+
+        if (savedViewFilters) {
+            return mergeFilterOverrides(
+                savedViewFilters.filter((filter) => filter.type !== 'date'),
+                [...expressionFilters, ...queryFilters],
+                getQueryFilterRemovalKeys(savedViewFilters, params)
+            );
+        }
+
+        if (expressionFilters.length > 0 || queryFilters.length > 0) {
+            return [...expressionFilters, ...queryFilters];
+        }
+
+        const filter = savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
+        return getFiltersFromCache(filterCacheKey(filter), filter).filter((currentFilter) => currentFilter.type !== 'date');
+    }
+
+    function getSavedViewFilters(): FacetedFilter.IFilter[] | null {
+        const savedView = savedViewsState.activeSavedView;
+        return savedView?.filter_definitions ? deserializeFilters(savedView.filter_definitions) : null;
+    }
+
+    function getQueryFilterRemovalKeys(savedViewFilters: FacetedFilter.IFilter[], params: SessionListFilterQueryParams): string[] {
+        const removedKeys: string[] = [];
+
+        if (params.bot === '') {
+            removedKeys.push('boolean-bot');
+        }
+
+        if (params.first === '') {
+            removedKeys.push('boolean-first');
+        }
+
+        if (params.level === '') {
+            removedKeys.push('level');
+        }
+
+        if (params.project === '') {
+            removedKeys.push('project');
+        }
+
+        if (params.reference === '') {
+            removedKeys.push('reference');
+        }
+
+        if (params.session === '') {
+            removedKeys.push('session');
+        }
+
+        if (params.stack === '') {
+            removedKeys.push('string-stack');
+        }
+
+        if (params.status === '') {
+            removedKeys.push('status');
+        }
+
+        if (params.tag === '') {
+            removedKeys.push('tag');
+        }
+
+        if (params.type === '') {
+            removedKeys.push('type');
+        }
+
+        if (params.version === '') {
+            removedKeys.push('version-version');
+        }
+
+        if (params.filter === '' || params.filters === '') {
+            removedKeys.push(...savedViewFilters.filter((filter) => filter.type !== 'date' && !isQueryParamFilter(filter)).map((filter) => filter.key));
+        }
+
+        return removedKeys;
+    }
+
+    function mergeFilterOverrides(
+        baseFilters: FacetedFilter.IFilter[],
+        overrideFilters: FacetedFilter.IFilter[],
+        removedFilterKeys: string[] = []
+    ): FacetedFilter.IFilter[] {
+        if (overrideFilters.length === 0 && removedFilterKeys.length === 0) {
+            return baseFilters;
+        }
+        const overrideKeys = new Set([...overrideFilters.map((filter) => filter.key), ...removedFilterKeys]);
+        return [...baseFilters.filter((filter) => !overrideKeys.has(filter.key)), ...overrideFilters];
+    }
+
+    let filters = $state(getCurrentFilters());
+    let isInternalFilterUpdate = false;
     watch(
-        [() => queryParams.filter, () => queryParams.time],
-        ([filter, time]) => {
-            table.resetRowSelection();
-            filters = applyTimeFilter(getFiltersFromCache(filterCacheKey(filter), filter), time);
+        [() => page.url.pathname, () => getSessionListFilterQueryParams(), () => savedViewsState.activeSavedView],
+        ([pathname, currentQueryParams, activeSavedView], [previousPathname, previousQueryParams, previousSavedView]) => {
+            const savedViewChanged = pathname !== previousPathname || activeSavedView?.id !== previousSavedView?.id;
+            const queryChanged = JSON.stringify(currentQueryParams) !== JSON.stringify(previousQueryParams);
+            if (savedViewChanged || queryChanged) {
+                table.resetRowSelection();
+            }
+
+            if (isInternalFilterUpdate && !savedViewChanged) {
+                isInternalFilterUpdate = false;
+                return;
+            }
+
+            isInternalFilterUpdate = false;
+            filters = getCurrentFilters(currentQueryParams);
         },
         {
             lazy: true
         }
     );
 
-    $effect(() => {
-        queryParams.limit ??= DEFAULT_LIMIT;
-    });
+    function handleResetToSaved(): void {
+        isInternalFilterUpdate = false;
+        table.resetRowSelection();
+        queryParams.update({
+            ...LIST_FILTER_QUERY_PARAM_RESET,
+            filters: null
+        });
+        savedViewsState.handleResetToSaved();
+        filters = getCurrentFilters();
+    }
 
     function onFilterChanged(addedOrUpdated: FacetedFilter.IFilter): void {
-        const isNew = !filters?.some((f) => f.id === addedOrUpdated.id);
+        const isNew = !filters?.some((filter) => filter.id === addedOrUpdated.id);
         const updatedFilters = filterChanged(filters ?? [], addedOrUpdated);
         updateFilters(updatedFilters);
         if (isNew) {
             filters = updatedFilters;
         }
-
         selectedEventId = null;
     }
 
@@ -139,57 +483,265 @@
         filters = updatedFilters;
     }
 
-    function updateFilters(updatedFilters: FacetedFilter.IFilter[]): void {
-        const filter = toFilter(updatedFilters.filter((f) => f.type !== 'date'));
-        const time = ((updatedFilters.find((f) => f.type === 'date') as DateFilter | undefined)?.value as string | undefined) ?? null;
+    function updateFilters(updatedFilters: FacetedFilter.IFilter[], options: { clearPagination?: boolean; history?: 'push' | 'replace' } = {}): void {
+        const shouldClearPagination = options.clearPagination ?? true;
+        const filter = toFilter(updatedFilters.filter((currentFilter) => currentFilter.type !== 'date'));
+        const expressionFilters = updatedFilters.filter((currentFilter) => currentFilter.type !== 'date' && !isQueryParamFilter(currentFilter));
+        const time = ((updatedFilters.find((currentFilter) => currentFilter.type === 'date') as DateFilter | undefined)?.value as string | undefined) ?? null;
+        const baseTime = savedViewsState.activeSavedView?.time ?? DEFAULT_TIME_RANGE;
+        const savedViewFilters = getSavedViewFilters();
+        const baseQueryFilterParams = getQueryFilterParams(savedViewFilters ?? []);
+        const queryFilterParams = getQueryFilterParamDeltas(getQueryFilterParams(updatedFilters), baseQueryFilterParams);
+        const baseExpressionFilters = savedViewFilters?.filter((currentFilter) => currentFilter.type !== 'date' && !isQueryParamFilter(currentFilter)) ?? [];
+        const serializedExpressionFilters = serializeFilters(expressionFilters);
+        const serializedBaseExpressionFilters = serializeFilters(baseExpressionFilters);
 
-        if (queryParams.filter !== filter || queryParams.time !== time) {
+        const newFiltersParam =
+            serializedExpressionFilters === serializedBaseExpressionFilters
+                ? null
+                : expressionFilters.length > 0
+                  ? serializedExpressionFilters
+                  : baseExpressionFilters.length > 0
+                    ? ''
+                    : null;
+        const newTimeParam = time === baseTime ? null : time ? serializeTimeQueryParam(time) : ALL_TIME_QUERY_VALUE;
+        const urlQueryWillChange =
+            queryParams.filter != null ||
+            newFiltersParam !== queryParams.filters ||
+            newTimeParam !== queryParams.time ||
+            queryFilterParams.bot !== queryParams.bot ||
+            queryFilterParams.first !== queryParams.first ||
+            queryFilterParams.level !== queryParams.level ||
+            queryFilterParams.project !== queryParams.project ||
+            queryFilterParams.reference !== queryParams.reference ||
+            queryFilterParams.session !== queryParams.session ||
+            queryFilterParams.stack !== queryParams.stack ||
+            queryFilterParams.status !== queryParams.status ||
+            queryFilterParams.tag !== queryParams.tag ||
+            queryFilterParams.type !== queryParams.type ||
+            queryFilterParams.version !== queryParams.version;
+        const effectiveQueryWillChange = (filter || null) !== getEffectiveFilter() || time !== getQueryTime();
+        const shouldClearPaginationForFilter = shouldClearPagination && effectiveQueryWillChange;
+        const paginationWillChange = shouldClearPaginationForFilter && (queryParams.after != null || queryParams.before != null || queryParams.page != null);
+
+        if (effectiveQueryWillChange) {
             table.resetRowSelection();
         }
-
         updateFilterCache(filterCacheKey(filter), updatedFilters);
-        queryParams.time = time;
-        queryParams.filter = filter;
-    }
-
-    // Build filter with active sessions toggle
-    function activeFilter(): string {
-        let filter = queryParams.filter ?? 'type:session';
-        if (viewActive) {
-            filter += ' _missing_:data.sessionend';
+        if (paginationWillChange || urlQueryWillChange) {
+            isInternalFilterUpdate = true;
         }
 
-        return filter;
+        queryParams.update(
+            {
+                after: shouldClearPaginationForFilter ? null : queryParams.after,
+                before: shouldClearPaginationForFilter ? null : queryParams.before,
+                bot: queryFilterParams.bot,
+                filter: null,
+                filters: newFiltersParam,
+                first: queryFilterParams.first,
+                level: queryFilterParams.level,
+                page: shouldClearPaginationForFilter ? null : queryParams.page,
+                project: queryFilterParams.project,
+                reference: queryFilterParams.reference,
+                session: queryFilterParams.session,
+                stack: queryFilterParams.stack,
+                status: queryFilterParams.status,
+                tag: queryFilterParams.tag,
+                time: newTimeParam,
+                type: queryFilterParams.type,
+                version: queryFilterParams.version
+            },
+            {
+                history: options.history
+            }
+        );
     }
 
-    const eventsQueryParameters: GetEventsParams = $state({
-        after: undefined,
-        before: undefined,
-        get filter() {
-            return activeFilter();
-        },
-        set filter(value) {
-            queryParams.filter = value;
-        },
-        get limit() {
-            return queryParams.limit!;
-        },
-        set limit(value) {
-            queryParams.limit = value;
-        },
-        mode: 'summary',
-        offset: DEFAULT_OFFSET,
-        get time() {
-            return queryParams.time!;
-        },
-        set time(value) {
-            queryParams.time = value;
+    $effect(() => {
+        const activeSavedViewId = savedViewsState.activeSavedView?.id;
+        if (!activeSavedViewId || activeSavedViewId !== savedViewsState.hydratedSavedViewId) {
+            normalizedSavedViewId = undefined;
+            return;
+        }
+
+        untrack(() => {
+            updateFilters(getCurrentFilters(getSessionListFilterQueryParams()), {
+                clearPagination: false,
+                history: 'replace'
+            });
+        });
+        normalizedSavedViewId = activeSavedViewId;
+    });
+
+    function getQueryFilterParams(currentFilters: FacetedFilter.IFilter[]) {
+        const botFilter = currentFilters.find((filter): filter is BooleanFilter => filter instanceof BooleanFilter && filter.term === 'bot');
+        const firstFilter = currentFilters.find((filter): filter is BooleanFilter => filter instanceof BooleanFilter && filter.term === 'first');
+        const levelFilter = currentFilters.find((filter): filter is LevelFilter => filter.type === 'level');
+        const projectFilter = currentFilters.find((filter): filter is ProjectFilter => filter.type === 'project');
+        const referenceFilter = currentFilters.find((filter): filter is ReferenceFilter => filter.type === 'reference');
+        const sessionFilter = currentFilters.find((filter): filter is SessionFilter => filter.type === 'session');
+        const stackFilter = currentFilters.find((filter): filter is StringFilter => filter.type === 'string' && filter.key === 'string-stack');
+        const statusFilter = currentFilters.find((filter): filter is StatusFilter => filter.type === 'status');
+        const tagFilter = currentFilters.find((filter): filter is TagFilter => filter.type === 'tag');
+        const typeFilter = currentFilters.find((filter): filter is TypeFilter => filter.type === 'type');
+        const versionFilter = currentFilters.find((filter): filter is VersionFilter => filter instanceof VersionFilter && filter.term === 'version');
+
+        return {
+            bot: botFilter?.value === undefined ? null : String(botFilter.value),
+            first: firstFilter?.value === undefined ? null : String(firstFilter.value),
+            level: levelFilter?.value.length ? levelFilter.value.join(',') : null,
+            project: projectFilter?.value.length ? projectFilter.value.join(',') : null,
+            reference: referenceFilter?.value?.trim() ? referenceFilter.value : null,
+            session: sessionFilter?.value?.trim() ? sessionFilter.value : null,
+            stack: stackFilter?.value?.trim() ? stackFilter.value : null,
+            status: statusFilter?.value.length ? statusFilter.value.join(',') : null,
+            tag: tagFilter?.value.length ? tagFilter.value.join(',') : null,
+            type: typeFilter?.value.length ? typeFilter.value.join(',') : null,
+            version: versionFilter?.value?.trim() ? versionFilter.value : null
+        };
+    }
+
+    function getQueryFilterParamDeltas(currentParams: ReturnType<typeof getQueryFilterParams>, baseParams: ReturnType<typeof getQueryFilterParams>) {
+        const getDelta = (currentValue: null | string, baseValue: null | string): null | string => {
+            if (currentValue === baseValue) {
+                return null;
+            }
+            return currentValue ?? (baseValue ? '' : null);
+        };
+
+        return {
+            bot: getDelta(currentParams.bot, baseParams.bot),
+            first: getDelta(currentParams.first, baseParams.first),
+            level: getDelta(currentParams.level, baseParams.level),
+            project: getDelta(currentParams.project, baseParams.project),
+            reference: getDelta(currentParams.reference, baseParams.reference),
+            session: getDelta(currentParams.session, baseParams.session),
+            stack: getDelta(currentParams.stack, baseParams.stack),
+            status: getDelta(currentParams.status, baseParams.status),
+            tag: getDelta(currentParams.tag, baseParams.tag),
+            type: getDelta(currentParams.type, baseParams.type),
+            version: getDelta(currentParams.version, baseParams.version)
+        };
+    }
+
+    function isQueryParamFilter(filter: FacetedFilter.IFilter): boolean {
+        if (filter.type === 'string' && filter.key === 'string-stack') {
+            return true;
+        }
+
+        if (filter.type === 'boolean' && filter instanceof BooleanFilter && (filter.term === 'bot' || filter.term === 'first') && filter.value !== undefined) {
+            return true;
+        }
+
+        if (filter.type === 'version' && filter instanceof VersionFilter && filter.term !== 'version') {
+            return false;
+        }
+        return ['level', 'project', 'reference', 'session', 'status', 'tag', 'type', 'version'].includes(filter.type);
+    }
+
+    const viewActive = $derived(
+        filters.some((filter) => filter instanceof BooleanFilter && filter.term === ACTIVE_SESSION_END_TERM && filter.value === undefined)
+    );
+
+    function setViewActive(value: boolean): void {
+        const activeFilter = filters.find(
+            (filter): filter is BooleanFilter => filter instanceof BooleanFilter && filter.term === ACTIVE_SESSION_END_TERM && filter.value === undefined
+        );
+        if (value === !!activeFilter) {
+            return;
+        }
+
+        const updatedFilters = activeFilter ? filterRemoved(filters, activeFilter) : [...filters];
+        if (!activeFilter) {
+            const filter = new BooleanFilter(ACTIVE_SESSION_END_TERM);
+            filter.hidden = true;
+            updatedFilters.push(filter);
+        }
+
+        updateFilters(updatedFilters);
+        filters = updatedFilters;
+    }
+
+    function getPageSize(): number {
+        return queryParams.limit ?? pageSizePreference.current;
+    }
+
+    function setPageSize(value: number): void {
+        pageSizePreference.current = value;
+        queryParams.limit = null;
+    }
+
+    $effect(() => {
+        if (queryParams.limit === pageSizePreference.current) {
+            queryParams.limit = null;
         }
     });
 
-    const client = useFetchClient();
-    const clientStatus = useFetchClientStatus(client);
-    let clientResponse = $state<FetchClientResponse<EventSummaryModel<SummaryTemplateKeys>[]>>();
+    const eventsQueryParameters: GetEventsParams = $state({
+        get after() {
+            return queryParams.after ?? undefined;
+        },
+        set after(value) {
+            queryParams.after = value ?? null;
+        },
+        get before() {
+            return queryParams.before ?? undefined;
+        },
+        set before(value) {
+            queryParams.before = value ?? null;
+        },
+        get filter() {
+            return getEffectiveFilter() ?? undefined;
+        },
+        set filter(value) {
+            queryParams.filter = value ?? null;
+        },
+        get limit() {
+            return getPageSize();
+        },
+        set limit(value) {
+            setPageSize(value ?? pageSizePreference.current);
+        },
+        mode: 'summary',
+        offset: DEFAULT_OFFSET,
+        get page() {
+            return queryParams.page ?? undefined;
+        },
+        set page(value) {
+            queryParams.page = value ?? null;
+        },
+        get sort() {
+            return getEffectiveSort() ?? undefined;
+        },
+        set sort(value) {
+            const baseSort = savedViewsState.activeSavedView?.sort ?? undefined;
+            queryParams.sort = value === baseSort ? null : (value ?? null);
+        },
+        get time() {
+            return getQueryTime() ?? undefined;
+        },
+        set time(value) {
+            queryParams.time = value ? serializeTimeQueryParam(value) : ALL_TIME_QUERY_VALUE;
+        }
+    });
+
+    const sessionsQuery = getOrganizationSessionsQuery({
+        enabled: () => hasPremiumFeatures && !isSavedViewRoutePending,
+        get params() {
+            const { page: ignoredPage, ...params } = {
+                ...eventsQueryParameters,
+                include: !eventsQueryParameters.after && !eventsQueryParameters.before ? ('total' as const) : undefined
+            };
+            void ignoredPage;
+            return params;
+        },
+        route: {
+            get organizationId() {
+                return organization.current;
+            }
+        }
+    });
 
     const table = createTable(
         getSharedTableOptions<EventSummaryModel<SummaryTemplateKeys>>({
@@ -197,25 +749,19 @@
             get columns() {
                 return getSessionColumns();
             },
+            defaultColumnVisibility: defaultSessionColumnVisibility,
+            enableColumnResizing: true,
             paginationStrategy: 'cursor',
             get queryData() {
-                return clientResponse?.data ?? [];
+                return sessionsQuery.data?.data ?? [];
             },
             get queryMeta() {
-                return clientResponse?.meta;
+                return sessionsQuery.data?.meta;
             },
             get queryParameters() {
                 return eventsQueryParameters;
             }
         })
-    );
-
-    watch(
-        () => viewActive,
-        () => reset(),
-        {
-            lazy: true
-        }
     );
 
     function reset() {
@@ -225,73 +771,48 @@
 
     async function handleRefresh() {
         table.resetRowSelection();
-        await loadData();
+        await Promise.all([sessionsQuery.refetch(), statsQuery.refetch()]);
     }
 
-    let loadDataRequestId = 0;
-    async function loadData() {
-        const requestId = ++loadDataRequestId;
-        if (!organization.current) {
-            return;
-        }
-
-        if (!hasPremiumFeatures) {
-            clientResponse = undefined;
-            return;
-        }
-
-        const response = await client.getJSON<EventSummaryModel<SummaryTemplateKeys>[]>(`organizations/${organization.current}/events/sessions`, {
-            expectedStatusCodes: [426],
-            params: eventsQueryParameters as Record<string, unknown>
-        });
-        if (requestId !== loadDataRequestId) {
-            return;
-        }
-
-        clientResponse = response;
-
-        if (clientResponse.problem) {
-            showBillingDialogOnUpgradeProblem(clientResponse.problem, organization.current, () => loadData());
-        }
-
-        if (clientResponse.ok && clientResponse.data?.length === 0 && table.store.state.pagination.pageIndex > 0) {
-            table.previousPage();
-        }
-    }
-
-    const debouncedLoadData = debounce(1500, loadData);
-    onDestroy(() => {
-        loadDataRequestId++;
-        debouncedLoadData.cancel();
+    const debouncedRefetch = debounce(1500, () => {
+        void sessionsQuery.refetch();
+        void statsQuery.refetch();
     });
+    onDestroy(() => debouncedRefetch.cancel());
 
     function onPersistentEventChanged(message: WebSocketMessageValue<'PersistentEventChanged'>) {
-        if (message.change_type === ChangeType.Removed && (!message.organization_id || message.organization_id === organization.current)) {
-            if (message.id) {
-                removeTableSelection(table, message.id);
-                removeTableData(table, (doc) => doc.id === message.id);
-            }
-
-            debouncedLoadData();
+        if (message.id && message.change_type === ChangeType.Removed) {
+            removeTableSelection(table, message.id);
+            removeTableData(table, (document) => document.id === message.id);
         }
     }
 
-    useEventListener(document, PERSISTENT_EVENT_DELETE_RECONCILE_EVENT, () => debouncedLoadData());
-    useEventListener(document, 'refresh', () => loadData());
+    useEventListener(document, PERSISTENT_EVENT_DELETE_RECONCILE_EVENT, () => debouncedRefetch());
+    useEventListener(document, 'refresh', handleRefresh);
     useEventListener(document, 'PersistentEventChanged', (event) => onPersistentEventChanged((event as CustomEvent).detail));
 
+    let lastProblem: unknown;
     $effect(() => {
-        loadData();
+        const problem = sessionsQuery.error ?? sessionsQuery.data?.problem;
+        if (!problem || problem === lastProblem) {
+            return;
+        }
+        lastProblem = problem;
+        untrack(() =>
+            showBillingDialogOnUpgradeProblem(problem, organization.current, async () => {
+                await sessionsQuery.refetch();
+            })
+        );
     });
 
-    // Session stats query with aggregations - only runs when premium
     const statsQuery = getOrganizationSessionsCountQuery({
+        enabled: () => hasPremiumFeatures && !isSavedViewRoutePending,
         params: {
             get aggregations() {
                 return `avg:value cardinality:user date:(date${DEFAULT_OFFSET ? `^${DEFAULT_OFFSET}` : ''} cardinality:user)`;
             },
             get filter() {
-                return activeFilter();
+                return eventsQueryParameters.filter;
             },
             get time() {
                 return eventsQueryParameters.time;
@@ -299,59 +820,36 @@
         },
         route: {
             get organizationId() {
-                return hasPremiumFeatures && organizationQuery.isSuccess ? organization.current : undefined;
+                return organization.current;
             }
         }
     });
 
-    // Compute stats from aggregations
     const stats = $derived.by(() => {
-        if (!statsQuery.data?.aggregations) {
-            return {
-                avgDuration: 0,
-                avgPerHour: 0,
-                totalSessions: 0,
-                totalUsers: 0
-            };
-        }
-
-        const avgValue = agg.average(statsQuery.data.aggregations, 'avg_value')?.value ?? 0;
-        const cardinalityUser = agg.cardinality(statsQuery.data.aggregations, 'cardinality_user')?.value ?? 0;
-        const total = statsQuery.data.total ?? 0;
-
-        // Calculate avg per hour based on time range
-        const timeRange = parseDateMathRange(queryParams.time);
-        const hours = (timeRange.end.getTime() - timeRange.start.getTime()) / (1000 * 60 * 60);
-        const avgPerHour = hours > 0 ? total / hours : 0;
-
+        const aggregations = statsQuery.data?.aggregations;
+        const total = statsQuery.data?.total ?? 0;
+        const timeRange = parseDateMathRange(getQueryTime() || undefined);
+        const hours = Math.max((timeRange.end.getTime() - timeRange.start.getTime()) / 3_600_000, 1);
         return {
-            avgDuration: avgValue,
-            avgPerHour,
+            avgDuration: agg.average(aggregations, 'avg_value')?.value ?? 0,
+            avgPerHour: total / hours,
             totalSessions: total,
-            totalUsers: cardinalityUser
+            totalUsers: agg.cardinality(aggregations, 'cardinality_user')?.value ?? 0
         };
     });
 
-    // Chart data from date histogram
     const chartData = $derived.by(() => {
-        const timeRange = parseDateMathRange(queryParams.time);
-
+        const timeRange = parseDateMathRange(getQueryTime() || undefined);
         const buildZeroFilledSeries = () =>
             fillDateSeries(timeRange.start, timeRange.end, (date: Date) => ({
                 date,
                 sessions: 0,
                 users: 0
             }));
-
-        if (!statsQuery.data?.aggregations) {
-            return buildZeroFilledSeries();
-        }
-
-        const dateHistogramBuckets = agg.dateHistogram(statsQuery.data.aggregations, 'date_date')?.buckets ?? [];
+        const dateHistogramBuckets = agg.dateHistogram(statsQuery.data?.aggregations, 'date_date')?.buckets ?? [];
         if (dateHistogramBuckets.length === 0) {
             return buildZeroFilledSeries();
         }
-
         return dateHistogramBuckets.map((bucket) => ({
             date: new Date(bucket.key),
             sessions: bucket.total ?? 0,
@@ -364,39 +862,84 @@
     }
 </script>
 
+{#if savedViewsState.isMissing}
+    {throwSavedViewNotFound()}
+{/if}
+
 <div class="flex flex-col">
     <div class="mb-4 flex flex-wrap items-start gap-2">
-        <H3 class="my-0 shrink-0">Sessions</H3>
+        <H3 class="my-0 shrink-0">{pageTitle}</H3>
         <div class="order-3 flex w-full flex-wrap items-start gap-1.5 md:order-none md:w-auto md:min-w-0 md:flex-1">
             <FacetedFilter.Root changed={onFilterChanged} {filters} remove={onFilterRemoved}>
                 <OrganizationDefaultsFacetedFilterBuilder />
             </FacetedFilter.Root>
         </div>
-        <div class="ml-auto flex shrink-0 items-center gap-2">
-            <div class="flex items-center gap-2">
-                <Switch id="view-active" bind:checked={viewActive} disabled={!hasPremiumFeatures} />
-                <Label for="view-active" class="text-sm">View Active</Label>
+        <div class="ml-auto flex shrink-0 items-start gap-2">
+            <div class="flex h-9 items-center gap-2">
+                <Switch checked={viewActive} disabled={!hasPremiumFeatures} id="view-active" onCheckedChange={setViewActive} />
+                <Label class="text-sm" for="view-active">View Active</Label>
             </div>
-            <RefreshButton onRefresh={handleRefresh} isRefreshing={clientStatus.isLoading} size="icon-lg" title="Refresh results" />
-            <DataTableViewOptions size="icon-lg" {table} />
+            {#if savedViewsState.isEnabled}
+                <SavedViewPicker
+                    activeSavedView={savedViewsState.activeSavedView}
+                    autoFillColumnId={savedViewsState.autoFillColumnId}
+                    canModifySavedView={savedViewsState.canModifySavedView}
+                    columnOrder={table.store.state.columnOrder}
+                    columnSizing={table.store.state.columnSizing}
+                    columnVisibility={table.store.state.columnVisibility}
+                    defaultAutoFillColumnId="summary"
+                    filters={filters ?? []}
+                    isModified={savedViewsState.isModified}
+                    onLoadView={savedViewsState.handleLoadView}
+                    onClearSavedView={savedViewsState.handleClearSavedView}
+                    onResetToSaved={handleResetToSaved}
+                    onSavedViewUpdated={savedViewsState.handleSavedViewUpdated}
+                    savedViews={savedViewsState.savedViews}
+                    setAutoFillColumnId={savedViewsState.setAutoFillColumnId}
+                    setWrappedColumnIds={savedViewsState.setWrappedColumnIds}
+                    {showChart}
+                    {showStats}
+                    setShowChart={(value) => (showChart = value)}
+                    setShowStats={(value) => (showStats = value)}
+                    sort={getEffectiveSort() ?? undefined}
+                    {table}
+                    time={getQueryTime() ?? undefined}
+                    view={VIEW}
+                    wrappedColumnIds={savedViewsState.wrappedColumnIds}
+                />
+            {/if}
+            <RefreshButton onRefresh={handleRefresh} isRefreshing={sessionsQuery.isFetching} size="icon-lg" title="Refresh results" />
         </div>
     </div>
 
     <div class="flex flex-col gap-y-4" class:opacity-60={!hasPremiumFeatures}>
-        <SessionsStatsDashboard
-            avgDuration={stats.avgDuration}
-            avgPerHour={stats.avgPerHour}
-            isLoading={statsQuery.isLoading}
-            totalSessions={stats.totalSessions}
-            totalUsers={stats.totalUsers}
-        />
+        {#if showStats}
+            <SessionsStatsDashboard
+                avgDuration={stats.avgDuration}
+                avgPerHour={stats.avgPerHour}
+                isLoading={isSavedViewRoutePending || (statsQuery.isLoading && !statsQuery.isSuccess)}
+                totalSessions={stats.totalSessions}
+                totalUsers={stats.totalUsers}
+            />
+        {/if}
 
-        <SessionsDashboardChart data={chartData} isLoading={statsQuery.isLoading && !statsQuery.isSuccess} {onRangeSelect} />
+        {#if showChart}
+            <SessionsDashboardChart data={chartData} isLoading={isSavedViewRoutePending || (statsQuery.isLoading && !statsQuery.isSuccess)} {onRangeSelect} />
+        {/if}
 
-        <EventsDataTable bind:limit={queryParams.limit!} isLoading={clientStatus.isLoading} rowClick={rowclick} {rowHref} {table}>
+        <EventsDataTable
+            autoFillColumnId={savedViewsState.autoFillColumnId}
+            bind:limit={eventsQueryParameters.limit!}
+            isLoading={isSavedViewRoutePending || sessionsQuery.isFetching}
+            onAutoFillColumnResized={() => savedViewsState.setAutoFillColumnId(null)}
+            {rowClick}
+            {rowHref}
+            {table}
+            wrappedColumnIds={savedViewsState.wrappedColumnIds}
+        >
             {#snippet footerChildren()}
                 <DataTable.Selection {table} />
-                <DataTable.Pager bind:value={queryParams.limit!} {table} variant="floating" />
+                <DataTable.Pager bind:value={eventsQueryParameters.limit!} {table} variant="floating" />
             {/snippet}
         </EventsDataTable>
     </div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
@@ -22,7 +22,6 @@
         StatusFilter,
         StringFilter,
         TagFilter,
-        TypeFilter,
         VersionFilter
     } from '$features/events/components/filters';
     import {
@@ -47,6 +46,7 @@
     import { defaultSessionColumnVisibility, getSessionColumns } from '$features/sessions/components/session-table-columns';
     import SessionsDashboardChart from '$features/sessions/components/sessions-dashboard-chart.svelte';
     import SessionsStatsDashboard from '$features/sessions/components/sessions-stats-dashboard.svelte';
+    import { getSessionQueryFilter, getSessionViewFilters, normalizeSessionSavedView } from '$features/sessions/saved-view-invariants';
     import * as agg from '$features/shared/api/aggregations';
     import { createPageSizePreference, getSharedTableOptions, removeTableData, removeTableSelection } from '$features/shared/table.svelte';
     import { fillDateSeries } from '$features/shared/utils/charts.js';
@@ -74,9 +74,8 @@
     };
 
     const ACTIVE_SESSION_END_TERM = 'data.sessionend';
-    const DEFAULT_FILTER = 'type:session';
     const DEFAULT_TIME_RANGE = '[now-7d TO now]';
-    const DEFAULT_FILTERS = [new DateFilter('date', DEFAULT_TIME_RANGE), new ProjectFilter([]), new TypeFilter(['session'])];
+    const DEFAULT_FILTERS = [new DateFilter('date', DEFAULT_TIME_RANGE), new ProjectFilter([])];
     const PAGE_SIZE_PREFERENCE_KEY = 'event-stack-list-page-size';
     const pageSizePreference = createPageSizePreference(PAGE_SIZE_PREFERENCE_KEY);
     const DEFAULT_PARAMS = {
@@ -124,10 +123,6 @@
 
     function filterCacheKey(filter: null | string): string {
         return buildFilterCacheKey(organization.current, page.url.pathname, filter);
-    }
-
-    function getSessionsStatsFilter(filter: null | string | undefined): string {
-        return filter ? `${DEFAULT_FILTER} AND (${filter})` : DEFAULT_FILTER;
     }
 
     function getQueryTime(params: ListFilterQueryParams = queryParams): null | string {
@@ -188,10 +183,6 @@
             queryFilters.push(new TagFilter(splitQueryParam(params.tag) as never[]));
         }
 
-        if (params.type) {
-            queryFilters.push(new TypeFilter(splitQueryParam(params.type) as never[]));
-        }
-
         if (params.version) {
             queryFilters.push(new VersionFilter('version', params.version));
         }
@@ -224,7 +215,7 @@
         return savedViewsState.activeSavedView?.sort ?? undefined;
     }
 
-    updateFilterCache(filterCacheKey(DEFAULT_FILTER), DEFAULT_FILTERS);
+    updateFilterCache(filterCacheKey(null), DEFAULT_FILTERS);
     const queryParams = createQueryParameters({
         defaults: DEFAULT_PARAMS,
         history: 'push',
@@ -256,16 +247,17 @@
     let showChart = $state(true);
     const savedViewsState = useSavedViews({
         applyFilters: (draftFilters, options) => {
-            updateFilters(draftFilters, {
+            const sessionFilters = getSessionViewFilters(draftFilters);
+            updateFilters(sessionFilters, {
                 clearPagination: false,
                 history: options?.history
             });
-            filters = draftFilters;
+            filters = sessionFilters;
         },
         baseHref: resolve('/(app)/sessions'),
         defaultAutoFillColumnId: 'summary',
         defaultColumnVisibility: defaultSessionColumnVisibility,
-        defaultFilter: DEFAULT_FILTER,
+        defaultFilter: null,
         defaultTime: DEFAULT_TIME_RANGE,
         filterCacheKey,
         getAvailableColumnIds: () =>
@@ -282,6 +274,7 @@
         getShowStats: () => showStats,
         getSort: getEffectiveSort,
         getTime: getQueryTime,
+        normalizeSavedView: normalizeSessionSavedView,
         queryParams,
         setColumnOrder: (value) => table.setColumnOrder(value),
         setColumnSizing: (value) => table.setColumnSizing(value),
@@ -319,7 +312,7 @@
             if (previousOrganizationId === undefined) {
                 return;
             }
-            updateFilterCache(filterCacheKey(DEFAULT_FILTER), DEFAULT_FILTERS);
+            updateFilterCache(filterCacheKey(null), DEFAULT_FILTERS);
             queryParams.update(DEFAULT_PARAMS);
             reset();
         },
@@ -342,7 +335,7 @@
     function getCurrentFiltersWithoutTime(params: SessionListFilterQueryParams = getSessionListFilterQueryParams()): FacetedFilter.IFilter[] {
         const savedViewFilters = getSavedViewFilters();
         const queryFilters = getQueryFilters(params) ?? [];
-        const serializedExpressionFilters = params.filters != null && params.filters ? deserializeFilters(params.filters) : [];
+        const serializedExpressionFilters = params.filters != null && params.filters ? getSessionViewFilters(deserializeFilters(params.filters)) : [];
         const rawExpressionFilters =
             params.filter != null && params.filter
                 ? getFiltersFromCache(filterCacheKey(params.filter), params.filter).filter((filter) => filter.type !== 'date')
@@ -361,7 +354,7 @@
             return [...expressionFilters, ...queryFilters];
         }
 
-        const filter = savedViewsState.activeSavedView?.filter ?? DEFAULT_FILTER;
+        const filter = savedViewsState.activeSavedView?.filter ?? null;
         return getFiltersFromCache(filterCacheKey(filter), filter).filter((currentFilter) => currentFilter.type !== 'date');
     }
 
@@ -375,7 +368,7 @@
             return deserializeFilters(savedView.filter_definitions);
         }
 
-        const filter = savedView.filter ?? DEFAULT_FILTER;
+        const filter = savedView.filter ?? null;
         return getFiltersFromCache(filterCacheKey(filter), filter);
     }
 
@@ -416,10 +409,6 @@
 
         if (params.tag === '') {
             removedKeys.push('tag');
-        }
-
-        if (params.type === '') {
-            removedKeys.push('type');
         }
 
         if (params.version === '') {
@@ -481,6 +470,10 @@
     }
 
     function onFilterChanged(addedOrUpdated: FacetedFilter.IFilter): void {
+        if (addedOrUpdated.type === 'type') {
+            return;
+        }
+
         const isNew = !filters?.some((filter) => filter.id === addedOrUpdated.id);
         const updatedFilters = filterChanged(filters ?? [], addedOrUpdated);
         updateFilters(updatedFilters);
@@ -497,14 +490,15 @@
     }
 
     function updateFilters(updatedFilters: FacetedFilter.IFilter[], options: { clearPagination?: boolean; history?: 'push' | 'replace' } = {}): void {
+        const sessionFilters = getSessionViewFilters(updatedFilters);
         const shouldClearPagination = options.clearPagination ?? true;
-        const filter = toFilter(updatedFilters.filter((currentFilter) => currentFilter.type !== 'date'));
-        const expressionFilters = updatedFilters.filter((currentFilter) => currentFilter.type !== 'date' && !isQueryParamFilter(currentFilter));
-        const time = ((updatedFilters.find((currentFilter) => currentFilter.type === 'date') as DateFilter | undefined)?.value as string | undefined) ?? null;
+        const filter = toFilter(sessionFilters.filter((currentFilter) => currentFilter.type !== 'date'));
+        const expressionFilters = sessionFilters.filter((currentFilter) => currentFilter.type !== 'date' && !isQueryParamFilter(currentFilter));
+        const time = ((sessionFilters.find((currentFilter) => currentFilter.type === 'date') as DateFilter | undefined)?.value as string | undefined) ?? null;
         const baseTime = savedViewsState.activeSavedView?.time ?? DEFAULT_TIME_RANGE;
         const savedViewFilters = getSavedViewFilters();
         const baseQueryFilterParams = getQueryFilterParams(savedViewFilters ?? []);
-        const queryFilterParams = getQueryFilterParamDeltas(getQueryFilterParams(updatedFilters), baseQueryFilterParams);
+        const queryFilterParams = getQueryFilterParamDeltas(getQueryFilterParams(sessionFilters), baseQueryFilterParams);
         const baseExpressionFilters = savedViewFilters?.filter((currentFilter) => currentFilter.type !== 'date' && !isQueryParamFilter(currentFilter)) ?? [];
         const serializedExpressionFilters = serializeFilters(expressionFilters);
         const serializedBaseExpressionFilters = serializeFilters(baseExpressionFilters);
@@ -531,7 +525,7 @@
             queryFilterParams.stack !== queryParams.stack ||
             queryFilterParams.status !== queryParams.status ||
             queryFilterParams.tag !== queryParams.tag ||
-            queryFilterParams.type !== queryParams.type ||
+            queryParams.type != null ||
             queryFilterParams.version !== queryParams.version;
         const effectiveQueryWillChange = (filter || null) !== getEffectiveFilter() || time !== getQueryTime();
         const shouldClearPaginationForFilter = shouldClearPagination && effectiveQueryWillChange;
@@ -540,7 +534,7 @@
         if (effectiveQueryWillChange) {
             table.resetRowSelection();
         }
-        updateFilterCache(filterCacheKey(filter), updatedFilters);
+        updateFilterCache(filterCacheKey(filter), sessionFilters);
         if (paginationWillChange || urlQueryWillChange) {
             isInternalFilterUpdate = true;
         }
@@ -562,7 +556,7 @@
                 status: queryFilterParams.status,
                 tag: queryFilterParams.tag,
                 time: newTimeParam,
-                type: queryFilterParams.type,
+                type: null,
                 version: queryFilterParams.version
             },
             {
@@ -597,7 +591,6 @@
         const stackFilter = currentFilters.find((filter): filter is StringFilter => filter.type === 'string' && filter.key === 'string-stack');
         const statusFilter = currentFilters.find((filter): filter is StatusFilter => filter.type === 'status');
         const tagFilter = currentFilters.find((filter): filter is TagFilter => filter.type === 'tag');
-        const typeFilter = currentFilters.find((filter): filter is TypeFilter => filter.type === 'type');
         const versionFilter = currentFilters.find((filter): filter is VersionFilter => filter instanceof VersionFilter && filter.term === 'version');
 
         return {
@@ -610,7 +603,6 @@
             stack: stackFilter?.value?.trim() ? stackFilter.value : null,
             status: statusFilter?.value.length ? statusFilter.value.join(',') : null,
             tag: tagFilter?.value.length ? tagFilter.value.join(',') : null,
-            type: typeFilter?.value.length ? typeFilter.value.join(',') : null,
             version: versionFilter?.value?.trim() ? versionFilter.value : null
         };
     }
@@ -633,7 +625,6 @@
             stack: getDelta(currentParams.stack, baseParams.stack),
             status: getDelta(currentParams.status, baseParams.status),
             tag: getDelta(currentParams.tag, baseParams.tag),
-            type: getDelta(currentParams.type, baseParams.type),
             version: getDelta(currentParams.version, baseParams.version)
         };
     }
@@ -650,7 +641,7 @@
         if (filter.type === 'version' && filter instanceof VersionFilter && filter.term !== 'version') {
             return false;
         }
-        return ['level', 'project', 'reference', 'session', 'status', 'tag', 'type', 'version'].includes(filter.type);
+        return ['level', 'project', 'reference', 'session', 'status', 'tag', 'version'].includes(filter.type);
     }
 
     const viewActive = $derived(
@@ -705,7 +696,7 @@
             queryParams.before = value ?? null;
         },
         get filter() {
-            return getEffectiveFilter() ?? undefined;
+            return getSessionQueryFilter(getEffectiveFilter());
         },
         set filter(value) {
             queryParams.filter = value ?? null;
@@ -847,7 +838,7 @@
                 return `avg:value cardinality:user date:(date${DEFAULT_OFFSET ? `^${DEFAULT_OFFSET}` : ''} cardinality:user)`;
             },
             get filter() {
-                return getSessionsStatsFilter(eventsQueryParameters.filter);
+                return eventsQueryParameters.filter;
             },
             get time() {
                 return eventsQueryParameters.time;
@@ -906,7 +897,7 @@
         <H3 class="my-0 shrink-0">{pageTitle}</H3>
         <div class="order-3 flex w-full flex-wrap items-start gap-1.5 md:order-none md:w-auto md:min-w-0 md:flex-1">
             <FacetedFilter.Root changed={onFilterChanged} {filters} remove={onFilterRemoved}>
-                <OrganizationDefaultsFacetedFilterBuilder />
+                <OrganizationDefaultsFacetedFilterBuilder includeTypeFacet={false} />
             </FacetedFilter.Root>
         </div>
         <div class="ml-auto flex shrink-0 items-start gap-2">

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/+page.svelte
@@ -791,6 +791,22 @@
     useEventListener(document, 'refresh', handleRefresh);
     useEventListener(document, 'PersistentEventChanged', (event) => onPersistentEventChanged((event as CustomEvent).detail));
 
+    let lastEmptyResponseAt = 0;
+    $effect(() => {
+        const dataUpdatedAt = sessionsQuery.dataUpdatedAt;
+        if (
+            sessionsQuery.isPlaceholderData ||
+            dataUpdatedAt === lastEmptyResponseAt ||
+            sessionsQuery.data?.data?.length !== 0 ||
+            table.store.state.pagination.pageIndex === 0
+        ) {
+            return;
+        }
+
+        lastEmptyResponseAt = dataUpdatedAt;
+        untrack(() => table.previousPage());
+    });
+
     let lastProblem: unknown;
     $effect(() => {
         const problem = sessionsQuery.error ?? sessionsQuery.data?.problem;

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/[slug=savedview]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/sessions/[slug=savedview]/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+    import SessionsPage from '../+page.svelte';
+</script>
+
+<SessionsPage />

--- a/src/Exceptionless.Web/Models/SavedView/NewSavedView.cs
+++ b/src/Exceptionless.Web/Models/SavedView/NewSavedView.cs
@@ -9,13 +9,14 @@ namespace Exceptionless.Web.Models;
 public record NewSavedView : IOwnedByOrganization, IValidatableObject
 {
     /// <summary>The set of valid dashboard view type identifiers.</summary>
-    public static readonly string[] ValidViewTypes = ["events", "stacks", "stream"];
+    public static readonly string[] ValidViewTypes = ["events", "sessions", "stacks", "stream"];
 
     /// <summary>Valid column IDs per view, matching the TanStack Table column definitions.</summary>
     public static readonly IReadOnlyDictionary<string, IReadOnlySet<string>> ValidColumnIds =
         new Dictionary<string, IReadOnlySet<string>>
         {
             ["events"] = new HashSet<string> { "summary", "user", "date", "project", "tags", "message", "type", "version", "exception_type", "source", "name", "level" },
+            ["sessions"] = new HashSet<string> { "summary", "duration", "user", "date" },
             ["stacks"] = new HashSet<string> { "summary", "project", "tags", "status", "users", "events", "first", "last" },
             ["stream"] = new HashSet<string> { "summary", "user", "date", "project", "tags", "message", "type", "version", "exception_type", "source", "name", "level" }
         };

--- a/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
@@ -64,6 +64,7 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         Assert.Contains(seededSystemViews, view => IsPredefinedSavedView(view, "events", "All"));
         Assert.Contains(seededSystemViews, view => IsPredefinedSavedView(view, "events", "Logs"));
         Assert.Contains(seededSystemViews, view => IsPredefinedSavedView(view, "events", "Errors"));
+        Assert.Contains(seededSystemViews, view => IsPredefinedSavedView(view, "sessions", "All"));
         Assert.Contains(seededSystemViews, view => IsPredefinedSavedView(view, "stacks", "All"));
         Assert.Contains(seededSystemViews, view => IsPredefinedSavedView(view, "stacks", "Most Frequent Errors"));
         Assert.Contains(seededSystemViews, view => IsPredefinedSavedView(view, "stacks", "Most Frequent 404s"));
@@ -133,6 +134,12 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         Assert.Equal("type:log (status:open OR status:regressed)", logs.Filter);
         var filterDefinitions = logs.FilterDefinitions ?? throw new Xunit.Sdk.XunitException("Expected FilterDefinitions to be non-null.");
         Assert.Equal(JsonValueKind.Array, filterDefinitions.ValueKind);
+
+        var sessions = definitions.FirstOrDefault(view => String.Equals(view.Key, "sessions:all", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(sessions);
+        Assert.Equal("sessions", sessions.ViewType);
+        Assert.Equal("type:session", sessions.Filter);
+        Assert.Equal("-date", sessions.Sort);
     }
 
     [Fact]
@@ -158,6 +165,7 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
 
         Assert.NotNull(predefinedViews);
         var logs = predefinedViews.First(view => IsPredefinedSavedView(view, "events", "Logs"));
+        var allSessions = predefinedViews.First(view => IsPredefinedSavedView(view, "sessions", "All"));
         var allStacks = predefinedViews.First(view => IsPredefinedSavedView(view, "stacks", "All"));
         var savedLogs = await _savedViewRepository.GetByIdAsync(logs.Id);
         Assert.NotNull(savedLogs);
@@ -165,6 +173,7 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         savedLogs.Filter = "type:error";
         savedLogs.Slug = "custom-logs";
         await _savedViewRepository.SaveAsync(savedLogs, o => o.ImmediateConsistency());
+        await _savedViewRepository.RemoveAsync(allSessions.Id, o => o.ImmediateConsistency());
         await _savedViewRepository.RemoveAsync(allStacks.Id, o => o.ImmediateConsistency());
 
         var testUser = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_ORG_USER_EMAIL);
@@ -222,6 +231,16 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
             view => String.Equals(view.PredefinedKey, "stacks:all", StringComparison.OrdinalIgnoreCase));
         Assert.True(IsPredefinedSavedView(recreatedAllStacksView, "stacks", "All"));
         Assert.Equal(PredefinedSavedViewContentHasher.GetContentHash(recreatedAllStacksView), recreatedAllStacksView.PredefinedContentHash);
+
+        var recreatedAllSessions = await _savedViewRepository.GetByViewAsync(
+            SampleDataService.TEST_ORG_ID,
+            "sessions",
+            o => o.ImmediateConsistency());
+        var recreatedAllSessionsView = Assert.Single(
+            recreatedAllSessions.Documents,
+            view => String.Equals(view.PredefinedKey, "sessions:all", StringComparison.OrdinalIgnoreCase));
+        Assert.True(IsPredefinedSavedView(recreatedAllSessionsView, "sessions", "All"));
+        Assert.Equal(PredefinedSavedViewContentHasher.GetContentHash(recreatedAllSessionsView), recreatedAllSessionsView.PredefinedContentHash);
 
         var unchangedPrivateLogs = await _savedViewRepository.GetByIdAsync(privateLogs.Id);
         Assert.NotNull(unchangedPrivateLogs);
@@ -705,6 +724,7 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
 
     [Theory]
     [InlineData("events")]
+    [InlineData("sessions")]
     [InlineData("stacks")]
     [InlineData("stream")]
     public async Task PostAsync_WithValidView_Succeeds(string view)
@@ -2436,11 +2456,13 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
     [Theory]
     [InlineData("events", "project")]
     [InlineData("events", "tags")]
+    [InlineData("sessions", "duration")]
+    [InlineData("sessions", "user")]
     [InlineData("stacks", "project")]
     [InlineData("stacks", "tags")]
     [InlineData("stream", "project")]
     [InlineData("stream", "tags")]
-    public Task PostAsync_ProjectAndTagColumnsForSupportedViews_Succeeds(string viewType, string column)
+    public Task PostAsync_ViewSpecificColumns_Succeeds(string viewType, string column)
     {
         // Arrange & Act & Assert
         return SendRequestAsync(r => r

--- a/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
@@ -138,8 +138,11 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         var sessions = definitions.FirstOrDefault(view => String.Equals(view.Key, "sessions:all", StringComparison.OrdinalIgnoreCase));
         Assert.NotNull(sessions);
         Assert.Equal("sessions", sessions.ViewType);
-        Assert.Equal("type:session", sessions.Filter);
+        Assert.Null(sessions.Filter);
         Assert.Equal("-date", sessions.Sort);
+        var sessionsFilterDefinitions = sessions.FilterDefinitions ?? throw new Xunit.Sdk.XunitException("Expected Sessions FilterDefinitions to be non-null.");
+        Assert.DoesNotContain(sessionsFilterDefinitions.EnumerateArray(), definition =>
+            definition.TryGetProperty("type", out var type) && String.Equals(type.GetString(), "type", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Migrations/AddSessionsPredefinedSavedViewMigrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/AddSessionsPredefinedSavedViewMigrationTests.cs
@@ -1,9 +1,12 @@
+using Exceptionless.Core.Billing;
 using Exceptionless.Core.Migrations;
+using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Seed;
 using Foundatio.Lock;
 using Foundatio.Repositories;
 using Foundatio.Repositories.Migrations;
+using Foundatio.Repositories.Utility;
 using Foundatio.Utility;
 using Xunit;
 
@@ -11,10 +14,12 @@ namespace Exceptionless.Tests.Migrations;
 
 public sealed class AddSessionsPredefinedSavedViewMigrationTests : IntegrationTestsBase
 {
+    private readonly IOrganizationRepository _organizationRepository;
     private readonly ISavedViewRepository _savedViewRepository;
 
     public AddSessionsPredefinedSavedViewMigrationTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
     {
+        _organizationRepository = GetService<IOrganizationRepository>();
         _savedViewRepository = GetService<ISavedViewRepository>();
     }
 
@@ -28,6 +33,35 @@ public sealed class AddSessionsPredefinedSavedViewMigrationTests : IntegrationTe
     [Fact]
     public async Task RunAsync_ExistingDefinitionsWithoutSessions_AddsSessionsDefinitionOnce()
     {
+        var organization = new Organization
+        {
+            Name = $"Sessions migration {ObjectId.GenerateNewId()}",
+            PlanId = GetService<BillingPlans>().FreePlan.Id,
+            Data = new Exceptionless.Core.Models.DataDictionary
+            {
+                [PredefinedSavedViewsDataSeed.PredefinedSavedViewsContentHashDataKey] = "legacy-definitions"
+            }
+        };
+        organization = await _organizationRepository.AddAsync(organization, options => options.ImmediateConsistency());
+
+        var organizationSessionViews = await _savedViewRepository.GetByViewAsync(
+            organization.Id,
+            "sessions",
+            options => options.PageLimit(1000).ImmediateConsistency());
+        if (organizationSessionViews.Documents.Count > 0)
+            await _savedViewRepository.RemoveAsync(organizationSessionViews.Documents, options => options.ImmediateConsistency());
+
+        await _savedViewRepository.AddAsync(new SavedView
+        {
+            OrganizationId = organization.Id,
+            UserId = PredefinedSavedViewsDataSeed.SystemUserId,
+            CreatedByUserId = PredefinedSavedViewsDataSeed.SystemUserId,
+            Name = "Private All Sessions",
+            Slug = "all",
+            ViewType = "sessions",
+            Version = 1
+        }, options => options.ImmediateConsistency());
+
         var systemViews = await _savedViewRepository.GetByOrganizationIdAsync(
             PredefinedSavedViewsDataSeed.SystemOrganizationId,
             options => options.PageLimit(1000).ImmediateConsistency());
@@ -59,6 +93,15 @@ public sealed class AddSessionsPredefinedSavedViewMigrationTests : IntegrationTe
         Assert.Equal("sessions", sessionsView.ViewType);
         Assert.Equal("All", sessionsView.Name);
         Assert.Equal(PredefinedSavedViewContentHasher.GetContentHash(sessionsView), sessionsView.PredefinedContentHash);
+
+        var migratedOrganizationViews = await _savedViewRepository.GetByViewAsync(
+            organization.Id,
+            "sessions",
+            options => options.PageLimit(1000).ImmediateConsistency());
+        var organizationSessionsView = Assert.Single(migratedOrganizationViews.Documents, view =>
+            view.UserId is null && String.Equals(view.PredefinedKey, AddSessionsPredefinedSavedView.PredefinedKey, StringComparison.OrdinalIgnoreCase));
+        Assert.Equal("all-2", organizationSessionsView.Slug);
+        Assert.Equal(PredefinedSavedViewContentHasher.GetContentHash(organizationSessionsView), organizationSessionsView.PredefinedContentHash);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Migrations/AddSessionsPredefinedSavedViewMigrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/AddSessionsPredefinedSavedViewMigrationTests.cs
@@ -92,6 +92,7 @@ public sealed class AddSessionsPredefinedSavedViewMigrationTests : IntegrationTe
             String.Equals(view.PredefinedKey, AddSessionsPredefinedSavedView.PredefinedKey, StringComparison.OrdinalIgnoreCase));
         Assert.Equal("sessions", sessionsView.ViewType);
         Assert.Equal("All", sessionsView.Name);
+        Assert.Null(sessionsView.Filter);
         Assert.Equal(PredefinedSavedViewContentHasher.GetContentHash(sessionsView), sessionsView.PredefinedContentHash);
 
         var migratedOrganizationViews = await _savedViewRepository.GetByViewAsync(

--- a/tests/Exceptionless.Tests/Migrations/AddSessionsPredefinedSavedViewMigrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/AddSessionsPredefinedSavedViewMigrationTests.cs
@@ -1,0 +1,77 @@
+using Exceptionless.Core.Migrations;
+using Exceptionless.Core.Repositories;
+using Exceptionless.Core.Seed;
+using Foundatio.Lock;
+using Foundatio.Repositories;
+using Foundatio.Repositories.Migrations;
+using Foundatio.Utility;
+using Xunit;
+
+namespace Exceptionless.Tests.Migrations;
+
+public sealed class AddSessionsPredefinedSavedViewMigrationTests : IntegrationTestsBase
+{
+    private readonly ISavedViewRepository _savedViewRepository;
+
+    public AddSessionsPredefinedSavedViewMigrationTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory)
+    {
+        _savedViewRepository = GetService<ISavedViewRepository>();
+    }
+
+    protected override void RegisterServices(IServiceCollection services)
+    {
+        services.AddTransient<AddSessionsPredefinedSavedView>();
+        services.AddSingleton<ILock>(EmptyLock.Empty);
+        base.RegisterServices(services);
+    }
+
+    [Fact]
+    public async Task RunAsync_ExistingDefinitionsWithoutSessions_AddsSessionsDefinitionOnce()
+    {
+        var systemViews = await _savedViewRepository.GetByOrganizationIdAsync(
+            PredefinedSavedViewsDataSeed.SystemOrganizationId,
+            options => options.PageLimit(1000).ImmediateConsistency());
+        var sessionsViews = systemViews.Documents
+            .Where(view => String.Equals(view.PredefinedKey, AddSessionsPredefinedSavedView.PredefinedKey, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (sessionsViews.Count > 0)
+            await _savedViewRepository.RemoveAsync(sessionsViews, options => options.ImmediateConsistency());
+
+        if (systemViews.Documents.Count == sessionsViews.Count)
+        {
+            var definitions = await PredefinedSavedViewsDataSeed.ReadDefaultSavedViewsAsync(TestCancellationToken);
+            var legacyDefinition = definitions.Single(view => String.Equals(view.Key, "events:all", StringComparison.OrdinalIgnoreCase));
+            await _savedViewRepository.AddAsync(
+                PredefinedSavedViewsDataSeed.CreateSavedView(legacyDefinition),
+                options => options.ImmediateConsistency());
+        }
+
+        var migration = GetService<AddSessionsPredefinedSavedView>();
+        var context = new MigrationContext(GetService<ILock>(), _logger, TestCancellationToken);
+        await migration.RunAsync(context);
+        await migration.RunAsync(context);
+
+        var migratedViews = await _savedViewRepository.GetByOrganizationIdAsync(
+            PredefinedSavedViewsDataSeed.SystemOrganizationId,
+            options => options.PageLimit(1000).ImmediateConsistency());
+        var sessionsView = Assert.Single(migratedViews.Documents, view =>
+            String.Equals(view.PredefinedKey, AddSessionsPredefinedSavedView.PredefinedKey, StringComparison.OrdinalIgnoreCase));
+        Assert.Equal("sessions", sessionsView.ViewType);
+        Assert.Equal("All", sessionsView.Name);
+        Assert.Equal(PredefinedSavedViewContentHasher.GetContentHash(sessionsView), sessionsView.PredefinedContentHash);
+    }
+
+    [Fact]
+    public async Task RunAsync_EmptySystemDefinitions_LeavesFreshInstallForDataSeed()
+    {
+        var systemViews = await _savedViewRepository.GetByOrganizationIdAsync(
+            PredefinedSavedViewsDataSeed.SystemOrganizationId,
+            options => options.PageLimit(1000).ImmediateConsistency());
+        await _savedViewRepository.RemoveAsync(systemViews.Documents, options => options.ImmediateConsistency());
+
+        var migration = GetService<AddSessionsPredefinedSavedView>();
+        await migration.RunAsync(new MigrationContext(GetService<ILock>(), _logger, TestCancellationToken));
+
+        Assert.Equal(0, await _savedViewRepository.CountByOrganizationIdAsync(PredefinedSavedViewsDataSeed.SystemOrganizationId));
+    }
+}

--- a/tests/Exceptionless.Tests/Migrations/MigrateSavedViewColumnsIntegrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrateSavedViewColumnsIntegrationTests.cs
@@ -96,8 +96,8 @@ public sealed class MigrateSavedViewColumnsIntegrationTests : IntegrationTestsBa
         var migrationStateRepository = GetService<IMigrationStateRepository>();
         await migrationStateRepository.AddAsync(new MigrationState
         {
-            Id = "8",
-            Version = 8,
+            Id = "9",
+            Version = 9,
             MigrationType = MigrationType.VersionedAndResumable,
             StartedUtc = DateTime.UtcNow,
             CompletedUtc = DateTime.UtcNow

--- a/tests/Exceptionless.Tests/Migrations/MigrationRegistrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrationRegistrationTests.cs
@@ -51,4 +51,16 @@ public sealed class MigrationRegistrationTests : TestWithServices
         Assert.Equal(MigrationType.VersionedAndResumable, migration.MigrationType);
         Assert.Equal(8, migration.Version);
     }
+
+    [Fact]
+    public void MigrationRegistration_SessionsPredefinedSavedViewMigration_IsRegisteredAsVersionedAndResumable()
+    {
+        var migration = GetService<IEnumerable<IMigration>>()
+            .DistinctBy(item => item.GetType())
+            .SingleOrDefault(item => item is AddSessionsPredefinedSavedView);
+
+        Assert.NotNull(migration);
+        Assert.Equal(MigrationType.VersionedAndResumable, migration.MigrationType);
+        Assert.Equal(9, migration.Version);
+    }
 }


### PR DESCRIPTION
## What changed

- add Sessions as a first-class saved-view type, including the predefined All view
- reuse the shared saved-view picker, filter/URL state, and table customization patterns from Events and Stacks
- persist View Active, filters, stats/chart visibility, column visibility/order/wrapping/widths, and autofill selection
- add saved Sessions routes, sidebar children, default-view routing support, and focused API/UI/E2E coverage

## Why

Sessions should support the same complete saved-view workflow as Events and Stacks instead of maintaining a separate fixed table configuration.

## Verification

- dotnet build: passed
- SavedViewEndpointTests: 122 passed
- OpenApiSnapshotTests: 4 passed
- npm run validate: passed
- npm run build: passed
- focused frontend unit tests: 84 passed
- Sessions saved-view Playwright E2E: passed
- existing session investigation Playwright E2E: passed
- localhost App and same-origin API smoke checks: HTTP 200

The full frontend unit run passed 728 tests and hit one unrelated existing failure in navigation-command.svelte.test.ts. It also fails in isolation on the unchanged test, expecting /next/stack while the current implementation navigates to /next/.

## Breaking changes

None.
