### PR TITLE
Add personal saved view ordering

### DIFF
--- a/src/Exceptionless.Core/Models/User.cs
+++ b/src/Exceptionless.Core/Models/User.cs
@@ -24,6 +24,7 @@ public record User : IIdentity, IHaveDates, IValidatableObject
     public DateTime PasswordResetTokenExpiration { get; set; }
     public ICollection<OAuthAccount> OAuthAccounts { get; init; } = new Collection<OAuthAccount>();
     public ICollection<UserOrganizationPreference> OrganizationPreferences { get; init; } = new Collection<UserOrganizationPreference>();
+    public ICollection<UserSavedViewOrderPreference> SavedViewOrders { get; init; } = new Collection<UserSavedViewOrderPreference>();
 
     /// <summary>
     /// Gets or sets the users Full Name.

--- a/src/Exceptionless.Core/Models/UserOrganizationPreference.cs
+++ b/src/Exceptionless.Core/Models/UserOrganizationPreference.cs
@@ -9,7 +9,5 @@ public sealed record UserOrganizationPreference
     public string OrganizationId { get; set; } = null!;
 
     [ObjectId]
-    public string? DefaultSavedViewId { get; set; }
-
-    public Dictionary<string, List<string>> SavedViewOrder { get; set; } = [];
+    public string DefaultSavedViewId { get; set; } = null!;
 }

--- a/src/Exceptionless.Core/Models/UserOrganizationPreference.cs
+++ b/src/Exceptionless.Core/Models/UserOrganizationPreference.cs
@@ -9,5 +9,7 @@ public sealed record UserOrganizationPreference
     public string OrganizationId { get; set; } = null!;
 
     [ObjectId]
-    public string DefaultSavedViewId { get; set; } = null!;
+    public string? DefaultSavedViewId { get; set; }
+
+    public Dictionary<string, List<string>> SavedViewOrder { get; set; } = [];
 }

--- a/src/Exceptionless.Core/Models/UserSavedViewOrderPreference.cs
+++ b/src/Exceptionless.Core/Models/UserSavedViewOrderPreference.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+using Exceptionless.Core.Attributes;
+
+namespace Exceptionless.Core.Models;
+
+public sealed record UserSavedViewOrderPreference
+{
+    [ObjectId]
+    public string OrganizationId { get; set; } = null!;
+
+    [Required]
+    public string ViewType { get; set; } = null!;
+
+    public List<string> SavedViewIds { get; set; } = [];
+}

--- a/src/Exceptionless.Core/Repositories/Interfaces/IUserRepository.cs
+++ b/src/Exceptionless.Core/Repositories/Interfaces/IUserRepository.cs
@@ -6,6 +6,7 @@ namespace Exceptionless.Core.Repositories;
 
 public interface IUserRepository : ISearchableRepository<User>
 {
+    Task<bool> SetSavedViewOrdersAsync(User user, CommandOptionsDescriptor<User>? options = null);
     Task<User?> GetByEmailAddressAsync(string emailAddress);
     Task<User?> GetByPasswordResetTokenAsync(string token);
     Task<User?> GetUserByOAuthProviderAsync(string provider, string providerUserId);

--- a/src/Exceptionless.Core/Repositories/UserRepository.cs
+++ b/src/Exceptionless.Core/Repositories/UserRepository.cs
@@ -17,6 +17,17 @@ public class UserRepository : RepositoryBase<User>, IUserRepository
         AddRequiredField(u => u.EmailAddress, u => u.OrganizationIds);
     }
 
+    public async Task<bool> SetSavedViewOrdersAsync(User user, CommandOptionsDescriptor<User>? options = null)
+    {
+        bool modified = await PatchAsync(
+            user.Id,
+            new PartialPatch(new { saved_view_orders = user.SavedViewOrders }),
+            options);
+
+        await Cache.RemoveAsync(EmailCacheKey(user.EmailAddress));
+        return modified;
+    }
+
     public async Task<User?> GetByEmailAddressAsync(string emailAddress)
     {
         if (String.IsNullOrWhiteSpace(emailAddress))

--- a/src/Exceptionless.Core/Repositories/UserRepository.cs
+++ b/src/Exceptionless.Core/Repositories/UserRepository.cs
@@ -17,15 +17,15 @@ public class UserRepository : RepositoryBase<User>, IUserRepository
         AddRequiredField(u => u.EmailAddress, u => u.OrganizationIds);
     }
 
-    public async Task<bool> SetSavedViewOrdersAsync(User user, CommandOptionsDescriptor<User>? options = null)
+    public Task<bool> SetSavedViewOrdersAsync(User user, CommandOptionsDescriptor<User>? options = null)
     {
-        bool modified = await PatchAsync(
-            user.Id,
-            new PartialPatch(new { saved_view_orders = user.SavedViewOrders }),
-            options);
-
-        await Cache.RemoveAsync(EmailCacheKey(user.EmailAddress));
-        return modified;
+        var savedViewOrders = user.SavedViewOrders.ToList();
+        return PatchAsync(user.Id, new ActionPatch<User>(currentUser =>
+        {
+            currentUser.SavedViewOrders.Clear();
+            foreach (var savedViewOrder in savedViewOrders)
+                currentUser.SavedViewOrders.Add(savedViewOrder);
+        }), options);
     }
 
     public async Task<User?> GetByEmailAddressAsync(string emailAddress)

--- a/src/Exceptionless.Core/Services/OrganizationService.cs
+++ b/src/Exceptionless.Core/Services/OrganizationService.cs
@@ -95,6 +95,8 @@ public class OrganizationService : IStartupAction
                     user.OrganizationIds.Remove(organization.Id);
                     foreach (var preference in user.OrganizationPreferences.Where(preference => String.Equals(preference.OrganizationId, organization.Id, StringComparison.Ordinal)).ToList())
                         user.OrganizationPreferences.Remove(preference);
+                    foreach (var preference in user.SavedViewOrders.Where(preference => String.Equals(preference.OrganizationId, organization.Id, StringComparison.Ordinal)).ToList())
+                        user.SavedViewOrders.Remove(preference);
                     usersToUpdate.Add(user);
                 }
             }

--- a/src/Exceptionless.Web/Api/Endpoints/SavedViewEndpoints.cs
+++ b/src/Exceptionless.Web/Api/Endpoints/SavedViewEndpoints.cs
@@ -92,6 +92,28 @@ public static class SavedViewEndpoints
             }
         });
 
+        group.MapPut("organizations/{organizationId:objectid}/saved-view-order/{viewType}", async (string organizationId, string viewType,
+            IMediator mediator, IMediatorResultMapper<HttpIResult> resultMapper, [FromBody] UpdateSavedViewOrder savedViewOrder)
+            => (await mediator.InvokeAsync<Result<UpdateSavedViewOrder>>(new SavedViewMessages.UpdateUserSavedViewOrder(organizationId, viewType, savedViewOrder))).ToHttpResult(resultMapper))
+        .Accepts<UpdateSavedViewOrder>("application/json", "application/*+json")
+        .Produces<UpdateSavedViewOrder>()
+        .ProducesProblem(StatusCodes.Status404NotFound)
+        .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+        .WithSummary("Update the current user's saved view order")
+        .WithMetadata(new EndpointDocumentation {
+            RequestBodyDescription = "The ordered saved view identifiers for one dashboard section. An empty list resets the section to alphabetical order.",
+            RequestBodyRequired = true,
+            ParameterDescriptions = new() {
+                ["organizationId"] = "The identifier of the organization.",
+                ["viewType"] = "The dashboard view type (events, sessions, stacks, or stream).",
+            },
+            ResponseDescriptions = new() {
+                ["200"] = "The personal saved view order was updated.",
+                ["404"] = "The organization could not be found.",
+                ["422"] = "The dashboard view type or saved view identifiers are invalid.",
+            }
+        });
+
         group.MapPut("organizations/{organizationId:objectid}/saved-view-defaults/organization", async (string organizationId, IMediator mediator, IMediatorResultMapper<HttpIResult> resultMapper,
             [FromBody] UpdateSavedViewDefault savedViewDefault)
             => (await mediator.InvokeAsync<Result<UpdateSavedViewDefault>>(new SavedViewMessages.UpdateOrganizationSavedViewDefault(organizationId, savedViewDefault))).ToHttpResult(resultMapper))

--- a/src/Exceptionless.Web/Api/Endpoints/SavedViewEndpoints.cs
+++ b/src/Exceptionless.Web/Api/Endpoints/SavedViewEndpoints.cs
@@ -76,6 +76,7 @@ public static class SavedViewEndpoints
             => (await mediator.InvokeAsync<Result<UpdateSavedViewDefault>>(new SavedViewMessages.UpdateUserSavedViewDefault(organizationId, savedViewDefault))).ToHttpResult(resultMapper))
         .Accepts<UpdateSavedViewDefault>("application/json", "application/*+json")
         .Produces<UpdateSavedViewDefault>()
+        .ProducesProblem(StatusCodes.Status409Conflict)
         .ProducesProblem(StatusCodes.Status404NotFound)
         .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .WithSummary("Update the current user's saved view default")
@@ -87,6 +88,7 @@ public static class SavedViewEndpoints
             },
             ResponseDescriptions = new() {
                 ["200"] = "The personal saved view default was updated.",
+                ["409"] = "The saved view preferences could not be updated due to a concurrent request.",
                 ["404"] = "The organization could not be found.",
                 ["422"] = "The saved view is not accessible in this organization.",
             }
@@ -97,6 +99,7 @@ public static class SavedViewEndpoints
             => (await mediator.InvokeAsync<Result<UpdateSavedViewOrder>>(new SavedViewMessages.UpdateUserSavedViewOrder(organizationId, viewType, savedViewOrder))).ToHttpResult(resultMapper))
         .Accepts<UpdateSavedViewOrder>("application/json", "application/*+json")
         .Produces<UpdateSavedViewOrder>()
+        .ProducesProblem(StatusCodes.Status409Conflict)
         .ProducesProblem(StatusCodes.Status404NotFound)
         .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
         .WithSummary("Update the current user's saved view order")
@@ -109,6 +112,7 @@ public static class SavedViewEndpoints
             },
             ResponseDescriptions = new() {
                 ["200"] = "The personal saved view order was updated.",
+                ["409"] = "The saved view preferences could not be updated due to a concurrent request.",
                 ["404"] = "The organization could not be found.",
                 ["422"] = "The dashboard view type or saved view identifiers are invalid.",
             }

--- a/src/Exceptionless.Web/Api/Endpoints/SavedViewEndpoints.cs
+++ b/src/Exceptionless.Web/Api/Endpoints/SavedViewEndpoints.cs
@@ -99,6 +99,7 @@ public static class SavedViewEndpoints
             => (await mediator.InvokeAsync<Result<UpdateSavedViewOrder>>(new SavedViewMessages.UpdateUserSavedViewOrder(organizationId, viewType, savedViewOrder))).ToHttpResult(resultMapper))
         .Accepts<UpdateSavedViewOrder>("application/json", "application/*+json")
         .Produces<UpdateSavedViewOrder>()
+        .ProducesProblem(StatusCodes.Status400BadRequest)
         .ProducesProblem(StatusCodes.Status409Conflict)
         .ProducesProblem(StatusCodes.Status404NotFound)
         .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
