### PR TITLE
Fix organization name search for administrators

### DIFF
--- a/src/Exceptionless.Core/Repositories/OrganizationRepository.cs
+++ b/src/Exceptionless.Core/Repositories/OrganizationRepository.cs
@@ -60,9 +60,13 @@ public class OrganizationRepository : RepositoryBase<Organization>, IOrganizatio
         var query = new RepositoryQuery<Organization>();
 
         if (!String.IsNullOrWhiteSpace(criteria))
+        {
+            string normalizedCriteria = criteria.Trim();
             query.FieldOr(g => g
-                .FieldEquals(o => o.Id, criteria)
-                .FieldEquals(o => o.Name, criteria));
+                .FieldEquals(o => o.Id, normalizedCriteria)
+                .FieldEquals(o => o.Name, normalizedCriteria)
+                .FieldContains(o => o.Name, normalizedCriteria));
+        }
 
         if (paid.HasValue)
         {

--- a/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
+++ b/tests/Exceptionless.Tests/Api/Endpoints/OrganizationEndpointTests.cs
@@ -160,6 +160,25 @@ public sealed class OrganizationEndpointTests : IntegrationTestsBase
         Assert.Contains(organizations, organization => organization.Id == expectedOrganizationId);
     }
 
+    [Theory]
+    [InlineData("NSW")]
+    [InlineData("nsw")]
+    [InlineData("  NSW  ")]
+    public async Task GetForAdminsAsync_WithNameCriteria_ReturnsMatchingOrganization(string criteria)
+    {
+        var organization = new Organization { Name = "NSW Planning Team", PlanId = _plans.FreePlan.Id };
+        await _organizationRepository.AddAsync(organization, options => options.ImmediateConsistency());
+
+        var organizations = await SendRequestAsAsync<IReadOnlyCollection<ViewOrganization>>(request => request
+            .AsGlobalAdminUser()
+            .AppendPaths("admin", "organizations")
+            .QueryString("criteria", criteria)
+            .StatusCodeShouldBeOk());
+
+        Assert.NotNull(organizations);
+        Assert.Equal(organization.Id, Assert.Single(organizations).Id);
+    }
+
     [Fact]
     public async Task GetIconAsync_WithExistingIcon_ReturnsImage()
     {

--- a/tests/Exceptionless.Tests/Repositories/OrganizationRepositoryTests.cs
+++ b/tests/Exceptionless.Tests/Repositories/OrganizationRepositoryTests.cs
@@ -64,15 +64,41 @@ public sealed class OrganizationRepositoryTests : IntegrationTestsBase
         Assert.Equal(0, _cache.Count);
     }
 
-    [Fact]
-    public async Task GetByCriteria_SearchById_ReturnsMatchingOrganization()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetByCriteriaAsync_SearchById_ReturnsMatchingOrganization(bool padCriteria)
     {
         // Arrange
         var organization = new Organization { Name = "Criteria Test Organization", PlanId = _plans.FreePlan.Id };
         await _repository.AddAsync(organization, o => o.ImmediateConsistency());
 
         // Act
-        var results = await _repository.GetByCriteriaAsync(organization.Id,
+        string criteria = padCriteria ? $"  {organization.Id}  " : organization.Id;
+        var results = await _repository.GetByCriteriaAsync(criteria,
+            o => o.PageLimit(10), OrganizationSortBy.Newest);
+
+        // Assert
+        Assert.Single(results.Documents);
+        Assert.Equal(organization.Id, results.Documents.First().Id);
+    }
+
+    [Theory]
+    [InlineData("NSW Planning Team")]
+    [InlineData("NSW")]
+    [InlineData("nsw")]
+    [InlineData("planning")]
+    [InlineData("NSW planning")]
+    [InlineData("  NSW  ")]
+    public async Task GetByCriteriaAsync_SearchByName_ReturnsMatchingOrganization(string criteria)
+    {
+        // Arrange
+        var organization = new Organization { Name = "NSW Planning Team", PlanId = _plans.FreePlan.Id };
+        var unrelatedOrganization = new Organization { Name = "Unrelated Company", PlanId = _plans.FreePlan.Id };
+        await _repository.AddAsync([organization, unrelatedOrganization], o => o.ImmediateConsistency());
+
+        // Act
+        var results = await _repository.GetByCriteriaAsync(criteria,
             o => o.PageLimit(10), OrganizationSortBy.Newest);
 
         // Assert
@@ -81,19 +107,37 @@ public sealed class OrganizationRepositoryTests : IntegrationTestsBase
     }
 
     [Fact]
-    public async Task GetByCriteria_SearchByName_ReturnsMatchingOrganization()
+    public async Task GetByCriteriaAsync_WithSymbolOnlyName_ReturnsMatchingOrganization()
     {
-        // Arrange
-        var organization = new Organization { Name = "Unique Search Name", PlanId = _plans.FreePlan.Id };
-        await _repository.AddAsync(organization, o => o.ImmediateConsistency());
+        var organization = new Organization { Name = "+++", PlanId = _plans.FreePlan.Id };
+        await _repository.AddAsync(organization, options => options.ImmediateConsistency());
 
-        // Act
-        var results = await _repository.GetByCriteriaAsync("Unique Search Name",
-            o => o.PageLimit(10), OrganizationSortBy.Newest);
+        var results = await _repository.GetByCriteriaAsync(organization.Name,
+            options => options.PageLimit(10), OrganizationSortBy.Newest);
 
-        // Assert
-        Assert.Single(results.Documents);
-        Assert.Equal("Unique Search Name", results.Documents.First().Name);
+        Assert.Equal(organization.Id, Assert.Single(results.Documents).Id);
+    }
+
+    [Fact]
+    public async Task GetByCriteriaAsync_WithNameAndPlanAndStatusFilters_ReturnsMatchingOrganization()
+    {
+        var organization = new Organization
+        {
+            Name = "NSW Planning Team",
+            PlanId = _plans.SmallPlan.Id,
+            BillingStatus = BillingStatus.Active
+        };
+        await _repository.AddAsync([
+            organization,
+            new Organization { Name = "NSW Free", PlanId = _plans.FreePlan.Id, BillingStatus = BillingStatus.Active },
+            new Organization { Name = "NSW Past Due", PlanId = _plans.SmallPlan.Id, BillingStatus = BillingStatus.PastDue },
+            new Organization { Name = "Unrelated Company", PlanId = _plans.SmallPlan.Id, BillingStatus = BillingStatus.Active }
+        ], options => options.ImmediateConsistency());
+
+        var results = await _repository.GetByCriteriaAsync("nsw", options => options.PageLimit(10),
+            OrganizationSortBy.Newest, paid: true, suspended: false);
+
+        Assert.Equal(organization.Id, Assert.Single(results.Documents).Id);
     }
 
     [Fact]


### PR DESCRIPTION
Searching for `NSW` in the impersonation dialog returned no results for an existing `NSW Planning Team` organization because name filtering required an exact, case-sensitive match. Add analyzed name matching and trim search whitespace while preserving exact name/ID lookup and the existing plan, status, sort, and paging behavior.

Validation: reproduced the empty result in the local browser and five failing repository regression cases before the fix. Verified the fixed dialog finds and selects the organization without browser errors; 123 focused repository/API tests cover name words, case, whitespace, exact IDs, punctuation-only names, combined filters, and existing organization operations. No migration or API contract changes.
