### PR TITLE
Fix sidebar actions and dashboard chart clipping

### DIFF
--- a/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-dashboard-chart.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/events/components/events-dashboard-chart.svelte
@@ -60,6 +60,7 @@
                 xScale={scaleUtc()}
                 yDomain={[0, Math.max(1, Math.max(...data.map((d) => d.events)))]}
                 {series}
+                seriesLayout="overlap"
                 axis={false}
                 grid={false}
                 brush={{

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/sessions/components/sessions-dashboard-chart.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/sessions/components/sessions-dashboard-chart.svelte
@@ -60,6 +60,7 @@
                 xScale={scaleUtc()}
                 yDomain={[0, Math.max(1, Math.max(...data.map((d) => Math.max(d.sessions, d.users))))]}
                 {series}
+                seriesLayout="overlap"
                 axis={false}
                 grid={false}
                 brush={{

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/(components)/layouts/sidebar.svelte
@@ -427,13 +427,13 @@
                                 <Sidebar.MenuItem {...collapsibleProps}>
                                     <Collapsible.Trigger>
                                         {#snippet child({ props: triggerProps })}
-                                            <Sidebar.MenuButton {...triggerProps}>
+                                            <Sidebar.MenuButton {...triggerProps} class="group-has-data-[sidebar=menu-action]/menu-item:pr-14">
                                                 {#snippet child({ props: buttonProps })}
                                                     <button type="button" title={route.title} {...buttonProps}>
                                                         <Icon />
                                                         <span>{route.title}</span>
                                                         <ChevronRight
-                                                            class="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
+                                                            class="absolute right-1 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90"
                                                         />
                                                     </button>
                                                 {/snippet}
@@ -444,6 +444,7 @@
                                         <Sidebar.MenuAction
                                             showOnHover
                                             aria-label={`Reorder ${route.title} views`}
+                                            class="right-7"
                                             title={`Reorder ${route.title} views`}
                                             onclick={(event) => openSavedViewOrderDialog(event, route)}
                                         >


### PR DESCRIPTION
## Summary

- place the saved-view reorder action to the left of the expand/collapse control
- render Events, Stacks, and Sessions dashboard series as overlapping areas
- prevent LayerChart's automatic multi-series stacking from drawing the second series beyond the chart's Y domain

## Verification

- `npm run validate`
- reproduced the Events and Stacks chart line extending 16 px above the plot area with the automatic series layout
- verified 0 px top overflow for Events, Stacks, and Sessions with the overlapping series layout
- verified the local Svelte app and `/api/v2/about` return HTTP 200 through the Aspire frontend endpoint

## Breaking changes

None.