@@ -112,6 +113,7 @@ public static class SavedViewEndpoints
             },
             ResponseDescriptions = new() {
                 ["200"] = "The personal saved view order was updated.",
+                ["400"] = "The request body is malformed or omits the saved view identifiers.",
                 ["409"] = "The saved view preferences could not be updated due to a concurrent request.",
                 ["404"] = "The organization could not be found.",
                 ["422"] = "The dashboard view type or saved view identifiers are invalid.",

--- a/src/Exceptionless.Web/Api/Handlers/OrganizationHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/OrganizationHandler.cs
@@ -706,6 +706,8 @@ public class OrganizationHandler(
             user.OrganizationIds.Remove(organization.Id);
             foreach (var preference in user.OrganizationPreferences.Where(preference => String.Equals(preference.OrganizationId, organization.Id, StringComparison.Ordinal)).ToList())
                 user.OrganizationPreferences.Remove(preference);
+            foreach (var preference in user.SavedViewOrders.Where(preference => String.Equals(preference.OrganizationId, organization.Id, StringComparison.Ordinal)).ToList())
+                user.SavedViewOrders.Remove(preference);
             await userRepository.SaveAsync(user, o => o.Cache());
             await messagePublisher.PublishAsync(new UserMembershipChanged
             {

--- a/src/Exceptionless.Web/Api/Handlers/SavedViewHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/SavedViewHandler.cs
@@ -102,20 +102,47 @@ public partial class SavedViewHandler(
         if (user is null)
             return Result.NotFound("User not found.");
 
-        foreach (var preference in user.OrganizationPreferences.Where(preference => String.Equals(preference.OrganizationId, message.OrganizationId, StringComparison.Ordinal)).ToList())
-            user.OrganizationPreferences.Remove(preference);
-
-        if (message.Default.SavedViewId is not null)
-        {
-            user.OrganizationPreferences.Add(new UserOrganizationPreference
-            {
-                OrganizationId = message.OrganizationId,
-                DefaultSavedViewId = message.Default.SavedViewId
-            });
-        }
+        var preference = MergeOrganizationPreferences(user, message.OrganizationId);
+        preference.DefaultSavedViewId = message.Default.SavedViewId;
+        SaveOrganizationPreference(user, preference);
 
         await userRepository.SaveAsync(user, o => o.Cache());
         return message.Default;
+    }
+
+    public async Task<Result<UpdateSavedViewOrder>> Handle(UpdateUserSavedViewOrder message)
+    {
+        if (!HttpContext.Request.CanAccessOrganization(message.OrganizationId))
+            return Result.NotFound("Organization not found.");
+
+        if (!NewSavedView.ValidViewTypes.Contains(message.ViewType))
+            return Result.Invalid(ValidationError.Create("view_type", $"View type must be one of: {String.Join(", ", NewSavedView.ValidViewTypes)}."));
+
+        if (await organizationRepository.GetByIdAsync(message.OrganizationId) is null)
+            return Result.NotFound("Organization not found.");
+
+        var accessibleViews = await repository.GetByViewForUserAsync(
+            message.OrganizationId,
+            message.ViewType,
+            GetCurrentUserId(),
+            o => o.PageLimit(MaxViewsPerOrganization));
+        var accessibleIds = accessibleViews.Documents.Select(savedView => savedView.Id).ToHashSet(StringComparer.Ordinal);
+        var normalizedIds = message.Order.SavedViewIds.Where(accessibleIds.Contains).ToList();
+
+        var user = await userRepository.GetByIdAsync(GetCurrentUserId(), o => o.Cache(false));
+        if (user is null)
+            return Result.NotFound("User not found.");
+
+        var preference = MergeOrganizationPreferences(user, message.OrganizationId);
+        if (normalizedIds.Count > 0)
+            preference.SavedViewOrder[message.ViewType] = normalizedIds;
+        else
+            preference.SavedViewOrder.Remove(message.ViewType);
+
+        SaveOrganizationPreference(user, preference);
+        await userRepository.SaveAsync(user, o => o.Cache());
+
+        return new UpdateSavedViewOrder { SavedViewIds = normalizedIds };
     }
 
     public async Task<Result<UpdateSavedViewDefault>> Handle(UpdateOrganizationSavedViewDefault message)
@@ -515,6 +542,46 @@ public partial class SavedViewHandler(
     }
 
     private List<ViewSavedView> MapToViewModels(IEnumerable<SavedView> models) => models.Select(MapToViewModel).ToList();
+
+    private static UserOrganizationPreference MergeOrganizationPreferences(User user, string organizationId)
+    {
+        var preferences = user.OrganizationPreferences
+            .Where(preference => String.Equals(preference.OrganizationId, organizationId, StringComparison.Ordinal))
+            .ToList();
+        var merged = new UserOrganizationPreference
+        {
+            OrganizationId = organizationId,
+            DefaultSavedViewId = preferences
+                .Select(preference => preference.DefaultSavedViewId)
+                .Where(savedViewId => !String.IsNullOrWhiteSpace(savedViewId))
+                .Order(StringComparer.Ordinal)
+                .FirstOrDefault()
+        };
+
+        foreach (var preference in preferences)
+        {
+            foreach (var (viewType, savedViewIds) in preference.SavedViewOrder ?? [])
+            {
+                if (!merged.SavedViewOrder.ContainsKey(viewType) && savedViewIds.Count > 0)
+                    merged.SavedViewOrder[viewType] = [.. savedViewIds];
+            }
+        }
+
+        return merged;
+    }
+
+    private static void SaveOrganizationPreference(User user, UserOrganizationPreference preference)
+    {
+        foreach (var existing in user.OrganizationPreferences
+            .Where(existing => String.Equals(existing.OrganizationId, preference.OrganizationId, StringComparison.Ordinal))
+            .ToList())
+        {
+            user.OrganizationPreferences.Remove(existing);
+        }
+
+        if (preference.DefaultSavedViewId is not null || preference.SavedViewOrder.Count > 0)
+            user.OrganizationPreferences.Add(preference);
+    }
 
     private async Task ClearDefaultReferencesAsync(IReadOnlyCollection<SavedView> deletedSavedViews)
     {

--- a/src/Exceptionless.Web/Api/Handlers/SavedViewHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/SavedViewHandler.cs
@@ -121,15 +121,19 @@ public partial class SavedViewHandler(
         if (await organizationRepository.GetByIdAsync(message.OrganizationId) is null)
             return Result.NotFound("Organization not found.");
 
-        var accessibleViews = await repository.GetByViewForUserAsync(
-            message.OrganizationId,
-            message.ViewType,
-            GetCurrentUserId(),
-            o => o.PageLimit(MaxViewsPerOrganization));
-        var accessibleIds = accessibleViews.Documents.Select(savedView => savedView.Id).ToHashSet(StringComparer.Ordinal);
+        string currentUserId = GetCurrentUserId();
+        IReadOnlyCollection<SavedView> requestedViews = message.Order.SavedViewIds.Count > 0
+            ? await repository.GetByIdsAsync(message.Order.SavedViewIds.ToArray(), o => o.Cache(false))
+            : [];
+        var accessibleIds = requestedViews
+            .Where(savedView => String.Equals(savedView.OrganizationId, message.OrganizationId, StringComparison.Ordinal)
+                && String.Equals(savedView.ViewType, message.ViewType, StringComparison.Ordinal)
+                && (String.IsNullOrEmpty(savedView.UserId) || String.Equals(savedView.UserId, currentUserId, StringComparison.Ordinal)))
+            .Select(savedView => savedView.Id)
+            .ToHashSet(StringComparer.Ordinal);
         var normalizedIds = message.Order.SavedViewIds.Where(accessibleIds.Contains).ToList();
 
-        var user = await userRepository.GetByIdAsync(GetCurrentUserId(), o => o.Cache(false));
+        var user = await userRepository.GetByIdAsync(currentUserId, o => o.Cache(false));
         if (user is null)
             return Result.NotFound("User not found.");
 
@@ -562,8 +566,17 @@ public partial class SavedViewHandler(
         {
             foreach (var (viewType, savedViewIds) in preference.SavedViewOrder ?? [])
             {
-                if (!merged.SavedViewOrder.ContainsKey(viewType) && savedViewIds.Count > 0)
-                    merged.SavedViewOrder[viewType] = [.. savedViewIds];
+                if (!merged.SavedViewOrder.TryGetValue(viewType, out var mergedIds))
+                {
+                    mergedIds = [];
+                    merged.SavedViewOrder[viewType] = mergedIds;
+                }
+
+                foreach (string savedViewId in savedViewIds)
+                {
+                    if (!mergedIds.Contains(savedViewId, StringComparer.Ordinal))
+                        mergedIds.Add(savedViewId);
+                }
             }
         }
 

--- a/src/Exceptionless.Web/Api/Handlers/SavedViewHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/SavedViewHandler.cs
@@ -98,15 +98,41 @@ public partial class SavedViewHandler(
                 return Result.Invalid(ValidationError.Create("saved_view_id", "The saved view is not accessible in this organization."));
         }
 
-        var user = await userRepository.GetByIdAsync(GetCurrentUserId(), o => o.Cache(false));
-        if (user is null)
+        string currentUserId = GetCurrentUserId();
+        bool userFound = true;
+        bool lockAcquired = await lockProvider.TryUsingAsync($"user-saved-view-preferences:{currentUserId}", async () =>
+        {
+            var user = await userRepository.GetByIdAsync(currentUserId, o => o.Cache(false));
+            if (user is null)
+            {
+                userFound = false;
+                return;
+            }
+
+            foreach (var preference in user.OrganizationPreferences
+                .Where(preference => String.Equals(preference.OrganizationId, message.OrganizationId, StringComparison.Ordinal))
+                .ToList())
+            {
+                user.OrganizationPreferences.Remove(preference);
+            }
+
+            if (message.Default.SavedViewId is not null)
+            {
+                user.OrganizationPreferences.Add(new UserOrganizationPreference
+                {
+                    OrganizationId = message.OrganizationId,
+                    DefaultSavedViewId = message.Default.SavedViewId
+                });
+            }
+
+            await userRepository.SaveAsync(user, o => o.Cache());
+        }, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(15));
+
+        if (!lockAcquired)
+            return Result.Conflict("Unable to update saved view preferences. Please try again.");
+        if (!userFound)
             return Result.NotFound("User not found.");
 
-        var preference = MergeOrganizationPreferences(user, message.OrganizationId);
-        preference.DefaultSavedViewId = message.Default.SavedViewId;
-        SaveOrganizationPreference(user, preference);
-
-        await userRepository.SaveAsync(user, o => o.Cache());
         return message.Default;
     }
 
@@ -133,18 +159,41 @@ public partial class SavedViewHandler(
             .ToHashSet(StringComparer.Ordinal);
         var normalizedIds = message.Order.SavedViewIds.Where(accessibleIds.Contains).ToList();
 
-        var user = await userRepository.GetByIdAsync(currentUserId, o => o.Cache(false));
-        if (user is null)
+        bool userFound = true;
+        bool lockAcquired = await lockProvider.TryUsingAsync($"user-saved-view-preferences:{currentUserId}", async () =>
+        {
+            var user = await userRepository.GetByIdAsync(currentUserId, o => o.Cache(false));
+            if (user is null)
+            {
+                userFound = false;
+                return;
+            }
+
+            foreach (var preference in user.SavedViewOrders
+                .Where(preference => String.Equals(preference.OrganizationId, message.OrganizationId, StringComparison.Ordinal)
+                    && String.Equals(preference.ViewType, message.ViewType, StringComparison.Ordinal))
+                .ToList())
+            {
+                user.SavedViewOrders.Remove(preference);
+            }
+
+            if (normalizedIds.Count > 0)
+            {
+                user.SavedViewOrders.Add(new UserSavedViewOrderPreference
+                {
+                    OrganizationId = message.OrganizationId,
+                    ViewType = message.ViewType,
+                    SavedViewIds = normalizedIds
+                });
+            }
+
+            await userRepository.SaveAsync(user, o => o.Cache());
+        }, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(15));
+
+        if (!lockAcquired)
+            return Result.Conflict("Unable to update saved view preferences. Please try again.");
+        if (!userFound)
             return Result.NotFound("User not found.");
-
-        var preference = MergeOrganizationPreferences(user, message.OrganizationId);
-        if (normalizedIds.Count > 0)
-            preference.SavedViewOrder[message.ViewType] = normalizedIds;
-        else
-            preference.SavedViewOrder.Remove(message.ViewType);
-
-        SaveOrganizationPreference(user, preference);
-        await userRepository.SaveAsync(user, o => o.Cache());
 
         return new UpdateSavedViewOrder { SavedViewIds = normalizedIds };
     }
@@ -546,55 +595,6 @@ public partial class SavedViewHandler(
     }
 
     private List<ViewSavedView> MapToViewModels(IEnumerable<SavedView> models) => models.Select(MapToViewModel).ToList();
-
-    private static UserOrganizationPreference MergeOrganizationPreferences(User user, string organizationId)
-    {
-        var preferences = user.OrganizationPreferences
-            .Where(preference => String.Equals(preference.OrganizationId, organizationId, StringComparison.Ordinal))
-            .ToList();
-        var merged = new UserOrganizationPreference
-        {
-            OrganizationId = organizationId,
-            DefaultSavedViewId = preferences
-                .Select(preference => preference.DefaultSavedViewId)
-                .Where(savedViewId => !String.IsNullOrWhiteSpace(savedViewId))
-                .Order(StringComparer.Ordinal)
-                .FirstOrDefault()
-        };
-
-        foreach (var preference in preferences)
-        {
-            foreach (var (viewType, savedViewIds) in preference.SavedViewOrder ?? [])
-            {
-                if (!merged.SavedViewOrder.TryGetValue(viewType, out var mergedIds))
-                {
-                    mergedIds = [];
-                    merged.SavedViewOrder[viewType] = mergedIds;
-                }
-
-                foreach (string savedViewId in savedViewIds)
-                {
-                    if (!mergedIds.Contains(savedViewId, StringComparer.Ordinal))
-                        mergedIds.Add(savedViewId);
-                }
-            }
-        }
-
-        return merged;
-    }
-
-    private static void SaveOrganizationPreference(User user, UserOrganizationPreference preference)
-    {
-        foreach (var existing in user.OrganizationPreferences
-            .Where(existing => String.Equals(existing.OrganizationId, preference.OrganizationId, StringComparison.Ordinal))
-            .ToList())
-        {
-            user.OrganizationPreferences.Remove(existing);
-        }
-
-        if (preference.DefaultSavedViewId is not null || preference.SavedViewOrder.Count > 0)
-            user.OrganizationPreferences.Add(preference);
-    }
 
     private async Task ClearDefaultReferencesAsync(IReadOnlyCollection<SavedView> deletedSavedViews)
     {

--- a/src/Exceptionless.Web/Api/Handlers/SavedViewHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/SavedViewHandler.cs
@@ -187,7 +187,7 @@ public partial class SavedViewHandler(
                 });
             }
 
-            await userRepository.SetSavedViewOrdersAsync(user, o => o.Cache());
+            await userRepository.SetSavedViewOrdersAsync(user, o => o.Cache().ImmediateConsistency());
         }, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(15));
 
         if (!lockAcquired)

--- a/src/Exceptionless.Web/Api/Handlers/SavedViewHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/SavedViewHandler.cs
@@ -187,7 +187,7 @@ public partial class SavedViewHandler(
                 });
             }
 
-            await userRepository.SaveAsync(user, o => o.Cache());
+            await userRepository.SetSavedViewOrdersAsync(user, o => o.Cache());
         }, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(15));
 
         if (!lockAcquired)

