### PR TITLE
Fix organization context when following resource links

### DIFF
--- a/src/Exceptionless.Web/ClientApp/e2e/tests/resource-organization-navigation.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/resource-organization-navigation.e2e.ts
@@ -12,19 +12,30 @@ test('organization deep links select the destination organization', async ({ e2e
     expect(e2eScenario.organizationId).not.toBe(e2eSecondaryOrganization.organizationId);
 });
 
-for (const resource of ['project', 'stack', 'event', 'stack event', 'project stack'] as const) {
+for (const resource of ['project', 'stack', 'event', 'stack event', 'project stack', 'mismatched project stack'] as const) {
     test(`${resource} deep links select the destination organization`, async ({ e2eApi, e2eScenario, e2eSecondaryOrganization, page }) => {
         const event = resource === 'project' ? undefined : await seedRepresentativeEvent(e2eApi, e2eScenario.userToken, e2eSecondaryOrganization);
-        const href =
-            resource === 'project'
-                ? `/next/project/${e2eSecondaryOrganization.projectId}/settings`
-                : resource === 'project stack'
-                  ? `/next/project/${e2eSecondaryOrganization.projectId}/stacks/${event!.stack_id}`
-                  : resource === 'stack'
-                    ? `/next/stack/${event!.stack_id}`
-                    : resource === 'event'
-                      ? `/next/event/${event!.id}`
-                      : `/next/stack/${event!.stack_id}/event/${event!.id}`;
+        let href: string;
+        switch (resource) {
+            case 'event':
+                href = `/next/event/${event!.id}`;
+                break;
+            case 'mismatched project stack':
+                href = `/next/project/${e2eScenario.projectId}/stacks/${event!.stack_id}`;
+                break;
+            case 'project':
+                href = `/next/project/${e2eSecondaryOrganization.projectId}/settings`;
+                break;
+            case 'project stack':
+                href = `/next/project/${e2eSecondaryOrganization.projectId}/stacks/${event!.stack_id}`;
+                break;
+            case 'stack':
+                href = `/next/stack/${event!.stack_id}`;
+                break;
+            case 'stack event':
+                href = `/next/stack/${event!.stack_id}/event/${event!.id}`;
+                break;
+        }
 
         await page.goto(href);
         await expectOrganization(page, e2eSecondaryOrganization.organizationId);

--- a/src/Exceptionless.Web/ClientApp/e2e/tests/resource-organization-navigation.e2e.ts
+++ b/src/Exceptionless.Web/ClientApp/e2e/tests/resource-organization-navigation.e2e.ts
@@ -1,0 +1,193 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/e2e-test';
+import { seedRepresentativeEvent } from '../support/event-data';
+
+test('organization deep links select the destination organization', async ({ e2eScenario, e2eSecondaryOrganization, page }) => {
+    await page.goto(`/next/organization/${e2eSecondaryOrganization.organizationId}/manage?from=link#settings`);
+
+    await expect(page).toHaveURL(new RegExp(`/organization/${e2eSecondaryOrganization.organizationId}/manage\\?from=link#settings$`));
+    await expect(page.getByRole('heading', { exact: true, name: `${e2eSecondaryOrganization.organizationName} Settings` })).toBeVisible();
+    await expectOrganization(page, e2eSecondaryOrganization.organizationId);
+    expect(e2eScenario.organizationId).not.toBe(e2eSecondaryOrganization.organizationId);
+});
+
+for (const resource of ['project', 'stack', 'event', 'stack event', 'project stack'] as const) {
+    test(`${resource} deep links select the destination organization`, async ({ e2eApi, e2eScenario, e2eSecondaryOrganization, page }) => {
+        const event = resource === 'project' ? undefined : await seedRepresentativeEvent(e2eApi, e2eScenario.userToken, e2eSecondaryOrganization);
+        const href =
+            resource === 'project'
+                ? `/next/project/${e2eSecondaryOrganization.projectId}/settings`
+                : resource === 'project stack'
+                  ? `/next/project/${e2eSecondaryOrganization.projectId}/stacks/${event!.stack_id}`
+                  : resource === 'stack'
+                    ? `/next/stack/${event!.stack_id}`
+                    : resource === 'event'
+                      ? `/next/event/${event!.id}`
+                      : `/next/stack/${event!.stack_id}/event/${event!.id}`;
+
+        await page.goto(href);
+        await expectOrganization(page, e2eSecondaryOrganization.organizationId);
+        if (event) {
+            await expect(page.getByText(e2eSecondaryOrganization.message, { exact: true }).filter({ visible: true }).first()).toBeVisible();
+            await expect(page).toHaveURL(resource === 'project stack' ? href : new RegExp(`/stack/${event.stack_id}/event/${event.id}$`));
+        } else {
+            await expect(page.getByRole('heading', { exact: true, name: `${e2eSecondaryOrganization.projectName} Settings` })).toBeVisible();
+        }
+
+        await page.reload();
+        await expectOrganization(page, e2eSecondaryOrganization.organizationId);
+        await page.getByRole('button').filter({ hasText: e2eSecondaryOrganization.organizationName }).filter({ visible: true }).first().click();
+        await page.getByRole('menuitem').filter({ hasText: e2eScenario.organizationName }).click();
+        await expectOrganization(page, e2eScenario.organizationId);
+        await expect(page).toHaveURL(/\/next\/stack\/all$/);
+    });
+}
+
+async function expectOrganization(page: Page, organizationId: string): Promise<void> {
+    await expect(async () => {
+        const activeOrganizationId = await page.evaluate(() => JSON.parse(localStorage.getItem('organization') ?? 'null'));
+        expect(activeOrganizationId).toBe(organizationId);
+    }).toPass({ timeout: 10_000 });
+}
+
+test('Exie usage organization links switch context and support browser history', async ({ e2eScenario, e2eSecondaryOrganization, page }) => {
+    const organizations = [e2eScenario, e2eSecondaryOrganization];
+    await page.route('**/api/v2/admin/assistant-usage?*', async (route) => {
+        await route.fulfill({
+            json: {
+                active_organizations: 2,
+                completion_tokens: 0,
+                cost_usd: 0,
+                month: '2026-09-01',
+                organizations: organizations.map((item) => ({
+                    blocked_by_concurrency: 0,
+                    blocked_by_cost_limit: 0,
+                    blocked_by_rate_limit: 0,
+                    blocked_by_token_limit: 0,
+                    cancelled: 0,
+                    completed: 0,
+                    completion_tokens: 0,
+                    cost_usd: 0,
+                    failed: 0,
+                    last_used_utc: new Date().toISOString(),
+                    organization_id: item.organizationId,
+                    organization_name: item.organizationName,
+                    plan_id: 'FREE',
+                    prompt_tokens: 0,
+                    provider_requests: 0,
+                    tool_calls: 0,
+                    turns: 0
+                })),
+                prompt_tokens: 0,
+                turns: 0
+            }
+        });
+    });
+
+    await page.goto('/next/system/exie');
+    await page.getByRole('link', { exact: true, name: e2eSecondaryOrganization.organizationName }).click();
+    await expect(page.getByRole('heading', { exact: true, name: `${e2eSecondaryOrganization.organizationName} Settings` })).toBeVisible();
+    await expectOrganization(page, e2eSecondaryOrganization.organizationId);
+    await expect(page).toHaveURL(new RegExp(`/organization/${e2eSecondaryOrganization.organizationId}/manage$`));
+
+    await test.info().attach('organization-link-destination', { body: await page.screenshot(), contentType: 'image/png' });
+    await page.goto(`/next/organization/${e2eScenario.organizationId}/manage`);
+    await expectOrganization(page, e2eScenario.organizationId);
+    await expect(page.getByRole('heading', { exact: true, name: `${e2eScenario.organizationName} Settings` })).toBeVisible();
+    await page.goBack();
+    await expect(page).toHaveURL(new RegExp(`/organization/${e2eSecondaryOrganization.organizationId}/manage$`));
+    await expectOrganization(page, e2eSecondaryOrganization.organizationId);
+    await page.goForward();
+    await expect(page).toHaveURL(new RegExp(`/organization/${e2eScenario.organizationId}/manage$`));
+    await expectOrganization(page, e2eScenario.organizationId);
+});
+
+test('organization users and billing links request the destination organization', async ({ e2eScenario, e2eSecondaryOrganization, page }) => {
+    const usersResponse = page.waitForResponse((response) => response.url().includes(`/organizations/${e2eSecondaryOrganization.organizationId}/users`));
+    await page.goto(`/next/organization/${e2eSecondaryOrganization.organizationId}/users`);
+    expect((await usersResponse).ok()).toBe(true);
+    await expectOrganization(page, e2eSecondaryOrganization.organizationId);
+    await expect(page.getByRole('button', { name: 'Invite User' })).toBeVisible();
+
+    const billingResponse = page.waitForResponse((response) => response.url().includes(`/organizations/${e2eScenario.organizationId}/invoices`));
+    await page.goto(`/next/organization/${e2eScenario.organizationId}/billing`);
+    expect([200, 404]).toContain((await billingResponse).status());
+    await expectOrganization(page, e2eScenario.organizationId);
+    await expect(page).toHaveURL(new RegExp(`/organization/${e2eScenario.organizationId}/billing$`));
+});
+
+test('organization project links switch before redirecting to the project list', async ({ e2eSecondaryOrganization, page }) => {
+    await page.goto(`/next/organization/${e2eSecondaryOrganization.organizationId}/projects`);
+    await expectOrganization(page, e2eSecondaryOrganization.organizationId);
+    await expect(page).toHaveURL(/\/next\/project\/list/);
+    await expect(page.getByText(e2eSecondaryOrganization.projectName, { exact: true }).filter({ visible: true }).first()).toBeVisible();
+});
+
+test('stack links select the owner when no events remain', async ({ e2eApi, e2eScenario, e2eSecondaryOrganization, page }) => {
+    const event = await seedRepresentativeEvent(e2eApi, e2eScenario.userToken, e2eSecondaryOrganization);
+    await page.route(`**/api/v2/stacks/${event.stack_id}/events?*`, async (route) => {
+        await route.fulfill({ json: [] });
+    });
+    await page.goto(`/next/stack/${event.stack_id}`);
+    await expect(page.getByText('No events available for this stack.')).toBeVisible();
+    await expectOrganization(page, e2eSecondaryOrganization.organizationId);
+    await expect(page).toHaveURL(new RegExp(`/stack/${event.stack_id}$`));
+});
+
+test('authorized invoice links select their organization', async ({ e2eSecondaryOrganization, page }) => {
+    const invoiceId = 'navigation-invoice';
+    await page.route(`**/api/v2/organizations/invoice/${invoiceId}`, async (route) => {
+        await route.fulfill({
+            json: {
+                date: new Date().toISOString(),
+                id: invoiceId,
+                items: [],
+                organization_id: e2eSecondaryOrganization.organizationId,
+                organization_name: e2eSecondaryOrganization.organizationName,
+                paid: true,
+                status: 'paid',
+                total: 0
+            }
+        });
+    });
+    await page.goto(`/next/payment/${invoiceId}`);
+    await expect(page.getByRole('cell', { exact: true, name: e2eSecondaryOrganization.organizationName })).toBeVisible();
+    await expectOrganization(page, e2eSecondaryOrganization.organizationId);
+    await expect(page).toHaveURL(new RegExp(`/payment/${invoiceId}$`));
+});
+
+test.describe('member access', () => {
+    test.use({ e2eUseGeneratedUser: true });
+
+    test('members can follow links to another organization they belong to', async ({ e2eScenario, e2eSecondaryOrganization, page }) => {
+        await page.goto(`/next/organization/${e2eSecondaryOrganization.organizationId}/manage`);
+        await expect(page.getByRole('heading', { exact: true, name: `${e2eSecondaryOrganization.organizationName} Settings` })).toBeVisible();
+        await expectOrganization(page, e2eSecondaryOrganization.organizationId);
+        await page.goto(`/next/project/${e2eScenario.projectId}/settings`);
+        await expect(page.getByRole('heading', { exact: true, name: `${e2eScenario.projectName} Settings` })).toBeVisible();
+        await expectOrganization(page, e2eScenario.organizationId);
+    });
+
+    for (const status of [403, 404]) {
+        test(`denied resource lookups (${status}) preserve the current organization`, async ({ e2eScenario, page }) => {
+            const resourceId = '000000000000000000000001';
+            await page.route(new RegExp(`/api/v2/(organizations|projects|stacks|events)/${resourceId}(?:[/?]|$)`), async (route) => {
+                await route.fulfill({ body: JSON.stringify({ status, title: 'Resource unavailable' }), contentType: 'application/problem+json', status });
+            });
+            for (const resource of ['organization', 'project', 'stack', 'event']) {
+                const response = page.waitForResponse((item) => item.url().includes(`/api/v2/${resource}s/${resourceId}`));
+                const suffix = resource === 'organization' ? '/manage' : resource === 'project' ? '/settings' : '';
+                await page.goto(`/next/${resource}/${resourceId}${suffix}`);
+                expect((await response).status()).toBe(status);
+                await expect(
+                    page
+                        .getByText(/Resource unavailable|could not be found|Unable to load stack event details/)
+                        .filter({ visible: true })
+                        .first()
+                ).toBeVisible();
+                await expectOrganization(page, e2eScenario.organizationId);
+            }
+        });
+    }
+});

--- a/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/table/options.svelte.ts
+++ b/src/Exceptionless.Web/ClientApp/src/lib/features/users/components/table/options.svelte.ts
@@ -67,12 +67,12 @@ export function getColumns<TUser extends ViewUser>(organizationId: string): Colu
 export function getTableOptions<TUser extends ViewUser>(
     queryParameters: GetOrganizationUsersParams,
     queryResponse: CreateQueryResult<FetchClientResponse<TUser[]>, ProblemDetails>,
-    organizationId: string
+    organizationId: (() => string) | string
 ) {
     return getSharedTableOptions<TUser>({
         columnPersistenceKey: 'users-column-visibility',
         get columns() {
-            return getColumns<TUser>(organizationId);
+            return getColumns<TUser>(typeof organizationId === 'function' ? organizationId() : organizationId);
         },
         paginationStrategy: 'offset',
         get queryData() {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/event/[eventId=objectid]/+page.svelte
@@ -11,21 +11,9 @@
     import EventsOverview from '$features/events/components/events-overview.svelte';
     import { buildEventDetailsHref } from '$features/events/components/summary';
     import { organization } from '$features/organizations/context.svelte';
-    import { watch } from 'runed';
     import { toast } from 'svelte-sonner';
 
     import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../../redirect-to-events.svelte.js';
-
-    // TODO: Have this happen automatically when the organization changes.
-    watch(
-        () => organization.current,
-        () => {
-            goto(resolve('/(app)/event'));
-        },
-        {
-            lazy: true
-        }
-    );
 
     async function filterChanged(addedOrUpdated: FacetedFilter.IFilter) {
         await redirectToEventsWithFilter(organization.current, addedOrUpdated, getEventsNavigationOptionsForFilter(addedOrUpdated));
@@ -41,6 +29,7 @@
     }
 
     async function handleEventLoaded(event: PersistentEvent) {
+        organization.current = event.organization_id;
         assistantPageContext.setPageEvent(event);
         await goto(buildEventDetailsHref(event.id, event.stack_id), {
             replaceState: true

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/+layout.svelte
@@ -44,9 +44,8 @@
             return;
         }
 
-        if (organizationQuery.isSuccess && organization.current && organizationId !== organization.current) {
-            goto(page.url.pathname.replace(`/organization/${organizationId}`, `/organization/${organization.current}`));
-            return;
+        if (organizationQuery.isSuccess) {
+            organization.current = organizationQuery.data.id;
         }
     });
 </script>
@@ -83,6 +82,8 @@
                 </A>
             {/each}
         </nav>
-        {@render children()}
+        {#if organizationQuery.isSuccess}
+            {@render children()}
+        {/if}
     </div>
 </div>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/billing/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/billing/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { resolve } from '$app/paths';
+    import { page } from '$app/state';
     import ErrorMessage from '$comp/error-message.svelte';
     import Currency from '$comp/formatters/currency.svelte';
     import DateTime from '$comp/formatters/date-time.svelte';
@@ -12,7 +13,6 @@
     import { ChangePlanDialog } from '$features/billing';
     import { getInvoiceStatusLabel } from '$features/billing/invoice';
     import { getInvoicesQuery, getOrganizationQuery } from '$features/organizations/api.svelte';
-    import { organization } from '$features/organizations/context.svelte';
     import GlobalUser from '$features/users/components/global-user.svelte';
     import { createQueryParameters } from '$shared/query-params';
     import CreditCard from '@lucide/svelte/icons/credit-card';
@@ -22,7 +22,7 @@
     const organizationQuery = getOrganizationQuery({
         route: {
             get id() {
-                return organization.current;
+                return page.params.organizationId;
             }
         }
     });
@@ -30,7 +30,7 @@
     const invoicesQuery = getInvoicesQuery({
         route: {
             get organizationId() {
-                return organization.current!;
+                return page.params.organizationId!;
             }
         }
     });

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/users/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/organization/[organizationId]/users/+page.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
     import type { ViewUser } from '$features/users/models';
 
+    import { page } from '$app/state';
     import DataTableViewOptions from '$comp/data-table/data-table-view-options.svelte';
     import { Muted } from '$comp/typography';
     import { Button } from '$comp/ui/button';
     import { showBillingDialogOnUpgradeProblem } from '$features/billing';
     import { addOrganizationUser } from '$features/organizations/api.svelte';
-    import { organization } from '$features/organizations/context.svelte';
     import { DEFAULT_LIMIT } from '$features/shared/api/api.svelte';
     import { type GetOrganizationUsersParams, getOrganizationUsersQuery } from '$features/users/api.svelte';
     import InviteUserDialog from '$features/users/components/invite-user-dialog.svelte';
@@ -18,7 +18,7 @@
     import { createTable } from '@tanstack/svelte-table';
     import { toast } from 'svelte-sonner';
 
-    const organizationId = organization.current!;
+    const organizationId = $derived(page.params.organizationId || '');
 
     const DEFAULT_PARAMS = {
         limit: DEFAULT_LIMIT
@@ -52,7 +52,7 @@
         }
     });
 
-    const table = createTable(getTableOptions<ViewUser>(usersQueryParameters, usersQuery, organizationId));
+    const table = createTable(getTableOptions<ViewUser>(usersQueryParameters, usersQuery, () => organizationId));
 
     const addUserMutation = addOrganizationUser({
         route: {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/payment/[id]/+page@.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/payment/[id]/+page@.svelte
@@ -26,12 +26,13 @@
     });
 
     $effect(() => {
-        if (!accessToken.current || !organization.current || invoiceQuery.isError) {
+        if (!accessToken.current || invoiceQuery.isError) {
             void goto(resolve('/'));
+            return;
         }
 
-        if (invoiceQuery.isSuccess && invoiceQuery.data?.organization_id !== organization.current) {
-            void goto(resolve('/'));
+        if (invoiceQuery.isSuccess && invoiceQuery.data?.organization_id) {
+            organization.current = invoiceQuery.data.organization_id;
         }
     });
 </script>

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/+layout.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/+layout.svelte
@@ -63,7 +63,7 @@
             goto(resolve('/(app)/project/list'));
         }
 
-        if (projectQuery.isSuccess && projectQuery.data.organization_id !== organization.current) {
+        if (projectQuery.isSuccess) {
             organization.current = projectQuery.data.organization_id;
         }
     });

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/[stackId]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/[stackId]/+page.svelte
@@ -8,26 +8,11 @@
     import { showBillingDialogOnUpgradeProblem } from '$features/billing';
     import { organization } from '$features/organizations/context.svelte';
     import StackDetails from '$features/stacks/components/stack-details.svelte';
-    import { watch } from 'runed';
     import { toast } from 'svelte-sonner';
 
     import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../../../../redirect-to-events.svelte.js';
 
     const stackId = $derived(page.params.stackId || '');
-
-    watch(
-        () => organization.current,
-        () => {
-            goto(
-                resolve('/(app)/project/[projectId]/stacks', {
-                    projectId: page.params.projectId || ''
-                })
-            );
-        },
-        {
-            lazy: true
-        }
-    );
 
     async function filterChanged(addedOrUpdated: IFilter) {
         await redirectToEventsWithFilter(organization.current, addedOrUpdated, getEventsNavigationOptionsForFilter(addedOrUpdated));

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/[stackId]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/project/[projectId]/stacks/[stackId]/+page.svelte
@@ -6,13 +6,36 @@
     import { resolve } from '$app/paths';
     import { page } from '$app/state';
     import { showBillingDialogOnUpgradeProblem } from '$features/billing';
+    import { buildStackDetailsHref } from '$features/events/components/summary';
     import { organization } from '$features/organizations/context.svelte';
+    import { getStackQuery } from '$features/stacks/api.svelte';
     import StackDetails from '$features/stacks/components/stack-details.svelte';
     import { toast } from 'svelte-sonner';
 
     import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../../../../redirect-to-events.svelte.js';
 
+    const projectId = $derived(page.params.projectId || '');
     const stackId = $derived(page.params.stackId || '');
+    const stackQuery = getStackQuery({
+        route: {
+            get id() {
+                return stackId;
+            }
+        }
+    });
+
+    $effect(() => {
+        if (stackQuery.isError) {
+            handleError(stackQuery.error);
+            return;
+        }
+
+        if (stackQuery.isSuccess && stackQuery.data.project_id !== projectId) {
+            void goto(buildStackDetailsHref(stackQuery.data.id), {
+                replaceState: true
+            });
+        }
+    });
 
     async function filterChanged(addedOrUpdated: IFilter) {
         await redirectToEventsWithFilter(organization.current, addedOrUpdated, getEventsNavigationOptionsForFilter(addedOrUpdated));
@@ -29,7 +52,7 @@
     async function handleDeleted() {
         await goto(
             resolve('/(app)/project/[projectId]/stacks', {
-                projectId: page.params.projectId || ''
+                projectId
             })
         );
     }
@@ -39,4 +62,6 @@
     });
 </script>
 
-<StackDetails {filterChanged} {handleError} onDeleted={handleDeleted} {stackId} />
+{#if stackQuery.isSuccess && stackQuery.data.project_id === projectId}
+    <StackDetails {filterChanged} {handleError} onDeleted={handleDeleted} {stackId} />
+{/if}

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/+page.svelte
@@ -12,22 +12,11 @@
     import { buildEventDetailsHref } from '$features/events/components/summary';
     import { organization } from '$features/organizations/context.svelte';
     import StackDetails from '$features/stacks/components/stack-details.svelte';
-    import { watch } from 'runed';
     import { toast } from 'svelte-sonner';
 
     import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../../redirect-to-events.svelte.js';
 
     const stackId = $derived(page.params.stackId || '');
-
-    watch(
-        () => organization.current,
-        () => {
-            goto(resolve('/(app)/stack'));
-        },
-        {
-            lazy: true
-        }
-    );
 
     async function filterChanged(addedOrUpdated: IFilter) {
         await redirectToEventsWithFilter(organization.current, addedOrUpdated, getEventsNavigationOptionsForFilter(addedOrUpdated));
@@ -46,6 +35,7 @@
     }
 
     async function handleEventLoaded(event: PersistentEvent) {
+        organization.current = event.organization_id;
         assistantPageContext.setPageEvent(event);
         await goto(buildEventDetailsHref(event.id, event.stack_id), {
             replaceState: true
@@ -53,6 +43,7 @@
     }
 
     function handleStackLoaded(stack: Stack) {
+        organization.current = stack.organization_id;
         assistantPageContext.setPageStack(stack);
     }
     async function handleNavigate(newEventId: string) {

--- a/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/event/[eventId=objectid]/+page.svelte
+++ b/src/Exceptionless.Web/ClientApp/src/routes/(app)/stack/[stackId=objectid]/event/[eventId=objectid]/+page.svelte
@@ -11,23 +11,12 @@
     import { buildEventDetailsHref } from '$features/events/components/summary';
     import { organization } from '$features/organizations/context.svelte';
     import StackDetails from '$features/stacks/components/stack-details.svelte';
-    import { watch } from 'runed';
     import { toast } from 'svelte-sonner';
 
     import { getEventsNavigationOptionsForFilter, redirectToEventsWithFilter } from '../../../../redirect-to-events.svelte.js';
 
     const stackId = $derived(page.params.stackId || '');
     const eventId = $derived(page.params.eventId || '');
-
-    watch(
-        () => organization.current,
-        () => {
-            goto(resolve('/(app)/stack'));
-        },
-        {
-            lazy: true
-        }
-    );
 
     async function filterChanged(addedOrUpdated: IFilter) {
         await redirectToEventsWithFilter(organization.current, addedOrUpdated, getEventsNavigationOptionsForFilter(addedOrUpdated));
@@ -46,6 +35,7 @@
     }
 
     async function handleEventLoaded(event: PersistentEvent) {
+        organization.current = event.organization_id;
         assistantPageContext.setPageEvent(event);
 
         if (event.id !== eventId || event.stack_id !== stackId) {


### PR DESCRIPTION
Links to another accessible organization previously redirected to the selected organization, while stack and event detail links could retain the wrong organization context. Select the organization from the successful resource lookup and preserve the requested destination, including project and invoice links. Nested project/stack URLs redirect to the stack’s canonical page when its owning project differs.

Keep organization Users and Billing scoped to the route, and preserve the current selection when access is denied. Public API contracts and authorization are unchanged.

Validation:
- `npm run validate`
- 17 Playwright cases covering resource links, the Exie usage table, history/reload, sidebar switching, ordinary members, and denied access
- 13 focused Vitest tests for organization APIs and event navigation

Exie usage rows, invoice data, empty-stack responses, and access-denial responses use controlled browser fixtures; resource records and event ingestion use the local Aspire stack.
