### PR TITLE
Add guarded migration rerun support

### DIFF
--- a/docs/docs/self-hosting/upgrading-self-hosted-instance.md
+++ b/docs/docs/self-hosting/upgrading-self-hosted-instance.md
@@ -16,6 +16,15 @@ We also upgraded to Elasticsearch 8 in the base images. One requirement of upgra
 
 You may also need to update the connection strings. In v8.2.7 we updated the Redis Connection String to remove the `server=` prefix.
 
+## Rerunning a completed migration
+
+Only migrations explicitly marked as safe to rerun can be started again. Create an Elasticsearch snapshot and stop older Exceptionless app and job instances before proceeding.
+
+- In the System UI, open **System → Migrations**, choose the migration's action menu, and select **Rerun migration**. The confirmation dialog shows the exact phrase you must enter.
+- From the job image or CLI, run `dotnet Exceptionless.Job.dll Migration --rerun <id>`, using the migration ID shown in the System UI. Pass the same Elasticsearch, Redis, and other configuration used by the normal migration job.
+
+A rerun does not change the recorded current migration version or the original migration completion timestamp. Its outcome is reported separately in the UI and application logs.
+
 ## Upgrading from v7 to v7.1
 
 We made some changes to email configuration. Yoy wukk now be required to set the `EX_SmtpFrom` config map/environment variable in order to send email. The value should be in the following format: `"Exceptionless <noreply@YOUR_CUSTOM_DOMAIN_NAME>"`

--- a/docs/docs/self-hosting/upgrading-self-hosted-instance.md
+++ b/docs/docs/self-hosting/upgrading-self-hosted-instance.md
@@ -23,6 +23,8 @@ Only migrations explicitly marked as safe to rerun can be started again. Create 
 - In the System UI, open **System → Migrations**, choose the migration's action menu, and select **Rerun migration**. The confirmation dialog shows the exact phrase you must enter.
 - From the job image or CLI, run `dotnet Exceptionless.Job.dll Migration --rerun <id>`, using the migration ID shown in the System UI. Pass the same Elasticsearch, Redis, and other configuration used by the normal migration job.
 
+A split deployment that runs jobs outside the web process must configure a distributed queue and Redis-backed cache to use the System UI action. If those services are unavailable, use the CLI command from the job instance instead.
+
 A rerun does not change the recorded current migration version or the original migration completion timestamp. Its outcome is reported separately in the UI and application logs.
 
 ## Upgrading from v7 to v7.1

--- a/src/Exceptionless.Core/Bootstrapper.cs
+++ b/src/Exceptionless.Core/Bootstrapper.cs
@@ -10,6 +10,7 @@ using Exceptionless.Core.Geo;
 using Exceptionless.Core.Jobs;
 using Exceptionless.Core.Jobs.WorkItemHandlers;
 using Exceptionless.Core.Mail;
+using Exceptionless.Core.Migrations;
 using Exceptionless.Core.Models.WorkItems;
 using Exceptionless.Core.Pipeline;
 using Exceptionless.Core.Plugins;
@@ -144,6 +145,7 @@ public class Bootstrapper
         services.AddSingleton<IEventRepository, EventRepository>();
         services.AddSingleton<IMigrationStateRepository, MigrationStateRepository>();
         services.AddSingleton<MigrationManager>();
+        services.AddSingleton<MigrationRerunService>();
         services.AddSingleton<MigrationIndex>(s => s.GetRequiredService<ExceptionlessElasticConfiguration>().Migrations);
         services.AddSingleton<IOrganizationRepository, OrganizationRepository>();
         services.AddSingleton<IOAuthApplicationRepository, OAuthApplicationRepository>();

--- a/src/Exceptionless.Core/Bootstrapper.cs
+++ b/src/Exceptionless.Core/Bootstrapper.cs
@@ -101,6 +101,7 @@ public class Bootstrapper
             handlers.Register<ReindexWorkItem>(s.GetRequiredService<ReindexWorkItemHandler>);
             handlers.Register<RemoveBotEventsWorkItem>(s.GetRequiredService<RemoveBotEventsWorkItemHandler>);
             handlers.Register<RemoveStacksWorkItem>(s.GetRequiredService<RemoveStacksWorkItemHandler>);