--- a/src/Exceptionless.Web/Api/Messages/SavedViewMessages.cs
+++ b/src/Exceptionless.Web/Api/Messages/SavedViewMessages.cs
@@ -8,6 +8,7 @@ public record GetSavedViewsByOrganization(string OrganizationId, int Page, int L
 public record GetSavedViewsByView(string OrganizationId, string ViewType, int Page, int Limit);
 public record GetSavedViewById(string Id);
 public record UpdateUserSavedViewDefault(string OrganizationId, UpdateSavedViewDefault Default);
+public record UpdateUserSavedViewOrder(string OrganizationId, string ViewType, UpdateSavedViewOrder Order);
 public record UpdateOrganizationSavedViewDefault(string OrganizationId, UpdateSavedViewDefault Default);
 public record CreateSavedView(string OrganizationId, NewSavedView SavedView);
 public record CreatePredefinedSavedViews(string OrganizationId);

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -146,7 +146,18 @@ test('saved view navigation order is personal, persistent, and resettable', asyn
     await expect(privateViewLink).toBeVisible({ timeout: 30_000 });
 
     await expect(privateViewLink).toHaveAttribute('draggable', 'true');
-    await privateViewLink.dragTo(sharedViewLink);
+    const privateViewBox = await privateViewLink.boundingBox();
+    const sharedViewBox = await sharedViewLink.boundingBox();
+    if (!privateViewBox || !sharedViewBox) {
+        throw new Error('Saved view links must have visible bounding boxes');
+    }
+
+    await page.mouse.move(privateViewBox.x + privateViewBox.width / 2, privateViewBox.y + privateViewBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(privateViewBox.x + privateViewBox.width / 2, privateViewBox.y - 8, { steps: 4 });
+    await page.mouse.move(sharedViewBox.x + sharedViewBox.width / 2, sharedViewBox.y + sharedViewBox.height / 2, { steps: 12 });
+    await expectSavedViewBefore(sharedViewLink, privateViewLink);
+    await page.mouse.up();
     await expect(page.getByText('Events view order saved.')).toBeVisible();
     await expectSavedViewBefore(privateViewLink, sharedViewLink);
 

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -1,4 +1,4 @@
-import type { Page, Request } from '@playwright/test';
+import type { Locator, Page, Request } from '@playwright/test';
 
 import { expect, test } from '../fixtures/e2e-test';
 import { ExceptionlessE2EJourney } from '../support/exceptionless-journey';
@@ -91,6 +91,97 @@ test('home navigation honors personal and organization saved views and survives 
         await page.goto('/next/');
         await expect(page).toHaveURL(/\/next\/stack\/all(?:[?#]|$)/);
     });
+
+    expect(failedApiRequests).toEqual([]);
+});
+
+test('saved view navigation order is personal, persistent, and resettable', async ({ e2eScenario, page, request }) => {
+    const failedApiRequests = captureFailedApiRequests(page);
+    const suffix = e2eScenario.run.slice(-24);
+    const sharedViewName = `AAA Shared ${suffix}`;
+    const privateViewName = `ZZZ Private ${suffix}`;
+    const authorizationHeaders = { Authorization: `Bearer ${e2eScenario.userToken}` };
+    const savedViewsPath = `/api/v2/organizations/${e2eScenario.organizationId}/saved-views`;
+
+    for (const [name, isPrivate] of [
+        [sharedViewName, false],
+        [privateViewName, true]
+    ] as const) {
+        const response = await request.post(savedViewsPath, {
+            data: {
+                filter: 'type:error',
+                is_private: isPrivate,
+                name,
+                organization_id: e2eScenario.organizationId,
+                slug: savedViewSlug(name),
+                view_type: 'events'
+            },
+            headers: authorizationHeaders
+        });
+        expect(response.status()).toBe(201);
+    }
+
+    await expect
+        .poll(
+            async () => {
+                const response = await request.get(`${savedViewsPath}/events`, { headers: authorizationHeaders });
+                const names = response.ok() ? ((await response.json()) as { name: string }[]).map((savedView) => savedView.name) : [];
+                return names.includes(sharedViewName) && names.includes(privateViewName);
+            },
+            { timeout: 30_000 }
+        )
+        .toBe(true);
+
+    await page.goto('/next/event');
+    const sidebar = page.locator('[data-sidebar="sidebar"]');
+    const sharedViewLink = sidebar.getByRole('link', { exact: true, name: sharedViewName });
+    const privateViewLink = sidebar.getByRole('link', { exact: true, name: privateViewName });
+    await expect(sharedViewLink).toBeVisible({ timeout: 30_000 });
+    await expect(privateViewLink).toBeVisible();
+    await expectSavedViewBefore(sharedViewLink, privateViewLink);
+
+    await page.getByRole('button', { name: 'Reorder Events views' }).click();
+    const dialog = page.getByRole('dialog', { name: 'Reorder Events Views' });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText(privateViewName, { exact: true }).locator('..').getByText('Private', { exact: true })).toBeVisible();
+    await expect(dialog.getByText(sharedViewName, { exact: true }).locator('..').getByText('Shared', { exact: true })).toBeVisible();
+
+    const movePrivateUp = dialog.getByRole('button', { name: `Move ${privateViewName} up` });
+    while (await movePrivateUp.isEnabled()) {
+        await movePrivateUp.click();
+    }
+    await dialog.getByRole('button', { name: 'Save order' }).click();
+    await expect(dialog).toBeHidden();
+    await expectSavedViewBefore(privateViewLink, sharedViewLink);
+
+    await page.reload();
+    await expect(privateViewLink).toBeVisible({ timeout: 30_000 });
+    await expectSavedViewBefore(privateViewLink, sharedViewLink);
+
+    const currentUserResponse = await request.get('/api/v2/users/me', { headers: authorizationHeaders });
+    expect(currentUserResponse.ok()).toBe(true);
+    const currentUser = (await currentUserResponse.json()) as {
+        organization_preferences: { organization_id: string; saved_view_order?: Record<string, string[]> }[];
+    };
+    expect(
+        currentUser.organization_preferences.find((preference) => preference.organization_id === e2eScenario.organizationId)?.saved_view_order?.events
+    ).toBeDefined();
+
+    await page.getByRole('button', { name: 'Reorder Events views' }).click();
+    await dialog.getByRole('button', { name: 'Reset to alphabetical' }).click();
+    await expect(dialog).toBeHidden();
+    await expectSavedViewBefore(sharedViewLink, privateViewLink);
+    await page.reload();
+    await expect(sharedViewLink).toBeVisible({ timeout: 30_000 });
+    await expectSavedViewBefore(sharedViewLink, privateViewLink);
+
+    const resetCurrentUserResponse = await request.get('/api/v2/users/me', { headers: authorizationHeaders });
+    const resetCurrentUser = (await resetCurrentUserResponse.json()) as {
+        organization_preferences: { organization_id: string; saved_view_order?: Record<string, string[]> }[];
+    };
+    expect(
+        resetCurrentUser.organization_preferences.find((preference) => preference.organization_id === e2eScenario.organizationId)?.saved_view_order?.events
+    ).toBeUndefined();
 
     expect(failedApiRequests).toEqual([]);
 });
@@ -1092,6 +1183,16 @@ async function expectColumnBefore(page: Page, firstColumn: string, secondColumn:
             const firstIndex = headings.findIndex((heading) => heading.trim().startsWith(firstColumn));
             const secondIndex = headings.findIndex((heading) => heading.trim().startsWith(secondColumn));
             return firstIndex >= 0 && secondIndex >= 0 && firstIndex < secondIndex;
+        })
+        .toBe(true);
+}
+
+async function expectSavedViewBefore(first: Locator, second: Locator): Promise<void> {
+    await expect
+        .poll(async () => {
+            const firstBox = await first.boundingBox();
+            const secondBox = await second.boundingBox();
+            return !!firstBox && !!secondBox && firstBox.y < secondBox.y;
         })
         .toBe(true);
 }

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -140,7 +140,13 @@ test('saved view navigation order is personal, persistent, and resettable', asyn
     await expect(privateViewLink).toBeVisible();
     await expectSavedViewBefore(sharedViewLink, privateViewLink);
 
-    await privateViewLink.locator('..').dragTo(sharedViewLink.locator('..'));
+    await sharedViewLink.click();
+    await expect(page).toHaveURL(new RegExp(`/next/event/${escapeRegExp(savedViewSlug(sharedViewName))}(?:[?#]|$)`));
+    await page.goto('/next/event');
+    await expect(privateViewLink).toBeVisible({ timeout: 30_000 });
+
+    await expect(privateViewLink).toHaveAttribute('draggable', 'true');
+    await privateViewLink.dragTo(sharedViewLink);
     await expect(page.getByText('Events view order saved.')).toBeVisible();
     await expectSavedViewBefore(privateViewLink, sharedViewLink);
 

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -140,18 +140,8 @@ test('saved view navigation order is personal, persistent, and resettable', asyn
     await expect(privateViewLink).toBeVisible();
     await expectSavedViewBefore(sharedViewLink, privateViewLink);
 
-    await page.getByRole('button', { name: 'Reorder Events views' }).click();
-    const dialog = page.getByRole('dialog', { name: 'Reorder Events Views' });
-    await expect(dialog).toBeVisible();
-    await expect(dialog.getByText(privateViewName, { exact: true }).locator('..').getByText('Private', { exact: true })).toBeVisible();
-    await expect(dialog.getByText(sharedViewName, { exact: true }).locator('..').getByText('Shared', { exact: true })).toBeVisible();
-
-    const movePrivateUp = dialog.getByRole('button', { name: `Move ${privateViewName} up` });
-    while (await movePrivateUp.isEnabled()) {
-        await movePrivateUp.click();
-    }
-    await dialog.getByRole('button', { name: 'Save order' }).click();
-    await expect(dialog).toBeHidden();
+    await privateViewLink.locator('..').dragTo(sharedViewLink.locator('..'));
+    await expect(page.getByText('Events view order saved.')).toBeVisible();
     await expectSavedViewBefore(privateViewLink, sharedViewLink);
 
     await page.reload();
@@ -169,6 +159,10 @@ test('saved view navigation order is personal, persistent, and resettable', asyn
     ).toBeDefined();
 
     await page.getByRole('button', { name: 'Reorder Events views' }).click();
+    const dialog = page.getByRole('dialog', { name: 'Reorder Events Views' });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText(privateViewName, { exact: true }).locator('..').getByText('Private', { exact: true })).toBeVisible();
+    await expect(dialog.getByText(sharedViewName, { exact: true }).locator('..').getByText('Shared', { exact: true })).toBeVisible();
     await dialog.getByRole('button', { name: 'Reset to alphabetical' }).click();
     await expect(dialog).toBeHidden();
     await expectSavedViewBefore(sharedViewLink, privateViewLink);

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/saved-views.e2e.ts
@@ -161,10 +161,11 @@ test('saved view navigation order is personal, persistent, and resettable', asyn
     const currentUserResponse = await request.get('/api/v2/users/me', { headers: authorizationHeaders });
     expect(currentUserResponse.ok()).toBe(true);
     const currentUser = (await currentUserResponse.json()) as {
-        organization_preferences: { organization_id: string; saved_view_order?: Record<string, string[]> }[];
+        saved_view_orders: { organization_id: string; saved_view_ids: string[]; view_type: string }[];
     };
     expect(
-        currentUser.organization_preferences.find((preference) => preference.organization_id === e2eScenario.organizationId)?.saved_view_order?.events
+        currentUser.saved_view_orders.find((preference) => preference.organization_id === e2eScenario.organizationId && preference.view_type === 'events')
+            ?.saved_view_ids
     ).toBeDefined();
 
     await page.getByRole('button', { name: 'Reorder Events views' }).click();
@@ -177,10 +178,10 @@ test('saved view navigation order is personal, persistent, and resettable', asyn
 
     const resetCurrentUserResponse = await request.get('/api/v2/users/me', { headers: authorizationHeaders });
     const resetCurrentUser = (await resetCurrentUserResponse.json()) as {
-        organization_preferences: { organization_id: string; saved_view_order?: Record<string, string[]> }[];
+        saved_view_orders: { organization_id: string; saved_view_ids: string[]; view_type: string }[];
     };
     expect(
-        resetCurrentUser.organization_preferences.find((preference) => preference.organization_id === e2eScenario.organizationId)?.saved_view_order?.events
+        resetCurrentUser.saved_view_orders.find((preference) => preference.organization_id === e2eScenario.organizationId && preference.view_type === 'events')
     ).toBeUndefined();
 
     expect(failedApiRequests).toEqual([]);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.svelte.ts
@@ -3,12 +3,12 @@ import type { WebSocketMessageValue } from '$features/websockets/models';
 
 import { accessToken } from '$features/auth/index.svelte';
 import { setOrganizationDefaultSavedView } from '$features/organizations/api.svelte';
-import { setCurrentUserSavedViewDefault } from '$features/users/api.svelte';
+import { setCurrentUserSavedViewDefault, setCurrentUserSavedViewOrder } from '$features/users/api.svelte';
 import { ChangeType } from '$features/websockets/models';
 import { type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, type QueryClient, useQueryClient } from '@tanstack/svelte-query';
 
-import type { NewSavedView, SavedView, UpdateSavedView, UpdateSavedViewDefault } from './models';
+import type { NewSavedView, SavedView, UpdateSavedView, UpdateSavedViewDefault, UpdateSavedViewOrder } from './models';
 
 export const SAVED_VIEW_REFRESH_DELAY_MS = 1500;
 export const SAVED_VIEW_QUERY_STALE_TIME_MS = 60 * 1000;
@@ -89,6 +89,10 @@ export const queryKeys = {
 };
 
 let deletedSavedViewIds = $state<string[]>([]);
+
+type UpdateUserSavedViewOrder = UpdateSavedViewOrder & {
+    view_type: string;
+};
 
 export function deletePredefinedSavedView(request: { route: { id: string | undefined } }) {
     return createMutation<void, ProblemDetails, void>(() => ({
@@ -251,6 +255,27 @@ export function putOrganizationSavedViewDefault(request: { route: { organization
 
 export function putUserSavedViewDefault(request: { route: { organizationId: string | undefined } }) {
     return putSavedViewDefault(request, 'user');
+}
+
+export function putUserSavedViewOrder(request: { route: { organizationId: string | undefined } }) {
+    const queryClient = useQueryClient();
+
+    return createMutation<UpdateSavedViewOrder, ProblemDetails, UpdateUserSavedViewOrder>(() => ({
+        enabled: () => !!accessToken.current && !!request.route.organizationId,
+        mutationFn: async ({ saved_view_ids, view_type }: UpdateUserSavedViewOrder) => {
+            const client = useFetchClient();
+            const response = await client.putJSON<UpdateSavedViewOrder>(`organizations/${request.route.organizationId}/saved-view-order/${view_type}`, {
+                saved_view_ids
+            });
+            return response.data!;
+        },
+        onSuccess: (data: UpdateSavedViewOrder, variables: UpdateUserSavedViewOrder) => {
+            const organizationId = request.route.organizationId;
+            if (organizationId) {
+                setCurrentUserSavedViewOrder(queryClient, organizationId, variables.view_type, data.saved_view_ids);
+            }
+        }
+    }));
 }
 
 export function removeSavedViewFromCaches(queryClient: QueryClient, savedView: SavedView, organizationId: string | undefined = savedView.organization_id) {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.svelte.ts
@@ -260,19 +260,22 @@ export function putUserSavedViewDefault(request: { route: { organizationId: stri
 export function putUserSavedViewOrder(request: { route: { organizationId: string | undefined } }) {
     const queryClient = useQueryClient();
 
-    return createMutation<UpdateSavedViewOrder, ProblemDetails, UpdateUserSavedViewOrder>(() => ({
+    return createMutation<{ order: UpdateSavedViewOrder; organizationId: string | undefined }, ProblemDetails, UpdateUserSavedViewOrder>(() => ({
         enabled: () => !!accessToken.current && !!request.route.organizationId,
         mutationFn: async ({ saved_view_ids, view_type }: UpdateUserSavedViewOrder) => {
             const client = useFetchClient();
-            const response = await client.putJSON<UpdateSavedViewOrder>(`organizations/${request.route.organizationId}/saved-view-order/${view_type}`, {
+            const organizationId = request.route.organizationId;
+            const response = await client.putJSON<UpdateSavedViewOrder>(`organizations/${organizationId}/saved-view-order/${view_type}`, {
                 saved_view_ids
             });
-            return response.data!;
+            return {
+                order: response.data!,
+                organizationId
+            };
         },
-        onSuccess: (data: UpdateSavedViewOrder, variables: UpdateUserSavedViewOrder) => {
-            const organizationId = request.route.organizationId;
+        onSuccess: ({ order, organizationId }, variables: UpdateUserSavedViewOrder) => {
             if (organizationId) {
-                setCurrentUserSavedViewOrder(queryClient, organizationId, variables.view_type, data.saved_view_ids);
+                setCurrentUserSavedViewOrder(queryClient, organizationId, variables.view_type, order.saved_view_ids);
             }
         }
     }));

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/api.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { UpdateSavedViewOrder } from './models';
+
+const fetchClientMocks = vi.hoisted(() => ({ putJSON: vi.fn() }));
+const queryClient = vi.hoisted(() => ({}));
+const setCurrentUserSavedViewOrder = vi.hoisted(() => vi.fn());
+
+vi.mock('$features/auth/index.svelte', () => ({ accessToken: { current: 'access-token' } }));
+vi.mock('$features/organizations/api.svelte', () => ({ setOrganizationDefaultSavedView: vi.fn() }));
+vi.mock('$features/users/api.svelte', () => ({
+    setCurrentUserSavedViewDefault: vi.fn(),
+    setCurrentUserSavedViewOrder
+}));
+vi.mock('@foundatiofx/fetchclient', () => ({
+    useFetchClient: () => ({ putJSON: fetchClientMocks.putJSON })
+}));
+vi.mock('@tanstack/svelte-query', () => ({
+    createMutation: (options: () => unknown) => options(),
+    createQuery: vi.fn(),
+    useQueryClient: () => queryClient
+}));
+
+import { putUserSavedViewOrder } from './api.svelte';
+
+type SavedViewOrderMutationOptions = {
+    mutationFn: (variables: UpdateSavedViewOrder & { view_type: string }) => Promise<{
+        order: UpdateSavedViewOrder;
+        organizationId: string | undefined;
+    }>;
+    onSuccess: (data: { order: UpdateSavedViewOrder; organizationId: string | undefined }, variables: UpdateSavedViewOrder & { view_type: string }) => void;
+};
+
+describe('putUserSavedViewOrder', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('updates the cache for the organization that originated the request', async () => {
+        const route = { organizationId: 'organization-a' as string | undefined };
+        const variables = { saved_view_ids: ['saved-view-id'], view_type: 'events' };
+        fetchClientMocks.putJSON.mockResolvedValue({ data: { saved_view_ids: variables.saved_view_ids } });
+        const mutation = putUserSavedViewOrder({ route }) as unknown as SavedViewOrderMutationOptions;
+
+        const resultPromise = mutation.mutationFn(variables);
+        route.organizationId = 'organization-b';
+        const result = await resultPromise;
+        mutation.onSuccess(result, variables);
+
+        expect(fetchClientMocks.putJSON).toHaveBeenCalledWith('organizations/organization-a/saved-view-order/events', {
+            saved_view_ids: variables.saved_view_ids
+        });
+        expect(setCurrentUserSavedViewOrder).toHaveBeenCalledWith(queryClient, 'organization-a', 'events', variables.saved_view_ids);
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-order-dialog.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/components/saved-view-order-dialog.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+    import { Badge } from '$comp/ui/badge';
+    import { Button } from '$comp/ui/button';
+    import * as Dialog from '$comp/ui/dialog';
+    import ChevronDown from '@lucide/svelte/icons/chevron-down';
+    import ChevronUp from '@lucide/svelte/icons/chevron-up';
+    import GripVertical from '@lucide/svelte/icons/grip-vertical';
+    import LoaderCircle from '@lucide/svelte/icons/loader-circle';
+    import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
+    import { toast } from 'svelte-sonner';
+
+    import type { SavedView } from '../models';
+
+    type SavedViewOrderItem = Pick<SavedView, 'id' | 'name' | 'user_id'>;
+
+    interface Props {
+        onSave: (savedViewIds: string[]) => Promise<void>;
+        open: boolean;
+        savedViews: SavedViewOrderItem[];
+        title: string;
+    }
+
+    let { onSave, open = $bindable(), savedViews, title }: Props = $props();
+    let draggedSavedViewId = $state<null | string>(null);
+    let orderedSavedViews = $state<SavedViewOrderItem[]>([]);
+    let saving = $state(false);
+    let wasOpen = $state(false);
+
+    $effect(() => {
+        if (open && !wasOpen) {
+            orderedSavedViews = [...savedViews];
+        }
+
+        wasOpen = open;
+    });
+
+    function applyOrder(savedViewIds: string[]): void {
+        const byId = new Map(orderedSavedViews.map((savedView) => [savedView.id, savedView]));
+        orderedSavedViews = savedViewIds.map((id) => byId.get(id)).filter((savedView): savedView is SavedViewOrderItem => !!savedView);
+    }
+
+    function move(savedViewId: string, offset: -1 | 1): void {
+        const savedViewIds = orderedSavedViews.map((savedView) => savedView.id);
+        const currentIndex = savedViewIds.indexOf(savedViewId);
+        const targetIndex = currentIndex + offset;
+        if (currentIndex < 0 || targetIndex < 0 || targetIndex >= savedViewIds.length) {
+            return;
+        }
+
+        [savedViewIds[currentIndex], savedViewIds[targetIndex]] = [savedViewIds[targetIndex]!, savedViewIds[currentIndex]!];
+        applyOrder(savedViewIds);
+    }
+
+    function handleDragStart(event: DragEvent, savedViewId: string): void {
+        draggedSavedViewId = savedViewId;
+        if (event.dataTransfer) {
+            event.dataTransfer.effectAllowed = 'move';
+            event.dataTransfer.setData('text/plain', savedViewId);
+        }
+    }
+
+    function handleDragOver(event: DragEvent, targetSavedViewId: string): void {
+        event.preventDefault();
+        if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = 'move';
+        }
+
+        if (!draggedSavedViewId || draggedSavedViewId === targetSavedViewId) {
+            return;
+        }
+
+        const savedViewIds = orderedSavedViews.map((savedView) => savedView.id);
+        const fromIndex = savedViewIds.indexOf(draggedSavedViewId);
+        const toIndex = savedViewIds.indexOf(targetSavedViewId);
+        if (fromIndex < 0 || toIndex < 0) {
+            return;
+        }
+
+        const [movedSavedViewId] = savedViewIds.splice(fromIndex, 1);
+        if (movedSavedViewId) {
+            savedViewIds.splice(toIndex, 0, movedSavedViewId);
+            applyOrder(savedViewIds);
+        }
+    }
+
+    async function save(savedViewIds: string[], successMessage: string): Promise<void> {
+        saving = true;
+        try {
+            await onSave(savedViewIds);
+            toast.success(successMessage);
+            open = false;
+        } catch {
+            toast.error(`Failed to update your ${title.toLowerCase()} view order. Please try again.`);
+        } finally {
+            saving = false;
+        }
+    }
+
+    function saveOrder(): void {
+        void save(
+            orderedSavedViews.map((savedView) => savedView.id),
+            `${title} view order saved.`
+        );
+    }
+
+    function resetOrder(): void {
+        void save([], `${title} views reset to alphabetical order.`);
+    }
+</script>
+
+<Dialog.Root bind:open>
+    <Dialog.Content class="max-h-[calc(100dvh-2rem)] gap-0 overflow-hidden p-0 sm:max-w-xl" preventScroll={false}>
+        <Dialog.Header class="border-b px-6 py-5 pr-14">
+            <Dialog.Title>Reorder {title} Views</Dialog.Title>
+            <Dialog.Description>This order is personal to you. Drag views or use the move buttons to arrange them.</Dialog.Description>
+        </Dialog.Header>
+
+        <div class="min-h-0 px-6 py-5">
+            <div class="border-input bg-muted/20 rounded-lg border p-2">
+                <div class="flex max-h-[24rem] flex-col gap-1.5 overflow-y-auto pr-1" role="list" aria-label={`${title} saved views`}>
+                    {#each orderedSavedViews as savedView, index (savedView.id)}
+                        <div
+                            class="bg-background hover:bg-muted/70 flex min-h-11 items-center gap-3 rounded-lg border px-3 text-sm shadow-xs transition-colors"
+                            draggable="true"
+                            ondragstart={(event) => handleDragStart(event, savedView.id)}
+                            ondragover={(event) => handleDragOver(event, savedView.id)}
+                            ondragend={() => (draggedSavedViewId = null)}
+                            role="listitem"
+                        >
+                            <GripVertical class="text-muted-foreground/70 cursor-grab" aria-hidden="true" />
+                            <span class="min-w-0 flex-1 truncate font-medium">{savedView.name}</span>
+                            <Badge variant={savedView.user_id ? 'secondary' : 'outline'}>{savedView.user_id ? 'Private' : 'Shared'}</Badge>
+                            <div class="flex shrink-0 items-center gap-1">
+                                <Button
+                                    variant="ghost"
+                                    size="icon-sm"
+                                    onclick={() => move(savedView.id, -1)}
+                                    disabled={saving || index === 0}
+                                    title={`Move ${savedView.name} up`}
+                                >
+                                    <ChevronUp />
+                                    <span class="sr-only">Move {savedView.name} up</span>
+                                </Button>
+                                <Button
+                                    variant="ghost"
+                                    size="icon-sm"
+                                    onclick={() => move(savedView.id, 1)}
+                                    disabled={saving || index === orderedSavedViews.length - 1}
+                                    title={`Move ${savedView.name} down`}
+                                >
+                                    <ChevronDown />
+                                    <span class="sr-only">Move {savedView.name} down</span>
+                                </Button>
+                            </div>
+                        </div>
+                    {/each}
+                </div>
+            </div>
+        </div>
+
+        <Dialog.Footer class="mx-0 mb-0 rounded-b-xl px-6 py-4">
+            <Button variant="outline" onclick={resetOrder} disabled={saving}>
+                <RotateCcw data-icon="inline-start" />
+                Reset to alphabetical
+            </Button>
+            <Dialog.Close>
+                {#snippet child({ props })}
+                    <Button variant="outline" disabled={saving} {...props}>Cancel</Button>
+                {/snippet}
+            </Dialog.Close>
+            <Button onclick={saveOrder} disabled={saving}>
+                {#if saving}
+                    <LoaderCircle data-icon="inline-start" class="animate-spin" />
+                {/if}
+                Save order
+            </Button>
+        </Dialog.Footer>
+    </Dialog.Content>
+</Dialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/defaults.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/defaults.test.ts
@@ -116,7 +116,6 @@ describe('getSavedViewDefaultHref', () => {
 function preference(defaultSavedViewId: string): UserOrganizationPreference {
     return {
         default_saved_view_id: defaultSavedViewId,
-        organization_id: 'organization-id',
-        saved_view_order: {}
+        organization_id: 'organization-id'
     };
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/defaults.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/defaults.test.ts
@@ -116,6 +116,7 @@ describe('getSavedViewDefaultHref', () => {
 function preference(defaultSavedViewId: string): UserOrganizationPreference {
     return {
         default_saved_view_id: defaultSavedViewId,
-        organization_id: 'organization-id'
+        organization_id: 'organization-id',
+        saved_view_order: {}
     };
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/defaults.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/defaults.ts
@@ -31,6 +31,7 @@ export function resolveSavedViewDefaults(options: ResolveSavedViewDefaultsOption
             (options.organizationPreferences ?? [])
                 .filter((preference) => preference.organization_id === options.organizationId)
                 .map((preference) => preference.default_saved_view_id)
+                .filter((savedViewId): savedViewId is string => !!savedViewId)
         )
     ].sort();
     const userDefault = userDefaultIds.map((savedViewId) => savedViewsById.get(savedViewId)).find((savedView) => !!savedView);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/defaults.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/defaults.ts
@@ -31,7 +31,6 @@ export function resolveSavedViewDefaults(options: ResolveSavedViewDefaultsOption
             (options.organizationPreferences ?? [])
                 .filter((preference) => preference.organization_id === options.organizationId)
                 .map((preference) => preference.default_saved_view_id)
-                .filter((savedViewId): savedViewId is string => !!savedViewId)
         )
     ].sort();
     const userDefault = userDefaultIds.map((savedViewId) => savedViewsById.get(savedViewId)).find((savedView) => !!savedView);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/models.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/models.ts
@@ -1,5 +1,5 @@
-import type { NewSavedView, SavedViewColumnSettings, UpdateSavedView, UpdateSavedViewDefault, ViewSavedView } from '$generated/api';
+import type { NewSavedView, SavedViewColumnSettings, UpdateSavedView, UpdateSavedViewDefault, UpdateSavedViewOrder, ViewSavedView } from '$generated/api';
 
 export type SavedView = ViewSavedView;
 
-export type { NewSavedView, SavedViewColumnSettings, UpdateSavedView, UpdateSavedViewDefault };
+export type { NewSavedView, SavedViewColumnSettings, UpdateSavedView, UpdateSavedViewDefault, UpdateSavedViewOrder };

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/ordering.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/ordering.test.ts
@@ -1,0 +1,59 @@
+import type { UserOrganizationPreference } from '$generated/api';
+
+import { describe, expect, it } from 'vitest';
+
+import type { SavedView } from './models';
+
+import { getPersonalSavedViewOrder, resolvePersonalSavedViewOrder } from './ordering';
+
+function savedView(id: string, name: string, userId?: string): SavedView {
+    return {
+        id,
+        name,
+        organization_id: 'organization-id',
+        slug: name.toLowerCase().replaceAll(' ', '-'),
+        user_id: userId,
+        view_type: 'events'
+    } as SavedView;
+}
+
+describe('getPersonalSavedViewOrder', () => {
+    it('combines legacy duplicate organization preferences without repeating identifiers', () => {
+        const preferences = [
+            {
+                organization_id: 'organization-id',
+                saved_view_order: { events: ['private-view', 'shared-view'] }
+            },
+            {
+                organization_id: 'organization-id',
+                saved_view_order: { events: ['shared-view', 'new-view'] }
+            },
+            {
+                organization_id: 'other-organization',
+                saved_view_order: { events: ['other-view'] }
+            }
+        ] as UserOrganizationPreference[];
+
+        expect(getPersonalSavedViewOrder(preferences, 'organization-id', 'events')).toEqual(['private-view', 'shared-view', 'new-view']);
+    });
+});
+
+describe('resolvePersonalSavedViewOrder', () => {
+    it('interleaves shared and private views and appends new views alphabetically', () => {
+        const sharedView = savedView('shared-view', 'Zulu Shared');
+        const privateView = savedView('private-view', 'Alpha Private', 'user-id');
+        const newSharedView = savedView('new-shared-view', 'Beta Shared');
+        const newPrivateView = savedView('new-private-view', 'Charlie Private', 'user-id');
+
+        expect(
+            resolvePersonalSavedViewOrder([sharedView, privateView, newPrivateView, newSharedView], ['private-view', 'missing-view', 'shared-view'])
+        ).toEqual([privateView, sharedView, newSharedView, newPrivateView]);
+    });
+
+    it('uses alphabetical order when no personal order exists', () => {
+        const zulu = savedView('zulu-view', 'Zulu');
+        const alpha = savedView('alpha-view', 'Alpha');
+
+        expect(resolvePersonalSavedViewOrder([zulu, alpha], [])).toEqual([alpha, zulu]);
+    });
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/ordering.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/ordering.test.ts
@@ -1,4 +1,4 @@
-import type { UserOrganizationPreference } from '$generated/api';
+import type { UserSavedViewOrderPreference } from '$generated/api';
 
 import { describe, expect, it } from 'vitest';
 
@@ -18,21 +18,29 @@ function savedView(id: string, name: string, userId?: string): SavedView {
 }
 
 describe('getPersonalSavedViewOrder', () => {
-    it('combines legacy duplicate organization preferences without repeating identifiers', () => {
+    it('combines duplicate order preferences without repeating identifiers', () => {
         const preferences = [
             {
                 organization_id: 'organization-id',
-                saved_view_order: { events: ['private-view', 'shared-view'] }
+                saved_view_ids: ['private-view', 'shared-view'],
+                view_type: 'events'
             },
             {
                 organization_id: 'organization-id',
-                saved_view_order: { events: ['shared-view', 'new-view'] }
+                saved_view_ids: ['shared-view', 'new-view'],
+                view_type: 'events'
             },
             {
                 organization_id: 'other-organization',
-                saved_view_order: { events: ['other-view'] }
+                saved_view_ids: ['other-view'],
+                view_type: 'events'
+            },
+            {
+                organization_id: 'organization-id',
+                saved_view_ids: ['other-section-view'],
+                view_type: 'stacks'
             }
-        ] as UserOrganizationPreference[];
+        ] as UserSavedViewOrderPreference[];
 
         expect(getPersonalSavedViewOrder(preferences, 'organization-id', 'events')).toEqual(['private-view', 'shared-view', 'new-view']);
     });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/ordering.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/ordering.ts
@@ -1,9 +1,9 @@
-import type { UserOrganizationPreference } from '$generated/api';
+import type { UserSavedViewOrderPreference } from '$generated/api';
 
 import type { SavedView } from './models';
 
 export function getPersonalSavedViewOrder(
-    organizationPreferences: null | undefined | UserOrganizationPreference[],
+    savedViewOrders: null | undefined | UserSavedViewOrderPreference[],
     organizationId: string | undefined,
     viewType: string
 ): string[] {
@@ -12,12 +12,12 @@ export function getPersonalSavedViewOrder(
     }
 
     const orderedIds: string[] = [];
-    for (const preference of organizationPreferences ?? []) {
-        if (preference.organization_id !== organizationId) {
+    for (const preference of savedViewOrders ?? []) {
+        if (preference.organization_id !== organizationId || preference.view_type !== viewType) {
             continue;
         }
 
-        for (const savedViewId of preference.saved_view_order?.[viewType] ?? []) {
+        for (const savedViewId of preference.saved_view_ids) {
             if (!orderedIds.includes(savedViewId)) {
                 orderedIds.push(savedViewId);
             }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/ordering.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/saved-views/ordering.ts
@@ -1,0 +1,50 @@
+import type { UserOrganizationPreference } from '$generated/api';
+
+import type { SavedView } from './models';
+
+export function getPersonalSavedViewOrder(
+    organizationPreferences: null | undefined | UserOrganizationPreference[],
+    organizationId: string | undefined,
+    viewType: string
+): string[] {
+    if (!organizationId) {
+        return [];
+    }
+
+    const orderedIds: string[] = [];
+    for (const preference of organizationPreferences ?? []) {
+        if (preference.organization_id !== organizationId) {
+            continue;
+        }
+
+        for (const savedViewId of preference.saved_view_order?.[viewType] ?? []) {
+            if (!orderedIds.includes(savedViewId)) {
+                orderedIds.push(savedViewId);
+            }
+        }
+    }
+
+    return orderedIds;
+}
+
+export function resolvePersonalSavedViewOrder(savedViews: SavedView[], orderedIds: null | string[] | undefined): SavedView[] {
+    const savedViewsById = new Map(savedViews.map((savedView) => [savedView.id, savedView]));
+    const resolved: SavedView[] = [];
+    const resolvedIds = new Set<string>();
+
+    for (const savedViewId of orderedIds ?? []) {
+        const savedView = savedViewsById.get(savedViewId);
+        if (!savedView || resolvedIds.has(savedView.id)) {
+            continue;
+        }
+
+        resolved.push(savedView);
+        resolvedIds.add(savedView.id);
+    }
+
+    const unordered = savedViews
+        .filter((savedView) => !resolvedIds.has(savedView.id))
+        .sort((left, right) => left.name.localeCompare(right.name) || left.id.localeCompare(right.id));
+
+    return [...resolved, ...unordered];
+}

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.svelte.ts
@@ -333,9 +333,13 @@ function mergeOrganizationPreferences(organizationPreferences: UserOrganizationP
 
     for (const preference of matches) {
         for (const [viewType, savedViewIds] of Object.entries(preference.saved_view_order ?? {})) {
-            if (!savedViewOrder[viewType] && savedViewIds.length > 0) {
-                savedViewOrder[viewType] = [...savedViewIds];
+            const mergedIds = savedViewOrder[viewType] ?? [];
+            for (const savedViewId of savedViewIds) {
+                if (!mergedIds.includes(savedViewId)) {
+                    mergedIds.push(savedViewId);
+                }
             }
+            savedViewOrder[viewType] = mergedIds;
         }
     }
 

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.svelte.ts
@@ -1,4 +1,5 @@
 import type { WebSocketMessageValue } from '$features/websockets/models';
+import type { UserOrganizationPreference } from '$generated/api';
 import type { WorkInProgressResult } from '$shared/models';
 
 import { setUserIdentity } from '$features/auth/exceptionless-session';
@@ -277,20 +278,25 @@ export function setCurrentUserSavedViewDefault(queryClient: QueryClient, organiz
         return;
     }
 
-    const organizationPreferences = currentUser.organization_preferences.filter((preference) => preference.organization_id !== organizationId);
-    if (savedViewId) {
-        organizationPreferences.push({
-            default_saved_view_id: savedViewId,
-            organization_id: organizationId
-        });
+    const preference = mergeOrganizationPreferences(currentUser.organization_preferences, organizationId);
+    preference.default_saved_view_id = savedViewId;
+    setCurrentUserOrganizationPreference(queryClient, currentUser, preference);
+}
+
+export function setCurrentUserSavedViewOrder(queryClient: QueryClient, organizationId: string, viewType: string, savedViewIds: string[]): void {
+    const currentUser = queryClient.getQueryData<ViewCurrentUser>(queryKeys.me());
+    if (!currentUser) {
+        return;
     }
 
-    const updatedUser = {
-        ...currentUser,
-        organization_preferences: organizationPreferences
-    };
-    queryClient.setQueryData(queryKeys.me(), updatedUser);
-    queryClient.setQueryData(queryKeys.id(currentUser.id), updatedUser);
+    const preference = mergeOrganizationPreferences(currentUser.organization_preferences, organizationId);
+    if (savedViewIds.length > 0) {
+        preference.saved_view_order[viewType] = [...savedViewIds];
+    } else {
+        delete preference.saved_view_order[viewType];
+    }
+
+    setCurrentUserOrganizationPreference(queryClient, currentUser, preference);
 }
 
 export function uploadUserAvatar(request: UserAvatarRequest) {
@@ -315,4 +321,43 @@ export function uploadUserAvatar(request: UserAvatarRequest) {
             }
         }
     }));
+}
+
+function mergeOrganizationPreferences(organizationPreferences: UserOrganizationPreference[], organizationId: string): UserOrganizationPreference {
+    const matches = organizationPreferences.filter((preference) => preference.organization_id === organizationId);
+    const defaultSavedViewId = matches
+        .map((preference) => preference.default_saved_view_id)
+        .filter((savedViewId): savedViewId is string => !!savedViewId)
+        .sort()[0];
+    const savedViewOrder: Record<string, string[]> = {};
+
+    for (const preference of matches) {
+        for (const [viewType, savedViewIds] of Object.entries(preference.saved_view_order ?? {})) {
+            if (!savedViewOrder[viewType] && savedViewIds.length > 0) {
+                savedViewOrder[viewType] = [...savedViewIds];
+            }
+        }
+    }
+
+    return {
+        default_saved_view_id: defaultSavedViewId,
+        organization_id: organizationId,
+        saved_view_order: savedViewOrder
+    };
+}
+
+function setCurrentUserOrganizationPreference(queryClient: QueryClient, currentUser: ViewCurrentUser, preference: UserOrganizationPreference): void {
+    const organizationPreferences = currentUser.organization_preferences.filter(
+        (existingPreference) => existingPreference.organization_id !== preference.organization_id
+    );
+    if (preference.default_saved_view_id || Object.keys(preference.saved_view_order).length > 0) {
+        organizationPreferences.push(preference);
+    }
+
+    const updatedUser = {
+        ...currentUser,
+        organization_preferences: organizationPreferences
+    };
+    queryClient.setQueryData(queryKeys.me(), updatedUser);
+    queryClient.setQueryData(queryKeys.id(currentUser.id), updatedUser);
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.svelte.ts
@@ -1,5 +1,4 @@
 import type { WebSocketMessageValue } from '$features/websockets/models';
-import type { UserOrganizationPreference } from '$generated/api';
 import type { WorkInProgressResult } from '$shared/models';
 
 import { setUserIdentity } from '$features/auth/exceptionless-session';
@@ -278,9 +277,17 @@ export function setCurrentUserSavedViewDefault(queryClient: QueryClient, organiz
         return;
     }
 
-    const preference = mergeOrganizationPreferences(currentUser.organization_preferences, organizationId);
-    preference.default_saved_view_id = savedViewId;
-    setCurrentUserOrganizationPreference(queryClient, currentUser, preference);
+    const organizationPreferences = currentUser.organization_preferences.filter((preference) => preference.organization_id !== organizationId);
+    if (savedViewId) {
+        organizationPreferences.push({
+            default_saved_view_id: savedViewId,
+            organization_id: organizationId
+        });
+    }
+
+    setCurrentUser(queryClient, currentUser, {
+        organization_preferences: organizationPreferences
+    });
 }
 
 export function setCurrentUserSavedViewOrder(queryClient: QueryClient, organizationId: string, viewType: string, savedViewIds: string[]): void {
@@ -289,14 +296,20 @@ export function setCurrentUserSavedViewOrder(queryClient: QueryClient, organizat
         return;
     }
 
-    const preference = mergeOrganizationPreferences(currentUser.organization_preferences, organizationId);
+    const savedViewOrders = (currentUser.saved_view_orders ?? []).filter(
+        (preference) => preference.organization_id !== organizationId || preference.view_type !== viewType
+    );
     if (savedViewIds.length > 0) {
-        preference.saved_view_order[viewType] = [...savedViewIds];
-    } else {
-        delete preference.saved_view_order[viewType];
+        savedViewOrders.push({
+            organization_id: organizationId,
+            saved_view_ids: [...savedViewIds],
+            view_type: viewType
+        });
     }
 
-    setCurrentUserOrganizationPreference(queryClient, currentUser, preference);
+    setCurrentUser(queryClient, currentUser, {
+        saved_view_orders: savedViewOrders
+    });
 }
 
 export function uploadUserAvatar(request: UserAvatarRequest) {
@@ -323,44 +336,10 @@ export function uploadUserAvatar(request: UserAvatarRequest) {
     }));
 }
 
-function mergeOrganizationPreferences(organizationPreferences: UserOrganizationPreference[], organizationId: string): UserOrganizationPreference {
-    const matches = organizationPreferences.filter((preference) => preference.organization_id === organizationId);
-    const defaultSavedViewId = matches
-        .map((preference) => preference.default_saved_view_id)
-        .filter((savedViewId): savedViewId is string => !!savedViewId)
-        .sort()[0];
-    const savedViewOrder: Record<string, string[]> = {};
-
-    for (const preference of matches) {
-        for (const [viewType, savedViewIds] of Object.entries(preference.saved_view_order ?? {})) {
-            const mergedIds = savedViewOrder[viewType] ?? [];
-            for (const savedViewId of savedViewIds) {
-                if (!mergedIds.includes(savedViewId)) {
-                    mergedIds.push(savedViewId);
-                }
-            }
-            savedViewOrder[viewType] = mergedIds;
-        }
-    }
-
-    return {
-        default_saved_view_id: defaultSavedViewId,
-        organization_id: organizationId,
-        saved_view_order: savedViewOrder
-    };
-}
-
-function setCurrentUserOrganizationPreference(queryClient: QueryClient, currentUser: ViewCurrentUser, preference: UserOrganizationPreference): void {
-    const organizationPreferences = currentUser.organization_preferences.filter(
-        (existingPreference) => existingPreference.organization_id !== preference.organization_id
-    );
-    if (preference.default_saved_view_id || Object.keys(preference.saved_view_order).length > 0) {
-        organizationPreferences.push(preference);
-    }
-
+function setCurrentUser(queryClient: QueryClient, currentUser: ViewCurrentUser, changes: Partial<ViewCurrentUser>): void {
     const updatedUser = {
         ...currentUser,
-        organization_preferences: organizationPreferences
+        ...changes
     };
     queryClient.setQueryData(queryKeys.me(), updatedUser);
     queryClient.setQueryData(queryKeys.id(currentUser.id), updatedUser);

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.test.ts
@@ -22,7 +22,7 @@ describe('setCurrentUserSavedViewDefault', () => {
 
         expect(queryClient.getQueryData<ViewCurrentUser>(queryKeys.me())?.organization_preferences).toEqual([
             { default_saved_view_id: 'other-view-id', organization_id: 'other-organization-id' },
-            { default_saved_view_id: 'new-view-id', organization_id: 'organization-id', saved_view_order: {} }
+            { default_saved_view_id: 'new-view-id', organization_id: 'organization-id' }
         ]);
     });
 
@@ -39,15 +39,21 @@ describe('setCurrentUserSavedViewDefault', () => {
         expect(queryClient.getQueryData<ViewCurrentUser>(queryKeys.me())?.organization_preferences).toEqual([]);
     });
 
-    it('preserves saved view ordering when the default changes or clears', () => {
+    it('preserves separate saved view ordering when the default changes or clears', () => {
         const queryClient = new QueryClient();
         const currentUser = {
             id: 'user-id',
             organization_preferences: [
                 {
                     default_saved_view_id: 'old-view-id',
+                    organization_id: 'organization-id'
+                }
+            ],
+            saved_view_orders: [
+                {
                     organization_id: 'organization-id',
-                    saved_view_order: { events: ['private-view-id', 'shared-view-id'] }
+                    saved_view_ids: ['private-view-id', 'shared-view-id'],
+                    view_type: 'events'
                 }
             ]
         } as unknown as ViewCurrentUser;
@@ -55,39 +61,13 @@ describe('setCurrentUserSavedViewDefault', () => {
 
         setCurrentUserSavedViewDefault(queryClient, 'organization-id', null);
 
-        expect(queryClient.getQueryData<ViewCurrentUser>(queryKeys.me())?.organization_preferences).toEqual([
+        const updatedUser = queryClient.getQueryData<ViewCurrentUser>(queryKeys.me());
+        expect(updatedUser?.organization_preferences).toEqual([]);
+        expect(updatedUser?.saved_view_orders).toEqual([
             {
-                default_saved_view_id: null,
                 organization_id: 'organization-id',
-                saved_view_order: { events: ['private-view-id', 'shared-view-id'] }
-            }
-        ]);
-    });
-
-    it('merges saved view identifiers from duplicate organization preferences', () => {
-        const queryClient = new QueryClient();
-        const currentUser = {
-            id: 'user-id',
-            organization_preferences: [
-                {
-                    organization_id: 'organization-id',
-                    saved_view_order: { events: ['first-view-id', 'shared-view-id'] }
-                },
-                {
-                    organization_id: 'organization-id',
-                    saved_view_order: { events: ['shared-view-id', 'second-view-id'] }
-                }
-            ]
-        } as unknown as ViewCurrentUser;
-        queryClient.setQueryData(queryKeys.me(), currentUser);
-
-        setCurrentUserSavedViewDefault(queryClient, 'organization-id', 'home-view-id');
-
-        expect(queryClient.getQueryData<ViewCurrentUser>(queryKeys.me())?.organization_preferences).toEqual([
-            {
-                default_saved_view_id: 'home-view-id',
-                organization_id: 'organization-id',
-                saved_view_order: { events: ['first-view-id', 'shared-view-id', 'second-view-id'] }
+                saved_view_ids: ['private-view-id', 'shared-view-id'],
+                view_type: 'events'
             }
         ]);
     });
@@ -101,9 +81,12 @@ describe('setCurrentUserSavedViewOrder', () => {
             organization_preferences: [
                 {
                     default_saved_view_id: 'home-view-id',
-                    organization_id: 'organization-id',
-                    saved_view_order: { stacks: ['stack-view-id'] }
+                    organization_id: 'organization-id'
                 }
+            ],
+            saved_view_orders: [
+                { organization_id: 'organization-id', saved_view_ids: ['stack-view-id'], view_type: 'stacks' },
+                { organization_id: 'other-organization-id', saved_view_ids: ['other-view-id'], view_type: 'events' }
             ]
         } as unknown as ViewCurrentUser;
         queryClient.setQueryData(queryKeys.me(), currentUser);
@@ -113,11 +96,16 @@ describe('setCurrentUserSavedViewOrder', () => {
         expect(queryClient.getQueryData<ViewCurrentUser>(queryKeys.me())?.organization_preferences).toEqual([
             {
                 default_saved_view_id: 'home-view-id',
+                organization_id: 'organization-id'
+            }
+        ]);
+        expect(queryClient.getQueryData<ViewCurrentUser>(queryKeys.me())?.saved_view_orders).toEqual([
+            { organization_id: 'organization-id', saved_view_ids: ['stack-view-id'], view_type: 'stacks' },
+            { organization_id: 'other-organization-id', saved_view_ids: ['other-view-id'], view_type: 'events' },
+            {
                 organization_id: 'organization-id',
-                saved_view_order: {
-                    events: ['private-view-id', 'shared-view-id'],
-                    stacks: ['stack-view-id']
-                }
+                saved_view_ids: ['private-view-id', 'shared-view-id'],
+                view_type: 'events'
             }
         ]);
     });

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.test.ts
@@ -63,6 +63,34 @@ describe('setCurrentUserSavedViewDefault', () => {
             }
         ]);
     });
+
+    it('merges saved view identifiers from duplicate organization preferences', () => {
+        const queryClient = new QueryClient();
+        const currentUser = {
+            id: 'user-id',
+            organization_preferences: [
+                {
+                    organization_id: 'organization-id',
+                    saved_view_order: { events: ['first-view-id', 'shared-view-id'] }
+                },
+                {
+                    organization_id: 'organization-id',
+                    saved_view_order: { events: ['shared-view-id', 'second-view-id'] }
+                }
+            ]
+        } as unknown as ViewCurrentUser;
+        queryClient.setQueryData(queryKeys.me(), currentUser);
+
+        setCurrentUserSavedViewDefault(queryClient, 'organization-id', 'home-view-id');
+
+        expect(queryClient.getQueryData<ViewCurrentUser>(queryKeys.me())?.organization_preferences).toEqual([
+            {
+                default_saved_view_id: 'home-view-id',
+                organization_id: 'organization-id',
+                saved_view_order: { events: ['first-view-id', 'shared-view-id', 'second-view-id'] }
+            }
+        ]);
+    });
 });
 
 describe('setCurrentUserSavedViewOrder', () => {

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.test.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/api.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { ViewCurrentUser } from './models';
 
-import { queryKeys, setCurrentUserSavedViewDefault } from './api.svelte';
+import { queryKeys, setCurrentUserSavedViewDefault, setCurrentUserSavedViewOrder } from './api.svelte';
 
 describe('setCurrentUserSavedViewDefault', () => {
     it('replaces duplicate organization preferences in the current-user cache', () => {
@@ -15,14 +15,14 @@ describe('setCurrentUserSavedViewDefault', () => {
                 { default_saved_view_id: 'duplicate-view-id', organization_id: 'organization-id' },
                 { default_saved_view_id: 'other-view-id', organization_id: 'other-organization-id' }
             ]
-        } as ViewCurrentUser;
+        } as unknown as ViewCurrentUser;
         queryClient.setQueryData(queryKeys.me(), currentUser);
 
         setCurrentUserSavedViewDefault(queryClient, 'organization-id', 'new-view-id');
 
         expect(queryClient.getQueryData<ViewCurrentUser>(queryKeys.me())?.organization_preferences).toEqual([
             { default_saved_view_id: 'other-view-id', organization_id: 'other-organization-id' },
-            { default_saved_view_id: 'new-view-id', organization_id: 'organization-id' }
+            { default_saved_view_id: 'new-view-id', organization_id: 'organization-id', saved_view_order: {} }
         ]);
     });
 
@@ -31,11 +31,66 @@ describe('setCurrentUserSavedViewDefault', () => {
         const currentUser = {
             id: 'user-id',
             organization_preferences: [{ default_saved_view_id: 'old-view-id', organization_id: 'organization-id' }]
-        } as ViewCurrentUser;
+        } as unknown as ViewCurrentUser;
         queryClient.setQueryData(queryKeys.me(), currentUser);
 
         setCurrentUserSavedViewDefault(queryClient, 'organization-id', null);
 
         expect(queryClient.getQueryData<ViewCurrentUser>(queryKeys.me())?.organization_preferences).toEqual([]);
+    });
+
+    it('preserves saved view ordering when the default changes or clears', () => {
+        const queryClient = new QueryClient();
+        const currentUser = {
+            id: 'user-id',
+            organization_preferences: [
+                {
+                    default_saved_view_id: 'old-view-id',
+                    organization_id: 'organization-id',
+                    saved_view_order: { events: ['private-view-id', 'shared-view-id'] }
+                }
+            ]
+        } as unknown as ViewCurrentUser;
+        queryClient.setQueryData(queryKeys.me(), currentUser);
+
+        setCurrentUserSavedViewDefault(queryClient, 'organization-id', null);
+
+        expect(queryClient.getQueryData<ViewCurrentUser>(queryKeys.me())?.organization_preferences).toEqual([
+            {
+                default_saved_view_id: null,
+                organization_id: 'organization-id',
+                saved_view_order: { events: ['private-view-id', 'shared-view-id'] }
+            }
+        ]);
+    });
+});
+
+describe('setCurrentUserSavedViewOrder', () => {
+    it('updates one section while preserving the personal default and other sections', () => {
+        const queryClient = new QueryClient();
+        const currentUser = {
+            id: 'user-id',
+            organization_preferences: [
+                {
+                    default_saved_view_id: 'home-view-id',
+                    organization_id: 'organization-id',
+                    saved_view_order: { stacks: ['stack-view-id'] }
+                }
+            ]
+        } as unknown as ViewCurrentUser;
+        queryClient.setQueryData(queryKeys.me(), currentUser);
+
+        setCurrentUserSavedViewOrder(queryClient, 'organization-id', 'events', ['private-view-id', 'shared-view-id']);
+
+        expect(queryClient.getQueryData<ViewCurrentUser>(queryKeys.me())?.organization_preferences).toEqual([
+            {
+                default_saved_view_id: 'home-view-id',
+                organization_id: 'organization-id',
+                saved_view_order: {
+                    events: ['private-view-id', 'shared-view-id'],
+                    stacks: ['stack-view-id']
+                }
+            }
+        ]);
     });
 });

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
@@ -673,6 +673,10 @@ export interface UpdateSavedViewDefault {
   saved_view_id?: null | string;
 }
 
+export interface UpdateSavedViewOrder {
+  saved_view_ids: string[];
+}
+
 /** A class the tracks changes (i.e. the Delta) for a particular TEntityType. */
 export interface UpdateToken {
   is_disabled: boolean;
@@ -763,7 +767,8 @@ export interface UserOrganizationPreference {
   /** @pattern ^[a-fA-F0-9]{24}$ */
   organization_id: string;
   /** @pattern ^[a-fA-F0-9]{24}$ */
-  default_saved_view_id: string;
+  default_saved_view_id?: null | string;
+  saved_view_order: Record<string, string[]>;
 }
 
 export interface ViewCurrentUser {

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/api.ts
@@ -736,6 +736,7 @@ export interface User {
   password_reset_token_expiration: string;
   o_auth_accounts: OAuthAccount[];
   organization_preferences: UserOrganizationPreference[];
+  saved_view_orders: UserSavedViewOrderPreference[];
   /** Gets or sets the users Full Name. */
   full_name: string;
   /** @format email */
@@ -767,8 +768,14 @@ export interface UserOrganizationPreference {
   /** @pattern ^[a-fA-F0-9]{24}$ */
   organization_id: string;
   /** @pattern ^[a-fA-F0-9]{24}$ */
-  default_saved_view_id?: null | string;
-  saved_view_order: Record<string, string[]>;
+  default_saved_view_id: string;
+}
+
+export interface UserSavedViewOrderPreference {
+  /** @pattern ^[a-fA-F0-9]{24}$ */
+  organization_id: string;
+  view_type: string;
+  saved_view_ids: string[];
 }
 
 export interface ViewCurrentUser {
@@ -776,6 +783,7 @@ export interface ViewCurrentUser {
   has_local_account: boolean;
   o_auth_accounts: OAuthAccount[];
   organization_preferences: UserOrganizationPreference[];
+  saved_view_orders: UserSavedViewOrderPreference[];
   /** @pattern ^[a-fA-F0-9]{24}$ */
   id: string;
   organization_ids: string[];

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
@@ -861,6 +861,7 @@ export const UserSchema = object({
   password_reset_token_expiration: iso.datetime(),
   o_auth_accounts: array(lazy(() => OAuthAccountSchema)),
   organization_preferences: array(lazy(() => UserOrganizationPreferenceSchema)),
+  saved_view_orders: array(lazy(() => UserSavedViewOrderPreferenceSchema)),
   full_name: string().min(1, "Full name is required"),
   email_address: email(),
   avatar_file_name: string()
@@ -895,13 +896,21 @@ export const UserOrganizationPreferenceSchema = object({
     .regex(/^[a-fA-F0-9]{24}$/, "Organization id has invalid format"),
   default_saved_view_id: string()
     .length(24, "Default saved view id must be exactly 24 characters")
-    .regex(/^[a-fA-F0-9]{24}$/, "Default saved view id has invalid format")
-    .nullable()
-    .optional(),
-  saved_view_order: record(string(), array(string())),
+    .regex(/^[a-fA-F0-9]{24}$/, "Default saved view id has invalid format"),
 });
 export type UserOrganizationPreferenceFormData = Infer<
   typeof UserOrganizationPreferenceSchema
+>;
+
+export const UserSavedViewOrderPreferenceSchema = object({
+  organization_id: string()
+    .length(24, "Organization id must be exactly 24 characters")
+    .regex(/^[a-fA-F0-9]{24}$/, "Organization id has invalid format"),
+  view_type: string().min(1, "View type is required"),
+  saved_view_ids: array(string()),
+});
+export type UserSavedViewOrderPreferenceFormData = Infer<
+  typeof UserSavedViewOrderPreferenceSchema
 >;
 
 export const ViewCurrentUserSchema = object({
@@ -909,6 +918,7 @@ export const ViewCurrentUserSchema = object({
   has_local_account: boolean(),
   o_auth_accounts: array(lazy(() => OAuthAccountSchema)),
   organization_preferences: array(lazy(() => UserOrganizationPreferenceSchema)),
+  saved_view_orders: array(lazy(() => UserSavedViewOrderPreferenceSchema)),
   id: string()
     .length(24, "Id must be exactly 24 characters")
     .regex(/^[a-fA-F0-9]{24}$/, "Id has invalid format"),

--- a/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/generated/schemas.ts
@@ -807,6 +807,13 @@ export type UpdateSavedViewDefaultFormData = Infer<
   typeof UpdateSavedViewDefaultSchema
 >;
 
+export const UpdateSavedViewOrderSchema = object({
+  saved_view_ids: array(string()),
+});
+export type UpdateSavedViewOrderFormData = Infer<
+  typeof UpdateSavedViewOrderSchema
+>;
+
 export const UpdateTokenSchema = object({
   is_disabled: boolean().optional(),
   notes: string().min(1, "Notes is required").nullable().optional(),
@@ -888,7 +895,10 @@ export const UserOrganizationPreferenceSchema = object({
     .regex(/^[a-fA-F0-9]{24}$/, "Organization id has invalid format"),
   default_saved_view_id: string()
     .length(24, "Default saved view id must be exactly 24 characters")
-    .regex(/^[a-fA-F0-9]{24}$/, "Default saved view id has invalid format"),
+    .regex(/^[a-fA-F0-9]{24}$/, "Default saved view id has invalid format")
+    .nullable()
+    .optional(),
+  saved_view_order: record(string(), array(string())),
 });
 export type UserOrganizationPreferenceFormData = Infer<
   typeof UserOrganizationPreferenceSchema

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar.svelte
@@ -11,7 +11,6 @@
     import SavedViewOrderDialog from '$features/saved-views/components/saved-view-order-dialog.svelte';
     import ArrowUpDown from '@lucide/svelte/icons/arrow-up-down';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
-    import GripVertical from '@lucide/svelte/icons/grip-vertical';
     import Settings from '@lucide/svelte/icons/settings-2';
     import Wrench from '@lucide/svelte/icons/wrench';
     import { onDestroy } from 'svelte';
@@ -456,21 +455,13 @@
                                         <Sidebar.MenuSub>
                                             {#each getOrderedRouteChildren(route) as savedItem (savedItem.href)}
                                                 <Sidebar.MenuSubItem
-                                                    class={[
-                                                        savedItem.savedView &&
-                                                            'group/saved-view [&_[data-sidebar=menu-sub-button]]:cursor-grab [&_[data-sidebar=menu-sub-button]]:active:cursor-grabbing',
-                                                        draggedSavedView?.savedViewId === savedItem.savedView?.id && 'opacity-50'
-                                                    ]}
+                                                    class={draggedSavedView?.savedViewId === savedItem.savedView?.id ? 'opacity-50' : undefined}
                                                     data-saved-view-id={savedItem.savedView?.id}
-                                                    draggable={!!savedItem.savedView && savingSavedViewOrderType !== route.view}
-                                                    ondragstart={(event) =>
-                                                        savedItem.savedView && handleSavedViewDragStart(event, route, savedItem.savedView.id)}
                                                     ondragover={(event) => savedItem.savedView && handleSavedViewDragOver(event, route, savedItem.savedView.id)}
                                                     ondrop={(event) => {
                                                         event.preventDefault();
                                                         void persistDraggedSavedViewOrder(route);
                                                     }}
-                                                    ondragend={() => handleSavedViewDragEnd(route)}
                                                 >
                                                     <Sidebar.MenuSubButton isActive={isChildItemActive(savedItem, route.href)}>
                                                         {#snippet child({ props: subProps })}
@@ -479,12 +470,12 @@
                                                                 href={savedItem.href}
                                                                 title={savedItem.title}
                                                                 onclick={onMenuClick}
-                                                                draggable={savedItem.savedView ? false : undefined}
+                                                                draggable={!!savedItem.savedView && savingSavedViewOrderType !== route.view}
+                                                                ondragstart={(event) =>
+                                                                    savedItem.savedView && handleSavedViewDragStart(event, route, savedItem.savedView.id)}
+                                                                ondragend={() => handleSavedViewDragEnd(route)}
                                                                 {...subProps}
                                                             >
-                                                                {#if savedItem.savedView}
-                                                                    <GripVertical class="text-muted-foreground/60" aria-hidden="true" />
-                                                                {/if}
                                                                 <span class="truncate">{savedItem.title}</span>
                                                             </A>
                                                         {/snippet}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar.svelte
@@ -166,10 +166,6 @@
             savedViewId,
             viewType: route.view
         };
-        pendingSavedViewOrders = {
-            ...pendingSavedViewOrders,
-            [route.view]: getSavedViewIds(route)
-        };
 
         if (event.dataTransfer) {
             event.dataTransfer.effectAllowed = 'move';
@@ -186,38 +182,37 @@
         if (event.dataTransfer) {
             event.dataTransfer.dropEffect = 'move';
         }
+    }
 
-        const savedViewIds = [...(pendingSavedViewOrders[route.view] ?? getSavedViewIds(route))];
-        const currentIndex = savedViewIds.indexOf(draggedSavedView.savedViewId);
+    function getDroppedSavedViewIds(route: NavigationItem, draggedSavedViewId: string, targetSavedViewId: string): string[] {
+        const savedViewIds = getSavedViewIds(route);
+        const currentIndex = savedViewIds.indexOf(draggedSavedViewId);
         const targetIndex = savedViewIds.indexOf(targetSavedViewId);
         if (currentIndex < 0 || targetIndex < 0) {
-            return;
+            return savedViewIds;
         }
 
         const [movedSavedViewId] = savedViewIds.splice(currentIndex, 1);
         if (!movedSavedViewId) {
-            return;
+            return savedViewIds;
         }
 
         savedViewIds.splice(targetIndex, 0, movedSavedViewId);
-        pendingSavedViewOrders = {
-            ...pendingSavedViewOrders,
-            [route.view]: savedViewIds
-        };
+        return savedViewIds;
     }
 
     function clearPendingSavedViewOrder(viewType: string): void {
         pendingSavedViewOrders = Object.fromEntries(Object.entries(pendingSavedViewOrders).filter(([key]) => key !== viewType));
     }
 
-    async function persistDraggedSavedViewOrder(route: NavigationItem): Promise<void> {
+    async function persistDraggedSavedViewOrder(route: NavigationItem, targetSavedViewId: string): Promise<void> {
         if (!route.view || draggedSavedView?.viewType !== route.view) {
             return;
         }
 
         const viewType = route.view;
         const currentSavedViewIds = getSavedViewIds(route);
-        const savedViewIds = pendingSavedViewOrders[viewType] ?? currentSavedViewIds;
+        const savedViewIds = getDroppedSavedViewIds(route, draggedSavedView.savedViewId, targetSavedViewId);
         const orderChanged = savedViewIds.some((savedViewId, index) => savedViewId !== currentSavedViewIds[index]);
         draggedSavedView = undefined;
         if (!orderChanged) {
@@ -225,6 +220,10 @@
             return;
         }
 
+        pendingSavedViewOrders = {
+            ...pendingSavedViewOrders,
+            [viewType]: savedViewIds
+        };
         savingSavedViewOrderType = viewType;
         try {
             await onSavedViewOrderChange(viewType, savedViewIds);
@@ -460,7 +459,9 @@
                                                     ondragover={(event) => savedItem.savedView && handleSavedViewDragOver(event, route, savedItem.savedView.id)}
                                                     ondrop={(event) => {
                                                         event.preventDefault();
-                                                        void persistDraggedSavedViewOrder(route);
+                                                        if (savedItem.savedView) {
+                                                            void persistDraggedSavedViewOrder(route, savedItem.savedView.id);
+                                                        }
                                                     }}
                                                 >
                                                     <Sidebar.MenuSubButton isActive={isChildItemActive(savedItem, route.href)}>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar.svelte
@@ -8,6 +8,8 @@
     import * as DropdownMenu from '$comp/ui/dropdown-menu';
     import * as Sidebar from '$comp/ui/sidebar';
     import { useSidebar } from '$comp/ui/sidebar';
+    import SavedViewOrderDialog from '$features/saved-views/components/saved-view-order-dialog.svelte';
+    import ArrowUpDown from '@lucide/svelte/icons/arrow-up-down';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
     import Settings from '@lucide/svelte/icons/settings-2';
     import Wrench from '@lucide/svelte/icons/wrench';
@@ -66,10 +68,11 @@
     type Props = ComponentProps<typeof Sidebar.Root> & {
         footer?: Snippet;
         header?: Snippet;
+        onSavedViewOrderChange: (viewType: string, savedViewIds: string[]) => Promise<void>;
         routes: NavigationItem[];
     };
 
-    let { footer, header, routes, ...props }: Props = $props();
+    let { footer, header, onSavedViewOrderChange, routes, ...props }: Props = $props();
     const dashboardRoutes = $derived(routes.filter((route) => route.group === 'Dashboards'));
 
     const settingsRoutes = $derived(routes.filter((route) => route.group === 'Settings'));
@@ -100,6 +103,32 @@
     let hoverMenuCloseTimeout = $state<ReturnType<typeof setTimeout> | undefined>(undefined);
     let expandedRouteHrefs = $state<Record<string, boolean>>({});
     let settingsExpanded = $state<boolean | undefined>(undefined);
+    let savedViewOrderRoute = $state<NavigationItem>();
+    let savedViewOrderDialogOpen = $state(false);
+
+    const savedViewsForOrderDialog = $derived(
+        (savedViewOrderRoute?.children ?? [])
+            .filter((child) => !!child.savedView)
+            .map((child) => ({
+                id: child.savedView!.id,
+                name: child.title,
+                user_id: child.savedView!.isPrivate ? 'current-user' : undefined
+            }))
+    );
+
+    function openSavedViewOrderDialog(event: MouseEvent, route: NavigationItem): void {
+        event.stopPropagation();
+        savedViewOrderRoute = route;
+        savedViewOrderDialogOpen = true;
+    }
+
+    async function saveSavedViewOrder(savedViewIds: string[]): Promise<void> {
+        if (!savedViewOrderRoute?.view) {
+            return;
+        }
+
+        await onSavedViewOrderChange(savedViewOrderRoute.view, savedViewIds);
+    }
 
     function onMenuClick() {
         if (sidebar.isMobile) {
@@ -296,6 +325,16 @@
                                             </Sidebar.MenuButton>
                                         {/snippet}
                                     </Collapsible.Trigger>
+                                    {#if route.view && (route.children ?? []).some((child) => !!child.savedView)}
+                                        <Sidebar.MenuAction
+                                            showOnHover
+                                            aria-label={`Reorder ${route.title} views`}
+                                            title={`Reorder ${route.title} views`}
+                                            onclick={(event) => openSavedViewOrderDialog(event, route)}
+                                        >
+                                            <ArrowUpDown />
+                                        </Sidebar.MenuAction>
+                                    {/if}
                                     <Collapsible.Content>
                                         <Sidebar.MenuSub>
                                             {#each route.children as savedItem (savedItem.href)}
@@ -420,3 +459,12 @@
         {/if}
     </Sidebar.Footer>
 </Sidebar.Root>
+
+{#if savedViewOrderRoute}
+    <SavedViewOrderDialog
+        bind:open={savedViewOrderDialogOpen}
+        onSave={saveSavedViewOrder}
+        savedViews={savedViewsForOrderDialog}
+        title={savedViewOrderRoute.title}
+    />
+{/if}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar.svelte
@@ -11,11 +11,13 @@
     import SavedViewOrderDialog from '$features/saved-views/components/saved-view-order-dialog.svelte';
     import ArrowUpDown from '@lucide/svelte/icons/arrow-up-down';
     import ChevronRight from '@lucide/svelte/icons/chevron-right';
+    import GripVertical from '@lucide/svelte/icons/grip-vertical';
     import Settings from '@lucide/svelte/icons/settings-2';
     import Wrench from '@lucide/svelte/icons/wrench';
     import { onDestroy } from 'svelte';
+    import { toast } from 'svelte-sonner';
 
-    import type { NavigationItem } from '../../../routes.svelte';
+    import type { NavigationChild, NavigationItem } from '../../../routes.svelte';
 
     function isSavedItemActive(savedItem: { href: string }, routeHref: string): boolean {
         const savedId = new URL(savedItem.href, page.url.origin).searchParams.get('saved');
@@ -105,6 +107,9 @@
     let settingsExpanded = $state<boolean | undefined>(undefined);
     let savedViewOrderRoute = $state<NavigationItem>();
     let savedViewOrderDialogOpen = $state(false);
+    let draggedSavedView = $state<{ savedViewId: string; viewType: string }>();
+    let pendingSavedViewOrders = $state<Record<string, string[]>>({});
+    let savingSavedViewOrderType = $state<string>();
 
     const savedViewsForOrderDialog = $derived(
         (savedViewOrderRoute?.children ?? [])
@@ -128,6 +133,118 @@
         }
 
         await onSavedViewOrderChange(savedViewOrderRoute.view, savedViewIds);
+    }
+
+    function getSavedViewIds(route: NavigationItem): string[] {
+        return (route.children ?? []).flatMap((child) => (child.savedView ? [child.savedView.id] : []));
+    }
+
+    function getOrderedRouteChildren(route: NavigationItem): NavigationChild[] {
+        if (!route.view) {
+            return route.children ?? [];
+        }
+
+        const pendingOrder = pendingSavedViewOrders[route.view];
+        if (!pendingOrder) {
+            return route.children ?? [];
+        }
+
+        const savedViewsById = new Map((route.children ?? []).flatMap((child) => (child.savedView ? [[child.savedView.id, child] as const] : [])));
+        const orderedSavedViews = pendingOrder.map((savedViewId) => savedViewsById.get(savedViewId)).filter((child): child is NavigationChild => !!child);
+        const unorderedSavedViews = (route.children ?? []).filter((child) => child.savedView && !pendingOrder.includes(child.savedView.id));
+        const builtInChildren = (route.children ?? []).filter((child) => !child.savedView);
+
+        return [...orderedSavedViews, ...unorderedSavedViews, ...builtInChildren];
+    }
+
+    function handleSavedViewDragStart(event: DragEvent, route: NavigationItem, savedViewId: string): void {
+        if (!route.view || savingSavedViewOrderType === route.view) {
+            event.preventDefault();
+            return;
+        }
+
+        draggedSavedView = {
+            savedViewId,
+            viewType: route.view
+        };
+        pendingSavedViewOrders = {
+            ...pendingSavedViewOrders,
+            [route.view]: getSavedViewIds(route)
+        };
+
+        if (event.dataTransfer) {
+            event.dataTransfer.effectAllowed = 'move';
+            event.dataTransfer.setData('text/plain', savedViewId);
+        }
+    }
+
+    function handleSavedViewDragOver(event: DragEvent, route: NavigationItem, targetSavedViewId: string): void {
+        if (!route.view || draggedSavedView?.viewType !== route.view || draggedSavedView.savedViewId === targetSavedViewId) {
+            return;
+        }
+
+        event.preventDefault();
+        if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = 'move';
+        }
+
+        const savedViewIds = [...(pendingSavedViewOrders[route.view] ?? getSavedViewIds(route))];
+        const currentIndex = savedViewIds.indexOf(draggedSavedView.savedViewId);
+        const targetIndex = savedViewIds.indexOf(targetSavedViewId);
+        if (currentIndex < 0 || targetIndex < 0) {
+            return;
+        }
+
+        const [movedSavedViewId] = savedViewIds.splice(currentIndex, 1);
+        if (!movedSavedViewId) {
+            return;
+        }
+
+        savedViewIds.splice(targetIndex, 0, movedSavedViewId);
+        pendingSavedViewOrders = {
+            ...pendingSavedViewOrders,
+            [route.view]: savedViewIds
+        };
+    }
+
+    function clearPendingSavedViewOrder(viewType: string): void {
+        pendingSavedViewOrders = Object.fromEntries(Object.entries(pendingSavedViewOrders).filter(([key]) => key !== viewType));
+    }
+
+    async function persistDraggedSavedViewOrder(route: NavigationItem): Promise<void> {
+        if (!route.view || draggedSavedView?.viewType !== route.view) {
+            return;
+        }
+
+        const viewType = route.view;
+        const currentSavedViewIds = getSavedViewIds(route);
+        const savedViewIds = pendingSavedViewOrders[viewType] ?? currentSavedViewIds;
+        const orderChanged = savedViewIds.some((savedViewId, index) => savedViewId !== currentSavedViewIds[index]);
+        draggedSavedView = undefined;
+        if (!orderChanged) {
+            clearPendingSavedViewOrder(viewType);
+            return;
+        }
+
+        savingSavedViewOrderType = viewType;
+        try {
+            await onSavedViewOrderChange(viewType, savedViewIds);
+            toast.success(`${route.title} view order saved.`);
+        } catch {
+            toast.error(`Failed to update your ${route.title.toLowerCase()} view order. Please try again.`);
+        } finally {
+            clearPendingSavedViewOrder(viewType);
+            savingSavedViewOrderType = undefined;
+        }
+    }
+
+    function handleSavedViewDragEnd(route: NavigationItem): void {
+        if (!route.view || draggedSavedView?.viewType !== route.view) {
+            return;
+        }
+
+        draggedSavedView = undefined;
+        clearPendingSavedViewOrder(route.view);
     }
 
     function onMenuClick() {
@@ -337,8 +454,24 @@
                                     {/if}
                                     <Collapsible.Content>
                                         <Sidebar.MenuSub>
-                                            {#each route.children as savedItem (savedItem.href)}
-                                                <Sidebar.MenuSubItem>
+                                            {#each getOrderedRouteChildren(route) as savedItem (savedItem.href)}
+                                                <Sidebar.MenuSubItem
+                                                    class={[
+                                                        savedItem.savedView &&
+                                                            'group/saved-view [&_[data-sidebar=menu-sub-button]]:cursor-grab [&_[data-sidebar=menu-sub-button]]:active:cursor-grabbing',
+                                                        draggedSavedView?.savedViewId === savedItem.savedView?.id && 'opacity-50'
+                                                    ]}
+                                                    data-saved-view-id={savedItem.savedView?.id}
+                                                    draggable={!!savedItem.savedView && savingSavedViewOrderType !== route.view}
+                                                    ondragstart={(event) =>
+                                                        savedItem.savedView && handleSavedViewDragStart(event, route, savedItem.savedView.id)}
+                                                    ondragover={(event) => savedItem.savedView && handleSavedViewDragOver(event, route, savedItem.savedView.id)}
+                                                    ondrop={(event) => {
+                                                        event.preventDefault();
+                                                        void persistDraggedSavedViewOrder(route);
+                                                    }}
+                                                    ondragend={() => handleSavedViewDragEnd(route)}
+                                                >
                                                     <Sidebar.MenuSubButton isActive={isChildItemActive(savedItem, route.href)}>
                                                         {#snippet child({ props: subProps })}
                                                             <A
@@ -346,8 +479,12 @@
                                                                 href={savedItem.href}
                                                                 title={savedItem.title}
                                                                 onclick={onMenuClick}
+                                                                draggable={savedItem.savedView ? false : undefined}
                                                                 {...subProps}
                                                             >
+                                                                {#if savedItem.savedView}
+                                                                    <GripVertical class="text-muted-foreground/60" aria-hidden="true" />
+                                                                {/if}
                                                                 <span class="truncate">{savedItem.title}</span>
                                                             </A>
                                                         {/snippet}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
@@ -629,7 +629,7 @@
                 return route;
             }
 
-            const orderedIds = getPersonalSavedViewOrder(meQuery.data?.organization_preferences, organization.current, viewKey);
+            const orderedIds = getPersonalSavedViewOrder(meQuery.data?.saved_view_orders, organization.current, viewKey);
             const orderedViews = resolvePersonalSavedViewOrder(viewSavedViews, orderedIds);
 
             const children = [

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/+layout.svelte
@@ -37,7 +37,8 @@
     import { premiumPage } from '$features/organizations/premium-page.svelte';
     import { getUtcMonthKey, ORGANIZATION_USAGE_ROLLOVER_CHECK_INTERVAL_MS } from '$features/organizations/utils';
     import { invalidateProjectQueries } from '$features/projects/api.svelte';
-    import { getSavedViewsQuery, invalidateSavedViewQueries, isSavedViewDeleted } from '$features/saved-views/api.svelte';
+    import { getSavedViewsQuery, invalidateSavedViewQueries, isSavedViewDeleted, putUserSavedViewOrder } from '$features/saved-views/api.svelte';
+    import { getPersonalSavedViewOrder, resolvePersonalSavedViewOrder } from '$features/saved-views/ordering';
     import { savedViewHref } from '$features/saved-views/slugs';
     import { appKeyboardShortcuts, isKeyboardShortcut } from '$features/shared/keyboard-shortcuts';
     import { createProjectStackNotificationRefresher, invalidateStackQueries, type ProjectStackNotificationRefresher } from '$features/stacks/api.svelte';
@@ -560,6 +561,20 @@
             }
         }
     });
+    const savedViewOrderMutation = putUserSavedViewOrder({
+        route: {
+            get organizationId() {
+                return organization.current;
+            }
+        }
+    });
+
+    async function saveSavedViewOrder(viewType: string, savedViewIds: string[]): Promise<void> {
+        await savedViewOrderMutation.mutateAsync({
+            saved_view_ids: savedViewIds,
+            view_type: viewType
+        });
+    }
 
     const viewToHref: Record<string, string> = {
         events: resolve('/(app)/event'),
@@ -614,11 +629,16 @@
                 return route;
             }
 
-            const sortedViews = [...viewSavedViews].sort((a, b) => a.name.localeCompare(b.name));
+            const orderedIds = getPersonalSavedViewOrder(meQuery.data?.organization_preferences, organization.current, viewKey);
+            const orderedViews = resolvePersonalSavedViewOrder(viewSavedViews, orderedIds);
 
             const children = [
-                ...sortedViews.map((savedView) => ({
+                ...orderedViews.map((savedView) => ({
                     href: buildSavedViewHref(savedView),
+                    savedView: {
+                        id: savedView.id,
+                        isPrivate: !!savedView.user_id
+                    },
                     title: savedView.name
                 })),
                 ...(route.children ?? [])
@@ -683,7 +703,7 @@
         openCommand={openCommandPalette}
         toggleAssistant={() => void toggleAssistantPanel()}
     />
-    <Sidebar routes={filteredRoutes}>
+    <Sidebar routes={filteredRoutes} onSavedViewOrderChange={saveSavedViewOrder}>
         {#snippet header()}
             <SidebarOrganizationSwitcher
                 bind:impersonateDialogOpen={isImpersonateOrganizationOpen}

--- a/src/Exceptionless.Web/ClientApp/src/routes/routes.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/routes/routes.svelte.ts
@@ -9,6 +9,7 @@ import { routes as authRoutes } from './(auth)/routes.svelte';
 
 export type NavigationChild = {
     href: string;
+    savedView?: SavedViewNavigationMetadata;
     title: string;
 };
 
@@ -29,6 +30,11 @@ export type NavigationItemContext = {
     authenticated: boolean;
     impersonating?: boolean;
     user?: ViewCurrentUser;
+};
+
+export type SavedViewNavigationMetadata = {
+    id: string;
+    isPrivate: boolean;
 };
 
 export function routes(): NavigationItem[] {

--- a/src/Exceptionless.Web/Models/SavedView/UpdateSavedViewOrder.cs
+++ b/src/Exceptionless.Web/Models/SavedView/UpdateSavedViewOrder.cs
@@ -8,7 +8,7 @@ public sealed record UpdateSavedViewOrder : IValidatableObject
 {
     [Required]
     [MaxLength(100)]
-    public IReadOnlyList<string> SavedViewIds { get; init; } = [];
+    public required IReadOnlyList<string> SavedViewIds { get; init; }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {

--- a/src/Exceptionless.Web/Models/SavedView/UpdateSavedViewOrder.cs
+++ b/src/Exceptionless.Web/Models/SavedView/UpdateSavedViewOrder.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
+using Exceptionless.Core.Attributes;
+
+namespace Exceptionless.Web.Models;
+
+public sealed record UpdateSavedViewOrder : IValidatableObject
+{
+    [Required]
+    [MaxLength(100)]
+    public IReadOnlyList<string> SavedViewIds { get; init; } = [];
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (SavedViewIds.Count != SavedViewIds.Distinct(StringComparer.Ordinal).Count())
+        {
+            yield return new ValidationResult(
+                "Saved view identifiers cannot be repeated.",
+                [nameof(SavedViewIds)]
+            );
+        }
+
+        if (SavedViewIds.Any(id => id is null || !Regex.IsMatch(id, ObjectIdAttribute.ObjectIdPattern)))
+        {
+            yield return new ValidationResult(
+                "Every saved view identifier must be a valid object identifier.",
+                [nameof(SavedViewIds)]
+            );
+        }
+    }
+}

--- a/src/Exceptionless.Web/Models/User/ViewCurrentUser.cs
+++ b/src/Exceptionless.Web/Models/User/ViewCurrentUser.cs
@@ -19,6 +19,7 @@ public record ViewCurrentUser : ViewUser
         IsActive = user.IsActive;
         Roles = user.Roles;
         OrganizationPreferences = user.OrganizationPreferences;
+        SavedViewOrders = user.SavedViewOrders;
 
         Hash = HMACSHA256HashString(user.Id, options);
         HasLocalAccount = !String.IsNullOrWhiteSpace(user.Password);
@@ -29,6 +30,7 @@ public record ViewCurrentUser : ViewUser
     public bool HasLocalAccount { get; set; }
     public ICollection<OAuthAccount> OAuthAccounts { get; set; }
     public ICollection<UserOrganizationPreference> OrganizationPreferences { get; set; }
+    public ICollection<UserSavedViewOrderPreference> SavedViewOrders { get; set; }
 
     private static string? HMACSHA256HashString(string value, IntercomOptions options)
     {

--- a/tests/Exceptionless.Tests/Api/Data/endpoint-manifest.json
+++ b/tests/Exceptionless.Tests/Api/Data/endpoint-manifest.json
@@ -1509,6 +1509,20 @@
     "authenticationSchemes": []
   },
   {
+    "method": "PUT",
+    "route": "/api/v2/organizations/{organizationId:objectid}/saved-view-order/{viewType}",
+    "displayName": "HTTP: PUT api/v2/organizations/{organizationId:objectid}/saved-view-order/{viewType}",
+    "tags": [
+      "SavedView"
+    ],
+    "allowAnonymous": false,
+    "authorizationPolicies": [
+      "UserPolicy"
+    ],
+    "authorizationRoles": [],
+    "authenticationSchemes": []
+  },
+  {
     "method": "GET",
     "route": "/api/v2/organizations/{organizationId:objectid}/saved-views",
     "displayName": "HTTP: GET api/v2/organizations/{organizationId:objectid}/saved-views",

--- a/tests/Exceptionless.Tests/Api/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Api/Data/openapi.json
@@ -3348,6 +3348,16 @@
               }
             }
           },
+          "409": {
+            "description": "The saved view preferences could not be updated due to a concurrent request.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "404": {
             "description": "The organization could not be found.",
             "content": {
@@ -3421,6 +3431,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UpdateSavedViewOrder"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The saved view preferences could not be updated due to a concurrent request.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }

--- a/tests/Exceptionless.Tests/Api/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Api/Data/openapi.json
@@ -13835,6 +13835,7 @@
           "password_reset_token_expiration",
           "o_auth_accounts",
           "organization_preferences",
+          "saved_view_orders",
           "email_notifications_enabled",
           "is_email_address_verified",
           "verify_email_address_token_expiration",
@@ -13892,6 +13893,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/UserOrganizationPreference"
+            }
+          },
+          "saved_view_orders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserSavedViewOrderPreference"
             }
           },
           "full_name": {
@@ -13976,7 +13983,7 @@
       "UserOrganizationPreference": {
         "required": [
           "organization_id",
-          "saved_view_order"
+          "default_saved_view_id"
         ],
         "type": "object",
         "properties": {
@@ -13990,18 +13997,31 @@
             "maxLength": 24,
             "minLength": 24,
             "pattern": "^[a-fA-F0-9]{24}$",
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": "string"
+          }
+        }
+      },
+      "UserSavedViewOrderPreference": {
+        "required": [
+          "view_type",
+          "organization_id",
+          "saved_view_ids"
+        ],
+        "type": "object",
+        "properties": {
+          "organization_id": {
+            "maxLength": 24,
+            "minLength": 24,
+            "pattern": "^[a-fA-F0-9]{24}$",
+            "type": "string"
           },
-          "saved_view_order": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+          "view_type": {
+            "type": "string"
+          },
+          "saved_view_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
             }
           }
         }
@@ -14011,6 +14031,7 @@
           "has_local_account",
           "o_auth_accounts",
           "organization_preferences",
+          "saved_view_orders",
           "id",
           "organization_ids",
           "full_name",
@@ -14042,6 +14063,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/UserOrganizationPreference"
+            }
+          },
+          "saved_view_orders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserSavedViewOrderPreference"
             }
           },
           "id": {

--- a/tests/Exceptionless.Tests/Api/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Api/Data/openapi.json
@@ -3371,6 +3371,83 @@
         }
       }
     },
+    "/api/v2/organizations/{organizationId}/saved-view-order/{viewType}": {
+      "put": {
+        "tags": [
+          "SavedView"
+        ],
+        "summary": "Update the current user\u0027s saved view order",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "description": "The identifier of the organization.",
+            "required": true,
+            "schema": {
+              "pattern": "^[a-zA-Z\\d]{24,36}$",
+              "type": "string"
+            }
+          },
+          {
+            "name": "viewType",
+            "in": "path",
+            "description": "The dashboard view type (events, sessions, stacks, or stream).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The ordered saved view identifiers for one dashboard section. An empty list resets the section to alphabetical order.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSavedViewOrder"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSavedViewOrder"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The personal saved view order was updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateSavedViewOrder"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The organization could not be found.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The dashboard view type or saved view identifiers are invalid.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/organizations/{organizationId}/saved-view-defaults/organization": {
       "put": {
         "tags": [
@@ -13628,6 +13705,21 @@
           }
         }
       },
+      "UpdateSavedViewOrder": {
+        "required": [
+          "saved_view_ids"
+        ],
+        "type": "object",
+        "properties": {
+          "saved_view_ids": {
+            "maxItems": 100,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "UpdateToken": {
         "type": "object",
         "properties": {
@@ -13884,7 +13976,7 @@
       "UserOrganizationPreference": {
         "required": [
           "organization_id",
-          "default_saved_view_id"
+          "saved_view_order"
         ],
         "type": "object",
         "properties": {
@@ -13898,7 +13990,19 @@
             "maxLength": 24,
             "minLength": 24,
             "pattern": "^[a-fA-F0-9]{24}$",
-            "type": "string"
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "saved_view_order": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           }
         }
       },

--- a/tests/Exceptionless.Tests/Api/Data/openapi.json
+++ b/tests/Exceptionless.Tests/Api/Data/openapi.json
@@ -3435,6 +3435,16 @@
               }
             }
           },
+          "400": {
+            "description": "The request body is malformed or omits the saved view identifiers.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "409": {
             "description": "The saved view preferences could not be updated due to a concurrent request.",
             "content": {

--- a/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
@@ -1457,6 +1457,94 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task PutSavedViewOrder_SharedAndPrivateViews_PersistsAccessiblePersonalOrder()
+    {
+        var sharedView = await CreateSavedViewAsync("Shared Ordered View", "status:open", "events");
+        var privateView = await CreateSavedViewAsync("Private Ordered View", "status:regressed", "events", isPrivate: true);
+        var inaccessiblePrivateView = await _savedViewRepository.AddAsync(new SavedView
+        {
+            OrganizationId = SampleDataService.TEST_ORG_ID,
+            UserId = TestConstants.UserId2,
+            Name = "Other User Private Ordered View",
+            Slug = "other-user-private-ordered-view",
+            ViewType = "events",
+            CreatedByUserId = TestConstants.UserId2
+        });
+        Assert.NotNull(sharedView);
+        Assert.NotNull(privateView);
+        await RefreshDataAsync();
+
+        var result = await SendRequestAsAsync<UpdateSavedViewOrder>(r => r
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-view-order", "events")
+            .Content(new UpdateSavedViewOrder
+            {
+                SavedViewIds = [privateView.Id, inaccessiblePrivateView.Id, sharedView.Id]
+            })
+            .StatusCodeShouldBeOk()
+        );
+
+        Assert.NotNull(result);
+        Assert.Equal([privateView.Id, sharedView.Id], result.SavedViewIds);
+
+        var user = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_USER_EMAIL);
+        Assert.NotNull(user);
+        var preference = Assert.Single(user.OrganizationPreferences, preference => preference.OrganizationId == SampleDataService.TEST_ORG_ID);
+        Assert.Equal([privateView.Id, sharedView.Id], preference.SavedViewOrder["events"]);
+    }
+
+    [Fact]
+    public async Task PutSavedViewDefaults_ExistingSavedViewOrder_PreservesOrderWhenDefaultChangesOrClears()
+    {
+        var sharedView = await CreateSavedViewAsync("Ordered Home View", "status:open", "stacks");
+        Assert.NotNull(sharedView);
+
+        await SendRequestAsync(r => r
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-view-order", "stacks")
+            .Content(new UpdateSavedViewOrder { SavedViewIds = [sharedView.Id] })
+            .StatusCodeShouldBeOk()
+        );
+        await SendRequestAsync(r => r
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-view-defaults", "user")
+            .Content(new UpdateSavedViewDefault { SavedViewId = sharedView.Id })
+            .StatusCodeShouldBeOk()
+        );
+        await SendRequestAsync(r => r
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-view-defaults", "user")
+            .Content(new UpdateSavedViewDefault { SavedViewId = null })
+            .StatusCodeShouldBeOk()
+        );
+
+        var user = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_USER_EMAIL);
+        Assert.NotNull(user);
+        var preference = Assert.Single(user.OrganizationPreferences, preference => preference.OrganizationId == SampleDataService.TEST_ORG_ID);
+        Assert.Null(preference.DefaultSavedViewId);
+        Assert.Equal([sharedView.Id], preference.SavedViewOrder["stacks"]);
+    }
+
+    [Fact]
+    public async Task PutSavedViewOrder_DuplicateIdentifiers_ReturnsUnprocessableEntity()
+    {
+        var savedView = await CreateSavedViewAsync("Duplicate Ordered View", "status:open", "events");
+        Assert.NotNull(savedView);
+
+        await SendRequestAsync(r => r
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-view-order", "events")
+            .Content(new UpdateSavedViewOrder { SavedViewIds = [savedView.Id, savedView.Id] })
+            .StatusCodeShouldBeUnprocessableEntity()
+        );
+    }
+
+    [Fact]
     public async Task PutOrganizationSavedViewDefault_PrivateView_ReturnsUnprocessableEntity()
     {
         var privateView = await CreateSavedViewAsync("Private Organization Home", "status:open", "events", isPrivate: true);
@@ -3020,7 +3108,15 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
             .Select(preference => new UserOrganizationPreference
             {
                 OrganizationId = preference.GetProperty("organization_id").GetString()!,
-                DefaultSavedViewId = preference.GetProperty("default_saved_view_id").GetString()!
+                DefaultSavedViewId = preference.TryGetProperty("default_saved_view_id", out var defaultSavedViewId)
+                    ? defaultSavedViewId.GetString()
+                    : null,
+                SavedViewOrder = preference.TryGetProperty("saved_view_order", out var savedViewOrder)
+                    ? savedViewOrder.EnumerateObject().ToDictionary(
+                        property => property.Name,
+                        property => property.Value.EnumerateArray().Select(value => value.GetString()!).ToList(),
+                        StringComparer.Ordinal)
+                    : []
             })
             .ToList();
     }

--- a/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
@@ -1586,6 +1586,34 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task PutSavedViewOrder_MissingIdentifiers_ReturnsBadRequestWithoutClearingOrder()
+    {
+        var savedView = await CreateSavedViewAsync("Preserved Ordered View", "status:open", "events");
+        Assert.NotNull(savedView);
+
+        await SendRequestAsync(r => r
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-view-order", "events")
+            .Content(new UpdateSavedViewOrder { SavedViewIds = [savedView.Id] })
+            .StatusCodeShouldBeOk()
+        );
+
+        await SendRequestAsync(r => r
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-view-order", "events")
+            .Content("{}", "application/json")
+            .StatusCodeShouldBeBadRequest()
+        );
+
+        var user = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_USER_EMAIL);
+        Assert.NotNull(user);
+        var preference = Assert.Single(user.SavedViewOrders, preference => preference.OrganizationId == SampleDataService.TEST_ORG_ID && preference.ViewType == "events");
+        Assert.Equal([savedView.Id], preference.SavedViewIds);
+    }
+
+    [Fact]
     public async Task PutOrganizationSavedViewDefault_PrivateView_ReturnsUnprocessableEntity()
     {
         var privateView = await CreateSavedViewAsync("Private Organization Home", "status:open", "events", isPrivate: true);

--- a/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
@@ -1457,7 +1457,7 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task PutSavedViewOrder_SharedAndPrivateViews_PersistsAccessiblePersonalOrder()
+    public async Task PutSavedViewOrder_SharedAndPrivateViews_ImmediatelyPersistsAccessiblePersonalOrder()
     {
         var sharedView = await CreateSavedViewAsync("Shared Ordered View", "status:open", "events");
         var privateView = await CreateSavedViewAsync("Private Ordered View", "status:regressed", "events", isPrivate: true);
@@ -1472,8 +1472,6 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         });
         Assert.NotNull(sharedView);
         Assert.NotNull(privateView);
-        await RefreshDataAsync();
-
         var result = await SendRequestAsAsync<UpdateSavedViewOrder>(r => r
             .Put()
             .AsGlobalAdminUser()
@@ -1492,6 +1490,42 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         Assert.NotNull(user);
         var preference = Assert.Single(user.OrganizationPreferences, preference => preference.OrganizationId == SampleDataService.TEST_ORG_ID);
         Assert.Equal([privateView.Id, sharedView.Id], preference.SavedViewOrder["events"]);
+    }
+
+    [Fact]
+    public async Task PutSavedViewDefaults_DuplicateOrganizationPreferences_MergesEverySavedViewOrderIdentifier()
+    {
+        var firstView = await CreateSavedViewAsync("First Legacy Ordered View", "status:open", "events");
+        var secondView = await CreateSavedViewAsync("Second Legacy Ordered View", "status:regressed", "events");
+        Assert.NotNull(firstView);
+        Assert.NotNull(secondView);
+
+        var user = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_USER_EMAIL);
+        Assert.NotNull(user);
+        user.OrganizationPreferences.Add(new UserOrganizationPreference
+        {
+            OrganizationId = SampleDataService.TEST_ORG_ID,
+            SavedViewOrder = new() { ["events"] = [firstView.Id] }
+        });
+        user.OrganizationPreferences.Add(new UserOrganizationPreference
+        {
+            OrganizationId = SampleDataService.TEST_ORG_ID,
+            SavedViewOrder = new() { ["events"] = [firstView.Id, secondView.Id] }
+        });
+        await _userRepository.SaveAsync(user, o => o.Cache());
+
+        await SendRequestAsync(r => r
+            .Put()
+            .AsGlobalAdminUser()
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-view-defaults", "user")
+            .Content(new UpdateSavedViewDefault { SavedViewId = null })
+            .StatusCodeShouldBeOk()
+        );
+
+        user = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_USER_EMAIL);
+        Assert.NotNull(user);
+        var preference = Assert.Single(user.OrganizationPreferences, preference => preference.OrganizationId == SampleDataService.TEST_ORG_ID);
+        Assert.Equal([firstView.Id, secondView.Id], preference.SavedViewOrder["events"]);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
@@ -1937,6 +1937,19 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         // Arrange — create an organization-wide view and a private view for the test organization user
         var testUser = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_ORG_USER_EMAIL);
         Assert.NotNull(testUser);
+        testUser.SavedViewOrders.Add(new UserSavedViewOrderPreference
+        {
+            OrganizationId = SampleDataService.TEST_ORG_ID,
+            ViewType = "events",
+            SavedViewIds = ["000000000000000000000101"]
+        });
+        testUser.SavedViewOrders.Add(new UserSavedViewOrderPreference
+        {
+            OrganizationId = SampleDataService.FREE_ORG_ID,
+            ViewType = "events",
+            SavedViewIds = ["000000000000000000000102"]
+        });
+        await _userRepository.SaveAsync(testUser, o => o.ImmediateConsistency().Cache());
 
         var organizationWideView = await _savedViewRepository.AddAsync(new SavedView
         {
@@ -1974,6 +1987,10 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         // Assert — private view is gone, organization-wide view remains
         Assert.Null(await _savedViewRepository.GetByIdAsync(privateView.Id));
         Assert.NotNull(await _savedViewRepository.GetByIdAsync(organizationWideView.Id));
+        testUser = await _userRepository.GetByIdAsync(testUser.Id, o => o.Cache(false));
+        Assert.NotNull(testUser);
+        Assert.DoesNotContain(testUser.SavedViewOrders, preference => preference.OrganizationId == SampleDataService.TEST_ORG_ID);
+        Assert.Contains(testUser.SavedViewOrders, preference => preference.OrganizationId == SampleDataService.FREE_ORG_ID);
     }
 
     [Fact]
@@ -1982,6 +1999,19 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         // Arrange
         var testUser = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_USER_EMAIL);
         Assert.NotNull(testUser);
+        testUser.SavedViewOrders.Add(new UserSavedViewOrderPreference
+        {
+            OrganizationId = SampleDataService.TEST_ORG_ID,
+            ViewType = "stacks",
+            SavedViewIds = ["000000000000000000000103"]
+        });
+        testUser.SavedViewOrders.Add(new UserSavedViewOrderPreference
+        {
+            OrganizationId = SampleDataService.FREE_ORG_ID,
+            ViewType = "stacks",
+            SavedViewIds = ["000000000000000000000104"]
+        });
+        await _userRepository.SaveAsync(testUser, o => o.ImmediateConsistency().Cache());
 
         await _savedViewRepository.AddAsync(new SavedView
         {
@@ -2019,6 +2049,10 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         // Assert
         long countAfter = await _savedViewRepository.CountByOrganizationIdAsync(SampleDataService.TEST_ORG_ID);
         Assert.Equal(0, countAfter);
+        testUser = await _userRepository.GetByIdAsync(testUser.Id, o => o.Cache(false));
+        Assert.NotNull(testUser);
+        Assert.DoesNotContain(testUser.SavedViewOrders, preference => preference.OrganizationId == SampleDataService.TEST_ORG_ID);
+        Assert.Contains(testUser.SavedViewOrders, preference => preference.OrganizationId == SampleDataService.FREE_ORG_ID);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
@@ -1472,6 +1472,11 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
         });
         Assert.NotNull(sharedView);
         Assert.NotNull(privateView);
+
+        var cachedUser = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_USER_EMAIL);
+        Assert.NotNull(cachedUser);
+        Assert.DoesNotContain(cachedUser.SavedViewOrders, preference => preference.OrganizationId == SampleDataService.TEST_ORG_ID && preference.ViewType == "events");
+
         var result = await SendRequestAsAsync<UpdateSavedViewOrder>(r => r
             .Put()
             .AsGlobalAdminUser()

--- a/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/SavedViewEndpointTests.cs
@@ -1488,12 +1488,12 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
 
         var user = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_USER_EMAIL);
         Assert.NotNull(user);
-        var preference = Assert.Single(user.OrganizationPreferences, preference => preference.OrganizationId == SampleDataService.TEST_ORG_ID);
-        Assert.Equal([privateView.Id, sharedView.Id], preference.SavedViewOrder["events"]);
+        var preference = Assert.Single(user.SavedViewOrders, preference => preference.OrganizationId == SampleDataService.TEST_ORG_ID && preference.ViewType == "events");
+        Assert.Equal([privateView.Id, sharedView.Id], preference.SavedViewIds);
     }
 
     [Fact]
-    public async Task PutSavedViewDefaults_DuplicateOrganizationPreferences_MergesEverySavedViewOrderIdentifier()
+    public async Task PutSavedViewOrder_DuplicatePreferences_ReplacesSectionOrder()
     {
         var firstView = await CreateSavedViewAsync("First Legacy Ordered View", "status:open", "events");
         var secondView = await CreateSavedViewAsync("Second Legacy Ordered View", "status:regressed", "events");
@@ -1502,30 +1502,32 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
 
         var user = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_USER_EMAIL);
         Assert.NotNull(user);
-        user.OrganizationPreferences.Add(new UserOrganizationPreference
+        user.SavedViewOrders.Add(new UserSavedViewOrderPreference
         {
             OrganizationId = SampleDataService.TEST_ORG_ID,
-            SavedViewOrder = new() { ["events"] = [firstView.Id] }
+            ViewType = "events",
+            SavedViewIds = [firstView.Id]
         });
-        user.OrganizationPreferences.Add(new UserOrganizationPreference
+        user.SavedViewOrders.Add(new UserSavedViewOrderPreference
         {
             OrganizationId = SampleDataService.TEST_ORG_ID,
-            SavedViewOrder = new() { ["events"] = [firstView.Id, secondView.Id] }
+            ViewType = "events",
+            SavedViewIds = [firstView.Id, secondView.Id]
         });
         await _userRepository.SaveAsync(user, o => o.Cache());
 
         await SendRequestAsync(r => r
             .Put()
             .AsGlobalAdminUser()
-            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-view-defaults", "user")
-            .Content(new UpdateSavedViewDefault { SavedViewId = null })
+            .AppendPaths("organizations", SampleDataService.TEST_ORG_ID, "saved-view-order", "events")
+            .Content(new UpdateSavedViewOrder { SavedViewIds = [secondView.Id, firstView.Id] })
             .StatusCodeShouldBeOk()
         );
 
         user = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_USER_EMAIL);
         Assert.NotNull(user);
-        var preference = Assert.Single(user.OrganizationPreferences, preference => preference.OrganizationId == SampleDataService.TEST_ORG_ID);
-        Assert.Equal([firstView.Id, secondView.Id], preference.SavedViewOrder["events"]);
+        var preference = Assert.Single(user.SavedViewOrders, preference => preference.OrganizationId == SampleDataService.TEST_ORG_ID && preference.ViewType == "events");
+        Assert.Equal([secondView.Id, firstView.Id], preference.SavedViewIds);
     }
 
     [Fact]
@@ -1558,9 +1560,9 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
 
         var user = await _userRepository.GetByEmailAddressAsync(SampleDataService.TEST_USER_EMAIL);
         Assert.NotNull(user);
-        var preference = Assert.Single(user.OrganizationPreferences, preference => preference.OrganizationId == SampleDataService.TEST_ORG_ID);
-        Assert.Null(preference.DefaultSavedViewId);
-        Assert.Equal([sharedView.Id], preference.SavedViewOrder["stacks"]);
+        Assert.DoesNotContain(user.OrganizationPreferences, preference => preference.OrganizationId == SampleDataService.TEST_ORG_ID);
+        var preference = Assert.Single(user.SavedViewOrders, preference => preference.OrganizationId == SampleDataService.TEST_ORG_ID && preference.ViewType == "stacks");
+        Assert.Equal([sharedView.Id], preference.SavedViewIds);
     }
 
     [Fact]
@@ -3142,15 +3144,7 @@ public sealed class SavedViewEndpointTests : IntegrationTestsBase
             .Select(preference => new UserOrganizationPreference
             {
                 OrganizationId = preference.GetProperty("organization_id").GetString()!,
-                DefaultSavedViewId = preference.TryGetProperty("default_saved_view_id", out var defaultSavedViewId)
-                    ? defaultSavedViewId.GetString()
-                    : null,
-                SavedViewOrder = preference.TryGetProperty("saved_view_order", out var savedViewOrder)
-                    ? savedViewOrder.EnumerateObject().ToDictionary(
-                        property => property.Name,
-                        property => property.Value.EnumerateArray().Select(value => value.GetString()!).ToList(),
-                        StringComparer.Ordinal)
-                    : []
+                DefaultSavedViewId = preference.GetProperty("default_saved_view_id").GetString()!
             })
             .ToList();
     }

--- a/tests/Exceptionless.Tests/Serializer/Models/UserSerializerTests.cs
+++ b/tests/Exceptionless.Tests/Serializer/Models/UserSerializerTests.cs
@@ -128,6 +128,36 @@ public class UserSerializerTests : TestWithServices
     }
 
     [Fact]
+    public void Deserialize_User_PreservesSavedViewOrders()
+    {
+        var original = new User
+        {
+            Id = "user123",
+            FullName = "Saved View User",
+            EmailAddress = "saved-views@example.com",
+            IsEmailAddressVerified = true,
+            SavedViewOrders =
+            [
+                new UserSavedViewOrderPreference
+                {
+                    OrganizationId = "organization-id",
+                    ViewType = "events",
+                    SavedViewIds = ["private-view-id", "shared-view-id"]
+                }
+            ]
+        };
+
+        string? json = _serializer.SerializeToString(original);
+        var deserialized = _serializer.Deserialize<User>(json);
+
+        Assert.NotNull(deserialized);
+        var preference = Assert.Single(deserialized.SavedViewOrders);
+        Assert.Equal("organization-id", preference.OrganizationId);
+        Assert.Equal("events", preference.ViewType);
+        Assert.Equal(["private-view-id", "shared-view-id"], preference.SavedViewIds);
+    }
+
+    [Fact]
     public void Deserialize_User_PreservesAllCollectionsTogether()
     {
         // Arrange - Tests all collections at once to ensure no interference

--- a/tests/http/saved-views.http
+++ b/tests/http/saved-views.http
@@ -95,6 +95,24 @@ Content-Type: application/json
     "saved_view_id": null
 }
 
+### Set personal saved view order
+PUT {{apiUrl}}/organizations/{{organizationId}}/saved-view-order/events
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "saved_view_ids": ["{{savedViewId}}"]
+}
+
+### Reset personal saved view order
+PUT {{apiUrl}}/organizations/{{organizationId}}/saved-view-order/events
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "saved_view_ids": []
+}
+
 ### Set organization saved view default
 PUT {{apiUrl}}/organizations/{{organizationId}}/saved-view-defaults/organization
 Authorization: Bearer {{token}}


### PR DESCRIPTION
## What changed

- add per-user, per-organization ordering for Events, Sessions, Stacks, and Stream saved views
- make saved views directly draggable in the expanded sidebar, saving their personal order on drop
- retain a reorder dialog with drag controls, keyboard-accessible move buttons, Shared/Private labels, and an alphabetical reset
- apply the same personal order to sidebar and command navigation while safely ignoring inaccessible or deleted views and appending new views alphabetically
- store ordering separately from existing personal home-view preferences, serialize preference writes, and clean up stale order when organization membership ends
- update saved-view order atomically so unrelated user-profile writes cannot silently overwrite it
- add the saved-view order API contract, generated client updates, HTTP samples, and focused API/unit/E2E coverage

## Why

Shared and private saved views appear together in navigation, but their preferred order belongs to each user. Separate per-user ordering lets every user arrange the combined list without changing shared saved-view records or the existing default-view contract.

## Verification

- `dotnet build tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-restore --maxcpucount:1`
- `dotnet test --project tests/Exceptionless.Tests/Exceptionless.Tests.csproj --no-build -- --filter-class Exceptionless.Tests.Api.Endpoints.SavedViewEndpointTests` (126 passed)
- focused serializer tests (10 passed)
- OpenAPI snapshot and endpoint-manifest tests (5 passed)
- `npm run validate`
- `npm run build`
- focused frontend unit tests (15 passed)
- focused saved-view sidebar drag ordering Playwright E2E (1 passed)

## Breaking changes

None.