+            handlers.Register<RerunMigrationWorkItem>(s.GetRequiredService<RerunMigrationWorkItemHandler>);
             handlers.Register<ResetProjectDataWorkItem>(s.GetRequiredService<ResetProjectDataWorkItemHandler>);
             handlers.Register<SetLocationFromGeoWorkItem>(s.GetRequiredService<SetLocationFromGeoWorkItemHandler>);
             handlers.Register<SetProjectIsConfiguredWorkItem>(s.GetRequiredService<SetProjectIsConfiguredWorkItemHandler>);

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/RerunMigrationWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/RerunMigrationWorkItemHandler.cs
@@ -20,6 +20,10 @@ public sealed class RerunMigrationWorkItemHandler(
         {
             throw;
         }
+        catch (MigrationRerunRecoveryPendingException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             Log.LogWarning(ex, "Migration rerun operation {MigrationRerunOperationId} failed and will not be retried automatically", workItem.OperationId);

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/RerunMigrationWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/RerunMigrationWorkItemHandler.cs
@@ -14,7 +14,10 @@ public sealed class RerunMigrationWorkItemHandler(
         var workItem = context.GetData<RerunMigrationWorkItem>()!;
         try
         {
-            await migrationRerunService.RunAsync(workItem.OperationId, context.CancellationToken);
+            await migrationRerunService.RunAsync(
+                workItem.OperationId,
+                context.CancellationToken,
+                retryOnCancellation: true);
         }
         catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
         {

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/RerunMigrationWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/RerunMigrationWorkItemHandler.cs
@@ -24,6 +24,10 @@ public sealed class RerunMigrationWorkItemHandler(
         {
             throw;
         }
+        catch (MigrationRerunCleanupPendingException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             var operation = await migrationRerunService.GetOperationAsync(workItem.OperationId);

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/RerunMigrationWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/RerunMigrationWorkItemHandler.cs
@@ -26,6 +26,13 @@ public sealed class RerunMigrationWorkItemHandler(
         }
         catch (Exception ex)
         {
+            var operation = await migrationRerunService.GetOperationAsync(workItem.OperationId);
+            if (operation?.Status != MigrationRerunStatus.Failed)
+            {
+                Log.LogWarning(ex, "Migration rerun operation {MigrationRerunOperationId} was interrupted before a failure was recorded and will be retried", workItem.OperationId);
+                throw;
+            }
+
             Log.LogWarning(ex, "Migration rerun operation {MigrationRerunOperationId} failed and will not be retried automatically", workItem.OperationId);
         }
     }

--- a/src/Exceptionless.Core/Jobs/WorkItemHandlers/RerunMigrationWorkItemHandler.cs
+++ b/src/Exceptionless.Core/Jobs/WorkItemHandlers/RerunMigrationWorkItemHandler.cs
@@ -1,0 +1,28 @@
+using Exceptionless.Core.Migrations;
+using Exceptionless.Core.Models.WorkItems;
+using Foundatio.Jobs;
+using Microsoft.Extensions.Logging;
+
+namespace Exceptionless.Core.Jobs.WorkItemHandlers;
+
+public sealed class RerunMigrationWorkItemHandler(
+    MigrationRerunService migrationRerunService,
+    ILoggerFactory loggerFactory) : WorkItemHandlerBase(loggerFactory)
+{
+    public override async Task HandleItemAsync(WorkItemContext context)
+    {
+        var workItem = context.GetData<RerunMigrationWorkItem>()!;
+        try
+        {
+            await migrationRerunService.RunAsync(workItem.OperationId, context.CancellationToken);
+        }
+        catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Log.LogWarning(ex, "Migration rerun operation {MigrationRerunOperationId} failed and will not be retried automatically", workItem.OperationId);
+        }
+    }
+}

--- a/src/Exceptionless.Core/Migrations/005_MigrateSavedViewColumns.cs
+++ b/src/Exceptionless.Core/Migrations/005_MigrateSavedViewColumns.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Exceptionless.Core.Migrations;
 
-public sealed class MigrateSavedViewColumns : MigrationBase
+public sealed class MigrateSavedViewColumns : MigrationBase, IRerunnableMigration
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/src/Exceptionless.Core/Migrations/IRerunnableMigration.cs
+++ b/src/Exceptionless.Core/Migrations/IRerunnableMigration.cs
@@ -1,0 +1,6 @@
+namespace Exceptionless.Core.Migrations;
+
+/// <summary>
+/// Marks a migration that can safely be run again after it has completed.
+/// </summary>
+public interface IRerunnableMigration;

--- a/src/Exceptionless.Core/Migrations/MigrationRerunOperation.cs
+++ b/src/Exceptionless.Core/Migrations/MigrationRerunOperation.cs
@@ -1,0 +1,31 @@
+namespace Exceptionless.Core.Migrations;
+
+public enum MigrationRerunStatus
+{
+    Queued,
+    Running,
+    Completed,
+    Failed,
+    Cancelled
+}
+
+public enum MigrationRerunSource
+{
+    UserInterface,
+    CommandLine
+}
+
+public record MigrationRerunOperation
+{
+    public required string Id { get; init; }
+    public required string MigrationId { get; init; }
+    public required int Version { get; init; }
+    public required MigrationRerunSource Source { get; init; }
+    public required MigrationRerunStatus Status { get; set; }
+    public string? RequestedByUserId { get; init; }
+    public required DateTime RequestedUtc { get; init; }
+    public DateTime? StartedUtc { get; set; }
+    public DateTime? CompletedUtc { get; set; }
+    public int AttemptCount { get; set; }
+    public string? ErrorMessage { get; set; }
+}

--- a/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
+++ b/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
@@ -16,7 +16,8 @@ public sealed class MigrationRerunService(
     ILoggerFactory loggerFactory)
 {
     private const string MigrationLockName = "migration-manager";
-    private static readonly TimeSpan OperationRetention = TimeSpan.FromDays(7);
+    private static readonly TimeSpan ActiveOperationRetention = TimeSpan.FromDays(7);
+    private static readonly TimeSpan OperationRetention = ActiveOperationRetention.Add(TimeSpan.FromMinutes(5));
     private static readonly TimeSpan MigrationLockDuration = TimeSpan.FromMinutes(30);
     private readonly ILogger _logger = loggerFactory.CreateLogger<MigrationRerunService>();
 
@@ -40,14 +41,11 @@ public sealed class MigrationRerunService(
         var migration = GetRerunnableMigration(migrationId);
         var state = await migrationStateRepository.GetByIdAsync(migrationId);
         if (state?.CompletedUtc is null)
-            throw new InvalidOperationException($"Migration '{migrationId}' must be completed before it can be rerun.");
+            throw new MigrationRerunValidationException($"Migration '{migrationId}' must be completed before it can be rerun.");
 
         EnsureUserInterfaceRerunAvailable(source);
 
         string operationId = Guid.NewGuid().ToString("N");
-        if (!await TryReserveMigrationAsync(migrationId, operationId))
-            throw new MigrationRerunAlreadyActiveException(migrationId);
-
         var operation = new MigrationRerunOperation
         {
             Id = operationId,
@@ -59,22 +57,22 @@ public sealed class MigrationRerunService(
             RequestedUtc = timeProvider.GetUtcNow().UtcDateTime
         };
 
-        try
+        // Persist the operation before publishing its active marker. This ordering guarantees that
+        // a marker without an operation record is stale and can be safely reclaimed.
+        await SaveOperationAsync(operation);
+        if (!await TryReserveMigrationAsync(migrationId, operationId))
         {
-            await SaveOperationAsync(operation);
-            _logger.LogInformation(
-                "Queued migration rerun {MigrationRerunOperationId} for migration {MigrationId}. Source: {MigrationRerunSource} RequestedByUserId: {RequestedByUserId}",
-                operation.Id,
-                operation.MigrationId,
-                operation.Source,
-                operation.RequestedByUserId);
-            return operation;
+            await cache.RemoveAsync(GetOperationCacheKey(operation.Id));
+            throw new MigrationRerunAlreadyActiveException(migrationId);
         }
-        catch
-        {
-            await RemoveActiveOperationAsync(operation);
-            throw;
-        }
+
+        _logger.LogInformation(
+            "Queued migration rerun {MigrationRerunOperationId} for migration {MigrationId}. Source: {MigrationRerunSource} RequestedByUserId: {RequestedByUserId}",
+            operation.Id,
+            operation.MigrationId,
+            operation.Source,
+            operation.RequestedByUserId);
+        return operation;
     }
 
     public Task<MigrationRerunOperation?> GetOperationAsync(string operationId)
@@ -216,30 +214,37 @@ public sealed class MigrationRerunService(
     private async Task<bool> TryReserveMigrationAsync(string migrationId, string operationId)
     {
         string activeOperationCacheKey = GetActiveOperationCacheKey(migrationId);
-        if (await cache.AddAsync(activeOperationCacheKey, operationId, OperationRetention))
+        if (await cache.AddAsync(activeOperationCacheKey, operationId, ActiveOperationRetention))
             return true;
 
         string? activeOperationId = await cache.GetAsync<string?>(activeOperationCacheKey, null);
         if (String.IsNullOrWhiteSpace(activeOperationId))
-            return false;
+            return await cache.AddAsync(activeOperationCacheKey, operationId, ActiveOperationRetention);
 
         var activeOperation = await GetOperationAsync(activeOperationId);
-        if (activeOperation is null || !IsTerminal(activeOperation.Status))
+        if (activeOperation is not null && !IsTerminal(activeOperation.Status))
             return false;
 
-        await RemoveActiveOperationAsync(activeOperation);
-        return await cache.AddAsync(activeOperationCacheKey, operationId, OperationRetention);
+        if (activeOperation is null)
+            await RemoveActiveReservationAsync(migrationId, activeOperationId);
+        else
+            await RemoveActiveOperationAsync(activeOperation);
+
+        return await cache.AddAsync(activeOperationCacheKey, operationId, ActiveOperationRetention);
     }
 
-    private async Task RemoveActiveOperationAsync(MigrationRerunOperation operation)
+    private Task RemoveActiveOperationAsync(MigrationRerunOperation operation)
+        => RemoveActiveReservationAsync(operation.MigrationId, operation.Id);
+
+    private async Task RemoveActiveReservationAsync(string migrationId, string operationId)
     {
         try
         {
-            await cache.RemoveIfEqualAsync(GetActiveOperationCacheKey(operation.MigrationId), operation.Id);
+            await cache.RemoveIfEqualAsync(GetActiveOperationCacheKey(migrationId), operationId);
         }
         catch (Exception ex)
         {
-            throw new MigrationRerunCleanupPendingException(operation.Id, ex);
+            throw new MigrationRerunCleanupPendingException(operationId, ex);
         }
     }
 
@@ -251,7 +256,7 @@ public sealed class MigrationRerunService(
         if (migration is null)
             throw new KeyNotFoundException($"Migration '{migrationId}' was not found.");
         if (migration is not IRerunnableMigration)
-            throw new InvalidOperationException($"Migration '{migrationId}' does not support reruns.");
+            throw new MigrationRerunValidationException($"Migration '{migrationId}' does not support reruns.");
 
         return migration;
     }
@@ -284,3 +289,5 @@ public sealed class MigrationRerunCleanupPendingException(string operationId, Ex
     : Exception($"Migration rerun operation '{operationId}' completed but its active-operation marker could not be removed and will be retried.", innerException);
 
 public sealed class MigrationRerunUnavailableException(string message) : Exception(message);
+
+public sealed class MigrationRerunValidationException(string message) : Exception(message);

--- a/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
+++ b/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
@@ -1,0 +1,206 @@
+using System.Diagnostics;
+using Foundatio.Caching;
+using Foundatio.Lock;
+using Foundatio.Repositories.Migrations;
+using Microsoft.Extensions.Logging;
+
+namespace Exceptionless.Core.Migrations;
+
+public sealed class MigrationRerunService(
+    MigrationManager migrationManager,
+    IMigrationStateRepository migrationStateRepository,
+    ICacheClient cache,
+    ILockProvider lockProvider,
+    TimeProvider timeProvider,
+    ILoggerFactory loggerFactory)
+{
+    private const string MigrationLockName = "migration-manager";
+    private static readonly TimeSpan OperationRetention = TimeSpan.FromDays(7);
+    private static readonly TimeSpan MigrationLockDuration = TimeSpan.FromMinutes(30);
+    private readonly ILogger _logger = loggerFactory.CreateLogger<MigrationRerunService>();
+
+    public IReadOnlySet<string> GetRerunnableMigrationIds()
+    {
+        EnsureMigrationsLoaded();
+        return migrationManager.Migrations
+            .Where(migration => migration is IRerunnableMigration)
+            .Select(migration => migration.GetId())
+            .Where(id => !String.IsNullOrWhiteSpace(id))
+            .Cast<string>()
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public async Task<MigrationRerunOperation> QueueAsync(
+        string migrationId,
+        MigrationRerunSource source,
+        string? requestedByUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var migration = GetRerunnableMigration(migrationId);
+        var state = await migrationStateRepository.GetByIdAsync(migrationId);
+        if (state?.CompletedUtc is null)
+            throw new InvalidOperationException($"Migration '{migrationId}' must be completed before it can be rerun.");
+
+        string operationId = Guid.NewGuid().ToString("N");
+        if (!await cache.AddAsync(GetActiveOperationCacheKey(migrationId), operationId, OperationRetention))
+            throw new MigrationRerunAlreadyActiveException(migrationId);
+
+        var operation = new MigrationRerunOperation
+        {
+            Id = operationId,
+            MigrationId = migrationId,
+            Version = migration.Version!.Value,
+            Source = source,
+            Status = MigrationRerunStatus.Queued,
+            RequestedByUserId = requestedByUserId,
+            RequestedUtc = timeProvider.GetUtcNow().UtcDateTime
+        };
+
+        try
+        {
+            await SaveOperationAsync(operation);
+            _logger.LogInformation(
+                "Queued migration rerun {MigrationRerunOperationId} for migration {MigrationId}. Source: {MigrationRerunSource} RequestedByUserId: {RequestedByUserId}",
+                operation.Id,
+                operation.MigrationId,
+                operation.Source,
+                operation.RequestedByUserId);
+            return operation;
+        }
+        catch
+        {
+            await cache.RemoveAsync(GetActiveOperationCacheKey(migrationId));
+            throw;
+        }
+    }
+
+    public Task<MigrationRerunOperation?> GetOperationAsync(string operationId)
+        => cache.GetAsync<MigrationRerunOperation?>(GetOperationCacheKey(operationId), null);
+
+    public async Task FailQueuedOperationAsync(string operationId, Exception exception)
+    {
+        var operation = await GetOperationAsync(operationId);
+        if (operation is null || operation.Status != MigrationRerunStatus.Queued)
+            return;
+
+        operation.Status = MigrationRerunStatus.Failed;
+        operation.CompletedUtc = timeProvider.GetUtcNow().UtcDateTime;
+        operation.ErrorMessage = exception.Message.Length > 1000 ? exception.Message[..1000] : exception.Message;
+        await SaveOperationAsync(operation);
+        await cache.RemoveAsync(GetActiveOperationCacheKey(operation.MigrationId));
+        _logger.LogError(
+            exception,
+            "Failed to dispatch migration rerun {MigrationRerunOperationId} for migration {MigrationId}",
+            operation.Id,
+            operation.MigrationId);
+    }
+
+    public async Task<MigrationRerunOperation> RunAsync(string operationId, CancellationToken cancellationToken = default)
+    {
+        var operation = await GetOperationAsync(operationId)
+            ?? throw new KeyNotFoundException($"Migration rerun operation '{operationId}' was not found.");
+        if (operation.Status != MigrationRerunStatus.Queued)
+            return operation;
+
+        var migration = GetRerunnableMigration(operation.MigrationId);
+
+        await using var migrationLock = await lockProvider.TryAcquireAsync(
+            MigrationLockName,
+            MigrationLockDuration,
+            cancellationToken);
+        if (migrationLock is null)
+        {
+            var exception = new InvalidOperationException("Another migration is currently running. Try the rerun again after it completes.");
+            await FailQueuedOperationAsync(operation.Id, exception);
+            throw exception;
+        }
+
+        operation.Status = MigrationRerunStatus.Running;
+        operation.StartedUtc = timeProvider.GetUtcNow().UtcDateTime;
+        operation.AttemptCount++;
+        operation.ErrorMessage = null;
+        await SaveOperationAsync(operation);
+
+        var stopwatch = Stopwatch.StartNew();
+        _logger.LogInformation(
+            "Starting migration rerun {MigrationRerunOperationId} for migration {MigrationId}. Attempt: {MigrationRerunAttempt} Source: {MigrationRerunSource} RequestedByUserId: {RequestedByUserId}",
+            operation.Id,
+            operation.MigrationId,
+            operation.AttemptCount,
+            operation.Source,
+            operation.RequestedByUserId);
+
+        try
+        {
+            await migration.RunAsync(new MigrationContext(
+                migrationLock,
+                loggerFactory.CreateLogger(migration.GetType()),
+                cancellationToken));
+
+            operation.Status = MigrationRerunStatus.Completed;
+            operation.CompletedUtc = timeProvider.GetUtcNow().UtcDateTime;
+            await SaveOperationAsync(operation);
+            _logger.LogInformation(
+                "Completed migration rerun {MigrationRerunOperationId} for migration {MigrationId} in {MigrationRerunDuration}",
+                operation.Id,
+                operation.MigrationId,
+                stopwatch.Elapsed);
+            return operation;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            operation.Status = MigrationRerunStatus.Cancelled;
+            operation.CompletedUtc = timeProvider.GetUtcNow().UtcDateTime;
+            await SaveOperationAsync(operation);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            operation.Status = MigrationRerunStatus.Failed;
+            operation.CompletedUtc = timeProvider.GetUtcNow().UtcDateTime;
+            operation.ErrorMessage = ex.Message.Length > 1000 ? ex.Message[..1000] : ex.Message;
+            await SaveOperationAsync(operation);
+            _logger.LogError(
+                ex,
+                "Failed migration rerun {MigrationRerunOperationId} for migration {MigrationId} after {MigrationRerunDuration}",
+                operation.Id,
+                operation.MigrationId,
+                stopwatch.Elapsed);
+            throw;
+        }
+        finally
+        {
+            await cache.RemoveAsync(GetActiveOperationCacheKey(operation.MigrationId));
+        }
+    }
+
+    private IMigration GetRerunnableMigration(string migrationId)
+    {
+        EnsureMigrationsLoaded();
+        var migration = migrationManager.Migrations.FirstOrDefault(candidate =>
+            String.Equals(candidate.GetId(), migrationId, StringComparison.OrdinalIgnoreCase));
+        if (migration is null)
+            throw new KeyNotFoundException($"Migration '{migrationId}' was not found.");
+        if (migration is not IRerunnableMigration)
+            throw new InvalidOperationException($"Migration '{migrationId}' does not support reruns.");
+
+        return migration;
+    }
+
+    private void EnsureMigrationsLoaded()
+    {
+        if (migrationManager.Migrations.Count == 0)
+            migrationManager.AddMigrationsFromLoadedAssemblies();
+    }
+
+    private Task SaveOperationAsync(MigrationRerunOperation operation)
+    {
+        return cache.SetAsync(GetOperationCacheKey(operation.Id), operation, OperationRetention);
+    }
+
+    private static string GetActiveOperationCacheKey(string migrationId) => $"migration-rerun:active:{migrationId}";
+    private static string GetOperationCacheKey(string operationId) => $"migration-rerun:operation:{operationId}";
+}
+
+public sealed class MigrationRerunAlreadyActiveException(string migrationId)
+    : Exception($"Migration '{migrationId}' already has a queued or running rerun.");

--- a/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
+++ b/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
@@ -99,8 +99,10 @@ public sealed class MigrationRerunService(
     {
         var operation = await GetOperationAsync(operationId)
             ?? throw new KeyNotFoundException($"Migration rerun operation '{operationId}' was not found.");
-        if (operation.Status != MigrationRerunStatus.Queued)
+        if (operation.Status is MigrationRerunStatus.Completed or MigrationRerunStatus.Failed or MigrationRerunStatus.Cancelled)
+        {
             return operation;
+        }
 
         var migration = GetRerunnableMigration(operation.MigrationId);
 
@@ -110,6 +112,11 @@ public sealed class MigrationRerunService(
             cancellationToken);
         if (migrationLock is null)
         {
+            if (operation.Status == MigrationRerunStatus.Running)
+            {
+                throw new MigrationRerunRecoveryPendingException(operation.Id);
+            }
+
             var exception = new InvalidOperationException("Another migration is currently running. Try the rerun again after it completes.");
             await FailQueuedOperationAsync(operation.Id, exception);
             throw exception;
@@ -204,3 +211,6 @@ public sealed class MigrationRerunService(
 
 public sealed class MigrationRerunAlreadyActiveException(string migrationId)
     : Exception($"Migration '{migrationId}' already has a queued or running rerun.");
+
+public sealed class MigrationRerunRecoveryPendingException(string operationId)
+    : Exception($"Migration rerun operation '{operationId}' is still running and will be retried.");

--- a/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
+++ b/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
@@ -139,6 +139,7 @@ public sealed class MigrationRerunService(
             operation.Source,
             operation.RequestedByUserId);
 
+        bool terminalStatePersisted = false;
         try
         {
             await migration.RunAsync(new MigrationContext(
@@ -149,6 +150,7 @@ public sealed class MigrationRerunService(
             operation.Status = MigrationRerunStatus.Completed;
             operation.CompletedUtc = timeProvider.GetUtcNow().UtcDateTime;
             await SaveOperationAsync(operation);
+            terminalStatePersisted = true;
             _logger.LogInformation(
                 "Completed migration rerun {MigrationRerunOperationId} for migration {MigrationId} in {MigrationRerunDuration}",
                 operation.Id,
@@ -163,6 +165,7 @@ public sealed class MigrationRerunService(
                 operation.Status = MigrationRerunStatus.Cancelled;
                 operation.CompletedUtc = timeProvider.GetUtcNow().UtcDateTime;
                 await SaveOperationAsync(operation);
+                terminalStatePersisted = true;
             }
             else
             {
@@ -180,6 +183,7 @@ public sealed class MigrationRerunService(
             operation.CompletedUtc = timeProvider.GetUtcNow().UtcDateTime;
             operation.ErrorMessage = ex.Message.Length > 1000 ? ex.Message[..1000] : ex.Message;
             await SaveOperationAsync(operation);
+            terminalStatePersisted = true;
             _logger.LogError(
                 ex,
                 "Failed migration rerun {MigrationRerunOperationId} for migration {MigrationId} after {MigrationRerunDuration}",
@@ -190,7 +194,7 @@ public sealed class MigrationRerunService(
         }
         finally
         {
-            if (IsTerminal(operation.Status))
+            if (terminalStatePersisted)
             {
                 await RemoveActiveOperationAsync(operation);
             }
@@ -286,7 +290,7 @@ public sealed class MigrationRerunRecoveryPendingException(string operationId)
     : Exception($"Migration rerun operation '{operationId}' is still running and will be retried.");
 
 public sealed class MigrationRerunCleanupPendingException(string operationId, Exception innerException)
-    : Exception($"Migration rerun operation '{operationId}' completed but its active-operation marker could not be removed and will be retried.", innerException);
+    : Exception($"Migration rerun operation '{operationId}' reached a terminal state but its active-operation marker could not be removed and will be retried.", innerException);
 
 public sealed class MigrationRerunUnavailableException(string message) : Exception(message);
 

--- a/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
+++ b/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 namespace Exceptionless.Core.Migrations;
 
 public sealed class MigrationRerunService(
+    AppOptions appOptions,
     MigrationManager migrationManager,
     IMigrationStateRepository migrationStateRepository,
     ICacheClient cache,
@@ -41,8 +42,10 @@ public sealed class MigrationRerunService(
         if (state?.CompletedUtc is null)
             throw new InvalidOperationException($"Migration '{migrationId}' must be completed before it can be rerun.");
 
+        EnsureUserInterfaceRerunAvailable(source);
+
         string operationId = Guid.NewGuid().ToString("N");
-        if (!await cache.AddAsync(GetActiveOperationCacheKey(migrationId), operationId, OperationRetention))
+        if (!await TryReserveMigrationAsync(migrationId, operationId))
             throw new MigrationRerunAlreadyActiveException(migrationId);
 
         var operation = new MigrationRerunOperation
@@ -69,7 +72,7 @@ public sealed class MigrationRerunService(
         }
         catch
         {
-            await cache.RemoveAsync(GetActiveOperationCacheKey(migrationId));
+            await RemoveActiveOperationAsync(operation);
             throw;
         }
     }
@@ -87,7 +90,7 @@ public sealed class MigrationRerunService(
         operation.CompletedUtc = timeProvider.GetUtcNow().UtcDateTime;
         operation.ErrorMessage = exception.Message.Length > 1000 ? exception.Message[..1000] : exception.Message;
         await SaveOperationAsync(operation);
-        await cache.RemoveAsync(GetActiveOperationCacheKey(operation.MigrationId));
+        await RemoveActiveOperationAsync(operation);
         _logger.LogError(
             exception,
             "Failed to dispatch migration rerun {MigrationRerunOperationId} for migration {MigrationId}",
@@ -101,6 +104,7 @@ public sealed class MigrationRerunService(
             ?? throw new KeyNotFoundException($"Migration rerun operation '{operationId}' was not found.");
         if (IsTerminal(operation.Status))
         {
+            await RemoveActiveOperationAsync(operation);
             return operation;
         }
 
@@ -190,8 +194,52 @@ public sealed class MigrationRerunService(
         {
             if (IsTerminal(operation.Status))
             {
-                await cache.RemoveAsync(GetActiveOperationCacheKey(operation.MigrationId));
+                await RemoveActiveOperationAsync(operation);
             }
+        }
+    }
+
+    private void EnsureUserInterfaceRerunAvailable(MigrationRerunSource source)
+    {
+        if (source != MigrationRerunSource.UserInterface || appOptions.RunJobsInProcess)
+            return;
+
+        bool hasDistributedCache = String.Equals(appOptions.CacheOptions.Provider, "redis", StringComparison.OrdinalIgnoreCase);
+        bool hasDistributedQueue = !String.IsNullOrWhiteSpace(appOptions.QueueOptions.Provider);
+        if (!hasDistributedCache || !hasDistributedQueue)
+        {
+            throw new MigrationRerunUnavailableException(
+                "Migration reruns from the System UI require a distributed cache and queue when jobs run outside the web process. Configure Redis-backed cache and a distributed queue, run jobs in the web process, or use the Migration --rerun command.");
+        }
+    }
+
+    private async Task<bool> TryReserveMigrationAsync(string migrationId, string operationId)
+    {
+        string activeOperationCacheKey = GetActiveOperationCacheKey(migrationId);
+        if (await cache.AddAsync(activeOperationCacheKey, operationId, OperationRetention))
+            return true;
+
+        string? activeOperationId = await cache.GetAsync<string?>(activeOperationCacheKey, null);
+        if (String.IsNullOrWhiteSpace(activeOperationId))
+            return false;
+
+        var activeOperation = await GetOperationAsync(activeOperationId);
+        if (activeOperation is null || !IsTerminal(activeOperation.Status))
+            return false;
+
+        await RemoveActiveOperationAsync(activeOperation);
+        return await cache.AddAsync(activeOperationCacheKey, operationId, OperationRetention);
+    }
+
+    private async Task RemoveActiveOperationAsync(MigrationRerunOperation operation)
+    {
+        try
+        {
+            await cache.RemoveIfEqualAsync(GetActiveOperationCacheKey(operation.MigrationId), operation.Id);
+        }
+        catch (Exception ex)
+        {
+            throw new MigrationRerunCleanupPendingException(operation.Id, ex);
         }
     }
 
@@ -231,3 +279,8 @@ public sealed class MigrationRerunAlreadyActiveException(string migrationId)
 
 public sealed class MigrationRerunRecoveryPendingException(string operationId)
     : Exception($"Migration rerun operation '{operationId}' is still running and will be retried.");
+
+public sealed class MigrationRerunCleanupPendingException(string operationId, Exception innerException)
+    : Exception($"Migration rerun operation '{operationId}' completed but its active-operation marker could not be removed and will be retried.", innerException);
+
+public sealed class MigrationRerunUnavailableException(string message) : Exception(message);

--- a/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
+++ b/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
@@ -106,7 +106,10 @@ public sealed class MigrationRerunService(
             operation.MigrationId);
     }
 
-    public async Task<MigrationRerunOperation> RunAsync(string operationId, CancellationToken cancellationToken = default)
+    public async Task<MigrationRerunOperation> RunAsync(
+        string operationId,
+        CancellationToken cancellationToken = default,
+        bool retryOnCancellation = false)
     {
         var operation = await GetOperationAsync(operationId)
             ?? throw new KeyNotFoundException($"Migration rerun operation '{operationId}' was not found.");
@@ -170,7 +173,7 @@ public sealed class MigrationRerunService(
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            if (operation.Source == MigrationRerunSource.CommandLine)
+            if (!retryOnCancellation)
             {
                 operation.Status = MigrationRerunStatus.Cancelled;
                 operation.CompletedUtc = timeProvider.GetUtcNow().UtcDateTime;

--- a/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
+++ b/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
@@ -99,7 +99,7 @@ public sealed class MigrationRerunService(
     {
         var operation = await GetOperationAsync(operationId)
             ?? throw new KeyNotFoundException($"Migration rerun operation '{operationId}' was not found.");
-        if (operation.Status is MigrationRerunStatus.Completed or MigrationRerunStatus.Failed or MigrationRerunStatus.Cancelled)
+        if (IsTerminal(operation.Status))
         {
             return operation;
         }
@@ -156,9 +156,20 @@ public sealed class MigrationRerunService(
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            operation.Status = MigrationRerunStatus.Cancelled;
-            operation.CompletedUtc = timeProvider.GetUtcNow().UtcDateTime;
-            await SaveOperationAsync(operation);
+            if (operation.Source == MigrationRerunSource.CommandLine)
+            {
+                operation.Status = MigrationRerunStatus.Cancelled;
+                operation.CompletedUtc = timeProvider.GetUtcNow().UtcDateTime;
+                await SaveOperationAsync(operation);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Migration rerun {MigrationRerunOperationId} for migration {MigrationId} was interrupted and will resume when the work item is redelivered",
+                    operation.Id,
+                    operation.MigrationId);
+            }
+
             throw;
         }
         catch (Exception ex)
@@ -177,7 +188,10 @@ public sealed class MigrationRerunService(
         }
         finally
         {
-            await cache.RemoveAsync(GetActiveOperationCacheKey(operation.MigrationId));
+            if (IsTerminal(operation.Status))
+            {
+                await cache.RemoveAsync(GetActiveOperationCacheKey(operation.MigrationId));
+            }
         }
     }
 
@@ -204,6 +218,9 @@ public sealed class MigrationRerunService(
     {
         return cache.SetAsync(GetOperationCacheKey(operation.Id), operation, OperationRetention);
     }
+
+    private static bool IsTerminal(MigrationRerunStatus status)
+        => status is MigrationRerunStatus.Completed or MigrationRerunStatus.Failed or MigrationRerunStatus.Cancelled;
 
     private static string GetActiveOperationCacheKey(string migrationId) => $"migration-rerun:active:{migrationId}";
     private static string GetOperationCacheKey(string operationId) => $"migration-rerun:operation:{operationId}";

--- a/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
+++ b/src/Exceptionless.Core/Migrations/MigrationRerunService.cs
@@ -60,9 +60,19 @@ public sealed class MigrationRerunService(
         // Persist the operation before publishing its active marker. This ordering guarantees that
         // a marker without an operation record is stale and can be safely reclaimed.
         await SaveOperationAsync(operation);
-        if (!await TryReserveMigrationAsync(migrationId, operationId))
+        var reservation = await TryReserveMigrationAsync(migrationId, operationId);
+        if (!reservation.IsReserved)
         {
             await cache.RemoveAsync(GetOperationCacheKey(operation.Id));
+            if (reservation.ActiveOperation?.Status == MigrationRerunStatus.Queued)
+            {
+                _logger.LogInformation(
+                    "Reusing queued migration rerun {MigrationRerunOperationId} for migration {MigrationId} so it can be dispatched again",
+                    reservation.ActiveOperation.Id,
+                    reservation.ActiveOperation.MigrationId);
+                return reservation.ActiveOperation;
+            }
+
             throw new MigrationRerunAlreadyActiveException(migrationId);
         }
 
@@ -215,26 +225,26 @@ public sealed class MigrationRerunService(
         }
     }
 
-    private async Task<bool> TryReserveMigrationAsync(string migrationId, string operationId)
+    private async Task<(bool IsReserved, MigrationRerunOperation? ActiveOperation)> TryReserveMigrationAsync(string migrationId, string operationId)
     {
         string activeOperationCacheKey = GetActiveOperationCacheKey(migrationId);
         if (await cache.AddAsync(activeOperationCacheKey, operationId, ActiveOperationRetention))
-            return true;
+            return (true, null);
 
         string? activeOperationId = await cache.GetAsync<string?>(activeOperationCacheKey, null);
         if (String.IsNullOrWhiteSpace(activeOperationId))
-            return await cache.AddAsync(activeOperationCacheKey, operationId, ActiveOperationRetention);
+            return (await cache.AddAsync(activeOperationCacheKey, operationId, ActiveOperationRetention), null);
 
         var activeOperation = await GetOperationAsync(activeOperationId);
         if (activeOperation is not null && !IsTerminal(activeOperation.Status))
-            return false;
+            return (false, activeOperation);
 
         if (activeOperation is null)
             await RemoveActiveReservationAsync(migrationId, activeOperationId);
         else
             await RemoveActiveOperationAsync(activeOperation);
 
-        return await cache.AddAsync(activeOperationCacheKey, operationId, ActiveOperationRetention);
+        return (await cache.AddAsync(activeOperationCacheKey, operationId, ActiveOperationRetention), null);
     }
 
     private Task RemoveActiveOperationAsync(MigrationRerunOperation operation)

--- a/src/Exceptionless.Core/Models/WorkItems/RerunMigrationWorkItem.cs
+++ b/src/Exceptionless.Core/Models/WorkItems/RerunMigrationWorkItem.cs
@@ -1,0 +1,10 @@
+using Foundatio.Queues;
+
+namespace Exceptionless.Core.Models.WorkItems;
+
+public record RerunMigrationWorkItem : IHaveUniqueIdentifier
+{
+    public required string OperationId { get; init; }
+
+    public string UniqueIdentifier => $"{nameof(RerunMigrationWorkItem)}:{OperationId}";
+}

--- a/src/Exceptionless.Job/JobRunnerOptions.cs
+++ b/src/Exceptionless.Job/JobRunnerOptions.cs
@@ -4,8 +4,22 @@ public class JobRunnerOptions
 {
     public JobRunnerOptions(string[] args)
     {
+        if (args.Length == 3
+            && String.Equals(args[0], nameof(Migration), StringComparison.OrdinalIgnoreCase)
+            && String.Equals(args[1], "--rerun", StringComparison.OrdinalIgnoreCase)
+            && !String.IsNullOrWhiteSpace(args[2]))
+        {
+            Migration = true;
+            RerunMigrationId = args[2];
+            JobName = $"{nameof(Migration)} Rerun {RerunMigrationId}";
+            ConfigurationArguments = [];
+            return;
+        }
+
         if (args.Length > 1)
-            throw new ArgumentException("More than one job argument specified. You must either specify 1 named job or don't pass any arguments to run all jobs.");
+            throw new ArgumentException("Specify one named job, no arguments to run all jobs, or 'Migration --rerun <id>' to rerun a supported migration.");
+
+        ConfigurationArguments = args;
 
         AllJobs = args.Length == 0;
 
@@ -79,6 +93,7 @@ public class JobRunnerOptions
     }
 
     public string JobName { get; } = "All";
+    public string[] ConfigurationArguments { get; }
     public bool AllJobs { get; }
     public bool CleanupData { get; }
     public bool CleanupOrphanedData { get; }
@@ -93,6 +108,7 @@ public class JobRunnerOptions
     public bool MailMessage { get; }
     public bool MaintainIndexes { get; }
     public bool Migration { get; }
+    public string? RerunMigrationId { get; }
     public bool RunDataSeedStartupAction => !Migration;
     public bool StackStatus { get; }
     public bool StackEventCount { get; }

--- a/src/Exceptionless.Job/Program.cs
+++ b/src/Exceptionless.Job/Program.cs
@@ -52,7 +52,7 @@ public class Program
             .AddYamlFile("appsettings.yml", optional: true, reloadOnChange: true)
             .AddYamlFile($"appsettings.{environment}.yml", optional: true, reloadOnChange: true)
             .AddCustomEnvironmentVariables()
-            .AddCommandLine(args)
+            .AddCommandLine(jobOptions.ConfigurationArguments)
             .Build();
 
         Log.Logger = new LoggerConfiguration()
@@ -177,7 +177,12 @@ public class Program
         if (options is { MaintainIndexes: true, AllJobs: false })
             services.AddJob<MaintainIndexesJob>();
 
-        if (options.Migration)
+        if (options.RerunMigrationId is not null)
+        {
+            services.AddSingleton(new RerunMigrationJobOptions(options.RerunMigrationId));
+            services.AddJob<RerunMigrationJob>(o => o.WaitForStartupActions());
+        }
+        else if (options.Migration)
             services.AddJob<MigrationJob>(o => o.WaitForStartupActions());
         if (options.StackStatus)
             services.AddJob<StackStatusJob>(o => o.WaitForStartupActions());

--- a/src/Exceptionless.Job/RerunMigrationJob.cs
+++ b/src/Exceptionless.Job/RerunMigrationJob.cs
@@ -1,0 +1,37 @@
+using Exceptionless.Core.Migrations;
+using Foundatio.Jobs;
+using Foundatio.Resilience;
+
+namespace Exceptionless.Job;
+
+public record RerunMigrationJobOptions(string MigrationId);
+
+[Job(Description = "Reruns an explicitly supported completed migration.", IsContinuous = false)]
+public sealed class RerunMigrationJob : JobBase
+{
+    private readonly MigrationRerunService _migrationRerunService;
+    private readonly RerunMigrationJobOptions _options;
+
+    public RerunMigrationJob(
+        MigrationRerunService migrationRerunService,
+        RerunMigrationJobOptions options,
+        TimeProvider timeProvider,
+        IResiliencePolicyProvider resiliencePolicyProvider,
+        ILoggerFactory loggerFactory)
+        : base(timeProvider, resiliencePolicyProvider, loggerFactory)
+    {
+        _migrationRerunService = migrationRerunService;
+        _options = options;
+    }
+
+    protected override async Task<JobResult> RunInternalAsync(JobContext context)
+    {
+        var operation = await _migrationRerunService.QueueAsync(
+            _options.MigrationId,
+            MigrationRerunSource.CommandLine,
+            null,
+            context.CancellationToken);
+        await _migrationRerunService.RunAsync(operation.Id, context.CancellationToken);
+        return JobResult.Success;
+    }
+}

--- a/src/Exceptionless.Web/Api/Endpoints/AdminEndpoints.cs
+++ b/src/Exceptionless.Web/Api/Endpoints/AdminEndpoints.cs
@@ -103,6 +103,7 @@ public static class AdminEndpoints
             .ProducesProblem(StatusCodes.Status404NotFound)
             .ProducesProblem(StatusCodes.Status409Conflict)
             .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .ProducesProblem(StatusCodes.Status503ServiceUnavailable)
             .WithSummary("Rerun a supported completed migration");
 
         group.MapGet("migrations/reruns/{operationId}", async (string operationId, IMediator mediator, IMediatorResultMapper<HttpIResult> resultMapper)

--- a/src/Exceptionless.Web/Api/Endpoints/AdminEndpoints.cs
+++ b/src/Exceptionless.Web/Api/Endpoints/AdminEndpoints.cs
@@ -96,6 +96,21 @@ public static class AdminEndpoints
         group.MapPost("generate-sample-events", async (IMediator mediator, IMediatorResultMapper<HttpIResult> resultMapper, int eventCount = 250, int daysBack = 7)
             => (await mediator.InvokeAsync<Result<object>>(new AdminGenerateSampleEvents(eventCount, daysBack))).ToHttpResult(resultMapper));
 
+        group.MapPost("migrations/{version:int}/rerun", async (int version, HttpContext httpContext, [FromBody] RerunMigrationRequest request, IMediator mediator, IMediatorResultMapper<HttpIResult> resultMapper)
+            => (await mediator.InvokeAsync<Result<WorkInProgressResult>>(new AdminRerunMigration(version, request.Confirmation, httpContext))).ToHttpResult(resultMapper))
+            .Accepts<RerunMigrationRequest>("application/json", "application/*+json")
+            .Produces<WorkInProgressResult>(StatusCodes.Status202Accepted)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesProblem(StatusCodes.Status422UnprocessableEntity)
+            .WithSummary("Rerun a supported completed migration");
+
+        group.MapGet("migrations/reruns/{operationId}", async (string operationId, IMediator mediator, IMediatorResultMapper<HttpIResult> resultMapper)
+            => (await mediator.InvokeAsync<Result<MigrationRerunOperationResponse>>(new GetAdminMigrationRerun(operationId))).ToHttpResult(resultMapper))
+            .Produces<MigrationRerunOperationResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .WithSummary("Get migration rerun status");
+
         return endpoints;
     }
 

--- a/src/Exceptionless.Web/Api/Handlers/AdminHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/AdminHandler.cs
@@ -2,6 +2,7 @@ using Exceptionless.Core;
 using Exceptionless.Core.Billing;
 using Exceptionless.Core.Extensions;
 using Exceptionless.Core.Messaging.Models;
+using Exceptionless.Core.Migrations;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Models.WorkItems;
 using Exceptionless.Core.Queues.Models;
@@ -10,6 +11,7 @@ using Exceptionless.Core.Repositories.Configuration;
 using Exceptionless.Core.Utility;
 using Exceptionless.DateTimeExtensions;
 using Exceptionless.Web.Api.Messages;
+using Exceptionless.Web.Api.Results;
 using Exceptionless.Web.Extensions;
 using Exceptionless.Web.Models.Admin;
 using Foundatio.Jobs;
@@ -37,6 +39,7 @@ public class AdminHandler(
     BillingManager billingManager,
     BillingPlans plans,
     IMigrationStateRepository migrationStateRepository,
+    MigrationRerunService migrationRerunService,
     SampleDataService sampleDataService,
     TimeProvider timeProvider,
     ILoggerFactory loggerFactory)
@@ -148,9 +151,18 @@ public class AdminHandler(
                 break;
         }
 
+        var rerunnableMigrationIds = migrationRerunService.GetRerunnableMigrationIds();
         var states = migrationStates
             .OrderByDescending(s => s.Version)
             .ThenByDescending(s => s.StartedUtc)
+            .Select(state => new MigrationStateResponse(
+                state.Id,
+                state.MigrationType,
+                state.Version,
+                state.StartedUtc,
+                state.CompletedUtc,
+                state.ErrorMessage,
+                state.CompletedUtc.HasValue && rerunnableMigrationIds.Contains(state.Id)))
             .ToArray();
 
         int currentVersion = states
@@ -160,6 +172,70 @@ public class AdminHandler(
             .Max();
 
         return new MigrationsResponse(currentVersion, states);
+    }
+
+    public async Task<Result<WorkInProgressResult>> Handle(AdminRerunMigration message)
+    {
+        string migrationId = message.Version.ToString();
+        string expectedConfirmation = $"RERUN {message.Version}";
+        if (!String.Equals(message.Confirmation?.Trim(), expectedConfirmation, StringComparison.Ordinal))
+            return Result.Invalid(ValidationError.Create("confirmation", $"Enter '{expectedConfirmation}' to confirm the migration rerun."));
+
+        try
+        {
+            var operation = await migrationRerunService.QueueAsync(
+                migrationId,
+                MigrationRerunSource.UserInterface,
+                message.Context.Request.GetUser().Id,
+                message.Context.RequestAborted);
+            try
+            {
+                await workItemQueue.EnqueueAsync(new RerunMigrationWorkItem { OperationId = operation.Id });
+            }
+            catch (Exception ex)
+            {
+                await migrationRerunService.FailQueuedOperationAsync(operation.Id, ex);
+                throw;
+            }
+
+            return new WorkInProgressResult([operation.Id]);
+        }
+        catch (KeyNotFoundException)
+        {
+            return Result.NotFound($"Migration '{migrationId}' was not found.");
+        }
+        catch (MigrationRerunAlreadyActiveException ex)
+        {
+            return Result.Conflict(ex.Message);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Result.Invalid(ValidationError.Create("version", ex.Message));
+        }
+    }
+
+    public async Task<Result<MigrationRerunOperationResponse>> Handle(GetAdminMigrationRerun message)
+    {
+        var operation = await migrationRerunService.GetOperationAsync(message.OperationId);
+        return operation is null
+            ? Result.NotFound("Migration rerun operation not found.")
+            : ToResponse(operation);
+    }
+
+    private static MigrationRerunOperationResponse ToResponse(MigrationRerunOperation operation)
+    {
+        return new MigrationRerunOperationResponse(
+            operation.Id,
+            operation.MigrationId,
+            operation.Version,
+            operation.Source.ToString(),
+            operation.Status.ToString(),
+            operation.RequestedByUserId,
+            operation.RequestedUtc,
+            operation.StartedUtc,
+            operation.CompletedUtc,
+            operation.AttemptCount,
+            operation.ErrorMessage);
     }
 
     public Task<Result<object>> Handle(GetAdminEcho message)

--- a/src/Exceptionless.Web/Api/Handlers/AdminHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/AdminHandler.cs
@@ -208,6 +208,10 @@ public class AdminHandler(
         {
             return Result.Conflict(ex.Message);
         }
+        catch (MigrationRerunUnavailableException ex)
+        {
+            return Result.Unavailable(ex.Message);
+        }
         catch (InvalidOperationException ex)
         {
             return Result.Invalid(ValidationError.Create("version", ex.Message));

--- a/src/Exceptionless.Web/Api/Handlers/AdminHandler.cs
+++ b/src/Exceptionless.Web/Api/Handlers/AdminHandler.cs
@@ -212,7 +212,7 @@ public class AdminHandler(
         {
             return Result.Unavailable(ex.Message);
         }
-        catch (InvalidOperationException ex)
+        catch (MigrationRerunValidationException ex)
         {
             return Result.Invalid(ValidationError.Create("version", ex.Message));
         }

--- a/src/Exceptionless.Web/Api/Messages/AdminMessages.cs
+++ b/src/Exceptionless.Web/Api/Messages/AdminMessages.cs
@@ -4,6 +4,8 @@ public record GetAdminSettings;
 public record GetAdminStats;
 public record GetAdminAssistantUsage(DateTime? Month, int Limit, HttpContext Context);
 public record GetAdminMigrations;
+public record AdminRerunMigration(int Version, string? Confirmation, HttpContext Context);
+public record GetAdminMigrationRerun(string OperationId);
 public record GetAdminEcho(HttpContext Context);
 public record GetAdminAssemblies;
 public record AdminChangePlan(string OrganizationId, string PlanId, HttpContext Context);

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/migration-rerun.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/migration-rerun.e2e.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '../fixtures/e2e-test';
+
+test('global admin can open the guarded migration rerun confirmation', async ({ e2eScenario, page }) => {
+    await page.route('**/api/v2/admin/migrations', async (route) => {
+        await route.fulfill({
+            body: JSON.stringify({
+                current_version: 9,
+                states: [
+                    {
+                        can_rerun: true,
+                        completed_utc: '2026-09-04T12:00:00Z',
+                        id: '5',
+                        migration_type: 2,
+                        started_utc: '2026-09-04T11:59:00Z',
+                        version: 5
+                    }
+                ]
+            }),
+            contentType: 'application/json',
+            status: 200
+        });
+    });
+
+    await page.goto('/next/system/migrations');
+
+    await expect(page.getByRole('heading', { name: 'System Administration' })).toBeVisible();
+    await expect(page.getByText(e2eScenario.organizationName, { exact: false }).first()).toBeVisible();
+
+    await page.getByRole('button', { name: 'Open actions for migration 5' }).click();
+    await page.getByRole('menuitem', { name: 'Rerun migration' }).click();
+
+    const dialog = page.getByRole('alertdialog', { name: 'Rerun Migration 5' });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('does not change the current migration version')).toBeVisible();
+
+    const rerunButton = dialog.getByRole('button', { name: 'Rerun Migration' });
+    await expect(rerunButton).toBeDisabled();
+    await dialog.getByLabel('Enter RERUN 5 to confirm').fill('RERUN 5');
+    await expect(rerunButton).toBeEnabled();
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/api.svelte.ts
@@ -1,3 +1,5 @@
+import type { WorkInProgressResult } from '$generated/api';
+
 import { invalidateAssistantAccessQueries } from '$features/assistant/api.svelte';
 import { type FetchClientResponse, type ProblemDetails, useFetchClient } from '@foundatiofx/fetchclient';
 import { createMutation, createQuery, useQueryClient } from '@tanstack/svelte-query';
@@ -9,6 +11,7 @@ import type {
     AdminStats,
     ElasticsearchInfo,
     ElasticsearchSnapshotsResponse,
+    MigrationRerunOperation,
     MigrationsResponse,
     OAuthApplication,
     OAuthApplicationRequest,
@@ -174,6 +177,29 @@ export function getEventSubmissionSettingsQuery() {
     }));
 }
 
+export function getMigrationRerunQuery(operationId: () => string | undefined) {
+    return createQuery<MigrationRerunOperation, ProblemDetails>(() => ({
+        enabled: () => !!operationId(),
+        queryFn: async ({ signal }: { signal: AbortSignal }) => {
+            const client = useFetchClient();
+            const response = await client.getJSON<MigrationRerunOperation>(`admin/migrations/reruns/${operationId()}`, {
+                signal
+            });
+
+            if (!response.ok) {
+                throw response.problem;
+            }
+
+            return response.data!;
+        },
+        queryKey: [...queryKeys.migrations, 'rerun', operationId()],
+        refetchInterval: (query) => {
+            const status = query.state.data?.status;
+            return status === 'Completed' || status === 'Failed' || status === 'Cancelled' ? false : 2000;
+        }
+    }));
+}
+
 export function getMigrationsQuery() {
     return createQuery<MigrationsResponse, ProblemDetails>(() => ({
         queryFn: async ({ signal }: { signal: AbortSignal }) => {
@@ -269,6 +295,23 @@ export function postForceUpdatePredefinedSavedViewsMutation() {
             if (!response.ok) {
                 throw response.problem;
             }
+        }
+    }));
+}
+
+export function postMigrationRerunMutation() {
+    return createMutation<WorkInProgressResult, ProblemDetails, { confirmation: string; version: number }>(() => ({
+        mutationFn: async ({ confirmation, version }) => {
+            const client = useFetchClient();
+            const response = await client.postJSON<WorkInProgressResult>(`admin/migrations/${version}/rerun`, {
+                confirmation
+            });
+
+            if (!response.ok) {
+                throw response.problem;
+            }
+
+            return response.data!;
         }
     }));
 }

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/migration-actions-cell.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/migration-actions-cell.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+    import * as AlertDialog from '$comp/ui/alert-dialog';
+    import { Button, buttonVariants } from '$comp/ui/button';
+    import * as DropdownMenu from '$comp/ui/dropdown-menu';
+    import { Input } from '$comp/ui/input';
+    import { getMigrationRerunQuery, postMigrationRerunMutation, queryKeys } from '$features/admin/api.svelte';
+    import { getProblemMessage } from '$features/shared/validation';
+    import EllipsisIcon from '@lucide/svelte/icons/ellipsis';
+    import RefreshCcw from '@lucide/svelte/icons/refresh-ccw';
+    import { useQueryClient } from '@tanstack/svelte-query';
+    import { toast } from 'svelte-sonner';
+
+    import type { MigrationStateRow } from './migrations-options.svelte';
+
+    interface Props {
+        migration: MigrationStateRow;
+    }
+
+    let { migration }: Props = $props();
+
+    const queryClient = useQueryClient();
+    const rerunMutation = postMigrationRerunMutation();
+    let confirmation = $state('');
+    let dialogOpen = $state(false);
+    let operationId = $state<string>();
+    let reportedStatus = $state<string>();
+    const operationQuery = getMigrationRerunQuery(() => operationId);
+    const expectedConfirmation = $derived(`RERUN ${migration.version}`);
+    const operationActive = $derived(operationQuery.data?.status === 'Queued' || operationQuery.data?.status === 'Running');
+
+    $effect(() => {
+        const operation = operationQuery.data;
+        if (!operation || operation.status === 'Queued' || operation.status === 'Running' || operation.status === reportedStatus) {
+            return;
+        }
+
+        reportedStatus = operation.status;
+        void queryClient.invalidateQueries({
+            queryKey: queryKeys.migrations
+        });
+        if (operation.status === 'Completed') {
+            toast.success(`Migration ${migration.version} rerun completed.`);
+        } else {
+            toast.error(operation.error_message || `Migration ${migration.version} rerun ${operation.status.toLowerCase()}.`);
+        }
+    });
+
+    async function rerunMigration() {
+        try {
+            const result = await rerunMutation.mutateAsync({
+                confirmation,
+                version: migration.version
+            });
+            operationId = result.workers[0];
+            reportedStatus = undefined;
+            dialogOpen = false;
+            confirmation = '';
+            toast.success(`Migration ${migration.version} rerun queued.`);
+        } catch (error) {
+            toast.error(getProblemMessage(error, `Failed to queue migration ${migration.version} rerun.`));
+        }
+    }
+</script>
+
+<DropdownMenu.Root>
+    <DropdownMenu.Trigger>
+        {#snippet child({ props })}
+            <Button {...props} variant="ghost" size="icon" class="relative size-8 p-0" disabled={operationActive}>
+                <span class="sr-only">Open actions for migration {migration.version}</span>
+                <EllipsisIcon class="size-4" aria-hidden="true" />
+            </Button>
+        {/snippet}
+    </DropdownMenu.Trigger>
+    <DropdownMenu.Content align="end">
+        <DropdownMenu.Item
+            disabled={rerunMutation.isPending || operationActive}
+            onclick={() => {
+                confirmation = '';
+                dialogOpen = true;
+            }}
+        >
+            <RefreshCcw class="size-4" aria-hidden="true" />
+            {operationActive ? 'Rerun in progress' : 'Rerun migration'}
+        </DropdownMenu.Item>
+    </DropdownMenu.Content>
+</DropdownMenu.Root>
+
+<AlertDialog.Root bind:open={dialogOpen}>
+    <AlertDialog.Content>
+        <AlertDialog.Header>
+            <AlertDialog.Title>Rerun Migration {migration.version}</AlertDialog.Title>
+            <AlertDialog.Description>
+                This migration can rewrite Elasticsearch data. Take a snapshot and stop older Exceptionless instances before continuing. The rerun executes in
+                the background and does not change the current migration version.
+            </AlertDialog.Description>
+        </AlertDialog.Header>
+
+        <div class="space-y-2">
+            <label class="text-sm font-medium" for={`migration-rerun-confirmation-${migration.version}`}>
+                Enter <span class="font-mono">{expectedConfirmation}</span> to confirm
+            </label>
+            <Input id={`migration-rerun-confirmation-${migration.version}`} bind:value={confirmation} autocomplete="off" placeholder={expectedConfirmation} />
+        </div>
+
+        <AlertDialog.Footer>
+            <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+            <AlertDialog.Action
+                class={buttonVariants({
+                    variant: 'destructive'
+                })}
+                disabled={rerunMutation.isPending || confirmation !== expectedConfirmation}
+                onclick={() => void rerunMigration()}
+            >
+                {rerunMutation.isPending ? 'Queuing...' : 'Rerun Migration'}
+            </AlertDialog.Action>
+        </AlertDialog.Footer>
+    </AlertDialog.Content>
+</AlertDialog.Root>

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/migrations-options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/components/table/migrations-options.svelte.ts
@@ -4,6 +4,7 @@ import DateTime from '$comp/formatters/date-time.svelte';
 import { getSharedTableOptions, type TableMemoryPagingParameters, withClientSortedRowModel } from '$features/shared/table.svelte';
 import { type ColumnDef, renderComponent, type StockFeatures } from '@tanstack/svelte-table';
 
+import MigrationActionsCell from './migration-actions-cell.svelte';
 import MigrationDurationCell from './migration-duration-cell.svelte';
 import MigrationErrorCell from './migration-error-cell.svelte';
 import MigrationStatusCell from './migration-status-cell.svelte';
@@ -87,6 +88,21 @@ export function getColumns(): ColumnDef<StockFeatures, MigrationStateRow, unknow
             header: 'Error',
             meta: {
                 class: 'max-w-xs'
+            }
+        },
+        {
+            cell: ({ row }) =>
+                row.original.can_rerun
+                    ? renderComponent(MigrationActionsCell, {
+                          migration: row.original
+                      })
+                    : '',
+            enableHiding: false,
+            enableSorting: false,
+            header: '',
+            id: 'actions',
+            meta: {
+                class: 'w-10'
             }
         }
     ];

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/admin/models.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/admin/models.ts
@@ -122,12 +122,27 @@ export type MaintenanceAction = {
 };
 
 export type MaintenanceActionCategory = 'Billing' | 'Configuration' | 'Elasticsearch' | 'Maintenance' | 'Security' | 'Users';
+export type MigrationRerunOperation = {
+    attempt_count: number;
+    completed_utc?: null | string;
+    error_message?: null | string;
+    id: string;
+    migration_id: string;
+    requested_by_user_id?: null | string;
+    requested_utc: string;
+    source: 'CommandLine' | 'UserInterface';
+    started_utc?: null | string;
+    status: 'Cancelled' | 'Completed' | 'Failed' | 'Queued' | 'Running';
+    version: number;
+};
+
 export type MigrationsResponse = {
     current_version: number;
     states: MigrationState[];
 };
 
 export type MigrationState = {
+    can_rerun: boolean;
     completed_utc?: null | string;
     error_message?: null | string;
     id: string;

--- a/src/Exceptionless.Web/Models/Admin/MigrationsResponse.cs
+++ b/src/Exceptionless.Web/Models/Admin/MigrationsResponse.cs
@@ -1,6 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Exceptionless.Web.Models.Admin;
 
 public record MigrationsResponse(
     int CurrentVersion,
-    Foundatio.Repositories.Migrations.MigrationState[] States
+    MigrationStateResponse[] States
+);
+
+public record MigrationStateResponse(
+    string Id,
+    Foundatio.Repositories.Migrations.MigrationType MigrationType,
+    int Version,
+    DateTime StartedUtc,
+    DateTime? CompletedUtc,
+    string? ErrorMessage,
+    bool CanRerun
+);
+
+public record RerunMigrationRequest([property: Required] string? Confirmation);
+
+public record MigrationRerunOperationResponse(
+    string Id,
+    string MigrationId,
+    int Version,
+    string Source,
+    string Status,
+    string? RequestedByUserId,
+    DateTime RequestedUtc,
+    DateTime? StartedUtc,
+    DateTime? CompletedUtc,
+    int AttemptCount,
+    string? ErrorMessage
 );

--- a/tests/Exceptionless.Tests/Api/Data/endpoint-manifest.json
+++ b/tests/Exceptionless.Tests/Api/Data/endpoint-manifest.json
@@ -435,6 +435,30 @@
   },
   {
     "method": "GET",
+    "route": "/api/v2/admin/migrations/reruns/{operationId}",
+    "displayName": "HTTP: GET api/v2/admin/migrations/reruns/{operationId}",
+    "tags": [],
+    "allowAnonymous": false,
+    "authorizationPolicies": [
+      "GlobalAdminPolicy"
+    ],
+    "authorizationRoles": [],
+    "authenticationSchemes": []
+  },
+  {
+    "method": "POST",
+    "route": "/api/v2/admin/migrations/{version:int}/rerun",
+    "displayName": "HTTP: POST api/v2/admin/migrations/{version:int}/rerun",
+    "tags": [],
+    "allowAnonymous": false,
+    "authorizationPolicies": [
+      "GlobalAdminPolicy"
+    ],
+    "authorizationRoles": [],
+    "authenticationSchemes": []
+  },
+  {
+    "method": "GET",
     "route": "/api/v2/admin/oauth-applications",
     "displayName": "HTTP: GET api/v2/admin/oauth-applications",
     "tags": [],

--- a/tests/Exceptionless.Tests/Api/Endpoints/AdminEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/AdminEndpointTests.cs
@@ -929,10 +929,17 @@ public class AdminEndpointTests : IntegrationTestsBase
         var appOptions = GetService<AppOptions>();
         bool runJobsInProcess = appOptions.RunJobsInProcess;
         WorkInProgressResult? result;
+        WorkInProgressResult? redispatchedResult;
         try
         {
             appOptions.RunJobsInProcess = true;
             result = await SendRequestAsAsync<WorkInProgressResult>(request => request
+                .Post()
+                .AsGlobalAdminUser()
+                .AppendPaths("admin", "migrations", "5", "rerun")
+                .Content(new RerunMigrationRequest("RERUN 5"))
+                .StatusCodeShouldBeAccepted());
+            redispatchedResult = await SendRequestAsAsync<WorkInProgressResult>(request => request
                 .Post()
                 .AsGlobalAdminUser()
                 .AppendPaths("admin", "migrations", "5", "rerun")
@@ -946,7 +953,9 @@ public class AdminEndpointTests : IntegrationTestsBase
 
         // Assert
         Assert.NotNull(result);
+        Assert.NotNull(redispatchedResult);
         Assert.Single(result.Workers);
+        Assert.Equal(result.Workers, redispatchedResult.Workers);
         var operation = await GetService<MigrationRerunService>().GetOperationAsync(result.Workers[0]);
         Assert.NotNull(operation);
         Assert.Equal(MigrationRerunStatus.Queued, operation.Status);

--- a/tests/Exceptionless.Tests/Api/Endpoints/AdminEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/AdminEndpointTests.cs
@@ -1,5 +1,7 @@
+using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Exceptionless.Core;
 using Exceptionless.Core.Billing;
 using Exceptionless.Core.Migrations;
 using Exceptionless.Core.Models;
@@ -924,12 +926,23 @@ public class AdminEndpointTests : IntegrationTestsBase
         });
 
         // Act
-        var result = await SendRequestAsAsync<WorkInProgressResult>(request => request
-            .Post()
-            .AsGlobalAdminUser()
-            .AppendPaths("admin", "migrations", "5", "rerun")
-            .Content(new RerunMigrationRequest("RERUN 5"))
-            .StatusCodeShouldBeAccepted());
+        var appOptions = GetService<AppOptions>();
+        bool runJobsInProcess = appOptions.RunJobsInProcess;
+        WorkInProgressResult? result;
+        try
+        {
+            appOptions.RunJobsInProcess = true;
+            result = await SendRequestAsAsync<WorkInProgressResult>(request => request
+                .Post()
+                .AsGlobalAdminUser()
+                .AppendPaths("admin", "migrations", "5", "rerun")
+                .Content(new RerunMigrationRequest("RERUN 5"))
+                .StatusCodeShouldBeAccepted());
+        }
+        finally
+        {
+            appOptions.RunJobsInProcess = runJobsInProcess;
+        }
 
         // Assert
         Assert.NotNull(result);
@@ -960,6 +973,29 @@ public class AdminEndpointTests : IntegrationTestsBase
         operation = await GetService<MigrationRerunService>().GetOperationAsync(operation.Id);
         Assert.NotNull(operation);
         Assert.Equal(MigrationRerunStatus.Completed, operation.Status);
+    }
+
+    [Fact]
+    public async Task RerunMigrationAsync_WithOutOfProcessJobsAndInMemoryInfrastructure_ReturnsServiceUnavailable()
+    {
+        // Arrange
+        var migrationStateRepository = GetService<IMigrationStateRepository>();
+        await migrationStateRepository.AddAsync(new MigrationState
+        {
+            Id = "5",
+            Version = 5,
+            MigrationType = MigrationType.VersionedAndResumable,
+            StartedUtc = DateTime.UtcNow.AddMinutes(-1),
+            CompletedUtc = DateTime.UtcNow
+        });
+
+        // Act / Assert
+        await SendRequestAsync(request => request
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "migrations", "5", "rerun")
+            .Content(new RerunMigrationRequest("RERUN 5"))
+            .ExpectedStatus(HttpStatusCode.ServiceUnavailable));
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Api/Endpoints/AdminEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/AdminEndpointTests.cs
@@ -955,6 +955,11 @@ public class AdminEndpointTests : IntegrationTestsBase
 
         var queueStats = await _workItemQueue.GetQueueStatsAsync();
         Assert.Equal(1, queueStats.Enqueued);
+
+        await _workItemJob.RunUntilEmptyAsync(TestCancellationToken);
+        operation = await GetService<MigrationRerunService>().GetOperationAsync(operation.Id);
+        Assert.NotNull(operation);
+        Assert.Equal(MigrationRerunStatus.Completed, operation.Status);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Api/Endpoints/AdminEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/AdminEndpointTests.cs
@@ -1010,6 +1010,27 @@ public class AdminEndpointTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task RerunMigrationAsync_WithIncompleteMigration_ReturnsValidationError()
+    {
+        // Arrange
+        await GetService<IMigrationStateRepository>().AddAsync(new MigrationState
+        {
+            Id = "5",
+            Version = 5,
+            MigrationType = MigrationType.VersionedAndResumable,
+            StartedUtc = DateTime.UtcNow
+        });
+
+        // Act / Assert
+        await SendRequestAsync(request => request
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "migrations", "5", "rerun")
+            .Content(new RerunMigrationRequest("RERUN 5"))
+            .StatusCodeShouldBeUnprocessableEntity());
+    }
+
+    [Fact]
     public Task RerunMigrationAsync_AsNonAdmin_ReturnsForbidden()
     {
         return SendRequestAsync(request => request

--- a/tests/Exceptionless.Tests/Api/Endpoints/AdminEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/AdminEndpointTests.cs
@@ -1,18 +1,21 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Exceptionless.Core.Billing;
+using Exceptionless.Core.Migrations;
 using Exceptionless.Core.Models;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Utility;
 using Exceptionless.Tests.Extensions;
 using Exceptionless.Tests.Utility;
 using Exceptionless.Web.Api.Handlers;
+using Exceptionless.Web.Api.Results;
 using Exceptionless.Web.Models.Admin;
 using Foundatio.Caching;
 using Foundatio.Jobs;
 using Foundatio.Queues;
 using Foundatio.Repositories;
 using Foundatio.Repositories.Models;
+using Foundatio.Repositories.Migrations;
 using Foundatio.Repositories.Utility;
 using Foundatio.Storage;
 using Xunit;
@@ -904,6 +907,76 @@ public class AdminEndpointTests : IntegrationTestsBase
 
         // Assert
         Assert.Equal("7.4s", duration);
+    }
+
+    [Fact]
+    public async Task RerunMigrationAsync_AsGlobalAdmin_QueuesSupportedCompletedMigration()
+    {
+        // Arrange
+        var migrationStateRepository = GetService<IMigrationStateRepository>();
+        await migrationStateRepository.AddAsync(new MigrationState
+        {
+            Id = "5",
+            Version = 5,
+            MigrationType = MigrationType.VersionedAndResumable,
+            StartedUtc = DateTime.UtcNow.AddMinutes(-1),
+            CompletedUtc = DateTime.UtcNow
+        });
+
+        // Act
+        var result = await SendRequestAsAsync<WorkInProgressResult>(request => request
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "migrations", "5", "rerun")
+            .Content(new RerunMigrationRequest("RERUN 5"))
+            .StatusCodeShouldBeAccepted());
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Workers);
+        var operation = await GetService<MigrationRerunService>().GetOperationAsync(result.Workers[0]);
+        Assert.NotNull(operation);
+        Assert.Equal(MigrationRerunStatus.Queued, operation.Status);
+        Assert.Equal(MigrationRerunSource.UserInterface, operation.Source);
+        Assert.False(String.IsNullOrWhiteSpace(operation.RequestedByUserId));
+        var status = await SendRequestAsAsync<MigrationRerunOperationResponse>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "migrations", "reruns", operation.Id)
+            .StatusCodeShouldBeOk());
+        Assert.NotNull(status);
+        Assert.Equal("Queued", status.Status);
+
+        var migrations = await SendRequestAsAsync<MigrationsResponse>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "migrations")
+            .StatusCodeShouldBeOk());
+        Assert.NotNull(migrations);
+        Assert.True(Assert.Single(migrations.States, state => state.Id == "5").CanRerun);
+
+        var queueStats = await _workItemQueue.GetQueueStatsAsync();
+        Assert.Equal(1, queueStats.Enqueued);
+    }
+
+    [Fact]
+    public Task RerunMigrationAsync_WithInvalidConfirmation_ReturnsValidationError()
+    {
+        return SendRequestAsync(request => request
+            .Post()
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "migrations", "5", "rerun")
+            .Content(new RerunMigrationRequest("5"))
+            .StatusCodeShouldBeUnprocessableEntity());
+    }
+
+    [Fact]
+    public Task RerunMigrationAsync_AsNonAdmin_ReturnsForbidden()
+    {
+        return SendRequestAsync(request => request
+            .Post()
+            .AsTestOrganizationUser()
+            .AppendPaths("admin", "migrations", "5", "rerun")
+            .Content(new RerunMigrationRequest("RERUN 5"))
+            .StatusCodeShouldBeForbidden());
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Jobs/JobRunnerOptionsTests.cs
+++ b/tests/Exceptionless.Tests/Jobs/JobRunnerOptionsTests.cs
@@ -28,4 +28,22 @@ public sealed class JobRunnerOptionsTests
 
         Assert.True(options.RunDataSeedStartupAction);
     }
+
+    [Fact]
+    public void Constructor_MigrationRerunArguments_SelectsOnlyMigrationRerun()
+    {
+        var options = new JobRunnerOptions([nameof(JobRunnerOptions.Migration), "--rerun", "5"]);
+
+        Assert.True(options.Migration);
+        Assert.False(options.AllJobs);
+        Assert.Equal("5", options.RerunMigrationId);
+        Assert.False(options.RunDataSeedStartupAction);
+        Assert.Empty(options.ConfigurationArguments);
+    }
+
+    [Fact]
+    public void Constructor_InvalidMultipleArguments_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => new JobRunnerOptions([nameof(JobRunnerOptions.Migration), "5"]));
+    }
 }

--- a/tests/Exceptionless.Tests/Migrations/MigrateSavedViewColumnsIntegrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrateSavedViewColumnsIntegrationTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Elastic.Clients.Elasticsearch;
+using Exceptionless.Core;
 using Exceptionless.Core.Migrations;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Repositories.Configuration;
@@ -210,7 +211,18 @@ public sealed class MigrateSavedViewColumnsIntegrationTests : IntegrationTestsBa
         });
 
         var rerunService = GetService<MigrationRerunService>();
-        var operation = await rerunService.QueueAsync("5", MigrationRerunSource.UserInterface, null, TestCancellationToken);
+        var appOptions = GetService<AppOptions>();
+        bool runJobsInProcess = appOptions.RunJobsInProcess;
+        MigrationRerunOperation operation;
+        try
+        {
+            appOptions.RunJobsInProcess = true;
+            operation = await rerunService.QueueAsync("5", MigrationRerunSource.UserInterface, null, TestCancellationToken);
+        }
+        finally
+        {
+            appOptions.RunJobsInProcess = runJobsInProcess;
+        }
         operation.Status = MigrationRerunStatus.Running;
         operation.StartedUtc = DateTime.UtcNow.AddHours(-1);
         operation.AttemptCount = 1;

--- a/tests/Exceptionless.Tests/Migrations/MigrateSavedViewColumnsIntegrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrateSavedViewColumnsIntegrationTests.cs
@@ -5,6 +5,7 @@ using Exceptionless.Core.Migrations;
 using Exceptionless.Core.Repositories;
 using Exceptionless.Core.Repositories.Configuration;
 using Exceptionless.Core.Seed;
+using Foundatio.Caching;
 using Foundatio.Lock;
 using Foundatio.Repositories;
 using Foundatio.Repositories.Migrations;
@@ -183,6 +184,44 @@ public sealed class MigrateSavedViewColumnsIntegrationTests : IntegrationTestsBa
         var duplicateResult = await rerunService.RunAsync(operation.Id, TestCancellationToken);
         Assert.Equal(MigrationRerunStatus.Completed, duplicateResult.Status);
         Assert.Equal(1, duplicateResult.AttemptCount);
+    }
+
+    [Fact]
+    public async Task RunAsync_RedeliveredRunningOperation_ResumesAndCompletes()
+    {
+        // Arrange
+        var completedUtc = DateTime.UtcNow.AddDays(-1);
+        var migrationStateRepository = GetService<IMigrationStateRepository>();
+        await migrationStateRepository.AddAsync(new MigrationState
+        {
+            Id = "5",
+            Version = 5,
+            MigrationType = MigrationType.VersionedAndResumable,
+            StartedUtc = completedUtc.AddMinutes(-1),
+            CompletedUtc = completedUtc
+        });
+        await migrationStateRepository.AddAsync(new MigrationState
+        {
+            Id = "9",
+            Version = 9,
+            MigrationType = MigrationType.VersionedAndResumable,
+            StartedUtc = completedUtc,
+            CompletedUtc = completedUtc
+        });
+
+        var rerunService = GetService<MigrationRerunService>();
+        var operation = await rerunService.QueueAsync("5", MigrationRerunSource.UserInterface, null, TestCancellationToken);
+        operation.Status = MigrationRerunStatus.Running;
+        operation.StartedUtc = DateTime.UtcNow.AddHours(-1);
+        operation.AttemptCount = 1;
+        await GetService<ICacheClient>().SetAsync($"migration-rerun:operation:{operation.Id}", operation, TimeSpan.FromDays(7));
+
+        // Act
+        operation = await rerunService.RunAsync(operation.Id, TestCancellationToken);
+
+        // Assert
+        Assert.Equal(MigrationRerunStatus.Completed, operation.Status);
+        Assert.Equal(2, operation.AttemptCount);
     }
 
     [Fact]

--- a/tests/Exceptionless.Tests/Migrations/MigrateSavedViewColumnsIntegrationTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrateSavedViewColumnsIntegrationTests.cs
@@ -114,6 +114,78 @@ public sealed class MigrateSavedViewColumnsIntegrationTests : IntegrationTestsBa
     }
 
     [Fact]
+    public async Task RerunAsync_CompletedMigration_ConvertsLegacyDocumentWithoutChangingMigrationState()
+    {
+        // Arrange
+        const string savedViewId = "770000000000000000000094";
+        var source = JsonNode.Parse(
+            $$"""
+            {
+              "id": "{{savedViewId}}",
+              "organization_id": "550000000000000000000001",
+              "created_by_user_id": "660000000000000000000001",
+              "name": "Legacy Columns Written After Migration",
+              "slug": "legacy-columns-after-migration",
+              "view_type": "events",
+              "columns": {
+                "level": true
+              },
+              "version": 1,
+              "created_utc": "2026-01-01T00:00:00Z",
+              "updated_utc": "2026-01-01T00:00:00Z"
+            }
+            """
+        )!.AsObject();
+
+        var completedUtc = DateTime.UtcNow.AddDays(-1);
+        var migrationStateRepository = GetService<IMigrationStateRepository>();
+        await migrationStateRepository.AddAsync(new MigrationState
+        {
+            Id = "5",
+            Version = 5,
+            MigrationType = MigrationType.VersionedAndResumable,
+            StartedUtc = completedUtc.AddMinutes(-1),
+            CompletedUtc = completedUtc
+        });
+        await migrationStateRepository.AddAsync(new MigrationState
+        {
+            Id = "9",
+            Version = 9,
+            MigrationType = MigrationType.VersionedAndResumable,
+            StartedUtc = completedUtc,
+            CompletedUtc = completedUtc
+        });
+
+        var indexResponse = await _client.IndexAsync(
+            source,
+            request => request
+                .Index(_configuration.SavedViews.VersionedName)
+                .Id(savedViewId)
+                .Refresh(Refresh.WaitFor),
+            TestCancellationToken);
+        Assert.True(indexResponse.IsValidResponse);
+
+        // Act
+        var rerunService = GetService<MigrationRerunService>();
+        var operation = await rerunService.QueueAsync("5", MigrationRerunSource.CommandLine, null, TestCancellationToken);
+        operation = await rerunService.RunAsync(operation.Id, TestCancellationToken);
+
+        // Assert
+        Assert.Equal(MigrationRerunStatus.Completed, operation.Status);
+        var savedView = await _repository.GetByIdAsync(savedViewId, options => options.ImmediateConsistency());
+        Assert.NotNull(savedView);
+        Assert.True(savedView.Columns?["level"].Visible);
+
+        var migrationState = await migrationStateRepository.GetByIdAsync("5");
+        Assert.NotNull(migrationState);
+        Assert.Equal(completedUtc, migrationState.CompletedUtc);
+
+        var duplicateResult = await rerunService.RunAsync(operation.Id, TestCancellationToken);
+        Assert.Equal(MigrationRerunStatus.Completed, duplicateResult.Status);
+        Assert.Equal(1, duplicateResult.AttemptCount);
+    }
+
+    [Fact]
     public async Task RunAsync_LegacySavedView_ReplacesDocumentWithStructuredColumns()
     {
         // Arrange

--- a/tests/Exceptionless.Tests/Migrations/MigrationRerunServiceTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrationRerunServiceTests.cs
@@ -1,3 +1,4 @@
+using Exceptionless.Core;
 using Exceptionless.Core.Jobs.WorkItemHandlers;
 using Exceptionless.Core.Migrations;
 using Exceptionless.Core.Models.WorkItems;
@@ -40,12 +41,111 @@ public sealed class MigrationRerunServiceTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task QueueAsync_UserInterfaceWithOutOfProcessJobsAndInMemoryInfrastructure_ThrowsUnavailable()
+    {
+        // Arrange
+        await ConfigureCompletedMigrationAsync();
+
+        // Act / Assert
+        await Assert.ThrowsAsync<MigrationRerunUnavailableException>(() =>
+            GetService<MigrationRerunService>().QueueAsync(
+                CancellableMigrationVersion.ToString(),
+                MigrationRerunSource.UserInterface,
+                null,
+                TestCancellationToken));
+    }
+
+    [Fact]
     public async Task RunAsync_CancelledUserInterfaceOperation_RemainsRetryable()
     {
         // Arrange
+        var migration = await ConfigureCompletedMigrationAsync();
+
+        var rerunService = GetService<MigrationRerunService>();
+        var appOptions = GetService<AppOptions>();
+        bool runJobsInProcess = appOptions.RunJobsInProcess;
+        MigrationRerunOperation operation;
+        try
+        {
+            appOptions.RunJobsInProcess = true;
+            operation = await rerunService.QueueAsync(
+                CancellableMigrationVersion.ToString(),
+                MigrationRerunSource.UserInterface,
+                null,
+                TestCancellationToken);
+        }
+        finally
+        {
+            appOptions.RunJobsInProcess = runJobsInProcess;
+        }
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        // Act
+        var interruptedRun = rerunService.RunAsync(operation.Id, cancellationTokenSource.Token);
+        await migration.Started.WaitAsync(TestCancellationToken);
+        await cancellationTokenSource.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => interruptedRun);
+
+        operation = (await rerunService.GetOperationAsync(operation.Id))!;
+        Assert.NotNull(operation);
+        Assert.Equal(MigrationRerunStatus.Running, operation.Status);
+        Assert.Null(operation.CompletedUtc);
+        Assert.Equal(1, operation.AttemptCount);
+        await Assert.ThrowsAsync<MigrationRerunAlreadyActiveException>(() => rerunService.QueueAsync(
+            CancellableMigrationVersion.ToString(),
+            MigrationRerunSource.CommandLine,
+            null,
+            TestCancellationToken));
+
+        migration.CompleteImmediately = true;
+        operation = await rerunService.RunAsync(operation.Id, TestCancellationToken);
+
+        // Assert
+        Assert.Equal(MigrationRerunStatus.Completed, operation.Status);
+        Assert.Equal(2, operation.AttemptCount);
+    }
+
+    [Fact]
+    public async Task RunAsync_RedeliveredTerminalOperation_RemovesStaleActiveMarker()
+    {
+        // Arrange
+        var migration = await ConfigureCompletedMigrationAsync();
+        migration.CompleteImmediately = true;
+        var rerunService = GetService<MigrationRerunService>();
+        var operation = await rerunService.QueueAsync(
+            CancellableMigrationVersion.ToString(),
+            MigrationRerunSource.CommandLine,
+            null,
+            TestCancellationToken);
+        operation = await rerunService.RunAsync(operation.Id, TestCancellationToken);
+        var cache = GetService<Foundatio.Caching.ICacheClient>();
+        Assert.True(await cache.AddAsync(
+            $"migration-rerun:active:{CancellableMigrationVersion}",
+            operation.Id,
+            TimeSpan.FromDays(7)));
+
+        // Act
+        var redeliveredOperation = await rerunService.RunAsync(operation.Id, TestCancellationToken);
+        var nextOperation = await rerunService.QueueAsync(
+            CancellableMigrationVersion.ToString(),
+            MigrationRerunSource.CommandLine,
+            null,
+            TestCancellationToken);
+
+        // Assert
+        Assert.Equal(MigrationRerunStatus.Completed, redeliveredOperation.Status);
+        Assert.Equal(1, redeliveredOperation.AttemptCount);
+        Assert.Equal(MigrationRerunStatus.Queued, nextOperation.Status);
+        await rerunService.FailQueuedOperationAsync(nextOperation.Id, new InvalidOperationException("Test cleanup"));
+    }
+
+    private async Task<CancellableRerunnableMigration> ConfigureCompletedMigrationAsync()
+    {
         var migration = GetService<CancellableRerunnableMigration>();
         migration.Reset();
-        GetService<MigrationManager>().Migrations.Add(migration);
+        var migrationManager = GetService<MigrationManager>();
+        if (!migrationManager.Migrations.Contains(migration))
+            migrationManager.Migrations.Add(migration);
 
         var completedUtc = DateTime.UtcNow.AddDays(-1);
         await GetService<IMigrationStateRepository>().AddAsync(new MigrationState
@@ -57,37 +157,7 @@ public sealed class MigrationRerunServiceTests : IntegrationTestsBase
             CompletedUtc = completedUtc
         });
 
-        var rerunService = GetService<MigrationRerunService>();
-        var operation = await rerunService.QueueAsync(
-            CancellableMigrationVersion.ToString(),
-            MigrationRerunSource.UserInterface,
-            null,
-            TestCancellationToken);
-        using var cancellationTokenSource = new CancellationTokenSource();
-
-        // Act
-        var interruptedRun = rerunService.RunAsync(operation.Id, cancellationTokenSource.Token);
-        await migration.Started.WaitAsync(TestCancellationToken);
-        await cancellationTokenSource.CancelAsync();
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => interruptedRun);
-
-        operation = await rerunService.GetOperationAsync(operation.Id);
-        Assert.NotNull(operation);
-        Assert.Equal(MigrationRerunStatus.Running, operation.Status);
-        Assert.Null(operation.CompletedUtc);
-        Assert.Equal(1, operation.AttemptCount);
-        await Assert.ThrowsAsync<MigrationRerunAlreadyActiveException>(() => rerunService.QueueAsync(
-            CancellableMigrationVersion.ToString(),
-            MigrationRerunSource.UserInterface,
-            null,
-            TestCancellationToken));
-
-        migration.CompleteImmediately = true;
-        operation = await rerunService.RunAsync(operation.Id, TestCancellationToken);
-
-        // Assert
-        Assert.Equal(MigrationRerunStatus.Completed, operation.Status);
-        Assert.Equal(2, operation.AttemptCount);
+        return migration;
     }
 }
 

--- a/tests/Exceptionless.Tests/Migrations/MigrationRerunServiceTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrationRerunServiceTests.cs
@@ -1,0 +1,126 @@
+using Exceptionless.Core.Jobs.WorkItemHandlers;
+using Exceptionless.Core.Migrations;
+using Exceptionless.Core.Models.WorkItems;
+using Foundatio.Jobs;
+using Foundatio.Lock;
+using Foundatio.Repositories.Migrations;
+using Foundatio.Utility;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Exceptionless.Tests.Migrations;
+
+public sealed class MigrationRerunServiceTests : IntegrationTestsBase
+{
+    private const int CancellableMigrationVersion = 1000;
+
+    public MigrationRerunServiceTests(ITestOutputHelper output, AppWebHostFactory factory) : base(output, factory) { }
+
+    protected override void RegisterServices(IServiceCollection services)
+    {
+        services.AddSingleton<CancellableRerunnableMigration>();
+        base.RegisterServices(services);
+    }
+
+    [Fact]
+    public Task HandleItemAsync_MissingOperation_ThrowsForQueueRetry()
+    {
+        // Arrange
+        var workItem = new RerunMigrationWorkItem { OperationId = "missing-operation" };
+        var context = new WorkItemContext(
+            workItem,
+            "test-job",
+            EmptyLock.Empty,
+            TestCancellationToken,
+            static (_, _) => Task.CompletedTask);
+
+        // Act / Assert
+        return Assert.ThrowsAsync<KeyNotFoundException>(() =>
+            GetService<RerunMigrationWorkItemHandler>().HandleItemAsync(context));
+    }
+
+    [Fact]
+    public async Task RunAsync_CancelledUserInterfaceOperation_RemainsRetryable()
+    {
+        // Arrange
+        var migration = GetService<CancellableRerunnableMigration>();
+        migration.Reset();
+        GetService<MigrationManager>().Migrations.Add(migration);
+
+        var completedUtc = DateTime.UtcNow.AddDays(-1);
+        await GetService<IMigrationStateRepository>().AddAsync(new MigrationState
+        {
+            Id = CancellableMigrationVersion.ToString(),
+            Version = CancellableMigrationVersion,
+            MigrationType = MigrationType.VersionedAndResumable,
+            StartedUtc = completedUtc.AddMinutes(-1),
+            CompletedUtc = completedUtc
+        });
+
+        var rerunService = GetService<MigrationRerunService>();
+        var operation = await rerunService.QueueAsync(
+            CancellableMigrationVersion.ToString(),
+            MigrationRerunSource.UserInterface,
+            null,
+            TestCancellationToken);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        // Act
+        var interruptedRun = rerunService.RunAsync(operation.Id, cancellationTokenSource.Token);
+        await migration.Started.WaitAsync(TestCancellationToken);
+        await cancellationTokenSource.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => interruptedRun);
+
+        operation = await rerunService.GetOperationAsync(operation.Id);
+        Assert.NotNull(operation);
+        Assert.Equal(MigrationRerunStatus.Running, operation.Status);
+        Assert.Null(operation.CompletedUtc);
+        Assert.Equal(1, operation.AttemptCount);
+        await Assert.ThrowsAsync<MigrationRerunAlreadyActiveException>(() => rerunService.QueueAsync(
+            CancellableMigrationVersion.ToString(),
+            MigrationRerunSource.UserInterface,
+            null,
+            TestCancellationToken));
+
+        migration.CompleteImmediately = true;
+        operation = await rerunService.RunAsync(operation.Id, TestCancellationToken);
+
+        // Assert
+        Assert.Equal(MigrationRerunStatus.Completed, operation.Status);
+        Assert.Equal(2, operation.AttemptCount);
+    }
+}
+
+internal sealed class CancellableRerunnableMigration : MigrationBase, IRerunnableMigration
+{
+    private TaskCompletionSource _started = CreateCompletionSource();
+
+    public CancellableRerunnableMigration(ILoggerFactory loggerFactory) : base(loggerFactory)
+    {
+        MigrationType = MigrationType.VersionedAndResumable;
+        Version = 1000;
+    }
+
+    public Task Started => _started.Task;
+    public bool CompleteImmediately { get; set; }
+
+    public override async Task RunAsync(MigrationContext context)
+    {
+        if (CompleteImmediately)
+        {
+            return;
+        }
+
+        _started.TrySetResult();
+        await Task.Delay(Timeout.InfiniteTimeSpan, context.CancellationToken);
+    }
+
+    public void Reset()
+    {
+        CompleteImmediately = false;
+        _started = CreateCompletionSource();
+    }
+
+    private static TaskCompletionSource CreateCompletionSource()
+        => new(TaskCreationOptions.RunContinuationsAsynchronously);
+}

--- a/tests/Exceptionless.Tests/Migrations/MigrationRerunServiceTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrationRerunServiceTests.cs
@@ -80,6 +80,31 @@ public sealed class MigrationRerunServiceTests : IntegrationTestsBase
     }
 
     [Fact]
+    public async Task QueueAsync_ExistingQueuedOperation_ReturnsItForRedispatch()
+    {
+        // Arrange
+        await ConfigureCompletedMigrationAsync();
+        var rerunService = GetService<MigrationRerunService>();
+        var queuedOperation = await rerunService.QueueAsync(
+            CancellableMigrationVersion.ToString(),
+            MigrationRerunSource.CommandLine,
+            null,
+            TestCancellationToken);
+
+        // Act
+        var redispatchedOperation = await rerunService.QueueAsync(
+            CancellableMigrationVersion.ToString(),
+            MigrationRerunSource.CommandLine,
+            null,
+            TestCancellationToken);
+
+        // Assert
+        Assert.Equal(queuedOperation.Id, redispatchedOperation.Id);
+        Assert.Equal(MigrationRerunStatus.Queued, redispatchedOperation.Status);
+        await rerunService.FailQueuedOperationAsync(queuedOperation.Id, new InvalidOperationException("Test cleanup"));
+    }
+
+    [Fact]
     public async Task RunAsync_CancelledUserInterfaceOperation_RemainsRetryable()
     {
         // Arrange

--- a/tests/Exceptionless.Tests/Migrations/MigrationRerunServiceTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrationRerunServiceTests.cs
@@ -1,4 +1,3 @@
-using Exceptionless.Core;
 using Exceptionless.Core.Jobs.WorkItemHandlers;
 using Exceptionless.Core.Migrations;
 using Exceptionless.Core.Models.WorkItems;
@@ -105,32 +104,24 @@ public sealed class MigrationRerunServiceTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task RunAsync_CancelledUserInterfaceOperation_RemainsRetryable()
+    public async Task RunAsync_CancelledWorkItemOperation_RemainsRetryableRegardlessOfSource()
     {
         // Arrange
         var migration = await ConfigureCompletedMigrationAsync();
 
         var rerunService = GetService<MigrationRerunService>();
-        var appOptions = GetService<AppOptions>();
-        bool runJobsInProcess = appOptions.RunJobsInProcess;
-        MigrationRerunOperation operation;
-        try
-        {
-            appOptions.RunJobsInProcess = true;
-            operation = await rerunService.QueueAsync(
-                CancellableMigrationVersion.ToString(),
-                MigrationRerunSource.UserInterface,
-                null,
-                TestCancellationToken);
-        }
-        finally
-        {
-            appOptions.RunJobsInProcess = runJobsInProcess;
-        }
+        var operation = await rerunService.QueueAsync(
+            CancellableMigrationVersion.ToString(),
+            MigrationRerunSource.CommandLine,
+            null,
+            TestCancellationToken);
         using var cancellationTokenSource = new CancellationTokenSource();
 
         // Act
-        var interruptedRun = rerunService.RunAsync(operation.Id, cancellationTokenSource.Token);
+        var interruptedRun = rerunService.RunAsync(
+            operation.Id,
+            cancellationTokenSource.Token,
+            retryOnCancellation: true);
         await migration.Started.WaitAsync(TestCancellationToken);
         await cancellationTokenSource.CancelAsync();
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => interruptedRun);

--- a/tests/Exceptionless.Tests/Migrations/MigrationRerunServiceTests.cs
+++ b/tests/Exceptionless.Tests/Migrations/MigrationRerunServiceTests.cs
@@ -2,6 +2,7 @@ using Exceptionless.Core;
 using Exceptionless.Core.Jobs.WorkItemHandlers;
 using Exceptionless.Core.Migrations;
 using Exceptionless.Core.Models.WorkItems;
+using Foundatio.Caching;
 using Foundatio.Jobs;
 using Foundatio.Lock;
 using Foundatio.Repositories.Migrations;
@@ -53,6 +54,29 @@ public sealed class MigrationRerunServiceTests : IntegrationTestsBase
                 MigrationRerunSource.UserInterface,
                 null,
                 TestCancellationToken));
+    }
+
+    [Fact]
+    public async Task QueueAsync_ActiveMarkerWithoutOperation_ReclaimsReservation()
+    {
+        // Arrange
+        await ConfigureCompletedMigrationAsync();
+        var cache = GetService<ICacheClient>();
+        string activeOperationCacheKey = $"migration-rerun:active:{CancellableMigrationVersion}";
+        Assert.True(await cache.AddAsync(activeOperationCacheKey, "missing-operation", TimeSpan.FromDays(7)));
+        var rerunService = GetService<MigrationRerunService>();
+
+        // Act
+        var operation = await rerunService.QueueAsync(
+            CancellableMigrationVersion.ToString(),
+            MigrationRerunSource.CommandLine,
+            null,
+            TestCancellationToken);
+
+        // Assert
+        Assert.Equal(MigrationRerunStatus.Queued, operation.Status);
+        Assert.Equal(operation.Id, await cache.GetAsync<string?>(activeOperationCacheKey, null));
+        await rerunService.FailQueuedOperationAsync(operation.Id, new InvalidOperationException("Test cleanup"));
     }
 
     [Fact]
@@ -118,7 +142,7 @@ public sealed class MigrationRerunServiceTests : IntegrationTestsBase
             null,
             TestCancellationToken);
         operation = await rerunService.RunAsync(operation.Id, TestCancellationToken);
-        var cache = GetService<Foundatio.Caching.ICacheClient>();
+        var cache = GetService<ICacheClient>();
         Assert.True(await cache.AddAsync(
             $"migration-rerun:active:{CancellableMigrationVersion}",
             operation.Id,

--- a/tests/http/admin.http
+++ b/tests/http/admin.http
@@ -167,6 +167,20 @@ Authorization: Bearer {{token}}
 GET {{apiUrl}}/admin/migrations
 Authorization: Bearer {{token}}
 
+### Rerun Migration
+# @name rerunMigration
+POST {{apiUrl}}/admin/migrations/5/rerun
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+    "confirmation": "RERUN 5"
+}
+
+### Get Migration Rerun Status
+GET {{apiUrl}}/admin/migrations/reruns/{{rerunMigration.response.body.$.workers[0]}}
+Authorization: Bearer {{token}}
+
 ### Elasticsearch Cluster Info
 GET {{apiUrl}}/admin/elasticsearch
 Authorization: Bearer {{token}}


### PR DESCRIPTION
## Summary

- add an explicit opt-in marker and shared service for rerunning completed migrations without changing migration history
- expose guarded System Migrations actions with typed confirmation, background execution, and status polling
- support the same rerun path from the job CLI with `Migration --rerun <id>` for instances that cannot start the UI
- mark saved-view column migration 5 as rerunnable and document the self-hosted recovery workflow

Addresses #2551.

## Safety

- only explicitly marked, completed migrations can be rerun
- reruns share the normal migration lock and reject concurrent running requests
- operation status is tracked separately; the recorded current version and original completion timestamp remain unchanged
- operation records precede active markers, and stale reservations plus terminal cleanup are recovered atomically
- queued operations are reused for safe UI redispatch or CLI recovery after a process exits before dispatch
- interrupted or infrastructure-blocked UI operations are retried by queue redelivery
- split Web/Job deployments fail fast unless the UI and worker share a distributed queue and Redis-backed cache
- completed, cancelled CLI, and durably recorded migration failures are not rerun automatically

## Verification

- `dotnet build Exceptionless.slnx --no-restore`
- focused migration retry, migration, CLI parsing, and admin endpoint tests (22 passed)
- endpoint manifest and OpenAPI snapshot tests (5 passed)
- `npm run validate`
- Playwright System Migrations confirmation flow (1 passed)
- local Aspire frontend and browser-facing API health checks

## Breaking changes

None.